### PR TITLE
fix: parser install unpack > tbl_flatten

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -155,7 +155,15 @@ local function run_install(cache_folder, package_path, ft, repo)
       info = 'Compiling...',
       err = 'Error during compilation',
       opts = {
-        args = { '-o', 'parser.so', '-shared', '-lstdc++', unpack(repo.files), '-Os', '-I./src' },
+        args = vim.tbl_flatten({
+            '-o',
+            'parser.so',
+            '-shared',
+            '-lstdc++',
+            '-Os',
+            '-I./src',
+            repo.files
+          }),
         cwd = compile_location
       }
     },
@@ -237,20 +245,20 @@ function M.checkhealth()
 end
 
 function M.list_parsers()
-    local max_len = 0
-    for parser_name, _ in pairs(repositories) do
-        if #parser_name > max_len then max_len = #parser_name end
-    end
+  local max_len = 0
+  for parser_name, _ in pairs(repositories) do
+    if #parser_name > max_len then max_len = #parser_name end
+  end
 
-    for parser_name, _ in pairs(repositories) do
-       local is_installed = #api.nvim_get_runtime_file('parser/'..parser_name..'.so', false) > 0
-       api.nvim_out_write(parser_name..string.rep(' ', max_len - #parser_name + 1))
-       if is_installed then
-           api.nvim_out_write("[✓] installed\n")
-       else
-           api.nvim_out_write("[✗] not installed\n")
-       end
+  for parser_name, _ in pairs(repositories) do
+    local is_installed = #api.nvim_get_runtime_file('parser/'..parser_name..'.so', false) > 0
+    api.nvim_out_write(parser_name..string.rep(' ', max_len - #parser_name + 1))
+    if is_installed then
+      api.nvim_out_write("[✓] installed\n")
+    else
+      api.nvim_out_write("[✗] not installed\n")
     end
+  end
 end
 
 return M


### PR DESCRIPTION
- fix parser install
- format install.lua

Parser installer was using `unpack(repo.files)` which didn't unpack properly. Using `vim.tbl_flatten({args,repo.files})` allows to expand source files in the command configurations for the compilation process.