### PR TITLE
Post user textobject refactor

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -104,7 +104,7 @@ end
 
 local function enable_module(mod, bufnr, lang)
   local bufnr = bufnr or api.nvim_get_current_buf()
-  local lang = lang or parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, 'ft'))
+  local lang = lang or parsers.get_buf_lang(bufnr)
 
   if not parsers.list[lang] then
     return
@@ -157,7 +157,7 @@ end
 
 local function disable_module(mod, bufnr, lang)
   local bufnr = bufnr or api.nvim_get_current_buf()
-  local lang = lang or parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, 'ft'))
+  local lang = lang or parsers.get_buf_lang(bufnr)
   if not lang then
     return
   end

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -54,7 +54,7 @@ hlmap["include"] = "TSInclude"
 
 function M.attach(bufnr, lang)
   local bufnr = bufnr or api.nvim_get_current_buf()
-  local lang = parsers.get_buf_lang(bufnr, lang)
+  local lang = lang or parsers.get_buf_lang(bufnr)
   local config = configs.get_module('highlight')
 
   for k, v in pairs(config.custom_captures) do

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -54,7 +54,7 @@ hlmap["include"] = "TSInclude"
 
 function M.attach(bufnr, lang)
   local bufnr = bufnr or api.nvim_get_current_buf()
-  local lang = lang or parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, 'ft'))
+  local lang = parsers.get_buf_lang(bufnr, lang)
   local config = configs.get_module('highlight')
 
   for k, v in pairs(config.custom_captures) do

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -2,6 +2,7 @@ local api = vim.api
 
 local configs = require'nvim-treesitter.configs'
 local ts_utils = require'nvim-treesitter.ts_utils'
+local locals = require'nvim-treesitter.locals'
 local parsers = require'nvim-treesitter.parsers'
 
 local M = {}
@@ -74,7 +75,7 @@ M.node_incremental = select_incremental(function(node)
 end)
 
 M.scope_incremental = select_incremental(function(node)
-  return ts_utils.containing_scope(node:parent() or node)
+  return locals.containing_scope(node:parent() or node)
 end)
 
 function M.node_decremental()

--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -1,73 +1,27 @@
 -- Functions to handle locals
 -- Locals are a generalization of definition and scopes
 -- its the way nvim-treesitter uses to "understand" the code
-local api = vim.api
 
 local queries = require'nvim-treesitter.query'
 local parsers = require'nvim-treesitter.parsers'
-local utils = require'nvim-treesitter.utils'
-
-local default_dict = {
-  __index = function(table, key)
-    local exists = rawget(table, key)
-    if not exists then
-      table[key] = {}
-    end
-    return rawget(table, key)
-  end
-}
-
-local query_cache = {}
-setmetatable(query_cache, default_dict)
+local ts_utils = require'nvim-treesitter.ts_utils'
+local api = vim.api
 
 local M = {}
 
-function M.collect_locals(bufnr, query_kind)
-  local locals = {}
-
-  for prepared_match in M.iter_locals(bufnr, nil, query_kind) do
-    table.insert(locals, prepared_match)
-  end
-
-  return locals
-end
-
-local function update_cached_locals(bufnr, changed_tick, query_kind)
-  query_cache[query_kind][bufnr] = {tick=changed_tick, cache=( M.collect_locals(bufnr, query_kind) or {} )}
+function M.collect_locals(bufnr)
+  return queries.collect_group_results(bufnr, 'locals')
 end
 
 -- Iterates matches from a locals query file.
 -- @param bufnr the buffer
 -- @param root the root node
--- @param query_kind the query file to use
-function M.iter_locals(bufnr, root, query_kind)
-  query_kind = query_kind or 'locals'
-
-  local lang = parsers.get_buf_lang(bufnr)
-  if not lang then return end
-
-  local query = queries.get_query(lang, query_kind)
-  if not query then return end
-
-  local parser = parsers.get_parser(bufnr, lang)
-  if not parser then return end
-
-  local root = root or parser:parse():root()
-  local start_row, _, end_row, _ = root:range()
-
-  return queries.iter_prepared_matches(query, root, bufnr, start_row, end_row)
+function M.iter_locals(bufnr, root)
+  return queries.iter_group_results(bufnr, 'locals', root)
 end
 
