### PR TITLE
Java locals

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -103,7 +103,7 @@
 ((identifier) @constant
   (#match? @constant "^_*[A-Z][A-Z\d_]+"))
 
-
+(this) @constant.builtin
 
 ; Literals
 

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -13,6 +13,8 @@
 ; Parameters
 (formal_parameter
   name: (identifier) @parameter)
+(catch_formal_parameter
+  name: (identifier) @parameter)
 
 ;; Lambda parameter
 (inferred_parameters (identifier) @parameter) ; (x,y) -> ...

--- a/queries/java/locals.scm
+++ b/queries/java/locals.scm
@@ -1,10 +1,69 @@
-; CREDITS @maxbrunsfeld (maxbrunsfeld@gmail.com)
-
+; SCOPES
+; declarations
+(program) @scope
 (class_declaration
-  name: (identifier) @name) @class
+  body: (_) @scope)
+(enum_declaration
+  body: (_) @scope)
+(method_declaration) @scope ; whole method_declaration because arguments
 
+; block
+(block) @scope
+
+; if/else
+(if_statement) @scope ; if+else
+(if_statement
+  consequence: (_) @scope) ; if body in case there are no braces
+(if_statement
+  alternative: (_) @scope) ; else body in case there are no braces
+
+; try/catch
+(try_statement) @scope ; covers try+catch, individual try and catch are covered by (block)
+(catch_clause) @scope ; needed because `Exception` variable
+
+; loops
+(for_statement) @scope ; whole for_statement because loop iterator variable
+(for_statement         ; "for" body in case there are no braces
+  body: (_) @scope)
+(do_statement
+  body: (_) @scope)
+(while_statement
+  body: (_) @scope)
+
+; Functions
+
+(constructor_declaration) @scope
 (method_declaration
-  name: (identifier) @name) @method
+  name: (identifier) @definition.scope) @scope
 
-(method_invocation
-  name: (identifier) @name) @call
+
+; DEFINITIONS
+ (package_declaration
+    (identifier) @definition.namespace) 
+(class_declaration
+  name: (identifier) @definition.class)
+(enum_declaration
+  name: (identifier) @definition.enum)
+(method_declaration
+  name: (identifier) @definition.method)
+
+(local_variable_declaration
+  declarator: (variable_declarator
+                name: (identifier) @definition.var))
+(formal_parameter
+  name: (identifier) @definition.var)
+(inferred_parameters (identifier) @definition.var) ; (x,y) -> ...
+(lambda_expression
+    parameters: (identifier) @definition.var) ; x -> ...
+
+(scoped_identifier
+   ((identifier) @definition.import))
+
+(field_declaration
+  declarator: (variable_declarator
+                name: (identifier) @definition.field))
+
+; REFERENCES
+(identifier) @reference
+((type_identifier) @reference
+ (set! reference.kind "type"))

--- a/queries/java/locals.scm
+++ b/queries/java/locals.scm
@@ -58,15 +58,9 @@
 (lambda_expression
     parameters: (identifier) @definition.var) ; x -> ...
 
-; we need submatch!
-; TODO: capture nested imports
-;(import_declaration
- ;(scoped_identifier
-   ;((identifier) @definition.import)))
-;(import_declaration
-  ;(scoped_identifier
-    ;(scoped_identifier
-      ;((identifier) @definition.import))))
+((scoped_identifier
+  (identifier) @definition.import)
+ (has-ancestor? @definition.import import_declaration))
 
 (field_declaration
   declarator: (variable_declarator

--- a/queries/java/locals.scm
+++ b/queries/java/locals.scm
@@ -52,6 +52,8 @@
                 name: (identifier) @definition.var))
 (formal_parameter
   name: (identifier) @definition.var)
+(catch_formal_parameter
+  name: (identifier) @definition.var)
 (inferred_parameters (identifier) @definition.var) ; (x,y) -> ...
 (lambda_expression
     parameters: (identifier) @definition.var) ; x -> ...

--- a/queries/java/locals.scm
+++ b/queries/java/locals.scm
@@ -56,8 +56,15 @@
 (lambda_expression
     parameters: (identifier) @definition.var) ; x -> ...
 
-(scoped_identifier
-   ((identifier) @definition.import))
+; we need submatch!
+; TODO: capture nested imports
+;(import_declaration
+ ;(scoped_identifier
+   ;((identifier) @definition.import)))
+;(import_declaration
+  ;(scoped_identifier
+    ;(scoped_identifier
+      ;((identifier) @definition.import))))
 
 (field_declaration
   declarator: (variable_declarator


### PR DESCRIPTION
This #204 by @PitcherTear22 , rebased (was very outdate), squashed and extended.

Now, imports are also definitions. The online playground cannot be fully trusted for Java. The parsers version seems to be outdated. The parsed tree for imports was drastically different. Stupid me was testing `first?` `last?` on this :-(

Using the `highlight_current_scope` with this scopes hints for a bug in finding the current scope (e.g. )... Need to investigate more, it works fine for the other languages.

![scope](https://user-images.githubusercontent.com/7189118/88339374-3806fa00-cd3a-11ea-8d83-5edcfa78b9b2.gif)

Maybe we need to wait for a simple version of submatch that only requires a specific parent node.

