### PR TITLE
fixes golang method highlights

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -2,6 +2,21 @@
 ;; Copyright (c) 2014 Max Brunsfeld (The MIT License)
 
 ;;
+; Identifiers
+
+(type_identifier) @type
+(field_identifier) @property
+(identifier) @variable
+
+(parameter_declaration (identifier) @parameter)
+(variadic_parameter_declaration (identifier) @parameter)
+
+((identifier) @constant
+ (#eq? @constant "_")) 
+
+((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z\\d_]+$"))
+
 ; Function calls
 
 (call_expression
@@ -18,21 +33,6 @@
 
 (method_declaration
   name: (field_identifier) @method)
-
-; Identifiers
-
-(type_identifier) @type
-(field_identifier) @property
-(identifier) @variable
-
-(parameter_declaration (identifier) @parameter)
-(variadic_parameter_declaration (identifier) @parameter)
-
-((identifier) @constant
- (#eq? @constant "_")) 
-
-((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]+$"))
 
 ; Operators
 


### PR DESCRIPTION
Method highlights is overwritten by property because of the ordering.

something like:

Before:

![screenshot_2020-07-22-085154](https://user-images.githubusercontent.com/63658381/88156685-48638b80-cbf9-11ea-9833-4e494fd10e5c.png)

After:

![screenshot_2020-07-22-085116](https://user-images.githubusercontent.com/63658381/88156688-4994b880-cbf9-11ea-990f-17739a359326.png)

Possibly connected to #198 but on golang instead of python