### PR TITLE
fix: add -fPIC flag to compiling

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -77,6 +77,7 @@ local function run_install(cache_folder, package_path, ft, repo)
             'parser.so',
             '-shared',
             '-lstdc++',
+            '-fPIC',
             '-Os',
             '-I./src',
             repo.files


### PR DESCRIPTION
On some of my system, `-fPIC` is required when compiling shared library. Adding `-fPIC` flag should also be fine on other system([reference](https://stackoverflow.com/questions/966960/what-does-fpic-mean-when-building-a-shared-library))