### PR TITLE
Goto: don't move the cursor if already on the node

### DIFF
--- a/lua/nvim-treesitter/refactor/navigation.lua
+++ b/lua/nvim-treesitter/refactor/navigation.lua
@@ -17,6 +17,9 @@ function M.goto_definition(bufnr)
   if not node_at_point then return end
 
   local definition, _ = locals.find_definition(node_at_point, bufnr)
+  -- Don't move the cursor if we are already there
+  if definition == node_at_point then return end
+
   local start_row, start_col, _ = definition:start()
 
   api.nvim_win_set_cursor(0, { start_row + 1, start_col })


### PR DESCRIPTION
For example, executing a goto over ba[r] will move the cursor to [b]ar.

```python
def foo(bar):
    pass
```

Not sure if this is the best way of doing this