### PR TITLE
Provide a statusline indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Some of these features are :
   - [ ] Syntax based code folding
   - [x] Consistent syntax highlighting (the api is not quite stable yet)
   - [x] Cursor movement in node hierachy
+  - [x] Statusline indicator (`require'nvim-treesitter'.statusline(size)`)
 
 You can find the roadmap [here](https://github.com/nvim-treesitter/nvim-treesitter/projects/1).
 The roadmap and all features of this plugin are open to change, and any suggestion will be highly appreciated!
@@ -166,6 +167,13 @@ List of currently supported languages:
 - [ ] julia
 - [ ] php
 - [ ] bash
+- [ ] scala
+- [ ] haskell
+- [ ] toml
+- [ ] vue
+- [ ] elm
+- [ ] yaml
+- [ ] nix
 
 ## Troubleshooting
 Before doing anything run `:checkhealth nvim_treesitter`. This will help you find where the bug might come from.

--- a/autoload/nvim_treesitter.vim
+++ b/autoload/nvim_treesitter.vim
@@ -1,0 +1,3 @@
+function! nvim_treesitter#statusline(len)
+  return luaeval("require'nvim-treesitter'.statusline(_A)", a:len)
+endfunction

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -97,5 +97,16 @@ A list of languages can be found at |:TSInstallInfo|
 
 List modules state for the current session.
 
- vim:tw=78:ts=8:noet:ft=help:norl:
+==============================================================================
+FUNCTIONS~
+						   *nvim-treesitter-functions*
 
+|nvim_treesitter#statusline(size)|
+						*nvim_treesitter#statusline()*
+
+Returns a string describing the current position in the syntax tree. This
+could be used as a statusline indicator.
+Note: The `size` argument is optionnal. When specified, the string will not be
+      longer than `size`.
+
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/tags
+++ b/doc/tags
@@ -7,5 +7,7 @@
 :TSModuleInfo	nvim-treesitter.txt	/*:TSModuleInfo*
 nvim-treesitter	nvim-treesitter.txt	/*nvim-treesitter*
 nvim-treesitter-commands	nvim-treesitter.txt	/*nvim-treesitter-commands*
+nvim-treesitter-functions	nvim-treesitter.txt	/*nvim-treesitter-functions*
 nvim-treesitter-intro	nvim-treesitter.txt	/*nvim-treesitter-intro*
 nvim-treesitter-quickstart	nvim-treesitter.txt	/*nvim-treesitter-quickstart*
+nvim_treesitter#statusline()	nvim-treesitter.txt	/*nvim_treesitter#statusline()*

--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -24,4 +24,35 @@ function M.setup(lang)
   end
 end
 
+function M.statusline(indicator_size)
+  local indicator_size = indicator_size or 1000
+  local expr = require"nvim-treesitter.utils".expression_at_point()
+  local current_node =
+    require'nvim-treesitter.node_movement'.current_node[api.nvim_get_current_buf()]
+
+  local indicator = ""
+  while expr and (#indicator + #(expr:type()) + 5) < indicator_size do
+
+    local prefix = ""
+    if expr:parent() then
+      prefix = "->"
+    end
+
+
+    if expr == current_node then
+      indicator = string.format("%s[%s]%s", prefix, expr:type(), indicator)
+    else
+      indicator = prefix .. expr:type() .. indicator
+    end
+
+    expr = expr:parent()
+  end
+
+  if expr then
+    return "..." .. indicator
+  else
+    return indicator
+  end
+end
+
 return M

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -5,11 +5,12 @@ local M = {}
 
 function M.has_parser(lang)
   local lang = lang or api.nvim_buf_get_option(0, 'filetype')
+  if not lang or #lang == 0 then return false end
   return #api.nvim_get_runtime_file('parser/' .. lang .. '.*', false) > 0
 end
 
 function M.get_parser(bufnr, lang)
-  if M.has_parser() then
+  if M.has_parser(lang) then
     local buf = bufnr or api.nvim_get_current_buf()
     local lang = lang or api.nvim_buf_get_option(buf, 'ft')
     if not M[buf] then


### PR DESCRIPTION
It will show the current branch at the cursor going the tree as such.
root->node->subnode->leaf

If an argument is provided to `statusline`, then the tree will be
truncated as follows :
..->subnode->subnode

Also fixes an issue with `expression_at_point`.