### PR TITLE
feat(queries): allow user query overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ List of currently supported languages:
 - [ ] nix
 - [ ] markdown
 
+## User Query Extensions
+
+You can add your own query files by placing a query file in vim's runtime path after `nvim-treesitter` is sourced.
+If the language has a built in query file, that file will be appended to or it will be used (useful for languages not yet supported).
+For example, you can add files to `<vim-config-dir>/after/queries/lua/highlights.scm` to add more queries to lua highlights.
+You can also manually add query paths to the runtime path by adding this to your vim config `set rtp+='path/to/queries'`.
+
 ## Troubleshooting
 Before doing anything run `:checkhealth nvim_treesitter`. This will help you find where the bug might come from.
 

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -3,14 +3,21 @@ local ts = vim.treesitter
 
 local M = {}
 
-local function read_query_file(fname)
-  return table.concat(vim.fn.readfile(fname), '\n')
+local function read_query_files(filenames)
+  local contents = {}
+
+  for _,filename in ipairs(filenames) do
+    vim.list_extend(contents, vim.fn.readfile(filename))
+  end
+
+  return table.concat(contents, '\n')
 end
 
 function M.get_query(ft, query_name)
-  local query_files = api.nvim_get_runtime_file(string.format('queries/%s/%s.scm', ft, query_name), false)
+  local query_files = api.nvim_get_runtime_file(string.format('queries/%s/%s.scm', ft, query_name), true)
+
   if #query_files > 0 then
-    return ts.parse_query(ft, read_query_file(query_files[1]))
+    return ts.parse_query(ft, read_query_files(query_files))
   end
 end
 


### PR DESCRIPTION
This allows the users to override built in queries. The use can provide their own file in their configuration at `queries/<filetype>/<query_name>.scm`. These files extend the existing query file, not replace it.
