### PR TITLE
User textobj

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,34 @@ require'nvim-treesitter.configs'.setup {
         }
       }
     },
+    textobjects = { -- syntax-aware textobjects
+	enable = true,
+	disable = {},
+	keymaps = {
+	    ["iL"] = { -- you can define your own textobjects directly here
+		python = "(function_definition) @function",
+		cpp = "(function_definition) @function",
+		c = "(function_definition) @function",
+		java = "(method_declaration) @function"
+	    },
+	    -- or you use the queries from supported languages with textobjects.scm
+	    ["af"] = "@function.outer",
+	    ["if"] = "@function.inner",
+	    ["aC"] = "@class.outer",
+	    ["iC"] = "@class.inner",
+	    ["ac"] = "@conditional.outer",
+	    ["ic"] = "@conditional.inner",
+	    ["ae"] = "@block.outer",
+	    ["ie"] = "@block.inner",
+	    ["al"] = "@loop.outer",
+	    ["il"] = "@loop.inner",
+	    ["is"] = "@statement.inner",
+	    ["as"] = "@statement.outer",
+	    ["ad"] = "@comment.outer",
+	    ["am"] = "@call.outer",
+	    ["im"] = "@call.inner"
+	}
+    },
     ensure_installed = 'all' -- one of 'all', 'language', or a list of languages
 }
 EOF
@@ -171,6 +199,7 @@ The roadmap and all features of this plugin are open to change, and any suggesti
 - `refactor.navigation`: Syntax based definition listing and navigation.
   * List all definitions
   * Go to definition
+- `textobjects`: Vim textobjects defined by treesitter queries
 
 ## Defining Modules
 
@@ -217,7 +246,7 @@ More information is available in the help file (`:help nvim-treesitter-utils`).
 
 ## Supported Languages
 
-For treesitter to work, we need to use query files such as those you can find in
+For `nvim-treesitter` to work, we need to use query files such as those you can find in
 `queries/{lang}/{locals,highlights,textobjects}.scm`
 
 We are looking for maintainers to write query files for their languages.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ More information is available in the help file (`:help nvim-treesitter-utils`).
 
 ## Supported Languages
 
