### PR TITLE
html: Highlight (quoted_attribute_value) as @string

### DIFF
--- a/queries/html/highlights.scm
+++ b/queries/html/highlights.scm
@@ -3,6 +3,7 @@
 (doctype) @constant
 (attribute_name) @property
 (attribute_value) @string
+(quoted_attribute_value) @string
 (comment) @comment
 
 "=" @operator


### PR DESCRIPTION
This will also highlight the quotes of attributes. @TravonteD 

Before:
![image](https://user-images.githubusercontent.com/7189118/83900030-b6431900-a759-11ea-9c77-2940cf9eff20.png)

After:
![image](https://user-images.githubusercontent.com/7189118/83899956-91e73c80-a759-11ea-8be7-68b57363a11e.png)