-function M.get_locals(bufnr, query_kind)
-  query_kind = query_kind or 'locals'
-
-  local bufnr = bufnr or api.nvim_get_current_buf()
-  local cached_local = query_cache[query_kind][bufnr]
-  if not cached_local or api.nvim_buf_get_changedtick(bufnr) > cached_local.tick then
-    update_cached_locals(bufnr,api.nvim_buf_get_changedtick(bufnr), query_kind)
-  end
-
-  return query_cache[query_kind][bufnr].cache
+function M.get_locals(bufnr)
+  return queries.get_matches(bufnr, 'locals')
 end
 
 function M.get_definitions(bufnr)
@@ -112,27 +66,179 @@ function M.get_references(bufnr)
   return refs
 end
 
---- Return all nodes in locals corresponding to a specific capture (like @scope, @reference)
--- Works like M.get_references or M.get_scopes except you can choose the capture
--- Can also be a nested capture like @definition.function to get all nodes defining a function
-function M.get_capture_matches(bufnr, capture_string, query_kind)
-    if not string.sub(capture_string, 1,2) == '@' then
-      print('capture_string must start with "@"')
-      return
-    end
+-- Finds the definition node and it's scope node of a node
+-- @param node starting node
+-- @param bufnr buffer
+-- @returns the definition node and the definition nodes scope node
+function M.find_definition(node, bufnr)
+  local bufnr = bufnr or api.nvim_get_current_buf()
+  local node_text = ts_utils.get_node_text(node)[1]
+  local current_scope = M.containing_scope(node)
+  local matching_def_nodes = {}
 
-    --remove leading "@"
-    capture_string = string.sub(capture_string, 2)
+  -- If a scope wasn't found then use the root node
+  if current_scope == node then
+    current_scope = parsers.get_parser(bufnr).tree:root()
+  end
 
-    local matches = {}
-    for _, match in pairs(M.get_locals(bufnr, query_kind)) do
-      local insert = utils.get_at_path(match, capture_string)
-
-      if insert then
-        table.insert(matches, insert)
+  -- Get all definitions that match the node text
+  for _, def in ipairs(M.get_definitions(bufnr)) do
+    for _, def_node in ipairs(M.get_local_nodes(def)) do
+      if ts_utils.get_node_text(def_node)[1] == node_text then
+        table.insert(matching_def_nodes, def_node)
       end
     end
-    return matches
+  end
+
+  -- Continue up each scope until we find the scope that contains the definition
+  while current_scope do
+    for _, def_node in ipairs(matching_def_nodes) do
+      if ts_utils.is_parent(current_scope, def_node) then
+        return def_node, current_scope
+      end
+    end
+    current_scope = M.containing_scope(current_scope:parent())
+  end
+
+  return node, parsers.get_parser(bufnr).tree:root()
+end
+
+-- Gets all nodes from a local list result.
+-- @param local_def the local list result
+-- @returns a list of nodes
+function M.get_local_nodes(local_def)
+  local result = {}
+
+  M.recurse_local_nodes(local_def, function(_, node)
+    table.insert(result, node)
+  end)
+
+  return result
+end
+
+-- Recurse locals results until a node is found.
+-- The accumulator function is given
+-- * The table of the node
+-- * The node
+-- * The full definition match `@definition.var.something` -> 'var.something'
+-- * The last definition match `@definition.var.something` -> 'something'
+-- @param The locals result
+-- @param The accumulator function
+-- @param The full match path to append to
+-- @param The last match
+function M.recurse_local_nodes(local_def, accumulator, full_match, last_match)
+  if local_def.node then
+    accumulator(local_def, local_def.node, full_match, last_match)
+  else
+    for match_key, def in pairs(local_def) do
+      M.recurse_local_nodes(
+        def,
+        accumulator,
+        full_match and (full_match..'.'..match_key) or match_key,
+        match_key)
+    end
+  end
+end
+
+-- Finds usages of a node in a given scope
+-- @param node the node to find usages for
+-- @param scope_node the node to look within
+-- @returns a list of nodes
+function M.find_usages(node, scope_node, bufnr)
+  local bufnr = bufnr or api.nvim_get_current_buf()
+  local node_text = ts_utils.get_node_text(node)[1]
+
+  if not node_text or #node_text < 1 then return {} end
+
+  local scope_node = scope_node or parsers.get_parser(bufnr).tree:root()
+  local usages = {}
+
+  for match in M.iter_locals(bufnr, scope_node) do
+    if match.reference
+      and match.reference.node
+      and ts_utils.get_node_text(match.reference.node)[1] == node_text
+    then
+      table.insert(usages, match.reference.node)
+    end
+  end
+
+  return usages
+end
+
+function M.containing_scope(node, bufnr)
+  local bufnr = bufnr or api.nvim_get_current_buf()
+
+  local scopes = M.get_scopes(bufnr)
+  if not node or not scopes then return end
+
+  local iter_node = node
+
+  while iter_node ~= nil and not vim.tbl_contains(scopes, iter_node) do
+    iter_node = iter_node:parent()
+  end
+
+  return iter_node or node
+end
+
+function M.nested_scope(node, cursor_pos)
+  local bufnr = api.nvim_get_current_buf()
+
+  local scopes = M.get_scopes(bufnr)
+  if not node or not scopes then return end
+
+  local row = cursor_pos.row
+  local col = cursor_pos.col
+  local scope = M.containing_scope(node)
+
+  for _, child in ipairs(ts_utils.get_named_children(scope)) do
+    local row_, col_ = child:start()
+    if vim.tbl_contains(scopes, child) and ((row_+1 == row and col_ > col) or row_+1 > row) then
+      return child
+    end
+  end
+end
+
+function M.next_scope(node)
+  local bufnr = api.nvim_get_current_buf()
+
+  local scopes = M.get_scopes(bufnr)
+  if not node or not scopes then return end
+
+  local scope = M.containing_scope(node)
+
+  local parent = scope:parent()
+  if not parent then return end
+
+  local is_prev = true
+  for _, child in ipairs(ts_utils.get_named_children(parent)) do
+    if child == scope then
+      is_prev = false
+    elseif not is_prev and vim.tbl_contains(scopes, child) then
+      return child
+    end
+  end
+end
+
+function M.previous_scope(node)
+  local bufnr = api.nvim_get_current_buf()
+
+  local scopes = M.get_scopes(bufnr)
+  if not node or not scopes then return end
+
+  local scope = M.containing_scope(node)
+
+  local parent = scope:parent()
+  if not parent then return end
+
+  local is_prev = true
+  local children = ts_utils.get_named_children(parent)
+  for i=#children,1,-1 do
+    if children[i] == scope then
+      is_prev = false
+    elseif not is_prev and vim.tbl_contains(scopes, children[i]) then
+      return children[i]
+    end
+  end
 end
 
 return M

