### PR TITLE
Add function 'nvim-treesitter/install'.ensure_installed

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -325,6 +325,9 @@ function M.setup(user_data)
       if config[mod].keymaps and type(data.keymaps) == 'table' then
         config[mod].keymaps = data.keymaps
       end
+      if mod == 'ensure_installed' then
+        require'nvim-treesitter/install'.ensure_installed(data)
+      end
     end
   end
 end

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -3,6 +3,7 @@ local fn = vim.fn
 local luv = vim.loop
 local configs = require'nvim-treesitter/configs'
 local parsers = configs.get_parser_configs()
+local has_parser = require'nvim-treesitter/parsers'.has_parser
 
 local M = {}
 
@@ -142,6 +143,24 @@ local function install(ft)
 
   run_install(cache_folder, package_path, ft, install_info)
 end
+
+
+M.ensure_installed = function(languages)
+  if type(languages) == 'string' then
+    if languages == 'all' then
+      languages = configs.available_parsers()
+    else
+      languages = {languages}
+    end
+  end
+
+  for _, ft in ipairs(languages) do
+    if not has_parser(ft) then
+      install(ft)
+    end
+  end
+end
+
 
 M.commands = {
   TSInstall = {

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -40,9 +40,11 @@ local function iter_cmd(cmd_list, i, ft)
   local attr = cmd_list[i]
   if attr.info then print(attr.info) end
 
+  local handle
+
   handle = luv.spawn(attr.cmd, attr.opts, vim.schedule_wrap(function(code)
     handle:close()
-    if code ~= 0 then return api.nvim_err_writeln(attr.err) end 
+    if code ~= 0 then return api.nvim_err_writeln(attr.err) end
     iter_cmd(cmd_list, i + 1, ft)
   end))
 end


### PR DESCRIPTION
Hello,

I was trying to create a function that users could put into their config to ensure that their favorite languages are parsers installed or get installed if not yet available.

Currently, you can do:
```
require'nvim-treesitter/install'.ensure_installed({'html', 'python'})
```
or just one language
```
require'nvim-treesitter/install'.ensure_installed('cpp')
```
or all available languages
```
require'nvim-treesitter/install'.ensure_installed('all')
```
I am not sure where to put this function in your repo structure and whether really all requested parsers get installed (the status only shows when a particular languages got installed). So I am looking forward for feedback!