### PR TITLE
C/C++ highlights: Small improvements for type definitions

### DIFF
--- a/queries/c/locals.scm
+++ b/queries/c/locals.scm
@@ -26,9 +26,12 @@
   declarator: (field_identifier) @definition.field)
 (type_definition
   declarator: (type_identifier) @definition.type)
+(struct_specifier
+  name: (type_identifier) @definition.type)
 
 ;; References
 (identifier) @reference
+(type_identifier) @reference
 
 ;; Scope
 [

--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -20,6 +20,9 @@
   name: (scoped_type_identifier
           name: (type_identifier) @definition.type))
 
+(alias_declaration
+  name: (type_identifier) @definition.type)
+
 ;; Function defintions
 (template_function
   name: (identifier) @definition.function) @scope


### PR DESCRIPTION
Definition of types by:
 - using (C++)
 - plain struct

Reference of types