### PR TITLE
Improve dart highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ List of currently supported languages:
 - [ ] markdown
 - [x] regex (maintained by @theHamsta)
 - [ ] jsdoc
-- [ ] dart
+- [x] dart (maintained by @Akin909)
 
 ## User Query Extensions
 

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -28,7 +28,7 @@ hlmap["character"] = "TSCharacter"
 hlmap["number"] = "TSNumber"
 hlmap["boolean"] = "TSBoolean"
 hlmap["float"] = "TSFloat"
-hlmap["attribute"] = "TSAttribute"
+hlmap["annotation"] = "TSAnnotation"
 
 -- Functions
 hlmap["function"] = "TSFunction"

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -28,6 +28,7 @@ hlmap["character"] = "TSCharacter"
 hlmap["number"] = "TSNumber"
 hlmap["boolean"] = "TSBoolean"
 hlmap["float"] = "TSFloat"
+hlmap["attribute"] = "TSAttribute"
 
 -- Functions
 hlmap["function"] = "TSFunction"

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -44,7 +44,7 @@ highlight default link TSMethod Function
 highlight default link TSField Identifier
 highlight default link TSProperty Identifier
 highlight default link TSConstructor Special
-highlight default link TSAttribute Identifier
+highlight default link TSAnnotation PreProc
 
 highlight default link TSConditional Conditional
 highlight default link TSRepeat Repeat

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -44,6 +44,7 @@ highlight default link TSMethod Function
 highlight default link TSField Identifier
 highlight default link TSProperty Identifier
 highlight default link TSConstructor Special
+highlight default link TSAttribute Identifier
 
 highlight default link TSConditional Conditional
 highlight default link TSRepeat Repeat

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -8,9 +8,9 @@
 
 ; Annotations
 (annotation
-  name: (identifier) @attribute)
+  name: (identifier) @annotation)
 (marker_annotation
-  name: (identifier) @attribute)
+  name: (identifier) @annotation)
 
 ; Operators
 

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -13,12 +13,42 @@
 (marker_annotation
   name: (identifier) @attribute)
 
-; TODO: operators
+; Operators
+
 [
- "@" 
+ "@"
+ "=>"
+ ".."
+ "??"
+ "=="
+ "?"
+ ":"
+ "&&"
+ "%"
+ "<"
+ ">"
+ ">="
+ "<="
+ "||"
+ (is_operator)
+ (prefix_operator)
+ (equality_operator)
  (additive_operator)
 ] @operator
-; TODO: delimiers/punctuation
+
+; Delimiters
+
+"." @punctuation.delimiter
+"," @punctuation.delimiter
+";" @punctuation.delimiter
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+
 
 ; Types
 
@@ -48,8 +78,8 @@
 
 ; Variables
 
-((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\d_]+"))
+((identifier) @type
+ (#match? @type "^[A-Z]"))
 
 (this) @constant.builtin
 
@@ -86,13 +116,18 @@
  "extends"
  "final"
  "implements"
- "is"
  "as"
  "mixin"
  "external"
  "new"
  "return"
  "static"
+ "required"
+ "var"
+ "const"
+ "async"
+ "await"
+ ; "rethrow"
  ] @keyword
 ;TODO: var, async, await
 ; "rethrow" @keyword

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -7,7 +7,6 @@
 (super) @function
 
 ; Annotations
-; TODO: highlight??
 (annotation
   name: (identifier) @attribute)
 (marker_annotation

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -62,6 +62,12 @@
   scope: (identifier) @type)
 (function_signature
   name: (identifier) @method)
+; using method_signature does not work
+; so specifically use getter and setter signatures
+(getter_signature
+  (identifier) @method)
+(setter_signature
+  name: (identifier) @method)
 (enum_declaration
   name: (identifier) @type)
 (enum_constant
@@ -127,9 +133,8 @@
  "const"
  "async"
  "await"
- ; "rethrow"
  ] @keyword
-;TODO: var, async, await
+;TODO:
 ; "rethrow" @keyword
 
 ["if" "else" "switch" "case"] @conditional


### PR DESCRIPTION
This PR adds a few more highlights for dart files, most notably tweaking the regex to match more classes, adding operators and punctuation.

I'd at some later date like to see if the upstream grammar can provide nodes/groups (is that the terminology) for methods calls and class instantiation properly but with these changes the highlighting is much improved (at least when working in flutter, it's already pretty good for a standard dart file)

### Before
![dart-treesitter](https://user-images.githubusercontent.com/22454918/88267027-208f2900-ccc8-11ea-858a-74461e9b5322.png)

### After
![treesitter-regex-dart](https://user-images.githubusercontent.com/22454918/88267050-27b63700-ccc8-11ea-8127-33d16666e694.png)
