### PR TITLE
C++ highlights: Add initial support for attributes

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -112,3 +112,9 @@
 
 "::" @operator
 "..." @operator
+
+; Annotations (not fully supported by parser)
+
+((ERROR) @annotation 
+         (vim-match? @annotation  "\[?\[.*\]\]?.*$"))
+(attribute) @annotation


### PR DESCRIPTION
C++ attributes are only recognized in very few places. So let's also highlight errors that look like attributes. Usually the attribute is the only region of the error that has no other highlight.