### PR TITLE
Attach kind of reference to query result instead of using subfields

### DIFF
--- a/queries/c/locals.scm
+++ b/queries/c/locals.scm
@@ -31,7 +31,8 @@
 
 ;; References
 (identifier) @reference
-(type_identifier) @reference.type
+((type_identifier) @reference
+                   (set! reference.kind "type"))
 
 ;; Scope
 [

--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -23,12 +23,17 @@
 (alias_declaration
   name: (type_identifier) @definition.type)
 
+;template <typename T>
+(type_parameter_declaration
+  (type_identifier) @definition.type)
+     
 ;; Namespaces
 (namespace_definition 
   name: (identifier) @definition.namespace
   body: (_) @scope)
 
-(namespace_identifier) @reference.namespace
+((namespace_identifier) @reference
+                        (set! reference.kind "namespace"))
 
 ;; Function defintions
 (template_function

--- a/queries/rust/locals.scm
+++ b/queries/rust/locals.scm
@@ -70,8 +70,10 @@
 
 ; References
 (identifier) @reference
-(type_identifier) @reference.type
-(field_identifier) @reference.field
+((type_identifier) @reference
+                   (set! reference.kind "type"))
+((field_identifier) @reference
+                   (set! reference.kind "field"))
 
 
 ; Macros


### PR DESCRIPTION
This makes smart_rename work also for types out of the box and we don't
need to search for the path of actual node.