### PR TITLE
PHP: Update locals query

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -33,6 +33,7 @@
 
 (member_access_expression
   name: (variable_name (name)) @property)
+
 (member_access_expression
   name: (name) @property)
 

--- a/queries/php/locals.scm
+++ b/queries/php/locals.scm
@@ -2,21 +2,42 @@
 ;-------
 
 (class_declaration) @scope
-(property_declaration) @scope
-(method_declaration) @scope
-(function_definition) @scope
 (while_statement) @scope
 (foreach_statement) @scope
 (if_statement) @scope
 (try_statement) @scope
+(method_declaration
+  name: (name) @definition.method) @scope
+(function_definition
+  name: (name) @definition.function) @scope
 
 ; Definitions
 ;------------
 
-(variable_name
-  (name) @definition.var)
+(simple_parameter
+  (variable_name
+    (name) @definition.var))
+
+(anonymous_function_use_clause
+  (variable_name
+    (name) @definition.var))
+
+(assignment_expression
+  left: (variable_name
+    (name) @definition.var))
+
+(property_declaration
+  (variable_name
+    (name) @definition.field))
+
+(namespace_use_clause
+  (qualified_name
+    (name) @definition.class))
+
+(class_declaration
+  name: (name) @definition.class)
 
 ; References
 ;------------
 
-(variable_name) @reference
+(name) @reference


### PR DESCRIPTION
Reference and definition queries have been improved as follows

Added definitions for methods, functions, and classes, and all specific names are now referenced.