--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -43,7 +43,7 @@ end
 function M.iter_locals(bufnr, root, query_kind)
   query_kind = query_kind or 'locals'
 
-  local lang = parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, "ft"))
+  local lang = parsers.get_buf_lang(bufnr)
   if not lang then return end
 
   local query = queries.get_query(lang, query_kind)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -256,14 +256,14 @@ end
 
 function M.has_parser(lang)
   local buf = api.nvim_get_current_buf()
-  local lang = lang or M.ft_to_lang(api.nvim_buf_get_option(buf, 'ft'))
+  local lang = M.get_buf_lang(buf) or lang
   if not lang or #lang == 0 then return false end
   return #api.nvim_get_runtime_file('parser/' .. lang .. '.*', false) > 0
 end
 
 function M.get_parser(bufnr, lang)
   local buf = bufnr or api.nvim_get_current_buf()
-  local lang = lang or M.ft_to_lang(api.nvim_buf_get_option(buf, 'ft'))
+  local lang = lang or M.get_buf_lang(buf)
 
   if M.has_parser(lang) then
     if not M[buf] then
@@ -274,6 +274,14 @@ function M.get_parser(bufnr, lang)
     end
     return M[buf][lang]
   end
+end
+
+-- get language of given buffer
+-- @param optional buffer number or current buffer
+-- @returns language string of buffer
+function M.get_buf_lang(bufnr)
+  bufnr = bufnr or api.nvim_get_current_buf()
+  return M.ft_to_lang(api.nvim_buf_get_option(bufnr, "ft"))
 end
 
 return M

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -256,7 +256,7 @@ end
 
 function M.has_parser(lang)
   local buf = api.nvim_get_current_buf()
-  local lang = M.get_buf_lang(buf) or lang
+  local lang = lang or M.get_buf_lang(buf)
   if not lang or #lang == 0 then return false end
   return #api.nvim_get_runtime_file('parser/' .. lang .. '.*', false) > 0
 end

--- a/lua/nvim-treesitter/refactor/highlight_current_scope.lua
+++ b/lua/nvim-treesitter/refactor/highlight_current_scope.lua
@@ -1,6 +1,7 @@
 -- This module highlights the current scope of at the cursor position
 
 local ts_utils = require'nvim-treesitter.ts_utils'
