### PR TITLE
Template scope

### DIFF
--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -29,7 +29,8 @@
 ;template <typename T>
 (type_parameter_declaration
   (type_identifier) @definition.type)
-     
+(template_declaration) @scope
+
 ;; Namespaces
 (namespace_definition 
   name: (identifier) @definition.namespace


### PR DESCRIPTION
C++: locals template_declaration must define their own scope in which their template arguments are valid