### PR TITLE
Deactivate highlighting of @error

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -10,7 +10,7 @@ local M = {
 local hlmap = vim.treesitter.TSHighlighter.hl_map
 
 -- Misc
-hlmap.error = "Error"
+hlmap.error = nil -- = "Error" activates highlighting of syntax errors
 hlmap["punctuation.delimiter"] = "Delimiter"
 hlmap["punctuation.bracket"] = "Delimiter"
 hlmap["punctuation.special"] = "Delimiter"


### PR DESCRIPTION
This can be annoying while typing  #78  while in some cases this might be
useful to detect syntax errors. We could change the default to no
highlighting of errors. We can keep it in the code to highlight that
users can still opt-in to an highlighting of `@error`.

I think languages should still include the `@error` query so the feature to highlight error can still be activated.