### PR TITLE
Adapt Python highlights to new query syntax

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -74,8 +74,7 @@
 ; Literals
 
 (none) @constant.builtin
-(true) @boolean
-(false) @boolean
+[(true) (false)] @boolean
 ((identifier) @constant.builtin
               (match? @constant.builtin "self"))
 
@@ -88,88 +87,78 @@
 
 ; Tokens
 
-"-" @operator
-"->" @operator
-"-=" @operator
-"!=" @operator
-"*" @operator
-"**" @operator
-"**=" @operator
-"*=" @operator
-"/" @operator
-"//" @operator
-"//=" @operator
-"/=" @operator
-"&" @operator
-"%" @operator
-"%=" @operator
-"^" @operator
-"+" @operator
-"+=" @operator
-"<" @operator
-"<<" @operator
-"<=" @operator
-"<>" @operator
-"=" @operator
-"==" @operator
-">" @operator
-">=" @operator
-">>" @operator
-"|" @operator
-"~" @operator
-"and" @operator
-"in" @operator
-"is" @operator
-"not" @operator
-"or" @operator
+[
+  "-"
+  "-="
+  "!="
+  "*"
+  "**"
+  "**="
+  "*="
+  "/"
+  "//"
+  "//="
+  "/="
+  "&"
+  "%"
+  "%="
+  "^"
+  "+"
+  "+="
+  "<"
+  "<<"
+  "<="
+  "<>"
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  "|"
+  "~"
+  "and"
+  "in"
+  "is"
+  "not"
+  "or"
+] @operator
 
 ; Keywords
 
-"as" @include
-"assert" @keyword
-"async" @keyword
-"await" @keyword
-"break" @repeat
-"class" @keyword
-"continue" @repeat
-"def" @keyword
-"del" @keyword
-"elif" @conditional
-"else" @conditional
-"except" @keyword
-"exec" @keyword
-"finally" @keyword
-"for" @repeat
-"from" @include
-"global" @keyword
-"if" @conditional
-"import" @include
-"lambda" @keyword
-"nonlocal" @keyword
-"pass" @keyword
-"print" @keyword
-"raise" @keyword
-"return" @keyword
-"try" @keyword
-"while" @repeat
-"with" @keyword
-"yield" @keyword
+[
+  "assert"
+  "await"
+  "class"
+  "def"
+  "del"
+  "except"
+  "exec"
+  "finally"
+  "global"
+  "lambda"
+  "nonlocal"
+  "pass"
+  "print"
+  "raise"
+  "return"
+  "try"
+  "with"
+  "yield"
+] @keyword
 
-; Additions for nvim-treesitter
-"(" @punctuation.bracket
-")" @punctuation.bracket
-"[" @punctuation.bracket
-"]" @punctuation.bracket
-"{" @punctuation.bracket
-"}" @punctuation.bracket
+[ "as" "from" "import"] @include
+
+[ "if" "elif" "else" ] @conditional
+
+[ "for" "while" "break" "continue" ] @repeat
+
+[ "(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 (interpolation
   "{" @punctuation.special
   "}" @punctuation.special) @embedded
 
-"," @punctuation.delimiter
-"." @punctuation.delimiter
-":" @punctuation.delimiter
+[ "," "." ":" ] @punctuation.delimiter
 
 ; Class definitions
 

--- a/queries/python/locals.scm
+++ b/queries/python/locals.scm
@@ -30,12 +30,8 @@
 
 ; Function defines function and scope
 (function_definition
-  name: (identifier) @definition.function) @scope
-
-;; Should be extended to when syntax supported
-;(function_definition
-  ;name: (identifier) @definition.function
-  ;body: (block (expression_statement (string) @definition.function.doc)?)) @scope
+  name: (identifier) @definition.function
+  body: (block (expression_statement (string) @definition.doc)?)) @scope
 
 
 (class_definition


### PR DESCRIPTION
#76

Maybe we should add `@defintion.class`. It's now also in the `tags.scm` of many treesitter repos.