### PR TITLE
RST: update textobjects

### DIFF
--- a/queries/rst/textobjects.scm
+++ b/queries/rst/textobjects.scm
@@ -1,2 +1,6 @@
 (directive
   body: (body) @function.inner) @function.outer
+
+(section (title) @class.inner) @class.outer
+
+(transition) @class.outer


### PR DESCRIPTION
So, these aren't really classes, but is mostly to make use of https://github.com/nvim-treesitter/nvim-treesitter/pull/218 without creating another mapping (and not sure if there is a way to override a mapping per filetype?).

Anyway, let me know if this makes sense or if you have a suggestion for introducing another group name.