### PR TITLE
Use <details> for checkhealth output in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,10 +20,15 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Output of `:checkhealth nvim_treesitter` ***
-```
+**Output of `:checkhealth nvim_treesitter`**
+
+<details>
+<code>
+
 Paste the output here
-```
+
+</code>
+</details>
 
 **Output of `nvim --version`**
 ```


### PR DESCRIPTION
The output of checkhealth can be quite lengthy.

Preview: https://github.com/theHamsta/nvim-treesitter/blob/details-bug-report/.github/ISSUE_TEMPLATE/bug_report.md