### PR TITLE
feat(configs): dynamic module defintions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ git clone https://github.com/nvim-treesitter/nvim-treesitter.git
 
 ## Adding parsers
 
-Treesitter is using a different _parser_ for every language. It can be quite a pain to install, but fortunately `nvim-treesitter` 
+Treesitter is using a different _parser_ for every language. It can be quite a pain to install, but fortunately `nvim-treesitter`
 provides two command to tackle this issue:
   - `TSInstall` to install one or more parser. You can use `TSInstall all` to download all parsers.
   - `TSInstallInfo` to know which parser is installed.
@@ -158,6 +158,41 @@ The roadmap and all features of this plugin are open to change, and any suggesti
 - `refactor.navigation`: Syntax based definition listing and navigation.
   * List all definitions
   * Go to definition
+
+## Defining Modules
+
+Users and plugin authors can take advantage of modules by creating their own. Modules provide:
+
+- Treesitter language detection support
+- Attach and detach to buffers
+- Works with all nvim-treesitter commands
+
+You can use the `define_modules` function to define one or more modules or module groups.
+
+```lua
+require 'nvim-treesitter'.define_modules {
+  my_cool_plugin = {
+    attach = function(bufnr, lang)
+      -- Do cool stuff here
+    end,
+    detach = function(bufnr)
+      -- Undo cool stuff here
+    end,
+    is_supported = function(lang)
+      -- Check if the language is supported
+    end
+  }
+}
+```
+
+Modules can consist of the following properties:
+
+- `module_path`: A require path (string) that exports a module with an `attach` and `detach` function. This is not required if the functions are on this definition.
+- `enable`: Determines if the module is enabled by default. This is usually overridden by the user.
+- `disable`: A list of languages that this module is disabled for. This is usually overridden by the user.
+- `is_supported`: A function that takes a language and determines if this module supports that language.
+- `attach`: A function that attachs to a buffer. This is required if `module_path` is not provided.
+- `detach`: A function that detaches from a buffer. This is required if `module_path` is not provided.
 
 ## Utils
 

--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -1,5 +1,3 @@
-local api = vim.api
-
 local install = require'nvim-treesitter.install'
 local utils = require'nvim-treesitter.utils'
 local ts_utils = require'nvim-treesitter.ts_utils'
@@ -13,17 +11,11 @@ function M.setup()
   utils.setup_commands('install', install.commands)
   utils.setup_commands('info', info.commands)
   utils.setup_commands('configs', configs.commands)
+  configs.init()
+end
 
-  for _, lang in pairs(parsers.available_parsers()) do
-    for _, mod in pairs(configs.available_modules()) do
-      if configs.is_enabled(mod, lang) then
-        local cmd = string.format("lua require'nvim-treesitter.%s'.attach()", mod)
-        for _, ft in pairs(parsers.lang_to_ft(lang)) do
-          api.nvim_command(string.format("autocmd NvimTreesitter FileType %s %s", ft, cmd))
-        end
-      end
-    end
-  end
+function M.define_modules(...)
+  configs.define_modules(...)
 end
 
 function M.statusline(indicator_size)


### PR DESCRIPTION
This reworks the module system to allow module definitions to be rendered dynamically.

## Why?
The module system takes care of a lot of boilerplate (language detection, enable/disable, query detection, buffer attachment, etc...) that could be leveraged if made public. These are the benefits this feature provides:

* Another way to consume this plugin. Plugin authors can just use the utils or right a module to take advantage of the interface this plugin provides.
* Module definitions no longer depend on the ordering of files that are loaded. We can load modules after the plugin is initialized and before or after the user has configured it (setup call). For example, if a plugin creates a module, that plugin could be loaded dynamically (vim-plug or others) without any issues and still get registered correctly.
* Simpler modules for plugins/users to write. No query file detection or language support logic has to be implemented by the plugin author or user.
* Builtin modules no longer have a reliance on directory structure of the project.
* User modules use the exact same api as the internal built in modules.

Here is an example of how a module can be registered.

```lua
require "nvim-treesitter".define_modules {
  some_cool_plugin = {
    feature_one = {
      module_path = "some_cool_plugin.feature_one"
    }
  }
}
```

These modules are just like any other module, so these commands work `:TSModuleInfo some_cool_plugin.feature_one`

Optionally, modules can provide `attach` and `detach` directly.

```lua
require "nvim-treesitter".define_modules {
  some_cool_plugin = {
    feature_one = {
      attach = function(bufnr, lang) end,
      detach = function(bufnr, lang) end
    }
  }
}
```

- [x] Docs