### PR TITLE
Python: update highlights

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -4,24 +4,24 @@
 ; Reset highlighing in f-string interpolations
 (interpolation) @Normal
 
-; Identifier naming conventions
+;; Identifier naming conventions
 ((identifier) @type
- (match? @type "^[A-Z]"))
+ (#match? @type "^[A-Z]"))
 ((identifier) @constant
- (match? @constant "^[A-Z][A-Z_0-9]*$"))
+ (#match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 ((identifier) @constant.builtin
- (match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
+ (#match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
 
 ((attribute
     attribute: (identifier) @field)
- (match? @field "^([A-Z])@!.*$"))
+ (#match? @field "^([A-Z])@!.*$"))
 
 ; Function calls
 
 (decorator) @function
 ((decorator (dotted_name (identifier) @function))
- (match? @function "^([A-Z])@!.*$"))
+ (#match? @function "^([A-Z])@!.*$"))
 
 (call
   function: (identifier) @function)
@@ -32,12 +32,12 @@
 
 ((call
    function: (identifier) @constructor)
- (match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 ((call
   function: (attribute
               attribute: (identifier) @constructor))
- (match? @constructor "^[A-Z]"))
+ (#match? @constructor "^[A-Z]"))
 
 ;; Builtin functions
 
@@ -52,19 +52,6 @@
 (function_definition
   name: (identifier) @function)
 
-((function_definition
-   name: (identifier) @method
-   parameters: (parameters
-                 (identifier) @self) )
- (eq? @self "self"))
-
-((function_definition
-   name: (identifier) @constructor
-   parameters: (parameters
-                 (identifier) @self) )
- (eq? @self "self")
- (vim-match? @constructor "(__new__|__init__)"))
-
 (type (identifier) @type)
 (type
   (subscript
@@ -73,9 +60,9 @@
 ((call
   function: (identifier) @isinstance
   arguments: (argument_list
-    (*)
+    (_)
     (identifier) @type))
- (eq? @isinstance "isinstance"))
+ (#eq? @isinstance "isinstance"))
 
 ; Normal parameters
 (parameters
@@ -112,7 +99,7 @@
 (none) @constant.builtin
 [(true) (false)] @boolean
 ((identifier) @constant.builtin
-              (match? @constant.builtin "self"))
+ (#match? @constant.builtin "self"))
 
 (integer) @number
 (float) @float
@@ -185,27 +172,31 @@
   "yield"
 ] @keyword
 
-[ "as" "from" "import"] @include
+["as" "from" "import"] @include
 
-[ "if" "elif" "else" ] @conditional
+["if" "elif" "else"] @conditional
 
-[ "for" "while" "break" "continue" ] @repeat
+["for" "while" "break" "continue"] @repeat
 
-[ "(" ")" "[" "]" "{" "}"] @punctuation.bracket
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 (interpolation
   "{" @punctuation.special
   "}" @punctuation.special) @embedded
 
-[ "," "." ":" (ellipsis) ] @punctuation.delimiter
+["," "." ":" (ellipsis)] @punctuation.delimiter
 
-; Class definitions
+;; Class definitions
 
 (class_definition
-  name: (identifier) @type)
+  name: (identifier) @type
+  body: (block
+          (function_definition
+            name: (identifier) @method)))
+
 (class_definition
   superclasses: (argument_list
-    (identifier) @type))
+                  (identifier) @type))
 
 ((class_definition
   body: (block
@@ -213,7 +204,20 @@
             (assignment
               left: (expression_list
                       (identifier) @field)))))
- (match? @field "^([A-Z])@!.*$"))
+ (#match? @field "^([A-Z])@!.*$"))
+
+((class_definition
+  (block
+    (function_definition
+      name: (identifier) @constructor)))
+ (#vim-match? @constructor "^(__new__|__init__)$"))
+
+; First parameter of a method is self or cls.
+((class_definition
+  body: (block
+          (function_definition
+            parameters: (parameters . (identifier) @constant.builtin))))
+ (#vim-match? @constant.builtin "^(self|obj|cls)$"))
 
 ;; Error
 (ERROR) @error


### PR DESCRIPTION
- Get rid of @self
- Highlight methods correctly
- Highlight self as the first parameter of a method
- Use new syntax (# for predicates, (_) instead of (*) for wildcards)

I would like to help to maintain the python queries