### PR TITLE
refacto/fix: filetype / parser name distinction

### DIFF
--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -5,6 +5,7 @@ local utils = require'nvim-treesitter.utils'
 local ts_utils = require'nvim-treesitter.ts_utils'
 local info = require'nvim-treesitter.info'
 local configs = require'nvim-treesitter.configs'
+local parsers = require'nvim-treesitter.parsers'
 
 local M = {}
 
@@ -13,9 +14,10 @@ function M.setup()
   utils.setup_commands('info', info.commands)
   utils.setup_commands('configs', configs.commands)
 
-  for _, ft in pairs(configs.available_parsers()) do
+  for _, lang in pairs(parsers.available_parsers()) do
     for _, mod in pairs(configs.available_modules()) do
-      if configs.is_enabled(mod, ft) then
+      if configs.is_enabled(mod, lang) then
+        local ft = parsers.lang_to_ft(lang)
         local cmd = string.format("lua require'nvim-treesitter.%s'.attach()", mod)
         api.nvim_command(string.format("autocmd NvimTreesitter FileType %s %s", ft, cmd))
       end

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -61,9 +61,9 @@ parserlist.ruby = {
   }
 }
 
-parserlist.bash = {
+parserlist.sh = {
   install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-bash",
+    url = "https://github.com/nvim-treesitter/tree-sitter-bash",
     files = { "src/parser.c", "src/scanner.cc" },
   }
 }
@@ -124,9 +124,9 @@ parserlist.swift = {
   }
 }
 
-parserlist.csharp = {
+parserlist.cs = {
   install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-c-sharp",
+    url = "https://github.com/nvim-treesitter/tree-sitter-c-sharp",
     files = { "src/parser.c", "src/scanner.c" },
   }
 }
@@ -139,9 +139,9 @@ parserlist.typescript = {
   }
 }
 
