### PR TITLE
 Introduce base languages for queries (for C++ locals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ List of currently supported languages:
 - [x] ruby (maintained by @TravonteD)
 - [x] c (maintained by @vigoux)
 - [x] go (maintained by @theHamsta)
-- [ ] cpp
+- [x] cpp (maintained by @theHamsta, extends C queries)
 - [ ] rust
 - [x] python (maintained by @theHamsta)
 - [ ] javascript

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -94,10 +94,10 @@
 (sized_type_specifier) @type
 
 ((identifier) @type
- (match? @type "^[A-Z]"))
+ (#match? @type "^[A-Z]"))
 
 ((identifier) @constant
- (match? @constant "^[A-Z][A-Z\\d_]+$"))
+ (#match? @constant "^[A-Z][A-Z\\d_]+$"))
 
 (comment) @comment
 
@@ -109,3 +109,4 @@
   (identifier)) @parameter
 
 (ERROR) @error
+

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -31,7 +31,6 @@
 
 "--" @operator
 "-" @operator
-"-=" @operator
 "->" @operator
 "!=" @operator
 "*" @operator
@@ -40,7 +39,6 @@
 "&&" @operator
 "+" @operator
 "++" @operator
-"+=" @operator
 "<" @operator
 "<=" @operator
 "==" @operator
@@ -50,6 +48,13 @@
 ">=" @operator
 "!" @operator
 "||" @operator
+
+"-=" @operator
+"+=" @operator
+"*=" @operator
+"/=" @operator
+"|=" @operator
+"&=" @operator
 
 "." @punctuation.delimiter
 ";" @punctuation.delimiter

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -78,3 +78,5 @@
  (match? @constant "^[A-Z][A-Z\\d_]+$"))
 
 (comment) @comment
+
+(ERROR) @error

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -84,6 +84,8 @@
   declarator: (identifier) @function)
 (preproc_function_def
   name: (identifier) @function.macro)
+(preproc_arg)  @function.macro
+; TODO (preproc_arg)  @embedded
 
 (field_identifier) @property
 (statement_identifier) @label
@@ -102,5 +104,8 @@
 ;; Parameters
 (parameter_list
   (parameter_declaration) @parameter)
+
+(preproc_params
+  (identifier)) @parameter
 
 (ERROR) @error

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -35,14 +35,20 @@
 "->" @operator
 "!=" @operator
 "*" @operator
+"/" @operator
 "&" @operator
 "&&" @operator
 "+" @operator
 "++" @operator
 "+=" @operator
 "<" @operator
+"<=" @operator
 "==" @operator
+"=" @operator
+"~" @operator
 ">" @operator
+">=" @operator
+"!" @operator
 "||" @operator
 
 "." @delimiter
@@ -78,5 +84,9 @@
  (match? @constant "^[A-Z][A-Z\\d_]+$"))
 
 (comment) @comment
