### PR TITLE
Fix invalid cursor position for tree root

### DIFF
--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -8,6 +8,11 @@ local function node_range_to_vim(node)
 
   local start_row, start_col, end_row, end_col = node:range()
 
+  if end_row + 1 > vim.fn.line('$') then
+    end_row = vim.fn.line('$') - 1
+    end_col = #vim.fn.getline('$') - 1
+  end
+
   local select_range = [[
   call cursor(%d, %d)
   normal v

--- a/queries/lua/locals.scm
+++ b/queries/lua/locals.scm
@@ -35,6 +35,7 @@
 ((for_in_statement) @scope)
 ((repeat_statement) @scope)
 ((while_statement) @scope)
+((program) @scope)
 
 ;;; REFERENCES
 ((identifier) @reference)


### PR DESCRIPTION
This happens when trying to select the whole program using incramental selection.

Also adds the `program` node to lua locals.