-parserlist.tsx = {
+parserlist.typescriptreact = {
   install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-typescript",
+    url = "https://github.com/nvim-treesitter/tree-sitter-typescript",
     files = { "src/parser.c", "src/scanner.c" },
     location = "tree-sitter-tsx/tsx"
   }

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -3,213 +3,6 @@ local api = vim.api
 local queries = require'nvim-treesitter.query'
 local parsers = require'nvim-treesitter.parsers'
 
-local parserlist = {}
-
-parserlist.javascript = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-javascript",
-    files = { "src/parser.c", "src/scanner.c" },
-  }
-}
-
-parserlist.c = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-c",
-    files = { "src/parser.c" }
-  }
-}
-
-parserlist.cpp = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-cpp",
-    files = { "src/parser.c", "src/scanner.cc" }
-  }
-}
-
-parserlist.rust = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-rust",
-    files = { "src/parser.c", "src/scanner.c" },
-  }
-}
-
-parserlist.lua = {
-  install_info = {
-    url = "https://github.com/nvim-treesitter/tree-sitter-lua",
-    files = { "src/parser.c", "src/scanner.cc" }
-  }
-}
-
-parserlist.python = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-python",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.go = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-go",
-    files = { "src/parser.c" },
-  }
-}
-
-parserlist.ruby = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-ruby",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.sh = {
-  install_info = {
-    url = "https://github.com/nvim-treesitter/tree-sitter-bash",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.php = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-php",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.java = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-java",
-    files = { "src/parser.c" },
-  }
-}
-
-parserlist.html = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-html",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.julia = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-julia",
-    files = { "src/parser.c", "src/scanner.c" },
-  }
-}
-
-parserlist.json = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-json",
-    files = { "src/parser.c" },
-  }
-}
-
-parserlist.css = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-css",
-    files = { "src/parser.c", "src/scanner.c" },
-  }
-}
-
-parserlist.ocaml = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-ocaml",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.swift = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-swift",
-    files = { "src/parser.c" },
-  }
-}
-
-parserlist.cs = {
-  install_info = {
-    url = "https://github.com/nvim-treesitter/tree-sitter-c-sharp",
-    files = { "src/parser.c", "src/scanner.c" },
-  }
-}
-
-parserlist.typescript = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-typescript",
-    files = { "src/parser.c", "src/scanner.c" },
-    location = "tree-sitter-typescript/typescript"
-  }
-}
-
-parserlist.typescriptreact = {
-  install_info = {
-    url = "https://github.com/nvim-treesitter/tree-sitter-typescript",
-    files = { "src/parser.c", "src/scanner.c" },
-    location = "tree-sitter-tsx/tsx"
-  }
-}
-
-parserlist.scala = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-scala",
-    files = { "src/parser.c", "src/scanner.c" },
-  }
-}
-
-parserlist.haskell = {
-  install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-haskell",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.markdown = {
-  install_info = {
-    url = "https://github.com/ikatyang/tree-sitter-markdown",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.toml = {
-  install_info = {
-    url = "https://github.com/ikatyang/tree-sitter-toml",
-    files = { "src/parser.c", "src/scanner.c" },
-  }
-}
-
-parserlist.vue = {
-  install_info = {
-    url = "https://github.com/ikatyang/tree-sitter-vue",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.elm = {
-  install_info = {
-    url = "https://github.com//razzeee/tree-sitter-elm",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.yaml = {
-  install_info = {
-    url = "https://github.com/ikatyang/tree-sitter-yaml",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.nix = {
-  install_info = {
-    url = "https://github.com/cstrahan/tree-sitter-nix",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
-
-parserlist.regex = {
-    install_info = {
-        url = "https://github.com/tree-sitter/tree-sitter-regex",
-        files = { "src/parser.c" }
-    }
-}
-
 -- @enable can be true or false
 -- @disable is a list of languages, only relevant if enable is true
 -- @keymaps list of user mappings for a given module if relevant
@@ -219,8 +12,8 @@ local config = {
     highlight = {
       enable = false,
       disable = {},
-      is_supported = function(ft)
-        return queries.get_query(ft, 'highlights') ~= nil
+      is_supported = function(lang)
+        return queries.get_query(lang, 'highlights') ~= nil
       end
     },
     incremental_selection = {
@@ -232,8 +25,8 @@ local config = {
         scope_incremental="grc",
         node_decremental="grm"
       },
-      is_supported = function(ft)
-        return queries.get_query(ft, 'locals')
+      is_supported = function(lang)
+        return queries.get_query(lang, 'locals')
       end
     }
   },
@@ -242,56 +35,62 @@ local config = {
 
 local M = {}
 
-local function enable_module(mod, bufnr, ft)
+local function enable_module(mod, bufnr, lang)
   local bufnr = bufnr or api.nvim_get_current_buf()
-  local ft = ft or api.nvim_buf_get_option(bufnr, 'ft')
-  if not parserlist[ft] or not config.modules[mod] then
+  local lang = lang or parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, 'ft'))
+  if not parsers.list[lang] or not config.modules[mod] then
     return
   end
 
   local loaded_mod = require(string.format("nvim-treesitter.%s", mod))
-  loaded_mod.attach(bufnr, ft)
+  loaded_mod.attach(bufnr, lang)
 end
 
-local function enable_mod_conf_autocmd(mod, ft)
-  if not config.modules[mod] or M.is_enabled(mod, ft) then return end
+local function enable_mod_conf_autocmd(mod, lang)
+  if not config.modules[mod] or M.is_enabled(mod, lang) then return end
 
+  local ft = parsers.lang_to_ft(lang)
   local cmd = string.format("lua require'nvim-treesitter.%s'.attach()", mod)
   api.nvim_command(string.format("autocmd FileType %s %s", ft, cmd))
   for i, parser in pairs(config.modules[mod].disable) do
-    if parser == ft then
+    if parser == lang then
       table.remove(config.modules[mod].disable, i)
       break
     end
   end
 end
 
-local function enable_all(mod, ft)
+local function enable_all(mod, lang)
   if not config.modules[mod] then return end
 
   for _, bufnr in pairs(api.nvim_list_bufs()) do
-    if not ft or api.nvim_buf_get_option(bufnr, 'ft') == ft then
-      enable_module(mod, bufnr, ft)
+    local ft = api.nvim_buf_get_option(bufnr, 'ft')
+    if not lang or ft == parsers.lang_to_ft(lang) then
+      enable_module(mod, bufnr, lang)
     end
   end
-  if ft then
-    if parsers.has_parser(ft) then
-      enable_mod_conf_autocmd(mod, ft)
+  if lang then
+    if parsers.has_parser(lang) then
+      enable_mod_conf_autocmd(mod, lang)
     end
   else
-    for _, ft in pairs(M.available_parsers()) do
-      if parsers.has_parser(ft) then
-        enable_mod_conf_autocmd(mod, ft)
+    for _, lang in pairs(parsers.available_parsers()) do
+      if parsers.has_parser(lang) then
+        enable_mod_conf_autocmd(mod, lang)
       end
     end
   end
   config.modules[mod].enable = true
 end
 
-local function disable_module(mod, bufnr, ft)
+local function disable_module(mod, bufnr, lang)
   local bufnr = bufnr or api.nvim_get_current_buf()
-  local ft = ft or api.nvim_buf_get_option(bufnr, 'ft')
-  if not parserlist[ft] or not config.modules[mod] then
+  local lang = lang or parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, 'ft'))
+  if not lang then
+    return
+  end
+
+  if not parsers.list[lang] or not config.modules[mod] then
     return
   end
 
@@ -299,24 +98,26 @@ local function disable_module(mod, bufnr, ft)
   loaded_mod.detach(bufnr, ft)
 end
 
-local function disable_mod_conf_autocmd(mod, ft)
-  if not config.modules[mod] or not M.is_enabled(mod, ft) then return end
+local function disable_mod_conf_autocmd(mod, lang)
+  if not config.modules[mod] or not M.is_enabled(mod, lang) then return end
 
+  local ft = parsers.lang_to_ft(lang)
   api.nvim_command(string.format("autocmd! FileType %s", ft))
-  table.insert(config.modules[mod].disable, ft)
+  table.insert(config.modules[mod].disable, lang)
 end
 
-local function disable_all(mod, ft)
+local function disable_all(mod, lang)
   for _, bufnr in pairs(api.nvim_list_bufs()) do
-    if not ft or api.nvim_buf_get_option(bufnr, 'ft') == ft then
-      disable_module(mod, bufnr, ft)
+    local ft = api.nvim_buf_get_option(bufnr, 'ft')
+    if not lang or ft == parsers.lang_to_ft(lang) then
+      disable_module(mod, bufnr, lang)
     end
   end
-  if ft then
-    disable_mod_conf_autocmd(mod, ft)
+  if lang then
+    disable_mod_conf_autocmd(mod, lang)
   else
-    for _, ft in pairs(M.available_parsers()) do
-      disable_mod_conf_autocmd(mod, ft)
+    for _, lang in pairs(parsers.available_parsers()) do
+      disable_mod_conf_autocmd(mod, lang)
     end
     config.modules[mod].enable = false
   end
@@ -359,15 +160,15 @@ M.commands = {
 
 -- @param mod: module (string)
 -- @param ft: filetype (string)
-function M.is_enabled(mod, ft)
-  if not M.get_parser_configs()[ft] or not parsers.has_parser(ft) then
+function M.is_enabled(mod, lang)
+  if not parsers.list[lang] or not parsers.has_parser(lang) then
     return false
   end
 
   local module_config = config.modules[mod]
   if not module_config then return false end
 
-  if not module_config.enable or not module_config.is_supported(ft) then
+  if not module_config.enable or not module_config.is_supported(lang) then
     return false
   end
 
@@ -401,14 +202,6 @@ function M.setup(user_data)
       require'nvim-treesitter.install'.ensure_installed(data)
     end
   end
-end
-
-function M.get_parser_configs()
-  return parserlist
-end
-
-function M.available_parsers()
-  return vim.tbl_keys(parserlist)
 end
 
 function M.available_modules()

--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -4,7 +4,7 @@ local fn = vim.fn
 local queries = require'nvim-treesitter.query'
 local locals = require'nvim-treesitter.locals'
 local highlight = require'nvim-treesitter.highlight'
-local configs = require'nvim-treesitter.configs'
+local parsers = require'nvim-treesitter.parsers'
 
 local health_start = vim.fn["health#report_start"]
 local health_ok = vim.fn['health#report_ok']
@@ -62,7 +62,7 @@ function M.checkhealth()
 
   local missing_parsers = {}
   -- Parser installation checks
-  for _, parser_name in pairs(configs.available_parsers()) do
+  for _, parser_name in pairs(parsers.available_parsers()) do
     local installed = #api.nvim_get_runtime_file('parser/'..parser_name..'.so', false)
 
     -- Only print informations about installed parsers

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -2,6 +2,7 @@ local api = vim.api
 local ts = vim.treesitter
 
 local queries = require'nvim-treesitter.query'
+local parsers = require'nvim-treesitter.parsers'
 
 local M = {
   highlighters = {}
@@ -49,14 +50,14 @@ hlmap["type.builtin"] = "Type"
 hlmap["structure"] = "Structure"
 hlmap["include"] = "Include"
 
-function M.attach(bufnr, ft)
-  local buf = bufnr or api.nvim_get_current_buf()
-  local ft = ft or api.nvim_buf_get_option(buf, 'ft')
+function M.attach(bufnr, lang)
+  local bufnr = bufnr or api.nvim_get_current_buf()
+  local lang = lang or parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, 'ft'))
 
-  local query = queries.get_query(ft, "highlights")
+  local query = queries.get_query(lang, "highlights")
   if not query then return end
 
-  M.highlighters[buf] = ts.TSHighlighter.new(query, buf, ft)
+  M.highlighters[bufnr] = ts.TSHighlighter.new(query, bufnr, lang)
 end
 
 function M.detach(bufnr)

--- a/lua/nvim-treesitter/info.lua
+++ b/lua/nvim-treesitter/info.lua
@@ -1,15 +1,16 @@
 local api = vim.api
 local configs = require'nvim-treesitter.configs'
+local parsers = require'nvim-treesitter.parsers'
 
 local M = {}
 
 local function install_info()
   local max_len = 0
-  for _, ft in pairs(configs.available_parsers()) do
+  for _, ft in pairs(parsers.available_parsers()) do
     if #ft > max_len then max_len = #ft end
   end
 
-  for _, ft in pairs(configs.available_parsers()) do
+  for _, ft in pairs(parsers.available_parsers()) do
     local is_installed = #api.nvim_get_runtime_file('parser/'..ft..'.so', false) > 0
     api.nvim_out_write(ft..string.rep(' ', max_len - #ft + 1))
     if is_installed then
@@ -66,7 +67,7 @@ end
 local function module_info(mod)
   if mod and not configs.get_config()[mod] then return end
 
-  local ft_by_len = configs.available_parsers()
+  local ft_by_len = parsers.available_parsers()
   table.sort(ft_by_len, function(a, b) return #a > #b end)
   if mod then
     print_info_module(ft_by_len, mod)

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -2,7 +2,6 @@ local api = vim.api
 local fn = vim.fn
 local luv = vim.loop
 
-local configs = require'nvim-treesitter.configs'
 local utils = require'nvim-treesitter.utils'
 local parsers = require'nvim-treesitter.parsers'
 
@@ -103,7 +102,7 @@ local function install(...)
       if not string.match(yesno, '^y.*') then return end
     end
 
-    local parser_config = configs.get_parser_configs()[ft]
+    local parser_config = parsers.get_parser_configs()[ft]
     if not parser_config then
       return api.nvim_err_writeln('Parser not available for language '..ft)
     end
@@ -122,15 +121,15 @@ end
 M.ensure_installed = function(languages)
   if type(languages) == 'string' then
     if languages == 'all' then
-      languages = configs.available_parsers()
+      languages = parsers.available_parsers()
     else
       languages = {languages}
     end
   end
 
-  for _, ft in ipairs(languages) do
-    if not parsers.has_parser(ft) then
-      install(ft)
+  for _, lang in ipairs(languages) do
+    if not parsers.has_parser(lang) then
+      install(lang)
     end
   end
 end

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1,17 +1,255 @@
 local api = vim.api
 local ts = vim.treesitter
 
-local M = {}
+local list = {}
+
+list.javascript = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-javascript",
+    files = { "src/parser.c", "src/scanner.c" },
+  }
+}
+
+list.c = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-c",
+    files = { "src/parser.c" }
+  }
+}
+
+list.cpp = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-cpp",
+    files = { "src/parser.c", "src/scanner.cc" }
+  }
+}
+
+list.rust = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-rust",
+    files = { "src/parser.c", "src/scanner.c" },
+  }
+}
+
+list.lua = {
+  install_info = {
+    url = "https://github.com/nvim-treesitter/tree-sitter-lua",
+    files = { "src/parser.c", "src/scanner.cc" }
+  }
+}
+
+list.python = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-python",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.go = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-go",
+    files = { "src/parser.c" },
+  }
+}
+
+list.ruby = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-ruby",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.bash = {
+  install_info = {
+    url = "https://github.com/nvim-treesitter/tree-sitter-bash",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  filetype = 'sh'
+}
+
+list.php = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-php",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.java = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-java",
+    files = { "src/parser.c" },
+  }
+}
+
+list.html = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-html",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.julia = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-julia",
+    files = { "src/parser.c", "src/scanner.c" },
+  }
+}
+
+list.json = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-json",
+    files = { "src/parser.c" },
+  }
+}
+
+list.css = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-css",
+    files = { "src/parser.c", "src/scanner.c" },
+  }
+}
+
+list.ocaml = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-ocaml",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.swift = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-swift",
+    files = { "src/parser.c" },
+  }
+}
+
+list.c_sharp = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-c-sharp",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  filetype = 'cs'
+}
+
+list.typescript = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-typescript",
+    files = { "src/parser.c", "src/scanner.c" },
+    location = "tree-sitter-typescript/typescript"
+  }
+}
+
+list.tsx = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-typescript",
+    files = { "src/parser.c", "src/scanner.c" },
+    location = "tree-sitter-tsx/tsx"
+  },
+  filetype = 'typescriptreact'
+}
+
+list.scala = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-scala",
+    files = { "src/parser.c", "src/scanner.c" },
+  }
+}
+
+list.haskell = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-haskell",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.markdown = {
+  install_info = {
+    url = "https://github.com/ikatyang/tree-sitter-markdown",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.toml = {
+  install_info = {
+    url = "https://github.com/ikatyang/tree-sitter-toml",
+    files = { "src/parser.c", "src/scanner.c" },
+  }
+}
+
+list.vue = {
+  install_info = {
+    url = "https://github.com/ikatyang/tree-sitter-vue",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.elm = {
+  install_info = {
+    url = "https://github.com//razzeee/tree-sitter-elm",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.yaml = {
+  install_info = {
+    url = "https://github.com/ikatyang/tree-sitter-yaml",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.nix = {
+  install_info = {
+    url = "https://github.com/cstrahan/tree-sitter-nix",
+    files = { "src/parser.c", "src/scanner.cc" },
+  }
+}
+
+list.regex = {
+    install_info = {
+        url = "https://github.com/tree-sitter/tree-sitter-regex",
+        files = { "src/parser.c" }
+    }
+}
+
+local M = {
+  list = list
+}
+
+local ft_to_parsername = {}
+for name, obj in pairs(M.list) do
+  if obj.filetype then
+    ft_to_parsername[obj.filetype] = name
+  else
+    ft_to_parsername[name] = name
+  end
+end
+
+function M.ft_to_lang(ft)
+  return ft_to_parsername[ft]
+end
+
+function M.lang_to_ft(lang)
+  return M.list[lang].filetype or lang
+end
+
+function M.available_parsers()
+  return vim.tbl_keys(M.list)
+end
+
+function M.get_parser_configs()
+  return M.list
+end
 
 function M.has_parser(lang)
-  local lang = lang or api.nvim_buf_get_option(0, 'filetype')
+  local buf = api.nvim_get_current_buf()
+  local lang = lang or M.ft_to_lang(api.nvim_buf_get_option(buf, 'ft'))
   if not lang or #lang == 0 then return false end
   return #api.nvim_get_runtime_file('parser/' .. lang .. '.*', false) > 0
 end
 
 function M.get_parser(bufnr, lang)
   local buf = bufnr or api.nvim_get_current_buf()
-  local lang = lang or api.nvim_buf_get_option(buf, 'ft')
+  local lang = lang or M.ft_to_lang(api.nvim_buf_get_option(buf, 'ft'))
 
   if M.has_parser(lang) then
     if not M[buf] then

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -21,15 +21,15 @@ M.base_language_map = {
   tsx = {'typescript', 'javascript'},
 }
 
-function M.get_query(ft, query_name)
-  local query_files = api.nvim_get_runtime_file(string.format('queries/%s/%s.scm', ft, query_name), true)
+function M.get_query(lang, query_name)
+  local query_files = api.nvim_get_runtime_file(string.format('queries/%s/%s.scm', lang, query_name), true)
   local query_string = ''
 
   if #query_files > 0 then
     query_string = read_query_files(query_files)..query_string
   end
 
-  for _, base_lang in ipairs(M.base_language_map[ft] or {}) do
+  for _, base_lang in ipairs(M.base_language_map[lang] or {}) do
     local base_files = api.nvim_get_runtime_file(string.format('queries/%s/%s.scm', base_lang, query_name), true)
     if base_files and #base_files > 0 then
         query_string = read_query_files(base_files)..query_string
@@ -37,7 +37,7 @@ function M.get_query(ft, query_name)
   end
 
   if #query_string > 0 then
-    return ts.parse_query(ft, query_string)
+    return ts.parse_query(lang, query_string)
   end
 end
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -11,7 +11,7 @@ let g:loaded_nvim_treesitter = 1
 
 lua << EOF
 ts_installable_parsers = function()
-  return table.concat(require'nvim-treesitter.configs'.available_parsers(), '\n')
+  return table.concat(require'nvim-treesitter.parsers'.available_parsers(), '\n')
 end
 ts_available_modules = function()
   return table.concat(require'nvim-treesitter.configs'.available_modules(), '\n')


### PR DESCRIPTION
fixes #84.

- move parser list in `parsers.lua`. All the code related to the parser is now basically in parsers.lua
- most `ft` variables have been renamed to `lang`, and the switch between those is easier to do with two function:
   - `parsers.ft_to_lang(ft) -> lang`
   - `parsers.lang_to_ft(lang) -> ft`
- filetypes are now only used when binding autocmd to Filetype on start and on commands like `TSBufEnable` and such. Otherwise, we use the `lang` to match the parser name we want. In the parser list, if a parser name does not match its filetype, we define a key `filetype`.