### PR TITLE
Go locals: range_clause can define variables

### DIFF
--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -23,6 +23,11 @@
 (parameter_declaration (identifier) @definition.var)
 (variadic_parameter_declaration (identifier) @definition.var)
 
+(for_statement
+ (range_clause
+   left: (expression_list
+           (identifier) @definition.var)))
+
 (type_declaration 
   (type_spec
     name: (type_identifier) @definition.type))


### PR DESCRIPTION
```go
for _, num := range numbers {
         fmt.Print(num, " ")
}
```