### PR TITLE
Python locals: typed_parameter -> @definition.var

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -49,6 +49,8 @@
   name: (identifier) @function)
 
 (type (identifier) @type)
+(subscript
+  (identifier) @type) ; type subscript: Tuple[int]
 
 ((call
   function: (identifier) @isinstance

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -66,6 +66,10 @@
 ; Naming parameters on call-site
 (default_parameter
   name: (identifier) @parameter)
+(typed_parameter
+  (identifier) @parameter)
+(typed_default_parameter
+  (identifier) @parameter)
 ; Variadic parameters *args, **kwargs
 (parameters
   (list_splat ; *args

--- a/queries/python/locals.scm
+++ b/queries/python/locals.scm
@@ -9,24 +9,27 @@
                       (identifier) @definition.associated))))) @scope
 
 ; Function with parameters, defines parameters
-(function_definition
-  name: (identifier)
-  parameters: (parameters
-                (identifier) @definition.var))
+(parameters
+  (identifier) @definition.var)
+
+(default_parameter
+  (identifier) @definition.var)
+
+(typed_parameter
+  (identifier) @definition.var)
+
+(typed_default_parameter
+  (identifier) @definition.var)
 
 ; *args parameter
-(function_definition
-  name: (identifier)
-  parameters: (parameters
-                (list_splat
-                  (identifier) @definition.var)))
+(parameters
+  (list_splat
+    (identifier) @definition.var))
 
 ; **kwargs parameter
-(function_definition
-  name: (identifier)
-  parameters: (parameters
-                (dictionary_splat
-                  (identifier) @definition.var)))
+(parameters
+  (dictionary_splat
+    (identifier) @definition.var))
 
 ; Function defines function and scope
 (function_definition


### PR DESCRIPTION
Parameters can be optionally typed in Python

![image](https://user-images.githubusercontent.com/7189118/86938815-2241e400-c141-11ea-8f13-f60e82c7380e.png)
