### PR TITLE
Some improvements to c/locals.scm

### DIFF
--- a/queries/c/locals.scm
+++ b/queries/c/locals.scm
@@ -1,25 +1,25 @@
 ;; Functions definitions
 (function_declarator
-  declarator: (identifier) @definition.function) @scope
+  declarator: (identifier) @definition.function)
 (preproc_function_def
   name: (identifier) @definition.macro) @scope
 
 (preproc_def
   name: (identifier) @definition.macro)
 (pointer_declarator
-  declarator: (identifier) @definition.variable)
+  declarator: (identifier) @definition.var)
 (parameter_declaration
-  declarator: (identifier) @definition.variable)
+  declarator: (identifier) @definition.var)
 (init_declarator
-  declarator: (identifier) @definition.variable)
+  declarator: (identifier) @definition.var)
 (array_declarator
-  declarator: (identifier) @definition.variable)
+  declarator: (identifier) @definition.var)
 (declaration
-  declarator: (identifier) @definition.variable)
+  declarator: (identifier) @definition.var)
 (enum_specifier
   name: (*) @definition.type
   (enumerator_list
-    (enumerator name: (identifier) @definition.variable)))
+    (enumerator name: (identifier) @definition.var)))
 
 ;; Type / Struct / Enum
 (field_declaration
@@ -34,3 +34,5 @@
 (for_statement) @scope
 (if_statement) @scope
 (while_statement) @scope
+(translation_unit) @scope
+(function_definition) @scope


### PR DESCRIPTION
- Fix function scope (was declaration only without body)
- Use @definition.var like the other local files (lua, ruby)
- Add translation_unit scope
~~- Add variable definitions by function parameters~~ not necessary! Already included in available queries.

I was experimenting with resolving variables for GCC and accidentally adapted the C locals.scm a bit. @vigoux, maybe some changes of this PR are useful...