### PR TITLE
Python textobjects: Include @decorators and improve @conditional.inner

### DIFF
--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -2,8 +2,14 @@
 (function_definition
   body: (block)? @function.inner) @function.outer
 
+(decorated_definition
+  (function_definition) @function.outer) @function.outer.start
+
 (class_definition
   body: (block)? @class.inner) @class.outer
+
+(decorated_definition
+  (class_definition) @class.outer) @class.outer.start
 
 (while_statement
   body: (block)? @loop.inner) @loop.outer
@@ -12,8 +18,10 @@
   body: (block)? @loop.inner) @loop.outer
 
 (if_statement
-  consequence: (block)? @conditional.inner
-  alternative: (_ (block) @conditional.inner)?) @conditional.outer
+  alternative: (_ (_) @conditional.inner)?) @conditional.outer
+
+(if_statement
+  consequence: (block)? @conditional.inner)
 
 (if_statement
   condition: (_) @conditional.inner)


### PR DESCRIPTION
Include decorators to functions and improve @conditional.inner for conditions of elif statements