+local locals = require'nvim-treesitter.locals'
 local api = vim.api
 local cmd = api.nvim_command
 
@@ -12,7 +13,7 @@ function M.highlight_current_scope(bufnr)
   M.clear_highlights(bufnr)
 
   local node_at_point = ts_utils.get_node_at_cursor()
-  local current_scope = ts_utils.containing_scope(node_at_point, bufnr)
+  local current_scope = locals.containing_scope(node_at_point, bufnr)
 
   local start_line = current_scope:start()
 

--- a/lua/nvim-treesitter/refactor/highlight_definitions.lua
+++ b/lua/nvim-treesitter/refactor/highlight_definitions.lua
@@ -20,8 +20,8 @@ function M.highlight_usages(bufnr)
     return
   end
 
-  local def_node, scope = ts_utils.find_definition(node_at_point, bufnr)
-  local usages = ts_utils.find_usages(node_at_point, scope)
+  local def_node, scope = locals.find_definition(node_at_point, bufnr)
+  local usages = locals.find_usages(node_at_point, scope)
 
   for _, usage_node in ipairs(usages) do
     if usage_node ~= node_at_point then

--- a/lua/nvim-treesitter/refactor/navigation.lua
+++ b/lua/nvim-treesitter/refactor/navigation.lua
@@ -16,7 +16,7 @@ function M.goto_definition(bufnr)
 
   if not node_at_point then return end
 
-  local definition, _ = ts_utils.find_definition(node_at_point, bufnr)
+  local definition, _ = locals.find_definition(node_at_point, bufnr)
   local start_row, start_col, _ = definition:start()
 
   api.nvim_win_set_cursor(0, { start_row + 1, start_col })
@@ -31,7 +31,7 @@ function M.list_definitions(bufnr)
   local qf_list = {}
 
   for _, def in ipairs(definitions) do
