### PR TITLE
Fix highlighting of symbols used in pairs

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -131,6 +131,7 @@
  (symbol)
  ] @constant
 
+(pair key: (symbol) ":" @constant)
 (regex) @string.regex
 (escape_sequence) @string.escape
 (integer) @number


### PR DESCRIPTION
Fixes the highlighting of symbols when used in pairs with the short hand `symbol: true`

