### PR TITLE
some refacto, doc fixes and jsx queries

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -228,33 +228,6 @@ Returns the previous node within the same parent.
 `allow_switch_parent` and `allow_prev_parent` follow the same rule
 as |ts_utils.get_next_node| but if the node is the first node.
 
-						   *ts_utils.containing_scope*
-containing_scope(node)~
-
-Returns the smallest scope containing the node.
-
-						       *ts_utils.parent_scope*
-parent_scope(node, cursor_pos)~
-
-Returns the parent scope of the current scope that contains the node.
-`cursor_pos` should be `{ row = number, col = number }`
-
-						       *ts_utils.nested_scope*
-nested_scope(node, cursor_pos)~
-
-Returns the first scope within current scope that contains the node.
-`cursor_pos` should be `{ row = number, col = number }`
-
-							 *ts_utils.next_scope*
-next_scope(node)~
-
-Returns the neighbour scope of the current node.
-
-						     *ts_utils.previous_scope*
-previous_scope(node)~
-
-Returns the previous neighbour scope of the current node.
-
 ==============================================================================
 FUNCTIONS                                          *nvim-treesitter-functions*
 

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -7,7 +7,8 @@ list.javascript = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-javascript",
     files = { "src/parser.c", "src/scanner.c" },
-  }
+  },
+  used_by = { 'javascriptreact' }
 }
 
 list.c = {

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -26,7 +26,7 @@ M.base_language_map = {
 }
 
 M.query_extensions = {
-  javascript = { 'jsx' },
+  javascript = { 'javascript.jsx' },
   tsx = {'javascript.jsx'}
 }
 
@@ -95,6 +95,9 @@ function M.get_query_files(lang, query_name)
   local query_files = {}
   local extensions = M.query_extensions[lang] or {}
 
+  local lang_files = filtered_runtime_queries(lang, query_name)
+  vim.list_extend(query_files, lang_files)
+
   for _, ext in ipairs(extensions) do
     local l = lang
     local e = ext
@@ -111,9 +114,7 @@ function M.get_query_files(lang, query_name)
     vim.list_extend(query_files, base_files)
   end
 
-  local lang_files = filtered_runtime_queries(lang, query_name)
-
-  return vim.list_extend(query_files, lang_files)
+  return query_files
 end
 
 function M.has_query_files(lang, query_name)

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -103,7 +103,8 @@
 (null) @constant.builtin
 (comment) @comment
 (string) @string
-(regex) @string.special
+(regex) @punctuation.delimiter
+(regex_pattern) @string.regex
 (template_string) @string
 (number) @number
 

--- a/queries/javascript/jsx.scm
+++ b/queries/javascript/jsx.scm
@@ -1,0 +1,9 @@
+(jsx_element
+  open_tag: (jsx_opening_element ["<" ">"] @operator))
+(jsx_element
+  close_tag: (jsx_closing_element ["<" "/" ">"] @operator))
+
+(jsx_closing_element name: (identifier) @variable.builtin)
+(jsx_opening_element name: (identifier) @variable.builtin)
+
+(jsx_text) @none


### PR DESCRIPTION
- compute query language extensions *after* default ones
(jsx after javascript)
- remove outdated ts_utils functions from docs
- add better regex detection to javascript
- javascriptreact to use javascript queries
- add javascript.jsx to javascript queries
- write jsx.scm hl file