### PR TITLE
C/C++ highlights: update to new syntax

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -1,24 +1,34 @@
-"break" @keyword
-"case" @conditional
-"const" @keyword
-"continue" @repeat
-"default" @keyword
-"do" @repeat
-"else" @conditional
-"enum" @keyword
-"extern" @keyword
-"for" @repeat
-"if" @conditional
-"inline" @keyword
-"return" @keyword
-"sizeof" @keyword
-"static" @keyword
-"struct" @keyword
-"switch" @keyword
-"typedef" @keyword
-"union" @keyword
-"volatile" @keyword
-"while" @repeat
+[ 
+  "const"
+  "default"
+  "enum"
+  "extern"
+  "inline"
+  "return"
+  "sizeof"
+  "static"
+  "struct"
+  "typedef"
+  "union"
+  "volatile"
+] @keyword
+
+[ 
+  "while"
+  "for"
+  "do"
+  "continue"
+  "break"
+] @repeat
+
+[
+ "if"
+ "else"
+ "case"
+ "switch" 
+] @conditional
+
+(conditional_expression [ "?" ":" ] @conditional)
 
 "#define" @constant.macro
 [
@@ -32,45 +42,38 @@
   (preproc_directive)
 ] @keyword
 
-"--" @operator
-"-" @operator
-"->" @operator
-"!=" @operator
-"*" @operator
-"/" @operator
-"&" @operator
-"&&" @operator
-"+" @operator
-"++" @operator
-"<" @operator
-"<=" @operator
-"==" @operator
-"=" @operator
-"~" @operator
-">" @operator
-">=" @operator
-"!" @operator
-"||" @operator
-(conditional_expression [ "?" ":" ] @conditional)
+[
+  "--"
+  "-"
+  "->"
+  "!="
+  "*"
+  "/"
+  "&"
+  "&&"
+  "+"
+  "++"
+  "<"
+  "<="
+  "=="
+  "="
+  "~"
+  ">"
+  ">="
+  "!"
+  "||"
 
-"-=" @operator
-"+=" @operator
-"*=" @operator
-"/=" @operator
-"|=" @operator
-"&=" @operator
+  "-="
+  "+="
+  "*="
+  "/="
+  "|="
+  "&="
+] @operator
 
-"." @punctuation.delimiter
-";" @punctuation.delimiter
-":" @punctuation.delimiter
-"," @punctuation.delimiter
+[ "." ";" ":" "," ] @punctuation.delimiter
 
-"(" @punctuation.bracket
-")" @punctuation.bracket
-"[" @punctuation.bracket
-"]" @punctuation.bracket
-"{" @punctuation.bracket
-"}" @punctuation.bracket
+[ "(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 (string_literal) @string
 (system_lib_string) @string

--- a/queries/c/locals.scm
+++ b/queries/c/locals.scm
@@ -31,9 +31,11 @@
 (identifier) @reference
 
 ;; Scope
-(for_statement) @scope
-(if_statement) @scope
-(while_statement) @scope
-(translation_unit) @scope
-(function_definition) @scope
-(compound_statement) @scope ; a block in curly braces
+[
+ (for_statement)
+ (if_statement)
+ (while_statement)
+ (translation_unit)
+ (function_definition)
+ (compound_statement) ; a block in curly braces
+] @scope

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -60,7 +60,6 @@
   (argument_list))
  (#match? @constructor "^[A-Z]"))
 
-(auto) @keyword
 
 ; Constants
 
@@ -72,25 +71,33 @@
 
 ; Keywords
 
-"catch" @exception
-"class" @keyword
-"constexpr" @keyword
-"delete" @keyword
-"explicit" @keyword
-"final" @exception
-"friend" @keyword
-"mutable" @keyword
-"namespace" @keyword
-"noexcept" @keyword
-"new" @keyword
-"override" @keyword
-"private" @keyword
-"protected" @keyword
-"public" @keyword
-"template" @keyword
-"throw" @keyword
-"try" @exception
-"typename" @keyword
-"using" @keyword
-"virtual" @keyword
+[
+ "try"
+ "catch"
+ "noexcept"
+ "throw"
+] @exception
+ 
+
+[
+ "class"
+ "constexpr"
+ "delete"
+ "explicit"
+ "final"
+ "friend"
+ "mutable"
+ "namespace"
+ "new"
+ "override"
+ "private"
+ "protected"
+ "public"
+ "template"
+ "typename"
+ "using"
+ "virtual"
+ (auto)
+] @keyword
+
 "::" @operator

--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -9,14 +9,14 @@
 
 (struct_specifier
   name: (scoped_type_identifier
-          name: (type_identifier) @definition.type) ) 
+          name: (type_identifier) @definition.type))
 
 (class_specifier
   name: (type_identifier) @definition.type) 
 
 (class_specifier
   name: (scoped_type_identifier
-          name: (type_identifier) @definition.type) ) 
+          name: (type_identifier) @definition.type))
 
 ;; Function defintions
 (template_function


### PR DESCRIPTION
This changed the highlight of "switch" to conditional and of "break" to repeat.