-    ts_utils.recurse_local_nodes(def, function(_, node, _, match)
+    locals.recurse_local_nodes(def, function(_, node, _, match)
       local lnum, col, _ = node:start()
 
       table.insert(qf_list, {

--- a/lua/nvim-treesitter/refactor/smart_rename.lua
+++ b/lua/nvim-treesitter/refactor/smart_rename.lua
@@ -2,6 +2,7 @@
 -- Can be used directly using the `smart_rename` function.
 
 local ts_utils = require'nvim-treesitter.ts_utils'
+local locals = require'nvim-treesitter.locals'
 local configs = require'nvim-treesitter.configs'
 local utils = require'nvim-treesitter.utils'
 local api = vim.api
@@ -23,8 +24,8 @@ function M.smart_rename(bufnr)
   -- Empty name cancels the interaction or ESC
   if not new_name or #new_name < 1 then return end
 
-  local definition, scope = ts_utils.find_definition(node_at_point, bufnr)
-  local nodes_to_rename = ts_utils.find_usages(node_at_point, scope)
+  local definition, scope = locals.find_definition(node_at_point, bufnr)
+  local nodes_to_rename = locals.find_usages(node_at_point, scope)
 
   if not vim.tbl_contains(nodes_to_rename, node_at_point) then
     table.insert(nodes_to_rename, node_at_point)

--- a/lua/nvim-treesitter/textobjects.lua
+++ b/lua/nvim-treesitter/textobjects.lua
@@ -11,9 +11,8 @@ local M = {}
 
 function M.select_textobject(query_string)
   local bufnr = vim.api.nvim_get_current_buf()
-  local ft = api.nvim_buf_get_option(bufnr, "ft")
-  if not ft then return end
-  local lang = parsers.ft_to_lang(ft)
+  local lang = parsers.get_buf_lang(bufnr)
+  if not lang then return end
 
   local row, col = unpack(vim.api.nvim_win_get_cursor(0))
   row = row - 1
@@ -77,7 +76,7 @@ end
 function M.attach(bufnr, lang)
   local buf = bufnr or api.nvim_get_current_buf()
   local config = configs.get_module("textobjects")
-  local lang = lang or parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, "ft"))
+  local lang = lang or parsers.get_buf_lang(buf)
 
   for mapping, query in pairs(config.keymaps) do
     if type(query) == 'table' then
@@ -96,7 +95,7 @@ end
 function M.detach(bufnr)
   local buf = bufnr or api.nvim_get_current_buf()
   local config = configs.get_module("textobjects")
-  local lang = parsers.ft_to_lang(api.nvim_buf_get_option(bufnr, "ft"))
+  local lang = parsers.get_buf_lang(bufnr)
 
   for mapping, query in pairs(config.keymaps) do
     if type(query) == 'table' then

--- a/lua/nvim-treesitter/textobjects.lua
+++ b/lua/nvim-treesitter/textobjects.lua
@@ -4,7 +4,6 @@ local ts = vim.treesitter
 local configs = require "nvim-treesitter.configs"
 local parsers = require "nvim-treesitter.parsers"
 local queries = require'nvim-treesitter.query'
-local locals = require'nvim-treesitter.locals'
 local ts_utils = require'nvim-treesitter.ts_utils'
 
 local M = {}
@@ -20,10 +19,11 @@ function M.select_textobject(query_string)
   local matches = {}
 
   if string.match(query_string, '^@.*') then
-    matches = locals.get_capture_matches(bufnr, query_string, 'textobjects')
+    matches = queries.get_capture_matches(bufnr, query_string, 'textobjects')
   else
     local parser = parsers.get_parser(bufnr, lang)
     local root = parser:parse():root()
+
     local start_row, _, end_row, _ = root:range()
 
     local query = ts.parse_query(lang, query_string)
@@ -41,7 +41,7 @@ function M.select_textobject(query_string)
   local earliest_start
 
   for _, m in pairs(matches) do
-    if ts_utils.is_in_node_range(m.node, row, col) then
+    if m.node and ts_utils.is_in_node_range(m.node, row, col) then
       local length = ts_utils.node_length(m.node)
       if not match_length or length < match_length then
         smallest_range = m

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -1,6 +1,5 @@
 local api = vim.api
 
-local locals = require'nvim-treesitter.locals'
 local parsers = require'nvim-treesitter.parsers'
 
 local M = {}
@@ -105,40 +104,6 @@ function M.get_previous_node(node, allow_switch_parents, allow_previous_parent)
   return destination_node
 end
 
-function M.parent_scope(node, cursor_pos)
-  local bufnr = api.nvim_get_current_buf()
-
-  local scopes = locals.get_scopes(bufnr)
-  if not node or not scopes then return end
-
-  local row = cursor_pos.row
-  local col = cursor_pos.col
-  local iter_node = node
-
-  while iter_node ~= nil do
-    local row_, col_ = iter_node:start()
-    if vim.tbl_contains(scopes, iter_node) and (row_+1 ~= row or col_ ~= col) then
-      return iter_node
-    end
-    iter_node = iter_node:parent()
-  end
-end
-
-function M.containing_scope(node, bufnr)
-  local bufnr = bufnr or api.nvim_get_current_buf()
-
-  local scopes = locals.get_scopes(bufnr)
-  if not node or not scopes then return end
-
-  local iter_node = node
-
-  while iter_node ~= nil and not vim.tbl_contains(scopes, iter_node) do
-    iter_node = iter_node:parent()
-  end
-
-  return iter_node or node
-end
-
 function M.get_named_children(node)
   local nodes = {}
   for i=0,node:named_child_count() - 1,1 do
@@ -147,170 +112,10 @@ function M.get_named_children(node)
   return nodes
 end
 
-function M.nested_scope(node, cursor_pos)
-  local bufnr = api.nvim_get_current_buf()
-
-  local scopes = locals.get_scopes(bufnr)
-  if not node or not scopes then return end
-
-  local row = cursor_pos.row
-  local col = cursor_pos.col
-  local scope = M.containing_scope(node)
-
-  for _, child in ipairs(M.get_named_children(scope)) do
-    local row_, col_ = child:start()
-    if vim.tbl_contains(scopes, child) and ((row_+1 == row and col_ > col) or row_+1 > row) then
-      return child
-    end
-  end
-end
-
-function M.next_scope(node)
-  local bufnr = api.nvim_get_current_buf()
-
-  local scopes = locals.get_scopes(bufnr)
-  if not node or not scopes then return end
-
-  local scope = M.containing_scope(node)
-
-  local parent = scope:parent()
-  if not parent then return end
-
-  local is_prev = true
-  for _, child in ipairs(M.get_named_children(parent)) do
-    if child == scope then
-      is_prev = false
-    elseif not is_prev and vim.tbl_contains(scopes, child) then
-      return child
-    end
-  end
-end
-
-function M.previous_scope(node)
-  local bufnr = api.nvim_get_current_buf()
-
-  local scopes = locals.get_scopes(bufnr)
-  if not node or not scopes then return end
-
-  local scope = M.containing_scope(node)
-
-  local parent = scope:parent()
-  if not parent then return end
-
-  local is_prev = true
-  local children = M.get_named_children(parent)
-  for i=#children,1,-1 do
-    if children[i] == scope then
-      is_prev = false
-    elseif not is_prev and vim.tbl_contains(scopes, children[i]) then
-      return children[i]
-    end
-  end
-end
-
 function M.get_node_at_cursor(winnr)
   local cursor = api.nvim_win_get_cursor(winnr or 0)
   local root = parsers.get_parser().tree:root()
   return root:named_descendant_for_range(cursor[1]-1,cursor[2],cursor[1]-1,cursor[2])
-end
-
--- Finds the definition node and it's scope node of a node
--- @param node starting node
--- @param bufnr buffer
--- @returns the definition node and the definition nodes scope node
-function M.find_definition(node, bufnr)
-  local bufnr = bufnr or api.nvim_get_current_buf()
-  local node_text = M.get_node_text(node)[1]
-  local current_scope = M.containing_scope(node)
-  local matching_def_nodes = {}
-
-  -- If a scope wasn't found then use the root node
-  if current_scope == node then
-    current_scope = parsers.get_parser(bufnr).tree:root()
-  end
-
-  -- Get all definitions that match the node text
-  for _, def in ipairs(locals.get_definitions(bufnr)) do
-    for _, def_node in ipairs(M.get_local_nodes(def)) do
-      if M.get_node_text(def_node)[1] == node_text then
-        table.insert(matching_def_nodes, def_node)
-      end
-    end
-  end
-
-  -- Continue up each scope until we find the scope that contains the definition
-  while current_scope do
-    for _, def_node in ipairs(matching_def_nodes) do
-      if M.is_parent(current_scope, def_node) then
-        return def_node, current_scope
-      end
-    end
-    current_scope = M.containing_scope(current_scope:parent())
-  end
-
-  return node, parsers.get_parser(bufnr).tree:root()
-end
-
--- Gets all nodes from a local list result.
--- @param local_def the local list result
--- @returns a list of nodes
-function M.get_local_nodes(local_def)
-  local result = {}
-
-  M.recurse_local_nodes(local_def, function(_, node)
-    table.insert(result, node)
-  end)
-
-  return result
-end
-
--- Recurse locals results until a node is found.
--- The accumulator function is given
--- * The table of the node
--- * The node
--- * The full definition match `@definition.var.something` -> 'var.something'
--- * The last definition match `@definition.var.something` -> 'something'
--- @param The locals result
--- @param The accumulator function
--- @param The full match path to append to
--- @param The last match
-function M.recurse_local_nodes(local_def, accumulator, full_match, last_match)
-  if local_def.node then
-    accumulator(local_def, local_def.node, full_match, last_match)
-  else
-    for match_key, def in pairs(local_def) do
-      M.recurse_local_nodes(
-        def,
-        accumulator,
-        full_match and (full_match..'.'..match_key) or match_key,
-        match_key)
-    end
-  end
-end
-
--- Finds usages of a node in a given scope
--- @param node the node to find usages for
--- @param scope_node the node to look within
--- @returns a list of nodes
-function M.find_usages(node, scope_node, bufnr)
-  local bufnr = bufnr or api.nvim_get_current_buf()
-  local node_text = M.get_node_text(node)[1]
-
-  if not node_text or #node_text < 1 then return {} end
-
-  local scope_node = scope_node or parsers.get_parser(bufnr).tree:root()
-  local usages = {}
-
-  for match in locals.iter_locals(bufnr, scope_node) do
-    if match.reference
-      and match.reference.node
-      and M.get_node_text(match.reference.node)[1] == node_text
-    then
-      table.insert(usages, match.reference.node)
-    end
-  end
-
-  return usages
 end
 
 function M.highlight_node(node, buf, hl_namespace, hl_group)


### PR DESCRIPTION
Currently based on #100 

Clean up some stuff after #100 to separate adding a new feature from a refactoring API change

- [x] add `parsers.get_buf_lang` (every module uses a similar statement to get the language of a buffer)
- [x] refactor locals module
     - [x] remove stuff that is shared between all query groups (now locals/textobjects) -> query.lua
     - [x] add stuff from ts_utils that is strongly related to locals (get_definition, scopes, etc.)