+
+;; Parameters
+(parameter_list
+  (parameter_declaration) @parameter)
 
 (ERROR) @error

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -97,7 +97,7 @@
  (#match? @type "^[A-Z]"))
 
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]+$"))
+ (#match? @constant "^[A-Z][A-Z0-9_]+$"))
 
 (comment) @comment
 

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -51,8 +51,17 @@
 "!" @operator
 "||" @operator
 
-"." @delimiter
-";" @delimiter
+"." @punctuation.delimiter
+";" @punctuation.delimiter
+":" @punctuation.delimiter
+"," @punctuation.delimiter
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
 
 (string_literal) @string
 (system_lib_string) @string

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -71,6 +71,9 @@
 (primitive_type) @type
 (sized_type_specifier) @type
 
+((identifier) @type
+ (match? @type "^[A-Z]"))
+
 ((identifier) @constant
  (match? @constant "^[A-Z][A-Z\\d_]+$"))
 

--- a/queries/c/locals.scm
+++ b/queries/c/locals.scm
@@ -36,3 +36,4 @@
 (while_statement) @scope
 (translation_unit) @scope
 (function_definition) @scope
+(compound_statement) @scope ; a block in curly braces

--- a/queries/c/locals.scm
+++ b/queries/c/locals.scm
@@ -17,7 +17,7 @@
 (declaration
   declarator: (identifier) @definition.var)
 (enum_specifier
-  name: (*) @definition.type
+  name: (_) @definition.type
   (enumerator_list
     (enumerator name: (identifier) @definition.var)))
 

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -62,11 +62,6 @@
 
 (auto) @keyword
 
-;; Parameters
-; normals
-(parameter_list
-  (parameter_declaration) @parameter)
-
 ; Constants
 
 ;(this) @constant.builtin

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -1,11 +1,11 @@
 ((identifier) @field
- (match? @field "^_"))
+ (#match? @field "^_"))
 
 ((identifier) @field
- (match? @field "^m_"))
+ (#match? @field "^m_"))
 
 ((identifier) @field
- (match? @field "_$"))
+ (#match? @field "_$"))
 
 ;(field_expression) @parameter ;; How to highlight this?
 (template_function
@@ -21,12 +21,12 @@
 (namespace_identifier) @constant
 
 ((namespace_identifier) @type
-                        (match? @type "^[A-Z]"))
+                        (#match? @type "^[A-Z]"))
 ((namespace_identifier) @constant
-                        (match? @constant "^[A-Z][A-Z_1-9]*$"))
+                        (#match? @constant "^[A-Z][A-Z_1-9]*$"))
 
 (destructor_name
-  name: (*) @function)
+  name: (_) @function)
 
 (function_declarator
       declarator: (scoped_identifier
@@ -34,7 +34,7 @@
 ((function_declarator
       declarator: (scoped_identifier
         name: (identifier) @constructor))
- (match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 (call_expression
   function: (scoped_identifier 
@@ -47,18 +47,18 @@
 ((call_expression
   function: (scoped_identifier 
               name: (identifier) @constructor))
-(match? @constructor "^[A-Z]"))
+(#match? @constructor "^[A-Z]"))
 
 ((call_expression
   function: (field_expression 
-              field: (field_identifier) @function))
-(match? @function "^[A-Z]"))
+              field: (field_identifier) @constructor))
+(#match? @function "^[A-Z]"))
 
 ;; constructing a type in a intizializer list: Constructor ():  **SuperType (1)**
 ((field_initializer
   (field_identifier) @constructor
   (argument_list))
- (match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 (auto) @keyword
 

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -1,0 +1,97 @@
+((identifier) @field
+ (match? @field "^_"))
+
+((identifier) @field
+ (match? @field "^m_"))
+
+((identifier) @field
+ (match? @field "_$"))
+
+;(field_expression) @parameter ;; How to highlight this?
+(template_function
+  name: (identifier) @function)
+
+(template_method
+  name: (field_identifier) @method)
+
+(template_function
+  name: (scoped_identifier
+    name: (identifier) @function))
+
+(namespace_identifier) @constant
+
+((namespace_identifier) @type
+                        (match? @type "^[A-Z]"))
+((namespace_identifier) @constant
+                        (match? @constant "^[A-Z][A-Z_1-9]*$"))
+
+(destructor_name
+  name: (*) @function)
+
+(function_declarator
+      declarator: (scoped_identifier
+        name: (identifier) @function))
+((function_declarator
+      declarator: (scoped_identifier
+        name: (identifier) @constructor))
+ (match? @constructor "^[A-Z]"))
+
+(call_expression
+  function: (scoped_identifier 
+              name: (identifier) @function))
+
+(call_expression
+  function: (field_expression 
+              field: (field_identifier) @function))
+
+((call_expression
+  function: (scoped_identifier 
+              name: (identifier) @constructor))
+(match? @constructor "^[A-Z]"))
+
+((call_expression
+  function: (field_expression 
+              field: (field_identifier) @function))
+(match? @function "^[A-Z]"))
+
+;; constructing a type in a intizializer list: Constructor ():  **SuperType (1)**
+((field_initializer
+  (field_identifier) @constructor
+  (argument_list))
+ (match? @constructor "^[A-Z]"))
+
+(auto) @keyword
+(class_specifier)
+
+; Constants
+
+;(this) @constant.builtin
+(this) @keyword
+(nullptr) @constant
+
+(true) @boolean
+(false) @boolean
+
+; Keywords
+
+"catch" @exception
+"class" @keyword
+"constexpr" @keyword
+"delete" @operator
+"explicit" @keyword
+"final" @exception
+"friend" @keyword
+"mutable" @keyword
+"namespace" @keyword
+"noexcept" @keyword
+"new" @operator
+"override" @keyword
+"private" @keyword
+"protected" @keyword
+"public" @keyword
+"template" @keyword
+"throw" @keyword
+"try" @exception
+"typename" @keyword
+"using" @keyword
+"virtual" @keyword

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -61,7 +61,11 @@
  (match? @constructor "^[A-Z]"))
 
 (auto) @keyword
-(class_specifier)
+
+;; Parameters
+; normals
+(parameter_list
+  (parameter_declaration) @parameter)
 
 ; Constants
 
@@ -77,14 +81,14 @@
 "catch" @exception
 "class" @keyword
 "constexpr" @keyword
-"delete" @operator
+"delete" @keyword
 "explicit" @keyword
 "final" @exception
 "friend" @keyword
 "mutable" @keyword
 "namespace" @keyword
 "noexcept" @keyword
-"new" @operator
+"new" @keyword
 "override" @keyword
 "private" @keyword
 "protected" @keyword
@@ -95,3 +99,4 @@
 "typename" @keyword
 "using" @keyword
 "virtual" @keyword
+"::" @operator

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -23,7 +23,7 @@
 ((namespace_identifier) @type
                         (#match? @type "^[A-Z]"))
 ((namespace_identifier) @constant
-                        (#match? @constant "^[A-Z][A-Z_1-9]*$"))
+                        (#match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 (destructor_name
   name: (_) @function)

--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -41,9 +41,9 @@
 
 ;; Control structures
 (try_statement
-  body: (*) @scope)
+  body: (_) @scope)
 
 (catch_clause) @scope
 
 (destructor_name
-  name: (*) @constructor)
+  name: (_) @constructor)

--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -1,0 +1,49 @@
+
+;; Class / struct defintions
+(class_specifier) @scope
+(struct_specifier) @scope
+
+
+(struct_specifier
+  name: (type_identifier) @definition.type) 
+
+(struct_specifier
+  name: (scoped_type_identifier
+          name: (type_identifier) @definition.type) ) 
+
+(class_specifier
+  name: (type_identifier) @definition.type) 
+
+(class_specifier
+  name: (scoped_type_identifier
+          name: (type_identifier) @definition.type) ) 
+
+;; Function defintions
+(template_function
+  name: (identifier) @definition.function) @scope
+
+(template_method
+  name: (field_identifier) @definition.method) @scope
+
+(template_function
+  name: (scoped_identifier
+    name: (identifier) @definition.function)) @scope
+
+(function_declarator
+  declarator: (scoped_identifier
+                name: (type_identifier) @definition.function)) @scope
+
+(field_declaration
+        declarator: (function_declarator
+                       (field_identifier) @definition.method))
+
+(lambda_expression) @scope
+
+;; Control structures
+(try_statement
+  body: (*) @scope)
+
+(catch_clause) @scope
+
+(destructor_name
+  name: (*) @constructor)


### PR DESCRIPTION
This PR should wait for #62 .

Some treesitter grammars just extend another treesitter grammar.
This enables us to use the C queries also for C++.
We only need to put additional queries in the C++ files to support additional C++ features (#52 ).

I would also like to include those additional queries for C++ in this PR to see whether this concept works well. Right now, C++ files have out-of-the-box syntax hightlighting from the C queries.
