### PR TITLE
Python highlights: Surround type subscript query with (type ...)

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -49,8 +49,9 @@
   name: (identifier) @function)
 
 (type (identifier) @type)
-(subscript
-  (identifier) @type) ; type subscript: Tuple[int]
+(type
+  (subscript
+    (identifier) @type)) ; type subscript: Tuple[int]
 
 ((call
   function: (identifier) @isinstance


### PR DESCRIPTION
Sorry.