### PR TITLE
fix(install): remove .gitignore from parser directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+parser/*.so

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -30,6 +30,12 @@ local function run_install(cache_folder, package_path, ft, repo)
   local parser_lib_name = package_path.."/parser/"..ft..".so"
   local command_list = {
     {
+      cmd = 'mkdir',
+      opts = {
+        args = { '-p', package_path.."/parser" }
+      }
+    },
+    {
       cmd = 'rm',
       opts = {
         args = { '-rf', project_repo },

--- a/parser/.gitignore
+++ b/parser/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
I kept getting this error when opening a buffer without a filetype (terminal buffers).

![Screen Shot 2020-06-19 at 10 59 50 AM](https://user-images.githubusercontent.com/2062154/85155241-22278600-b21e-11ea-9c7d-4cd5208bbeed.png)

Seems like it's trying to read the .gitignore file as a parser. This change removes the file from that directory and moves it the root of the project. I also had to create the parser directory on install since git won't track in anymore.