### PR TITLE
[WIP]: Node shifting

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -223,6 +223,17 @@ local config = {
       },
       is_supported = function() return true end
     },
+    node_movement = {                        -- this enables incremental selection
+      enable = false,
+      disable = {},
+      is_supported = function() return true end,
+      keymaps = {
+        move_up = "<a-k>",
+        move_down = "<a-j>",
+        move_left = "<a-h>",
+        move_right = "<a-l>",
+      },
+    },
     -- folding = {
     --   enable = false,
     --   disable = {},

--- a/lua/nvim-treesitter/node_movement.lua
+++ b/lua/nvim-treesitter/node_movement.lua
@@ -57,10 +57,10 @@ M.do_node_movement = function(kind, move_node)
       end
     -- LEFT
     elseif kind == M.NodeMovementKind.left then
-      destination_node = utils.get_previous_node(current_node, true, true)
+      destination_node = utils.get_previous_node(current_node, not move_node, not move_node)
     -- RIGHT
     elseif kind == M.NodeMovementKind.right then
-      destination_node = utils.get_next_node(current_node, true, true)
+      destination_node = utils.get_next_node(current_node, not move_node, not move_node)
     end
     M.current_node[buf] = destination_node or current_node
   end
@@ -68,6 +68,7 @@ M.do_node_movement = function(kind, move_node)
   if destination_node then
     node_start_to_vim(destination_node)
     if move_node then
+      node_start_to_vim(destination_node)
       if kind ~= M.NodeMovementKind.down then
         local dst_range
         if kind ~= M.NodeMovementKind.up then
@@ -85,7 +86,8 @@ M.do_node_movement = function(kind, move_node)
         local root = parsers.get_parser():parse():root()
         if dst_range then
           local new_destination_node = utils.node_from_lsp_range(root, dst_range)
-          M.current_node[buf] = new_destination_node or current_node
+          M.current_node[buf] = new_destination_node
+          node_start_to_vim(M.current_node[buf])
         end
       end
     end

--- a/lua/nvim-treesitter/node_movement.lua
+++ b/lua/nvim-treesitter/node_movement.lua
@@ -17,12 +17,40 @@ local function node_start_to_vim(node)
   if not node then return end
 
   local row, col = node:start()
-  local exec_command = string.format('call cursor(%d, %d)', row+1, col+1)
-  api.nvim_exec(exec_command, false)
+
+  local mode = api.nvim_get_mode().mode
+  print(vim.inspect(mode))
+  --if mode == 'v' then
+    --local _, current_line, current_col, _ = unpack(vim.fn.getpos("."))
+    --local _, sel_start_line, sel_start_col, _ = unpack(vim.fn.getpos("'<"))
+    --local _, sel_end_line, sel_end_col, _ = unpack(vim.fn.getpos("'>"))
+
+    --if current_line == sel_start_line and current_col == sel_start_col then
+      --sel_start_line = row + 1
+      --sel_start_col = col + 1
+      --vim.fn.setpos("'<", {row + 1, col + 1})
+    --end
+    --if current_line == sel_end_line and current_col == sel_end_col then
+      --row, col = node:end_()
+      --sel_end_line = row + 1
+      --sel_end_col = col
+      --vim.fn.setpos("'>", {row + 1, col + 1})
+    --end
+    --local exec_command = string.format(select_range,
+      --sel_start_line, sel_start_col,
+      --sel_end_line, sel_end_col)
+
+  --api.nvim_exec(exec_command, false)
+  --else
+    api.nvim_exec('normal gv', false)
+    api.nvim_exec('normal o', false)
+    api.nvim_win_set_cursor(0, {row + 1, col})
+  --end
 end
 
-M.do_node_movement = function(kind)
-  local buf, line, col = unpack(vim.fn.getpos("."))
+M.do_node_movement = function(kind, move_node)
+  local line, col = unpack(api.nvim_win_get_cursor(0))
+  local buf = api.nvim_win_get_buf(0)
 
   local current_node = M.current_node[buf]
 
@@ -39,7 +67,6 @@ M.do_node_movement = function(kind)
     if not current_node then
       current_node = root:named_descendant_for_range(line-1, col-1, line-1, col)
     end
-
 
      --UP
     if kind == M.NodeMovementKind.up then
@@ -66,6 +93,20 @@ M.do_node_movement = function(kind)
 
   if destination_node then
     node_start_to_vim(destination_node)
+    if move_node then
+      if kind ~= M.NodeMovementKind.down then
+        local _, new_destination_range = utils.swap_nodes(buf, current_node, destination_node)
+
+        local root = parsers.get_parser():parse():root()
+        if new_destination_range then
+          local new_destination_node = root:named_descendant_for_range(new_destination_range[0],
+                                                                       new_destination_range[1],
+                                                                       new_destination_range[2],
+                                                                       new_destination_range[3])
+          M.current_node[buf] = new_destination_node or current_node
+        end
+      end
+    end
   end
 end
 
@@ -73,6 +114,11 @@ M.move_up = function() M.do_node_movement(M.NodeMovementKind.up) end
 M.move_down = function() M.do_node_movement(M.NodeMovementKind.down) end
 M.move_left = function() M.do_node_movement(M.NodeMovementKind.left) end
 M.move_right = function() M.do_node_movement(M.NodeMovementKind.right) end
+
+M.node_move_up = function() M.do_node_movement(M.NodeMovementKind.up, true) end
+M.node_move_down = function() M.do_node_movement(M.NodeMovementKind.down, true) end
+M.node_move_left = function() M.do_node_movement(M.NodeMovementKind.left, true) end
+M.node_move_right = function() M.do_node_movement(M.NodeMovementKind.right, true) end
 
 function M.attach(bufnr)
   local buf = bufnr or api.nvim_get_current_buf()

--- a/lua/nvim-treesitter/node_movement.lua
+++ b/lua/nvim-treesitter/node_movement.lua
@@ -69,7 +69,19 @@ M.do_node_movement = function(kind, move_node)
     node_start_to_vim(destination_node)
     if move_node then
       if kind ~= M.NodeMovementKind.down then
-        local _, dst_range = utils.swap_nodes(buf, current_node, destination_node)
+        local dst_range
+        if kind ~= M.NodeMovementKind.up then
+           _, dst_range = utils.swap_nodes(buf, current_node, destination_node)
+        else
+          --if current_node:parent() == destination_node:parent() then
+          _, dst_range = utils.swap_nodes(buf, current_node, destination_node)
+          --elseif M.node_move_left then
+            ----_, dst_range = utils.move_node_before_other(buf, current_node, destination_node)
+          --elseif M.node_move_right then
+            --_, dst_range = utils.move_node_before_other(buf, current_node, destination_node)
+          --end
+        end
+
         local root = parsers.get_parser():parse():root()
         if dst_range then
           local new_destination_node = utils.node_from_lsp_range(root, dst_range)

--- a/lua/nvim-treesitter/node_movement.lua
+++ b/lua/nvim-treesitter/node_movement.lua
@@ -1,0 +1,96 @@
+local api = vim.api
+local parsers = require'nvim-treesitter.parsers'
+local utils = require'nvim-treesitter.utils'
+local M = {}
+
+
+M.NodeMovementKind = {
+  up = 'up',
+  down = 'down',
+  left = 'left',
+  right = 'right',
+}
+
+M.current_node = {}
+
+local function node_start_to_vim(node)
+  if not node then return end
+
+  local row, col = node:start()
+  local exec_command = string.format('call cursor(%d, %d)', row+1, col+1)
+  api.nvim_exec(exec_command, false)
+end
+
+M.do_node_movement = function(kind)
+  local buf, line, col = unpack(vim.fn.getpos("."))
+
+  local current_node = M.current_node[buf]
+
+  if current_node then
+    local node_line, node_col = current_node:start()
+    if line-1 ~= node_line or  col-1 ~= node_col then
+      current_node = nil
+    end
+  end
+  local destination_node
+
+  if parsers.has_parser() then
+    local root = parsers.get_parser():parse():root()
+    if not current_node then
+      current_node = root:named_descendant_for_range(line-1, col-1, line-1, col)
+    end
+
+
+     --UP
+    if kind == M.NodeMovementKind.up then
+       destination_node = current_node:parent()
+    -- DOWN
+    elseif kind == M.NodeMovementKind.down then
+      if current_node:named_child_count() > 0 then
+        destination_node = current_node:named_child(0)
+      else
+        local next_node = utils.get_next_node(current_node)
+        if next_node and next_node:named_child_count() > 0 then
+          destination_node = next_node:named_child(0)
+        end
+      end
+    -- LEFT
+    elseif kind == M.NodeMovementKind.left then
+      destination_node = utils.get_previous_node(current_node, true, true)
+    -- RIGHT
+    elseif kind == M.NodeMovementKind.right then
+      destination_node = utils.get_next_node(current_node, true, true)
+    end
+    M.current_node[buf] = destination_node or current_node
+  end
+
+  if destination_node then
+    node_start_to_vim(destination_node)
+  end
+end
+
+M.move_up = function() M.do_node_movement(M.NodeMovementKind.up) end
+M.move_down = function() M.do_node_movement(M.NodeMovementKind.down) end
+M.move_left = function() M.do_node_movement(M.NodeMovementKind.left) end
+M.move_right = function() M.do_node_movement(M.NodeMovementKind.right) end
+
+function M.attach(bufnr)
+  local buf = bufnr or api.nvim_get_current_buf()
+
+  local config = require'nvim-treesitter.configs'.get_module('node_movement')
+  for funcname, mapping in pairs(config.keymaps) do
+    api.nvim_buf_set_keymap(buf, 'n', mapping,
+      string.format(":lua require'nvim-treesitter.node_movement'.%s()<CR>", funcname), { silent = true })
+  end
+end
+
+function M.detach(bufnr)
+  local buf = bufnr or api.nvim_get_current_buf()
+
+  local config = require'nvim-treesitter.configs'.get_module('node_movement')
+  for _, mapping in pairs(config.keymaps) do
+    api.nvim_buf_del_keymap(buf, 'n', mapping)
+  end
+end
+
+return M

--- a/lua/nvim-treesitter/node_movement.lua
+++ b/lua/nvim-treesitter/node_movement.lua
@@ -69,10 +69,10 @@ M.do_node_movement = function(kind, move_node)
     node_start_to_vim(destination_node)
     if move_node then
       if kind ~= M.NodeMovementKind.down then
-        local new_destination_range = utils.swap_nodes(buf, current_node, destination_node)
+        local _, dst_range = utils.swap_nodes(buf, current_node, destination_node)
         local root = parsers.get_parser():parse():root()
-        if new_destination_range then
-          local new_destination_node = utils.node_from_lsp_range(root, new_destination_range)
+        if dst_range then
+          local new_destination_node = utils.node_from_lsp_range(root, dst_range)
           M.current_node[buf] = new_destination_node or current_node
         end
       end

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -130,7 +130,7 @@ function M.replace_node_text(buf, node, replacement_lines)
 end
 
 
---- Swaps the contents of two nodes returning new range of destination (LSP range)
+--- Swaps the contents of two nodes returning new ranges (LSP ranges)
 -- @param buf           buffer number
 -- @param source        first node
 -- @param destination   second node
@@ -148,17 +148,17 @@ function M.swap_nodes(buf, source, destination)
     local source_text = M.get_node_text(source)
     local destination_text = M.get_node_text(destination)
 
-    local dst_range
+    local src_range, dst_range
 
     if dst_end <= src_start then
-       M.replace_node_text(buf, source, destination_text)
+       src_range = M.replace_node_text(buf, source, destination_text)
        dst_range = M.replace_node_text(buf, destination, source_text)
-       return 
+       return
     elseif src_end <= dst_start then
        dst_range = M.replace_node_text(buf, destination, source_text)
-       M.replace_node_text(buf, source, destination_text)
+       src_range = M.replace_node_text(buf, source, destination_text)
     end
-    return dst_range
+    return src_range, dst_range
 end
 
 

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -126,7 +126,8 @@ function M.replace_range_text(buf, lsp_range, replacement_lines)
   end
 
   range['end'] = { line = range.start.line + #replacement_lines - 1,
-                   character =  end_char }
+                   character = end_char }
+  return range
 end
 
 --- Replace node text and return new range (LSP range)
