### PR TITLE
fix(ts_utils): be sure to parse to get root

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -210,7 +210,7 @@ end
 
 function M.get_node_at_cursor(winnr)
   local cursor = api.nvim_win_get_cursor(winnr or 0)
-  local root = parsers.get_parser().tree:root()
+  local root = parsers.get_parser():parse():root()
   return root:named_descendant_for_range(cursor[1]-1,cursor[2],cursor[1]-1,cursor[2])
 end
 


### PR DESCRIPTION
Be sure to call `parser:parser()` to get a tree instead of getting the
tree directly. This will not cost anything is the buffer is freshly
parsed.

Fixes #181