### PR TITLE
fix(javascript): set booleans to boolean highlights

### DIFF
--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -87,8 +87,8 @@
 (this) @variable.builtin
 (super) @variable.builtin
 
-(true) @constant.builtin
-(false) @constant.builtin
+(true) @boolean
+(false) @boolean
 (null) @constant.builtin
 (comment) @comment
 (string) @string


### PR DESCRIPTION
I missed this in my original pr.