-For treesitter to work, we need to use query files such as those you can find in `queries/{lang}/{locals,highlights}.scm`
+For treesitter to work, we need to use query files such as those you can find in
+`queries/{lang}/{locals,highlights,textobjects}.scm`
 
 We are looking for maintainers to write query files for their languages.
 

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -47,6 +47,48 @@ By default, everything is disabled. To enable support for features, in your `ini
           node_decremental = "grm",      -- decrement to the previous node
         }
     },
+    refactor = {
+      highlight_defintions = {
+        enable = true
+      },
+      smart_rename = {
+        enable = true,
+        smart_rename = "grr"              -- mapping to rename reference under cursor
+      },
+      navigation = {
+        enable = true,
+        goto_definition = "gnd",          -- mapping to go to definition of symbol under cursor
+        list_definitions = "gnD"          -- mapping to list all definitions in current file
+      }
+    },
+    textobjects = { -- syntax-aware textobjects
+	enable = true,
+	disable = {},
+	keymaps = {
+	    ["iL"] = { -- you can define your own textobjects directly here
+		python = "(function_definition) @function",
+		cpp = "(function_definition) @function",
+		c = "(function_definition) @function",
+		java = "(method_declaration) @function"
+	    },
+	    -- or you use the queries from supported languages with textobjects.scm
+	    ["af"] = "@function.outer",
+	    ["if"] = "@function.inner",
+	    ["aC"] = "@class.outer",
+	    ["iC"] = "@class.inner",
+	    ["ac"] = "@conditional.outer",
+	    ["ic"] = "@conditional.inner",
+	    ["ae"] = "@block.outer",
+	    ["ie"] = "@block.inner",
+	    ["al"] = "@loop.outer",
+	    ["il"] = "@loop.inner",
+	    ["is"] = "@statement.inner",
+	    ["as"] = "@statement.outer",
+	    ["ad"] = "@comment.outer",
+	    ["am"] = "@call.outer",
+	    ["im"] = "@call.inner"
+	}
+    },
     ensure_installed = 'all' -- one of 'all', 'language', or a list of languages
   }
   EOF

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -4,6 +4,19 @@ local queries = require'nvim-treesitter.query'
 local parsers = require'nvim-treesitter.parsers'
 local utils = require'nvim-treesitter.utils'
 
+local M = {}
+
+local function has_some_textobject_mapping(lang)
+  for _, v in pairs(M.get_module('textobjects').keymaps) do
+    if type(v) == 'table' then
+      if v[lang] then
+        return true
+      end
+    end
+  end
+  return false
+end
+
 local config = {
   modules = {},
   ensure_installed = nil
@@ -65,12 +78,21 @@ local builtin_modules = {
         list_definitions = "gnD"
       }
     }
+  },
+  textobjects = {
+    module_path = 'nvim-treesitter.textobjects',
+    enable = false,
+    disable = {},
+    is_supported = function(lang)
+      return has_some_textobject_mapping(lang) or queries.has_textobjects(lang)
+    end,
+    keymaps = {
+      inverse_mappings = true
+    }
   }
 }
 
 local special_config_keys = {'enable', 'disable', 'keymaps'}
-
-local M = {}
 
 -- Resolves a module by requiring the `module_path` or using the module definition.
 local function resolve_module(mod_name)
@@ -279,12 +301,17 @@ function M.setup_module(mod, data, mod_name)
       mod.disable = data.disable
     end
     if mod.keymaps and type(data.keymaps) == 'table' then
-      for f, map in pairs(data.keymaps) do
-        if mod.keymaps[f] then
-          mod.keymaps[f] = map
+      if mod.keymaps.inverse_mappings then
+        mod.keymaps = data.keymaps
+      else
+        for f, map in pairs(data.keymaps) do
+          if mod.keymaps[f] then
+            mod.keymaps[f] = map
+          end
         end
       end
     end
+
     for k, v in pairs(data) do
       -- Just copy all non-special configuration keys
       if not vim.tbl_contains(special_config_keys, k) then

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -35,6 +35,7 @@ M.query_extensions = {
 }
 
 M.has_locals = get_query_guard('locals')
+M.has_textobjects = get_query_guard('textobjects')
 M.has_highlights = get_query_guard('highlights')
 
 function M.get_query(lang, query_name)

--- a/lua/nvim-treesitter/textobjects.lua
+++ b/lua/nvim-treesitter/textobjects.lua
@@ -1,0 +1,96 @@
+local api = vim.api
+local ts = vim.treesitter
+
+local configs = require "nvim-treesitter.configs"
+local parsers = require "nvim-treesitter.parsers"
+local queries = require'nvim-treesitter.query'
+local locals = require'nvim-treesitter.locals'
+local ts_utils = require'nvim-treesitter.ts_utils'
+
+local M = {}
+
+function M.select_textobject(query_string)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local ft = api.nvim_buf_get_option(bufnr, "ft")
+  if not ft then return end
+  local lang = parsers.ft_to_lang(ft)
+
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  row = row - 1
+
+  local matches = {}
+
+  if string.match(query_string, '^@.*') then
+    matches = locals.get_capture_matches(bufnr, query_string, 'textobjects')
+  else
+    local parser = parsers.get_parser(bufnr, lang)
+    local root = parser:parse():root()
+    local start_row, _, end_row, _ = root:range()
+
+    local nested = {}
+    local query = ts.parse_query(lang, query_string)
+    for m in queries.iter_prepared_matches(query, root, bufnr, start_row, end_row) do
+      for _, n in pairs(m) do
+        if n.node then
+          table.insert(matches, n.node)
+        end
+      end
+    end
+  end
+
+  local match_length
+  local smallest_range
+
+  for _, m in pairs(matches) do
+    if ts_utils.is_in_node_range(m, row, col) then
+      local length = ts_utils.node_length(m)
+      if not match_length or length < match_length then
+        smallest_range = m
+        match_length = length
+      end
+    end
+  end
+
+  if smallest_range then
+    ts_utils.update_selection(bufnr, smallest_range)
+  end
+end
+
+function M.attach(bufnr, lang)
+  local buf = bufnr or api.nvim_get_current_buf()
+  local config = configs.get_module("textobjects")
+  local lang = lang or parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, "ft"))
+
+  for mapping, query in pairs(config.keymaps) do
+    if type(query) == 'table' then
+      query = query[lang]
+    elseif not queries.get_query(lang, 'textobjects') then
+      query = nil
+    end
+    if query then
+      local cmd = ":lua require'nvim-treesitter.textobjects'.select_textobject('"..query.."')<CR>"
+      api.nvim_buf_set_keymap(buf, "o", mapping, cmd, {silent = true})
+      api.nvim_buf_set_keymap(buf, "v", mapping, cmd, {silent = true})
+    end
+  end
+end
+
+function M.detach(bufnr)
+  local buf = bufnr or api.nvim_get_current_buf()
+  local config = configs.get_module("textobjects")
+  local lang = parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, "ft"))
+
+  for mapping, query in pairs(config.keymaps) do
+    if type(query) == 'table' then
+      query = query[lang]
+    elseif not queries.get_query(lang, 'textobjects') then
+      query = nil
+    end
+    if query then
+      api.nvim_buf_del_keymap(buf, "o", mapping)
+      api.nvim_buf_del_keymap(buf, "v", mapping)
+    end
+  end
+end
+
+return M

--- a/lua/nvim-treesitter/textobjects.lua
+++ b/lua/nvim-treesitter/textobjects.lua
@@ -27,7 +27,6 @@ function M.select_textobject(query_string)
     local root = parser:parse():root()
     local start_row, _, end_row, _ = root:range()
 
-    local nested = {}
     local query = ts.parse_query(lang, query_string)
     for m in queries.iter_prepared_matches(query, root, bufnr, start_row, end_row) do
       for _, n in pairs(m) do

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -46,7 +46,7 @@ end
 
 -- Gets a property at path
 -- @param tbl the table to access
--- @param path the '.' seperated path
+-- @param path the '.' separated path
 -- @returns the value at path or nil
 function M.get_at_path(tbl, path)
   local segments = vim.split(path, '.', true)

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -1,0 +1,8 @@
+;; TODO: supported by official Tree-sitter  if (_)* is more than one node
+;; Neovim: will only match if (_) is exactly one node
+;(function_definition
+  ;body:  (compound_statement
+                          ;("{" (_)* @function.inner "}"))?) @function.outer
+
+(function_definition
+  body:  (compound_statement) @function.inner) @function.outer

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -6,3 +6,50 @@
 
 (function_definition
   body:  (compound_statement) @function.inner) @function.outer
+
+(struct_specifier
+  body: (_) @class.inner) @class.outer
+
+; conditional
+(if_statement
+  consequence: (_)? @conditional.inner
+  alternative: (_)? @conditional.inner
+  ) @conditional.outer
+
+(if_statement
+  condition: (_) @conditional.inner)
+
+; loops
+(for_statement 
+  (_)? @loop.inner) @loop.outer
+(while_statement
+  (_)? @loop.inner) @loop.outer
+(do_statement
+  (_)? @loop.inner) @loop.outer
+
+
+(compound_statement) @block.outer
+(comment) @comment.outer
+
+(call_expression) @call.outer
+(call_expression (_) @call.inner)
+
+; Statements
+
+;(expression_statement ;; this is what we actually want to capture in most cases (";" is missing) probaly 
+  ;(_) @statement.inner) ;; the otther statement like node type is declaration but declaration has a ";"
+
+(compound_statement
+  (_) @statement.outer)
+
+(field_declaration_list
+  (_) @statement.outer)
+
+(preproc_if
+  (_) @statement.outer)
+
+(preproc_elif
+  (_) @statement.outer)
+
+(preproc_else
+  (_) @statement.outer)

--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -1,0 +1,6 @@
+
+(class_specifier
+  body: (_) @class.inner) @class.outer
+
+(for_range_loop 
+  (_)? @loop.inner) @loop.outer

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -1,3 +1,27 @@
 
 (function_definition
   body: (block)? @function.inner) @function.outer
+
+(class_definition
+  body: (block)? @class.inner) @class.outer
+
+(while_statement
+  body: (block)? @loop.inner) @loop.outer
+
+(for_statement
+  body: (block)? @loop.inner) @loop.outer
+
+(if_statement
+  consequence: (block)? @conditional.inner
+  alternative: (_ (block) @conditional.inner)?) @conditional.outer
+
+(if_statement
+  condition: (_) @conditional.inner)
+
+(_ (block) @block.inner) @block.outer
+(comment) @comment.outer
+
+(block (_) @statement.outer)
+
+(call) @call.outer
+(call (_) @call.inner)

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -1,0 +1,3 @@
+
+(function_definition
+  body: (block)? @function.inner) @function.outer

--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -2,7 +2,7 @@
 local function do_check()
   local parsers = require 'nvim-treesitter.parsers'.available_parsers()
   local queries = require 'nvim-treesitter.query'
-  local query_types = {'highlights', 'locals'}
+  local query_types = {'highlights', 'locals', 'textobjects'}
 
   for _, lang in pairs(parsers) do
     for _, query_type in pairs(query_types) do


### PR DESCRIPTION
I thought it would be cool if users could define their own text object by queries.

Everything in this PR is not implemented the proper way. The module is just activated for easier review and faster testing.

With the given hard-coded config you can delete a function text object in Python/C++. Maybe the queries should also come from `locals.scm` but this is a more direct way for a user to achieve that for a specific query.

PS: Why was the operator pending mapping removed from `incremental_selection`?