### PR TITLE
Swap textobject

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,31 @@ require'nvim-treesitter.configs'.setup {
         ["ad"] = "@comment.outer",
         ["am"] = "@call.outer",
         ["im"] = "@call.inner"
-      }
+      },
+      -- swap parameters (keymap -> textobject query)
+      swap_next = {
+        ["<a-p>"] = "@parameter.inner",
+      },
+      swap_previous = {
+        ["<a-P>"] = "@parameter.inner",
+      },
+      -- set mappings to go to start/end of adjacent textobjects (keymap -> textobject query)
+      goto_previous_start = {
+        ["[m"] = "@function.outer",
+        ["[["] = "@class.outer",
+      },
+      goto_previous_end = {
+        ["[M"] = "@function.outer",
+        ["[]"] = "@class.outer",
+      },
+      goto_next_start = {
+        ["]m"] = "@function.outer",
+        ["]]"] = "@class.outer",
+      },
+      goto_next_end = {
+        ["]M"] = "@function.outer",
+        ["]["] = "@class.outer",
+      },
     },
     ensure_installed = "all" -- one of "all", "language", or a list of languages
 }

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -94,7 +94,31 @@ By default, everything is disabled. To enable support for features, in your `ini
 	  ["ad"] = "@comment.outer",
 	  ["am"] = "@call.outer",
 	  ["im"] = "@call.inner"
-	}
+	},
+        -- swap parameters (keymap -> textobject query)
+	swap_next = {
+	  ["<a-p>"] = "@parameter.inner",
+	},
+	swap_previous = {
+	  ["<a-P>"] = "@parameter.inner",
+	},
+        -- set mappings to go to start/end of adjacent textobjects (keymap -> textobject query)
+	goto_previous_start = {
+	  ["[m"] = "@function.outer",
+	  ["[["] = "@class.outer",
+	},
+	goto_previous_end = {
+	  ["[M"] = "@function.outer",
+	  ["[]"] = "@class.outer",
+	},
+	goto_next_start = {
+	  ["]m"] = "@function.outer",
+	  ["]]"] = "@class.outer",
+	},
+	goto_next_end = {
+	  ["]M"] = "@function.outer",
+	  ["]["] = "@class.outer",
+	},
       },
       ensure_installed = "all" -- one of "all", "language", or a list of languages
   }

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -86,8 +86,12 @@ local builtin_modules = {
       return has_some_textobject_mapping(lang) or queries.has_textobjects(lang)
     end,
     keymaps = {},
-    swap_next_keymaps = {},
-    swap_previous_keymaps = {}
+    swap_next = {},
+    swap_previous = {},
+    goto_next_start = {},
+    goto_next_end = {},
+    goto_previous_start = {},
+    goto_previous_end = {}
   }
 }
 

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -85,7 +85,9 @@ local builtin_modules = {
     is_supported = function(lang)
       return has_some_textobject_mapping(lang) or queries.has_textobjects(lang)
     end,
-    keymaps = {}
+    keymaps = {},
+    swap_next_keymaps = {},
+    swap_previous_keymaps = {}
   }
 }
 

--- a/lua/nvim-treesitter/refactor/navigation.lua
+++ b/lua/nvim-treesitter/refactor/navigation.lua
@@ -1,6 +1,7 @@
 -- Definition based navigation module
 
 local ts_utils = require'nvim-treesitter.ts_utils'
+local utils = require'nvim-treesitter.utils'
 local locals = require'nvim-treesitter.locals'
 local configs = require'nvim-treesitter.configs'
 local api = vim.api
@@ -11,8 +12,7 @@ function M.goto_definition(bufnr)
   local bufnr = bufnr or api.nvim_get_current_buf()
   local node_at_point = ts_utils.get_node_at_cursor()
 
-  -- Set the item in jump list
-  vim.cmd "normal! m'"
+  utils.set_jump()
 
   if not node_at_point then return end
 

--- a/lua/nvim-treesitter/textobjects.lua
+++ b/lua/nvim-treesitter/textobjects.lua
@@ -8,7 +8,7 @@ local ts_utils = require'nvim-treesitter.ts_utils'
 
 local M = {}
 
-function M.select_textobject(query_string)
+local function get_textobject_at_point(query_string)
   local bufnr = vim.api.nvim_get_current_buf()
   local lang = parsers.get_buf_lang(bufnr)
   if not lang then return end
@@ -66,11 +66,93 @@ function M.select_textobject(query_string)
     if smallest_range.start then
       local start_range = {smallest_range.start.node:range()}
       local node_range = {smallest_range.node:range()}
-      ts_utils.update_selection(bufnr, {start_range[1], start_range[2], node_range[3], node_range[4]})
+      return bufnr, {start_range[1], start_range[2], node_range[3], node_range[4]}, smallest_range.node
     else
-      ts_utils.update_selection(bufnr, smallest_range.node)
+      return bufnr, {smallest_range.node:range()}, smallest_range.node
     end
   end
+end
+
+function M.select_textobject(query_string)
+  local bufnr, textobject = get_textobject_at_point(query_string)
+  if textobject then
+    ts_utils.update_selection(bufnr, textobject)
+  end
+end
+
+local function swap_textobject(query_string, direction)
+  local bufnr, textobject_range, node = get_textobject_at_point(query_string)
+  local step = direction > 0 and 1 or -1
+  if not node then return end
+  for _ = 1, math.abs(direction), step do
+      if direction > 0 then
+        ts_utils.swap_nodes(textobject_range, M.next_textobject(node, query_string, true, bufnr), bufnr, "yes, set cursor!")
+      else
+        ts_utils.swap_nodes(textobject_range, M.previous_textobject(node, query_string, true, bufnr), bufnr, "yes, set cursor!")
+      end
+  end
+end
+
+function M.swap_textobject_next(query_string)
+  swap_textobject(query_string, 1)
+end
+
+function M.swap_textobject_previous(query_string)
+  swap_textobject(query_string, -1)
+end
+
+function M.next_textobject(node, query_string, same_parent, bufnr)
+  local bufnr = bufnr or api.nvim_get_current_buf()
+
+  local matches = queries.get_capture_matches(bufnr, query_string, 'textobjects')
+  local _, _ , node_end = node:end_()
+  local next_node
+  local next_node_start
+
+  for _, m in pairs(matches) do
+    local _, _, other_end = m.node:start()
+    if other_end > node_end then
+      if not same_parent or node:parent() == m.node:parent() then
+        if not next_node then
+          next_node = m
+          _, _, next_node_start = next_node.node:start()
+        end
+        if other_end < next_node_start then
+          next_node = m
+          _, _, next_node_start = next_node.node:start()
+        end
+      end
+    end
+  end
+
+  return next_node and next_node.node
+end
+
+function M.previous_textobject(node, query_string, same_parent, bufnr)
+  local bufnr = bufnr or api.nvim_get_current_buf()
+
+  local matches = queries.get_capture_matches(bufnr, query_string, 'textobjects')
+  local _, _ , node_start = node:start()
+  local previous_node
+  local previous_node_end
+
+  for _, m in pairs(matches) do
+    local _, _, other_end = m.node:end_()
+    if other_end < node_start then
+      if not same_parent or node:parent() == m.node:parent() then
+        if not previous_node then
+          previous_node = m
+          _, _, previous_node_end = previous_node.node:end_()
+        end
+        if other_end > previous_node_end then
+          previous_node = m
+          _, _, previous_node_end = previous_node.node:end_()
+        end
+      end
+    end
+  end
+
+  return previous_node and previous_node.node
 end
 
 function M.attach(bufnr, lang)
@@ -90,6 +172,28 @@ function M.attach(bufnr, lang)
       api.nvim_buf_set_keymap(buf, "v", mapping, cmd, {silent = true, noremap = true })
     end
   end
+  for mapping, query in pairs(config.swap_next_keymaps) do
+    if type(query) == 'table' then
+      query = query[lang]
+    elseif not queries.get_query(lang, 'textobjects') then
+      query = nil
+    end
+    if query then
+      local cmd = ":lua require'nvim-treesitter.textobjects'.swap_textobject_next('"..query.."')<CR>"
+      api.nvim_buf_set_keymap(buf, "n", mapping, cmd, {silent = true})
+    end
+  end
+  for mapping, query in pairs(config.swap_previous_keymaps) do
+    if type(query) == 'table' then
+      query = query[lang]
+    elseif not queries.get_query(lang, 'textobjects') then
+      query = nil
+    end
+    if query then
+      local cmd = ":lua require'nvim-treesitter.textobjects'.swap_textobject_previous('"..query.."')<CR>"
+      api.nvim_buf_set_keymap(buf, "n", mapping, cmd, {silent = true})
+    end
+  end
 end
 
 function M.detach(bufnr)
@@ -106,6 +210,16 @@ function M.detach(bufnr)
     if query then
       api.nvim_buf_del_keymap(buf, "o", mapping)
       api.nvim_buf_del_keymap(buf, "v", mapping)
+    end
+  end
+  for mapping, query in pairs(config.swap_next_keymaps) or pairs(config.swap_previous_keymaps) do
+    if type(query) == 'table' then
+      query = query[lang]
+    elseif not queries.get_query(lang, 'textobjects') then
+      query = nil
+    end
+    if query then
+      api.nvim_buf_del_keymap(buf, "n", mapping)
     end
   end
 end

--- a/lua/nvim-treesitter/textobjects.lua
+++ b/lua/nvim-treesitter/textobjects.lua
@@ -101,7 +101,40 @@ function M.swap_textobject_previous(query_string)
   swap_textobject(query_string, -1)
 end
 
+function M.goto_adjacent_textobejct(query_string, forward, start, same_parent)
+  local bufnr, _, node = get_textobject_at_point(query_string)
+  local ajacent_textobject
+  if forward then
+    ajacent_textobject = M.next_textobject(node,  query_string, same_parent, bufnr)
+  else
+    ajacent_textobject = M.previous_textobject(node,  query_string, same_parent, bufnr)
+  end
+
+  if ajacent_textobject then
+    local adjacent_textobject_range = {ajacent_textobject:range()}
+    if start then
+      api.nvim_win_set_cursor(api.nvim_get_current_win(), { adjacent_textobject_range[1] + 1, adjacent_textobject_range[2] })
+    else
+      api.nvim_win_set_cursor(api.nvim_get_current_win(), { adjacent_textobject_range[3] + 1, adjacent_textobject_range[4] })
+    end
+  end
+end
+
+M.goto_next_textobject_start = function(query_string) M.goto_adjacent_textobejct(query_string, 'forward', 'start', false) end
+M.goto_next_textobject_end = function(query_string) M.goto_adjacent_textobejct(query_string, 'forward', false, false) end
+M.goto_previous_textobject_start = function(query_string) M.goto_adjacent_textobejct(query_string, false, 'start', false) end
+M.goto_previous_textobject_end = function(query_string) M.goto_adjacent_textobejct(query_string, false, false, false) end
+
+function M.goto_next_textobject_end(query_string)
+  local bufnr, _, node = get_textobject_at_point(query_string)
+  if not node then return end
+  local next_textobject = M.next_textobject(node,  query_string, false, bufnr)
+  local next_textobject_range = next_textobject:range()
+  api.nvim_win_set_cursor(api.nvim_get_current_win(), { next_textobject_range[3] + 1, next_textobject_range[4] + 1 })
+end
+
 function M.next_textobject(node, query_string, same_parent, bufnr)
+  local node = node or ts_utils.get_node_at_cursor()
   local bufnr = bufnr or api.nvim_get_current_buf()
 
   local matches = queries.get_capture_matches(bufnr, query_string, 'textobjects')
@@ -129,6 +162,7 @@ function M.next_textobject(node, query_string, same_parent, bufnr)
 end
 
 function M.previous_textobject(node, query_string, same_parent, bufnr)
+  local node = node or ts_utils.get_node_at_cursor()
   local bufnr = bufnr or api.nvim_get_current_buf()
 
   local matches = queries.get_capture_matches(bufnr, query_string, 'textobjects')

--- a/lua/nvim-treesitter/textobjects.lua
+++ b/lua/nvim-treesitter/textobjects.lua
@@ -87,17 +87,17 @@ local function swap_textobject(query_string, direction)
   local overlapping_range_ok = false
   local same_parent = true
   for _ = 1, math.abs(direction), step do
-      if direction > 0 then
-        ts_utils.swap_nodes(textobject_range,
-                            M.next_textobject(node, query_string, same_parent, overlapping_range_ok, bufnr),
-                            bufnr,
-                            "yes, set cursor!")
-      else
-        ts_utils.swap_nodes(textobject_range,
-                            M.previous_textobject(node, query_string, same_parent, overlapping_range_ok, bufnr),
-                            bufnr,
-                            "yes, set cursor!")
-      end
+    if direction > 0 then
+      ts_utils.swap_nodes(textobject_range,
+                          M.next_textobject(node, query_string, same_parent, overlapping_range_ok, bufnr),
+                          bufnr,
+                          "yes, set cursor!")
+    else
+      ts_utils.swap_nodes(textobject_range,
+                          M.previous_textobject(node, query_string, same_parent, overlapping_range_ok, bufnr),
+                          bufnr,
+                          "yes, set cursor!")
+    end
   end
 end
 
@@ -146,7 +146,6 @@ function M.next_textobject(node, query_string, same_parent, overlapping_range_ok
   local search_start, _
   if overlapping_range_ok then
     _, _, search_start = node:start()
-    search_start = search_start - 1
   else
     _, _, search_start = node:end_()
   end
@@ -159,7 +158,7 @@ function M.next_textobject(node, query_string, same_parent, overlapping_range_ok
                                               if not same_parent or node:parent() == match.node:parent() then
                                                 local _, _, start = match.node:start()
                                                 local _, _, end_ = match.node:end_()
-                                                return start > search_start and end_ > node_end
+                                                return start > search_start and end_ >= node_end
                                               end
                                             end,
                                             function(match)

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 
 local parsers = require'nvim-treesitter.parsers'
+local utils = require'nvim-treesitter.utils'
 
 local M = {}
 
@@ -241,8 +242,7 @@ function M.swap_nodes(node_or_range1, node_or_range2, bufnr, cursor_to_second)
   vim.lsp.util.apply_text_edits({edit1, edit2}, bufnr)
 
   if cursor_to_second then
-    -- Set the item in jump list
-    vim.cmd "normal! m'"
+    utils.set_jump()
 
     local char_delta = 0
     local line_delta = 0

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -67,4 +67,8 @@ function M.print_warning(text)
   api.nvim_command(string.format([[echohl WarningMsg | echo "%s" | echohl None]], text))
 end
 
+function M.set_jump()
+  vim.cmd "normal! m'"
+end
+
 return M

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -53,3 +53,6 @@
 
 (preproc_else
   (_) @statement.outer)
+
+(parameter_list
+  (parameter_declaration) @parameter.inner)

--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -13,3 +13,6 @@
 
 (template_declaration
   (class_specifier) @class.outer) @class.outer.start
+
+(parameter_list
+  (optional_parameter_declaration) @parameter.inner)


### PR DESCRIPTION
Swap textobject (thinking mainly of function parameters, statements and functions).

What needs to be done first:
- add @object.inner.end (to catch the big enemy of this feature: line comments)
- don't swap with next node but next textobject of same kind (e.g. also a parameter), take documentation and line comments with it.
- to include adjacent comments into the textobject we need the `adjacent?` predicate

But if you want to swap just parameters it already works now (only failure case: there's a line comment behind a parameter)