### PR TITLE
docs: advertise zulip instead of gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Gitter](https://badges.gitter.im/nvim-treesitter/community.svg)](https://gitter.im/nvim-treesitter/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 ![Linting and style checking](https://github.com/nvim-treesitter/nvim-treesitter/workflows/Linting%20and%20style%20checking/badge.svg?branch=master)
 ![Check loading of syntax files](https://github.com/nvim-treesitter/nvim-treesitter/workflows/Check%20loading%20of%20syntax%20files/badge.svg)
+
+[Join us on Zulip !](https://nvim-treesitter.zulipchat.com/join/1twnvjqumn0t97p65eragu5o/)
 
 # nvim-treesitter
 


### PR DESCRIPTION
We moved to zulip, we will stay on gitter partially but if you want to help in the dev process, or ask questions, it will be better there than on gitter.