### PR TITLE
Go highlights

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,13 @@ are optional and will not have any effect for now.
   `macro`
   `type`
   `field`
+  `doc` for documentation adjecent to a definition. E.g.
+
+```scheme
+  (comment)* @definition.doc
+    (method_declaration
+        name: (field_identifier) @definition.method)
+```
 
 `@scope`
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ List of currently supported languages:
 - [x] lua  (maintained by @vigoux)
 - [x] ruby (maintained by @TravonteD)
 - [x] c (maintained by @vigoux)
-- [ ] go
+- [x] go (maintained by @theHamsta)
 - [ ] cpp
 - [ ] rust
 - [x] python (maintained by @theHamsta)

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -1,0 +1,136 @@
+;; Forked from tree-sitter-go 
+;; Copyright (c) 2014 Max Brunsfeld (The MIT License)
+
+;;
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @method))
+
+; Function definitions
+
+(function_declaration
+  name: (identifier) @function)
+
+(method_declaration
+  name: (field_identifier) @method)
+
+; Identifiers
+
+(type_identifier) @type
+(field_identifier) @property
+(identifier) @variable
+
+(parameter_declaration (identifier) @parameter)
+(variadic_parameter_declaration (identifier) @parameter)
+
+((identifier) @constant
+ (#eq? @constant "_")) 
+
+((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z\\d_]+$"))
+
+; Operators
+
+"--" @operator
+"-" @operator
+"-=" @operator
+":=" @operator
+"!" @operator
+"!=" @operator
+"..." @operator
+"*" @operator
+"*" @operator
+"*=" @operator
+"/" @operator
+"/=" @operator
+"&" @operator
+"&&" @operator
+"&=" @operator
+"%" @operator
+"%=" @operator
+"^" @operator
+"^=" @operator
+"+" @operator
+"++" @operator
+"+=" @operator
+"<-" @operator
+"<" @operator
+"<<" @operator
+"<<=" @operator
+"<=" @operator
+"=" @operator
+"==" @operator
+">" @operator
+">=" @operator
+">>" @operator
+">>=" @operator
+"|" @operator
+"|=" @operator
+"||" @operator
+
+; Keywords
+
+"break" @keyword
+"case" @conditional
+"chan" @keyword
+"const" @keyword
+"continue" @keyword
+"default" @keyword
+"defer" @keyword
+"else" @conditional
+"fallthrough" @keyword
+"for" @repeat
+"func" @keyword
+"go" @keyword
+"goto" @keyword
+"if" @conditional
+"import" @include
+"interface" @keyword
+"map" @keyword
+"package" @include
+"range" @keyword
+"return" @keyword
+"select" @keyword
+"struct" @keyword
+"switch" @conditional
+"type" @keyword
+"var" @keyword
+
+; Delimiters
+
+"." @punctuation.delimiter
+"," @punctuation.delimiter
+":" @punctuation.delimiter
+";" @punctuation.delimiter
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+
+
+; Literals
+
+(interpreted_string_literal) @string
+(raw_string_literal) @string
+(rune_literal) @string
+(escape_sequence) @escape
+
+(int_literal) @number
+(float_literal) @float
+(imaginary_literal) @number
+
+(true) @boolean
+(false) @boolean
+(nil) @constant.builtin
+
+(comment) @comment
+
+(ERROR) @error

--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -1,0 +1,43 @@
+(
+    (comment)* @definition.doc
+    (function_declaration
+        name: (identifier) @definition.function) ;@function 
+    (#strip! @definition.doc "^//\\s*") ; <- does nothing at the moment
+)
+
+(
+    (comment)* @definition.doc
+    (method_declaration
+        name: (field_identifier) @definition.method); @method
+    (#strip! @definition.doc "^//\\s*") ; <- does nothing at the moment
+)
+
+
+(short_var_declaration 
+  left: (expression_list
+          (identifier) @definition.var)) 
+
+(var_spec 
+  name: (identifier) @definition.var)
+
+(parameter_declaration (identifier) @definition.var)
+(variadic_parameter_declaration (identifier) @definition.var)
+
+(type_declaration 
+  (type_spec
+    name: (type_identifier) @definition.type))
+
+;; reference
+(identifier) @reference
+(type_identifier) @reference
+(field_identifier) @reference
+
+;; Scopes
+
+(source_file) @scope
+(function_declaration) @scope
+(if_statement) @scope
+(block) @scope
+(expression_switch_statement) @scope
+(for_statement) @scope
+(method_declaration) @scope

--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -32,6 +32,23 @@
 (type_identifier) @reference
 (field_identifier) @reference
 
+;; Call references
+(call_expression
+    function: (identifier) @reference.call) @call
+
+(call_expression
+    function: (selector_expression
+        field: (field_identifier) @reference.call)) @call
+
+(call_expression
+    function: (parenthesized_expression
+        (identifier) @reference.call)) @call
+
+(call_expression
+    function: (parenthesized_expression
+        (selector_expression
+            field: (field_identifier) @reference.call))) @call
+
 ;; Scopes
 
 (source_file) @scope


### PR DESCRIPTION
I never do anything in Go, but when I looked at the syntax highlighting of random Go file in vim I had to do something. Mostly copied from tree-sitter-go.

Right now most tree-sitter-repos get a file `tags.scm` added. They include information on how to extract documentation #58 and defininition for call references. The question is whether we want to have call references.  