@@ -159,12 +160,36 @@ function M.swap_nodes(buf, source, destination)
     local src_range, dst_range
 
     if dst_end <= src_start then
-       src_range = M.replace_node_text(buf, source, destination_text)
+       src_range = M.node_to_lsp_range(source)
+       local new_src_range = M.replace_node_text(buf, source, destination_text)
        dst_range = M.replace_node_text(buf, destination, source_text)
-       return
+
+       -- Correct range of first change
+       src_range.start.line = src_range['end'].line - (#destination_text - 1) -- Total end stays the same
+       src_range.start.character = new_src_range.start.character
+       src_range.start.character = new_src_range.start.character
+       if dst_range['end'].line == src_range.start.line then
+          src_range.start.character = src_range.start.character + #(source_text[#source_text]) - #(destination_text[#destination_text])
+       else
+       end
+       if dst_range['end'].line == dst_range['end'].line then
+          src_range['end'].character = src_range['end'].character + #(source_text[#source_text]) - #(destination_text[#destination_text])
+      end
     elseif src_end <= dst_start then
-       dst_range = M.replace_node_text(buf, destination, source_text)
+       dst_range = M.node_to_lsp_range(destination)
+       local new_dst_range = M.replace_node_text(buf, destination, source_text)
        src_range = M.replace_node_text(buf, source, destination_text)
+
+       -- Correct range of first change
+       dst_range.start.line = dst_range['end'].line - (#source_text - 1) -- Total end stays the same
+       dst_range.start.character = new_dst_range.start.character
+       dst_range.start.character = new_dst_range.start.character
+       if src_range['end'].line == dst_range.start.line then
+          dst_range.start.character = new_dst_range.start.character + #(destination_text[#destination_text]) - #(source_text[#source_text])
+      end
+       if src_range['end'].line == dst_range['end'].line then
+          dst_range['end'].character = new_dst_range['end'].character + #(destination_text[#destination_text]) - #(source_text[#source_text])
+      end
     end
     return src_range, dst_range
 end

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -93,4 +93,63 @@ function M.smallest_containing_scope(node, bufnr)
   return current or root
 end
 
+--- Get next node with same parent
+-- @param node                 node
+-- @param allow_switch_parents allow switching parents if last node
+-- @param allow_next_parent    allow next parent if last node and next parent without children
+function M.get_next_node(node, allow_switch_parents, allow_next_parent)
+ local destination_node
+  local parent = node:parent()
+
+  if parent then
+    local found_pos = 0
+    for i = 0,parent:named_child_count()-1,1 do
+      if parent:named_child(i) == node then
+        found_pos = i
+        break
+      end
+    end
+    if parent:named_child_count() > found_pos + 1 then
+      destination_node = parent:named_child(found_pos + 1)
+    elseif allow_switch_parents then
+      local next_node = M.get_next_node(node:parent())
+      if next_node and next_node:named_child_count() > 0 then
+        destination_node = next_node:named_child(0)
+      elseif next_node and allow_next_parent then
+        destination_node = next_node
+      end
+    end
+  end
+  return destination_node
+end
+
+--- Get previous node with same parent
+-- @param node                     node
+-- @param allow_switch_parents     allow switching parents if first node
+-- @param allow_previous_parent    allow previous parent if first node and previous parent without children
+function M.get_previous_node(node, allow_switch_parents, allow_previous_parent)
+  local destination_node
+  local parent = node:parent()
+  if parent then
+    local found_pos = 0
+    for i = 0,parent:named_child_count()-1,1 do
+      if parent:named_child(i) == node then
+        found_pos = i
+        break
+      end
+    end
+    if 0 <= found_pos - 1 then
+      destination_node = parent:named_child(found_pos - 1)
+    elseif allow_switch_parents then
+        local previous_node = M.get_previous_node(node:parent())
+        if previous_node and previous_node:named_child_count() > 0 then
+          destination_node = previous_node:named_child(previous_node:named_child_count() - 1)
+        elseif previous_node and allow_previous_parent then
+          destination_node = previous_node
+        end
+      end
+  end
+  return destination_node
+end
+
 return M


### PR DESCRIPTION
In the current state this is just a hack. The feature should be waiting for #45 #42 and on a decision on the general future of node_movement.

Just placing it here for some of the utility functions that might be handy.

Works well for lisp, where almost all swapping of parens is admissible 
![lisp](https://user-images.githubusercontent.com/7189118/81473799-77c14980-9201-11ea-9a47-68b1ff46fcce.gif)

For other languages you have to be careful to not destroy the syntax while moving the node
![java](https://user-images.githubusercontent.com/7189118/81473826-9de6e980-9201-11ea-9baf-6f8ca9fccba5.gif)
In this gif everything works fine. However if I were to move a node after the position of a line comment, the line comment annihilates this node from the syntax tree and it can not be moved further (since it got merged with the comment).

For those languages, only swapping of functions, parameters or statements could make sense.

