### PR TITLE
Add html highlight queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ List of currently supported languages:
 - [ ] typescript
 - [ ] tsx
 - [ ] json
-- [ ] html
+- [x] html (maintained by @TravonteD)
 - [ ] csharp
 - [ ] swift
 - [ ] java

--- a/queries/html/highlights.scm
+++ b/queries/html/highlights.scm
@@ -1,0 +1,14 @@
+(tag_name) @type
+(erroneous_end_tag_name) @error
+(doctype) @constant
+(attribute_name) @property
+(attribute_value) @string
+(comment) @comment
+
+"=" @operator
+
+"<" @punctuation.bracket
+">" @punctuation.bracket
+"</" @punctuation.bracket
+"/>" @punctuation.bracket
+


### PR DESCRIPTION
Add basic html highlight queries, in the future I would like to add the injections for css and javascript
