### PR TITLE
Rename @function.method to @method

### DIFF
--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -35,22 +35,22 @@
 (function_declaration
   name: (identifier) @function)
 (method_definition
-  name: (property_identifier) @function.method)
+  name: (property_identifier) @method)
 
 (pair
-  key: (property_identifier) @function.method
+  key: (property_identifier) @method
   value: (function))
 (pair
-  key: (property_identifier) @function.method
+  key: (property_identifier) @method
   value: (arrow_function))
 
 (assignment_expression
   left: (member_expression
-    property: (property_identifier) @function.method)
+    property: (property_identifier) @method)
   right: (arrow_function))
 (assignment_expression
   left: (member_expression
-    property: (property_identifier) @function.method)
+    property: (property_identifier) @method)
   right: (function))
 
 (variable_declarator
@@ -75,7 +75,7 @@
 
 (call_expression
   function: (member_expression
-    property: (property_identifier) @function.method))
+    property: (property_identifier) @method))
 
 ; Variables
 ;----------


### PR DESCRIPTION
`queries/javascript/highlights.scm` has a few references to `@function.method`, which is not mentioned at all in `hlmap`. I figured it'd make sense to consolidate these references to `@method`, so they can be highlighted properly. 
