### PR TITLE
[WIP]: Add @definition.*.doc to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,8 @@ are optional and will not have any effect for now.
   `type`
   `field`
 
+If you can extract documentation adjacent to a definition use `@definition.*.doc` (e.g. `@definition.function.doc`).
+
 `@scope`
 
 `@reference`


### PR DESCRIPTION
We should add doc to definitions as soon as more advanced query syntax is available.
```scheme
(function_definition
  name: (identifier) @definition.function
  body: (block (expression_statement (string) @definition.function.doc)?)) @scope
```
And instructions that strip away the quotes. (strip is used by official treesitter).

```lisp
    (function_definition
      name: (identifier) @name
      body: (block . (expression_statement (string) @doc))) @function
    (#strip! @doc "(^['\"\\s]*)|(['\"\\s]*$)")
```