### PR TITLE
fix issue with typescript parser definition

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -148,7 +148,6 @@ list.tsx = {
     files = { "src/parser.c", "src/scanner.c" },
     location = "tree-sitter-tsx/tsx"
   },
-  used_by = { "typescript.tsx" },
   filetype = 'typescriptreact'
 }
 


### PR DESCRIPTION
remove the used_by key that has no meaning in this context except create bugs.