### PR TITLE
@definition.parameter for Python, C/C++

### DIFF
--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -5,6 +5,9 @@ local info = require'nvim-treesitter.info'
 local configs = require'nvim-treesitter.configs'
 local parsers = require'nvim-treesitter.parsers'
 
+-- Registers all query predicates
+require"nvim-treesitter.query_predicates"
+
 local M = {}
 
 function M.setup()

--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -35,3 +35,18 @@ query.add_predicate('has-ancestor?', function(match, pattern, bufnr, pred)
   end
   return false
 end)
+
+query.add_predicate('is?', function(match, pattern, bufnr, pred)
+  if #pred < 3 then error("is? must have at least two arguments!") return end
+
+  -- Avoid circular dependencies
+  local locals = require"nvim-treesitter.locals"
+  local node = match[pred[2]]
+  local types = {unpack(pred, 3)}
+
+  if not node then return true end
+
+  local _, _, kind = locals.find_definition(node, bufnr)
+
+  return vim.tbl_contains(types, kind)
+end)

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -131,8 +131,10 @@
 (comment) @comment
 
 ;; Parameters
-(parameter_list
-  (parameter_declaration) @parameter)
+(parameter_declaration
+  declarator: (identifier) @parameter)
+((identifier) @parameter
+              (is? @parameter parameter))
 
 (preproc_params
   (identifier)) @parameter

--- a/queries/c/locals.scm
+++ b/queries/c/locals.scm
@@ -9,7 +9,7 @@
 (pointer_declarator
   declarator: (identifier) @definition.var)
 (parameter_declaration
-  declarator: (identifier) @definition.var)
+  declarator: (identifier) @definition.parameter)
 (init_declarator
   declarator: (identifier) @definition.var)
 (array_declarator

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -8,7 +8,12 @@
  (#match? @field "_$"))
 
 ; function(Foo ...foo)
-(variadic_parameter_declaration) @parameter
+(variadic_parameter_declaration
+  declarator: (variadic_declarator
+                (identifier) @parameter))
+; int foo = 0
+(optional_parameter_declaration
+    declarator: (identifier) @parameter)
 
 ;(field_expression) @parameter ;; How to highlight this?
 (template_function

--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -1,3 +1,9 @@
+;; Parameters
+(variadic_parameter_declaration
+  declarator: (variadic_declarator
+                (identifier) @definition.parameter))
+(optional_parameter_declaration
+  declarator: (identifier) @definition.parameter)
 
 ;; Class / struct defintions
 (class_specifier) @scope
@@ -39,7 +45,7 @@
 ((namespace_identifier) @reference
                         (set! reference.kind "namespace"))
 
-;; Function defintions
+;; Function definitions
 (template_function
   name: (identifier) @definition.function) @scope
 

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -1,23 +1,37 @@
 ; Types
 
 ; Javascript
+
+; Properties
+;-----------
+
+(property_identifier) @property
+
 ; Special identifiers
 ;--------------------
 
+(identifier) @variable
+
 ((identifier) @constant
- (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+ (match? @constant "^[A-Z_][A-Z\\d_]+$"))
 
 ((shorthand_property_identifier) @constant
- (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+ (match? @constant "^[A-Z_][A-Z\\d_]+$"))
 
 ((identifier) @constructor
- (#match? @constructor "^[A-Z]"))
+ (match? @constructor "^[A-Z]"))
 
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^(arguments|module|console|window|document)$"))
+ (not-is? @variable.builtin import var parameter)
+ (match? @variable.builtin "^(arguments|module|console|window|document)$"))
 
 ((identifier) @function.builtin
- (#eq? @function.builtin "require"))
+ (not-is? @function.builtin import var parameter)
+ (eq? @function.builtin "require"))
+
+((identifier) @parameter
+ (is? @parameter parameter))
+
 
 ; Function and method definitions
 ;--------------------------------
@@ -77,13 +91,6 @@
 (formal_parameters
   (rest_parameter
     (identifier) @parameter))
-
-(identifier) @variable
-
-; Properties
-;-----------
-
-(property_identifier) @property
 
 ; Literals
 ;---------

--- a/queries/javascript/locals.scm
+++ b/queries/javascript/locals.scm
@@ -14,28 +14,28 @@
 ;------------
 
 (formal_parameters
-  (identifier) @definition.var)
+  (identifier) @definition.parameter)
 
 (formal_parameters
   (object_pattern
-    (identifier) @definition.var))
+    (identifier) @definition.parameter))
 
 ; function(arg = []) {
 (formal_parameters
   (assignment_pattern
-    (shorthand_property_identifier) @definition.var))
+    (shorthand_property_identifier) @definition.parameter))
 
 (formal_parameters
   (object_pattern
-    (shorthand_property_identifier) @definition.var))
+    (shorthand_property_identifier) @definition.parameter))
 
 (formal_parameters
   (array_pattern
-    (identifier) @definition.var))
+    (identifier) @definition.parameter))
 
 (formal_parameters
   (rest_parameter
-    (identifier) @definition.var))
+    (identifier) @definition.parameter))
 
 (variable_declarator
   name: (identifier) @definition.var)

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -80,6 +80,8 @@
 ; Normal parameters
 (parameters
   (identifier) @parameter)
+((identifier) @parameter
+              (is? @parameter parameter))
 ; Lambda parameters
 (lambda_parameters
   (identifier) @parameter)

--- a/queries/python/locals.scm
+++ b/queries/python/locals.scm
@@ -18,16 +18,16 @@
 
 ; Function with parameters, defines parameters
 (parameters
-  (identifier) @definition.var)
+  (identifier) @definition.parameter)
 
 (default_parameter
-  (identifier) @definition.var)
+  (identifier) @definition.parameter)
 
 (typed_parameter
-  (identifier) @definition.var)
+  (identifier) @definition.parameter)
 
 (typed_default_parameter
-  (identifier) @definition.var)
+  (identifier) @definition.parameter)
 
 (with_statement
   (with_item
@@ -36,12 +36,12 @@
 ; *args parameter
 (parameters
   (list_splat
-    (identifier) @definition.var))
+    (identifier) @definition.parameter))
 
 ; **kwargs parameter
 (parameters
   (dictionary_splat
-    (identifier) @definition.var))
+    (identifier) @definition.parameter))
 
 ; Function defines function and scope
 (function_definition


### PR DESCRIPTION
Add `@definition.parameter` in virtue of #303 