### PR TITLE
feat(textobjects): Add `start` to include preceding things like documentation

### DIFF
--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -126,7 +126,7 @@ function M.get_capture_matches(bufnr, capture_string, query_kind)
 
     local matches = {}
     for _, match in pairs(M.get_locals(bufnr, query_kind)) do
-      local insert = utils.get_at_path(match, capture_string..'.node')
+      local insert = utils.get_at_path(match, capture_string)
 
       if insert then
         table.insert(matches, insert)

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -325,7 +325,12 @@ end
 
 -- Set visual selection to node
 function M.update_selection(buf, node)
-  local start_row, start_col, end_row, end_col = node:range()
+  local start_row, start_col, end_row, end_col
+  if type(node) == 'table' then
+    start_row, start_col, end_row, end_col = unpack(node)
+  else
+    start_row, start_col, end_row, end_col = node:range()
+  end
 
   if end_row == vim.fn.line('$') then
     end_col = #vim.fn.getline('$')

--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -4,3 +4,12 @@
 
 (for_range_loop 
   (_)? @loop.inner) @loop.outer
+
+(template_declaration
+  (function_definition) @function.outer) @function.outer.start
+
+(template_declaration
+  (struct_specifier) @class.outer) @class.outer.start
+
+(template_declaration
+  (class_specifier) @class.outer) @class.outer.start


### PR DESCRIPTION
Idea shamelessly stolen from: https://github.com/nvim-treesitter/nvim-tree-docs

This allows to include starting positions for textobjects like:
```scheme
(template_declaration
  (function_definition
    body:  (compound_statement) @function.inner) @function.outer) @function.outer.start
```
when we have
```cpp
template <typename T>
T* givePtr( T& t )
{
    return &t;
}
```
also the following c query will match
```scheme
(function_definition
    body:  (compound_statement) @function.inner) @function.outer
```
both matches have the same length, though refer to the same thing.
We prefer the query that has earliest start (if any).
Users can use this to attach documentation to text objects.