### PR TITLE
Introduce @definition.import for Python/Javascript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,8 @@ are optional and will not have any effect for now.
   macro
   type
   field
-  doc for documentation adjecent to a definition. E.g.
+  import for imported names
+  doc for documentation adjacent to a definition. E.g.
 ```
 
 ```scheme

--- a/queries/javascript/locals.scm
+++ b/queries/javascript/locals.scm
@@ -29,7 +29,7 @@
   name: (identifier) @definition)
 
 (import_specifier
-  (identifier) @definition)
+  (identifier) @definition.import)
 
 ; References
 ;------------

--- a/queries/python/locals.scm
+++ b/queries/python/locals.scm
@@ -8,6 +8,14 @@
               left: (expression_list
                       (identifier) @definition.associated))))) @scope
 
+; Imports
+(aliased_import
+	alias: (identifier) @definition.import)
+(import_statement
+	name: (dotted_name ((identifier) @definition.import)))
+(import_from_statement
+	name: (dotted_name ((identifier) @definition.import)))
+
 ; Function with parameters, defines parameters
 (function_definition
   name: (identifier)


### PR DESCRIPTION
We could introduce a new kind of definition: `import`
Alternatively, I could also declare Pythons imports as `@definition.var`

Problem: `import skimage.io` defines `skimage` and `io` where it should only define `skimage.io`. 

Edit: maybe this can be solved by a new query for reference.