### PR TITLE
feat: enable typescript and tsx install 

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -76,7 +76,16 @@ M.repositories = {
     url = "https://github.com/tree-sitter/tree-sitter-c-sharp",
     files = { "src/parser.c", "src/scanner.c" },
   },
-  -- TODO: find a way to install typescript properly
+  typescript = {
+    url = "https://github.com/tree-sitter/tree-sitter-typescript",
+    files = { "src/parser.c", "src/scanner.c" },
+    location = "tree-sitter-typescript/typescript"
+  },
+  tsx = {
+    url = "https://github.com/tree-sitter/tree-sitter-typescript",
+    files = { "src/parser.c", "src/scanner.c" },
+    location = "tree-sitter-tsx/tsx"
+  }
 }
 
 local function get_package_path()
@@ -122,6 +131,8 @@ end
 local function run_install(cache_folder, package_path, ft, repo)
   local project_name = 'tree-sitter-'..ft
   local project_repo = cache_folder..'/'..project_name
+  -- compile_location only needed for typescript installs.
+  local compile_location = cache_folder..'/'..(repo.location or project_name)
   local parser_lib_name = package_path.."/parser/"..ft..".so"
   local command_list = {
     {
@@ -145,13 +156,13 @@ local function run_install(cache_folder, package_path, ft, repo)
       err = 'Error during compilation',
       opts = {
         args = { '-o', 'parser.so', '-shared', '-lstdc++', unpack(repo.files), '-Os', '-I./src' },
-        cwd = project_repo
+        cwd = compile_location
       }
     },
     {
       cmd = 'mv',
       opts = {
-        args = { project_repo..'/parser.so', parser_lib_name }
+        args = { compile_location..'/parser.so', parser_lib_name }
       }
     },
     {
@@ -207,17 +218,19 @@ function M.checkhealth()
 
   if fn.executable('git') == 0 then
     health_error('`git` executable not found.', {
-      'Install it with your package manager.',
-      'Check that your `$PATH` is set correctly.'})
+        'Install it with your package manager.',
+        'Check that your `$PATH` is set correctly.'
+      })
   else
     health_ok('`git` executable found.')
   end
 
   if fn.executable('cc') == 0 then
     health_error('`cc` executable not found.', {
-      'Install `gcc` with your package manager.',
-      'Install `clang` with your package manager.',
-      'Check that your `$PATH` is set correctly.'})
+        'Install `gcc` with your package manager.',
+        'Install `clang` with your package manager.',
+        'Check that your `$PATH` is set correctly.'
+      })
   else
     health_ok('`cc` executable found.')
   end

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -72,11 +72,11 @@ M.repositories = {
     url = "https://github.com/tree-sitter/tree-sitter-swift",
     files = { "src/parser.c" },
   },
-  -- TODO: find a way to install c-sharp and typescript properly
-  -- csharp = {
-  --   url = "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  --   files = { "src/parser.c", "src/scanner.c" },
-  -- },
+  csharp = {
+    url = "https://github.com/tree-sitter/tree-sitter-c-sharp",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  -- TODO: find a way to install typescript properly
 }
 
 local function get_package_path()
@@ -120,7 +120,8 @@ local function iter_cmd(cmd_list, i, ft)
 end
 
 local function run_install(cache_folder, package_path, ft, repo)
-  local project_repo = cache_folder..'/tree-sitter-'..ft
+  local project_name = 'tree-sitter-'..ft
+  local project_repo = cache_folder..'/'..project_name
   local parser_lib_name = package_path.."/parser/"..ft..".so"
   local command_list = {
     {
@@ -134,7 +135,7 @@ local function run_install(cache_folder, package_path, ft, repo)
       info = 'Downloading...',
       err = 'Error during download, please verify your internet connection',
       opts = {
-        args = { 'clone', repo.url },
+        args = { 'clone', '--single-branch', '--branch', 'master', '--depth', '1', repo.url, project_name },
         cwd = cache_folder,
       },
     },


### PR DESCRIPTION
fixes #9. Use a `repository.location` to compile at certain place. A `compile_location` variable is declared before configuring the commands to launch.
Typescript and Tsx parsers will need to be downloaded one at a time.