### PR TITLE
feat/refacto: add configs.lua, setup install cmd

### DIFF
--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -1,9 +1,14 @@
 local api = vim.api
 local parsers = require'nvim-treesitter.parsers'
+local configs = require 'nvim-treesitter.configs'
 local install = require'nvim-treesitter.install'
 local locals = require'nvim-treesitter.locals'
 
 local M = {}
+
+function M.available_parsers()
+  return vim.tbl_keys(configs.repositories)
+end
 
 -- This function sets up everythin needed for a given language
 -- this is the main interface through the plugin
@@ -12,9 +17,11 @@ function M.setup(lang)
   end
 end
 
--- To install, run `:lua require'nvim-treesitter'.install_parser('language')`
--- we should add a vim layer over the lua function
-M.install_parser = install.install_parser
-M.list_parsers = install.list_parsers
+-- This function initialize the plugin
+-- it is run at startup
+M._root = {}
+function M._root.setup()
+  install.setup()
+end
 
 return M

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -1,0 +1,88 @@
+local M = {}
+
+M.repositories = {
+  javascript = {
+    url = "https://github.com/tree-sitter/tree-sitter-javascript",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  c = {
+    url = "https://github.com/tree-sitter/tree-sitter-c",
+    files = { "src/parser.c" }
+  },
+  cpp = {
+    url = "https://github.com/tree-sitter/tree-sitter-cpp",
+    files = { "src/parser.c", "src/scanner.cc" }
+  },
+  rust = {
+    url = "https://github.com/tree-sitter/tree-sitter-rust",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  lua = {
+    url = "https://github.com/nvim-treesitter/tree-sitter-lua",
+    files = { "src/parser.c", "src/scanner.cc" }
+  },
+  python = {
+    url = "https://github.com/tree-sitter/tree-sitter-python",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  go = {
+    url = "https://github.com/tree-sitter/tree-sitter-go",
+    files = { "src/parser.c" },
+  },
+  ruby = {
+    url = "https://github.com/tree-sitter/tree-sitter-ruby",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  bash = {
+    url = "https://github.com/tree-sitter/tree-sitter-bash",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  php = {
+    url = "https://github.com/tree-sitter/tree-sitter-php",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  java = {
+    url = "https://github.com/tree-sitter/tree-sitter-java",
+    files = { "src/parser.c" },
+  },
+  html = {
+    url = "https://github.com/tree-sitter/tree-sitter-html",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  julia = {
+    url = "https://github.com/tree-sitter/tree-sitter-julia",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  json = {
+    url = "https://github.com/tree-sitter/tree-sitter-json",
+    files = { "src/parser.c" },
+  },
+  css = {
+    url = "https://github.com/tree-sitter/tree-sitter-css",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  ocaml = {
+    url = "https://github.com/tree-sitter/tree-sitter-ocaml",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  swift = {
+    url = "https://github.com/tree-sitter/tree-sitter-swift",
+    files = { "src/parser.c" },
+  },
+  csharp = {
+    url = "https://github.com/tree-sitter/tree-sitter-c-sharp",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  typescript = {
+    url = "https://github.com/tree-sitter/tree-sitter-typescript",
+    files = { "src/parser.c", "src/scanner.c" },
+    location = "tree-sitter-typescript/typescript"
+  },
+  tsx = {
+    url = "https://github.com/tree-sitter/tree-sitter-typescript",
+    files = { "src/parser.c", "src/scanner.c" },
+    location = "tree-sitter-tsx/tsx"
+  }
+}
+
+return M

--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -1,8 +1,9 @@
 local api = vim.api
+local fn = vim.fn
 
-local install = require'nvim-treesitter.install'
 local queries = require'nvim-treesitter.query'
 local locals = require'nvim-treesitter.locals'
+local configs = require'nvim-treesitter.configs'
 
 local health_start = vim.fn["health#report_start"]
 local health_ok = vim.fn['health#report_ok']
@@ -12,15 +13,36 @@ local health_error = vim.fn['health#report_error']
 
 local M = {}
 
+local function configs_health()
+  if fn.executable('git') == 0 then
+    health_error('`git` executable not found.', {
+        'Install it with your package manager.',
+        'Check that your `$PATH` is set correctly.'
+      })
+  else
+    health_ok('`git` executable found.')
+  end
+
+  if fn.executable('cc') == 0 then
+    health_error('`cc` executable not found.', {
+        'Install `gcc` with your package manager.',
+        'Install `clang` with your package manager.',
+        'Check that your `$PATH` is set correctly.'
+      })
+  else
+    health_ok('`cc` executable found.')
+  end
+end
+
 -- TODO(vigoux): Maybe we should move each check to be perform in its own module
 function M.checkhealth()
   -- Installation dependency checks
   health_start('Installation')
-  install.checkhealth()
+  configs_health()
 
   local missing_parsers = {}
   -- Parser installation checks
-  for parser_name, repo in pairs(install.repositories) do
+  for parser_name in pairs(configs.repositories) do
     local installed = #api.nvim_get_runtime_file('parser/'..parser_name..'.so', false)
 
     -- Only print informations about installed parsers
@@ -42,7 +64,7 @@ function M.checkhealth()
 
     -- TODO(vigoux): The installation command should be changed so that its easier to find
     health_warn('Some parsers are not installed:\n' .. table.concat(missing_parsers, '\n'), {
-      "Install them using `:lua require'nvim-treesitter'.install_parser('language')`"})
+      "Install them using `:TSInstall language"})
   end
 end
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -4,6 +4,13 @@ if exists('g:loaded_nvim_treesitter')
   finish
 endif
 
+lua << EOF
+ts_installable_parsers = function()
+  return table.concat(require'nvim-treesitter'.available_parsers(), '\n')
+end
+require'nvim-treesitter'._root.setup()
+EOF
+
 let g:loaded_nvim_treesitter = 1
 
 augroup NvimTreesitter


### PR DESCRIPTION
- configs.lua holds the `repositories` data
- install health moved to `health.lua`
- plugins loads _root.setup() on startup
- install and list command are available through vim
> use them with `:TSInstall lang` and `:TSInstallInfo`

note: this is working, but code organization is quite messy in my opinion.
- the `available_parsers` function in `nvim-treesitter.lua` must be moved somewhere else
- the `health.lua` file needs better naming for the health_config function
- the health function in locals might need to be moved inside the health file.