### PR TITLE
add used_by key to parsers

### DIFF
--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -17,9 +17,10 @@ function M.setup()
   for _, lang in pairs(parsers.available_parsers()) do
     for _, mod in pairs(configs.available_modules()) do
       if configs.is_enabled(mod, lang) then
-        local ft = parsers.lang_to_ft(lang)
         local cmd = string.format("lua require'nvim-treesitter.%s'.attach()", mod)
-        api.nvim_command(string.format("autocmd NvimTreesitter FileType %s %s", ft, cmd))
+        for _, ft in pairs(parsers.lang_to_ft(lang)) do
+          api.nvim_command(string.format("autocmd NvimTreesitter FileType %s %s", ft, cmd))
+        end
       end
     end
   end


### PR DESCRIPTION
Enables the use of multiple filetypes for one parser.
You can now say that `zsh` uses the parser for `bash`, or any other ones.
This way you can setup parsers like
```lua
local parserlist = require'nvim-treesitter.parsers'.list
parserlist.some_parser.used_by = {'some_filetype', 'some_other_filetype'}
```
this doesn't fix any issue that i'm aware of, there is still work to do around the language integrations.
this could also be used as a temporary fix to #94 by disabling the typescript parser and use only the tsx one by commenting the typescript parser and adding the `used_by` key in the tsx config with `{ 'typescript' }` in it.