### PR TITLE
fix: check 'after' against third directory

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -74,7 +74,7 @@ local function filter_files(file_list)
 
   for _, fname in ipairs(file_list) do
     -- Only get the name of the directory containing the queries directory
-    if vim.fn.fnamemodify(fname, ":p:h:h:t") == "after" then
+    if vim.fn.fnamemodify(fname, ":p:h:h:h:t") == "after" then
       table.insert(after, fname)
     -- The first one is the one with most priority
     elseif #main == 0 then


### PR DESCRIPTION
`after` directory is third parent (not second) of query extension files. 

For example:

```lua
local path = "/home/user/.config/nvim/after/queries/lua/highlights.scm"

print(vim.fn.fnamemodify(path, ":p:h:h:t") ) -- queries
print(vim.fn.fnamemodify(path, ":p:h:h:h:t")) -- after

```