### PR TITLE
rust: various fixes in highlights

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -43,6 +43,9 @@
     name: (identifier) @type)
  (#match? @type "^[A-Z]"))
 
+(use_list (identifier) @type (#match? @type "^[A-Z]"))
+(use_as_clause alias: (identifier) @type (#match? @type "^[A-Z]"))
+
 ;; Correct enum constructors
 (call_expression
   function: (scoped_identifier

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -119,6 +119,8 @@
 "type"
 "union"
 "unsafe"
+"async"
+"await"
 "use"
 "where"
 (mutable_specifier)


### PR DESCRIPTION
* Adds `async` and `await` keywords.
* Fixes some type highlights.