### PR TITLE
Go locals: use reference.kind for calls

### DIFF
--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -37,22 +37,30 @@
 (type_identifier) @reference
 (field_identifier) @reference
 
+(package_clause
+   (package_identifier) @definition.namespace)
+
 ;; Call references
-(call_expression
-    function: (identifier) @reference.call) @call
+((call_expression
+   function: (identifier) @reference) @call
+ (set! reference.kind "call" ))
 
-(call_expression
+((call_expression
     function: (selector_expression
-        field: (field_identifier) @reference.call)) @call
+                field: (field_identifier) @reference)) @call
+ (set! reference.kind "call" ))
 
-(call_expression
-    function: (parenthesized_expression
-        (identifier) @reference.call)) @call
 
-(call_expression
+((call_expression
     function: (parenthesized_expression
-        (selector_expression
-            field: (field_identifier) @reference.call))) @call
+                (identifier) @reference)) @call
+ (set! reference.kind "call" ))
+
+((call_expression
+   function: (parenthesized_expression
+               (selector_expression
+                 field: (field_identifier) @reference))) @call
+ (set! reference.kind "call" ))
 
 ;; Scopes
 

--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -12,7 +12,6 @@
     (#strip! @definition.doc "^//\\s*") ; <- does nothing at the moment
 )
 
-
 (short_var_declaration 
   left: (expression_list
           (identifier) @definition.var)) 
@@ -36,6 +35,8 @@
 (identifier) @reference
 (type_identifier) @reference
 (field_identifier) @reference
+((package_identifier) @reference
+  (set! reference.kind "namespace"))
 
 (package_clause
    (package_identifier) @definition.namespace)
@@ -64,6 +65,7 @@
 
 ;; Scopes
 
+(func_literal) @scope
 (source_file) @scope
 (function_declaration) @scope
 (if_statement) @scope


### PR DESCRIPTION
We really have to decide whether or not adopt tree-sitter's `@reference.thing` captures. If yes, we need to update smart refactor to support it.