### PR TITLE
C highlights: Make ? an operator in c highlights

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -48,6 +48,7 @@
 ">=" @operator
 "!" @operator
 "||" @operator
+"?" @operator
 
 "-=" @operator
 "+=" @operator

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -48,7 +48,7 @@
 ">=" @operator
 "!" @operator
 "||" @operator
-"?" @operator
+(conditional_expression [ "?" ":" ] @conditional)
 
 "-=" @operator
 "+=" @operator
@@ -110,4 +110,3 @@
   (identifier)) @parameter
 
 (ERROR) @error
-


### PR DESCRIPTION
Question: Should ":" also be highlighted as an operator if used in the context of "?"? For me, `@delimiter` is also ok.