### PR TITLE
docs: missing EOF for init.vim

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -46,6 +46,7 @@ By default, everything is disabled. To enable support for features, in your `ini
     },
     ensure_installed = 'all' -- one of 'all', 'language', or a list of languages
   }
+  EOF
 <
 
 ==============================================================================


### PR DESCRIPTION
`README.md` has it, but the doc text file is missing `EOF` at the end of the block.