### PR TITLE
Export configs.parsers to enable users to register their own parsers

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -245,6 +245,7 @@ local config = {
 }
 
 local M = {}
+M.parsers = parsers
 
 local function enable_module(mod, bufnr, ft)
   local bufnr = bufnr or api.nvim_get_current_buf()


### PR DESCRIPTION
Export configs.parsers to enable users to register their own parsers from the internet or override the repo if they prefer an alternative parser.

E.g.

```lua
    require "nvim-treesitter.configs".parsers.lisp = {
        install_info = {
            url = "https://github.com/theHamsta/tree-sitter-clojure",
            files = {"src/parser.c"}
        }
    }
```