### PR TITLE
[WIP] Node movement hightlight

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -232,6 +232,7 @@ local config = {
         move_down = "<a-j>",
         move_left = "<a-h>",
         move_right = "<a-l>",
+        select_current_node = "grn",
       },
     },
     -- folding = {

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -3,23 +3,6 @@ local utils = require'nvim-treesitter.utils'
 local parsers = require'nvim-treesitter.parsers'
 local M = {}
 
-local function node_range_to_vim(node)
-  if not node then return end
-
-  local start_row, start_col, end_row, end_col = node:range()
-
-  local select_range = [[
-  call cursor(%d, %d)
-  normal v
-  call cursor(%d, %d)
-  ]]
-  local exec_command = string.format(select_range,
-    start_row+1, start_col+1,
-    end_row+1, end_col+1)
-
-  api.nvim_exec(exec_command, false)
-end
-
 local function select_incremental(increment_func)
   return function()
     local buf, sel_start_line, sel_start_col, _ = unpack(vim.fn.getpos("'<"))
@@ -37,7 +20,7 @@ local function select_incremental(increment_func)
       end
     end
 
-    return node_range_to_vim(node)
+    return utils.node_range_to_vim(node)
   end
 end
 

--- a/lua/nvim-treesitter/node_movement.lua
+++ b/lua/nvim-treesitter/node_movement.lua
@@ -69,6 +69,22 @@ M.move_down = function() M.do_node_movement(M.NodeMovementKind.down) end
 M.move_left = function() M.do_node_movement(M.NodeMovementKind.left) end
 M.move_right = function() M.do_node_movement(M.NodeMovementKind.right) end
 
+M.select_current_node = function()
+  local buf, line, col = unpack(vim.fn.getpos("."))
+  local current_node = M.current_node[buf]
+  if current_node then
+    local node_line, node_col = current_node:start()
+    if line-1 ~= node_line or  col-1 ~= node_col then
+      current_node = nil
+    end
+  end
+  if not current_node then
+    local root = parsers.get_parser():parse():root()
+    current_node = root:named_descendant_for_range(line-1, col-1, line-1, col)
+  end
+  utils.node_range_to_vim(current_node)
+end
+
 function M.attach(bufnr)
   local buf = bufnr or api.nvim_get_current_buf()
 

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -152,4 +152,21 @@ function M.get_previous_node(node, allow_switch_parents, allow_previous_parent)
   return destination_node
 end
 
+function M.node_range_to_vim(node)
+  if not node then return end
+
+  local start_row, start_col, end_row, end_col = node:range()
+
+  local select_range = [[
+  call cursor(%d, %d)
+  normal v
+  call cursor(%d, %d)
+  ]]
+  local exec_command = string.format(select_range,
+    start_row+1, start_col+1,
+    end_row+1, end_col+1)
+
+  api.nvim_exec(exec_command, false)
+end
+
 return M


### PR DESCRIPTION
Add optional hightlights for current node in `node_movement`. This PR is on top of #37 

TODO:

- [ ] clear autocmd on detach
- [ ] define Highlight group somewhere

I've never developed vim plugins, so I don't know what's the best practice in defining highlights.
Maybe place something like `highlight NvimTreesitterCurrentNode guibg=#444400
` here: https://github.com/nvim-treesitter/nvim-treesitter/blob/0207836eb2aaa876d52ffddd1ec89ec347c67996/plugin/nvim-treesitter.vim#L7