### PR TITLE
Syntax highlighting

### DIFF
--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -3,6 +3,7 @@ local parsers = require'nvim-treesitter.parsers'
 local configs = require 'nvim-treesitter.configs'
 local install = require'nvim-treesitter.install'
 local locals = require'nvim-treesitter.locals'
+local highlight = require'nvim-treesitter.highlight'
 
 local M = {}
 
@@ -14,6 +15,8 @@ end
 -- this is the main interface through the plugin
 function M.setup(lang)
   if parsers.has_parser(lang) then
+    local autocmd = "autocmd NvimTreesitter FileType %s lua require'nvim-treesitter.highlight'.setup()"
+    api.nvim_command(string.format(autocmd, lang))
   end
 end
 

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -2,7 +2,9 @@ local api = vim.api
 local queries = require'nvim-treesitter.query'
 local ts = vim.treesitter
 
-local M = {}
+local M = {
+  highlighters={}
+}
 
 function M.setup(bufnr, ft)
   local buf = bufnr or api.nvim_get_current_buf()
@@ -11,7 +13,7 @@ function M.setup(bufnr, ft)
   local query = queries.get_query(ft, "highlights")
   if not query then return end
 
-  ts.TSHighlighter.new(query, buf, ft)
+  M.highlighters[buf] = ts.TSHighlighter.new(query, buf, ft)
 end
 
 return M

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -1,0 +1,17 @@
+local api = vim.api
+local queries = require'nvim-treesitter.query'
+local ts = vim.treesitter
+
+local M = {}
+
+function M.setup(bufnr, ft)
+  local buf = bufnr or api.nvim_get_current_buf()
+  local ft = ft or api.nvim_buf_get_option(buf, 'ft')
+
+  local query = queries.get_query(ft, "highlights")
+  if not query then return end
+
+  ts.TSHighlighter.new(query, buf, ft)
+end
+
+return M

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -62,7 +62,7 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
       local preds = query.info.patterns[pattern]
       if preds then
         for _, pred in pairs(preds) do
-          if pred[1] == "set!" and pred[2] ~= nil then
+          if pred[1] == "set!" and type(pred[2]) == "string" then
             insert_to_path(prepared_match, split(pred[2]), pred[3])
           end
         end

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -1,0 +1,36 @@
+;;; Highlighting for lua
+
+;;; Builtins
+;; Keywords
+"local" @keyword
+"if" @keyword
+"then" @keyword
+"else" @keyword
+"elseif" @keyword
+"end" @keyword
+"return" @keyword
+"do" @keyword
+"while" @keyword
+"repeat" @keyword
+"for" @keyword
+
+;; Operators
+"~=" @operator
+"==" @operator
+"not" @operator
+"and" @operator
+"or" @operator
+
+;; Constants
+(false) @constant
+(true) @constant
+(nil) @constant
+
+;; Nodes
+(function "function" @function "end" @function)
+(comment) @comment
+(string) @string
+(number) @constant
+
+;; Error
+(ERROR) @Error

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -13,24 +13,48 @@
 "while" @keyword
 "repeat" @keyword
 "for" @keyword
+(break_statement) @keyword
+"goto" @keyword
 
 ;; Operators
 "~=" @operator
 "==" @operator
+"<=" @operator
+">=" @operator
 "not" @operator
 "and" @operator
 "or" @operator
+"<" @operator
+">" @operator
+
+"+" @operator
+"-" @operator
+"%" @operator
+"/" @operator
+"//" @operator
+"*" @operator
+"^" @operator
+"&" @operator
+"~" @operator
+"|" @operator
+">>" @operator
+"<<" @operator
+".." @operator
+"#" @operator
 
 ;; Constants
 (false) @constant
 (true) @constant
 (nil) @constant
+(spread) @constant ;; "..."
 
 ;; Nodes
 (function "function" @function "end" @function)
+(table "{" @operator "}" @operator)
 (comment) @comment
 (string) @string
-(number) @constant
+(number) @number
+(label_statement) @label
 
 ;; Error
 (ERROR) @Error


### PR DESCRIPTION
Rought draft of syntax highlighting.
Is uses a `highlights.scm` query file, and an example `lua` query is provided.

One thing to consider is the `ERROR` node, which is built in treesitter and we might want to move it out of the query itself.

Some other things to consider are :
  - `is?` and `is-not?` predicates, which would allow us to have really powerful syntax highlighting
  - naming conventions for highlight groups
  - Do we have to use the builtin `TSHighlighter` or do we use our own highlighter based on a copy of the builtin on ?