### PR TITLE
Dart highlighs: disable invalid nodes after parser update to fix CI

### DIFF
--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -112,14 +112,14 @@
 
 [
  "abstract"
- "assert"
- "break"
+ ;"assert"
+ ;"break"
  "on"
  "class"
  "default"
  "enum"
  "extends"
- "final"
+ ;"final"
  "implements"
  "as"
  "mixin"
@@ -129,14 +129,15 @@
  "static"
  "required"
  "var"
- "const"
+ ;"const"
  "async"
  "await"
  ] @keyword
 ;TODO:
 ; "rethrow" @keyword
 
-["if" "else" "switch" "case"] @conditional
+["if" "else" "switch" "default"] @conditional
+; TODO: case
 
 ["try" "throw" "catch" "finally"] @exception
 

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -104,6 +104,7 @@
 (false) @boolean
 (null_literal) @constant.builtin
 
+(documentation_comment) @comment
 (comment) @comment
 
 ; Keywords


### PR DESCRIPTION
Dart highlights currently break our CI. Apparently, the grammar has changed upstream. I did some bisecting to deactivate all invalid nodes: @Akin909 

Related: #222 @ray-x