### PR TITLE
feat(refactor.navigation): add navigation.goto_{next,previous}_usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ EOF
 
 Provides "go to definition" for the symbol under the cursor,
 and lists the definitions from the current file.
+goto_next_usage/goto_previous_usage go to the next usage of the
+identifier under the cursor.
+
 
 ```lua
 lua <<EOF
@@ -195,6 +198,8 @@ require'nvim-treesitter.configs'.setup {
       keymaps = {
         goto_definition = "gnd",
         list_definitions = "gnD",
+        goto_next_usage = "<a-*>",
+        goto_previous_usage = "<a-#>",
       },
     },
   },

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -246,6 +246,10 @@ Supported options:
     Defaults to `gnd`.
   - list_definitions: list all definitions from the current file.
     Defaults to `gnD`.
+  - goto_next_usage: go to next usage of identifier under the cursor.
+    Defaults to `<a-*>`.
+  - goto_previous_usage: go to previous usage of identifier.
+    Defaults to `<a-#>`.
 
 >
   lua <<EOF
@@ -256,6 +260,8 @@ Supported options:
         keymaps = {
           goto_definition = "gnd",
           list_definitions = "gnD",
+          goto_next_usage = "<a-*>",
+          goto_previous_usage = "<a-#>",
         },
       },
     },
@@ -512,6 +518,14 @@ get_previous_node(node, allow_switch_parents, allow_prev_parent)~
 Returns the previous node within the same parent.
 `allow_switch_parent` and `allow_prev_parent` follow the same rule
 as |ts_utils.get_next_node| but if the node is the first node.
+
+                                                         *ts_utils.goto_node*
+goto_node(node, goto_end, avoid_set_jump)~
+
+Sets cursor to the position of `node` in the current windows.
+If `goto_end` is truthy, the cursor is set to the end the node range.
+Setting `avoid_set_jump` to `true`, avoids setting the current cursor position
+to the jump list.
 
 ==============================================================================
 FUNCTIONS                                          *nvim-treesitter-functions*

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -75,7 +75,9 @@ local builtin_modules = {
       is_supported = queries.has_locals,
       keymaps = {
         goto_definition = "gnd",
-        list_definitions = "gnD"
+        list_definitions = "gnD",
+        goto_next_usage = "<a-*>",
+        goto_previous_usage = "<a-#>",
       }
     }
   },

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -1,7 +1,6 @@
-local utils = require'nvim-treesitter.utils'
+local ts_utils = require'nvim-treesitter.ts_utils'
 local shared = require'nvim-treesitter.textobjects.shared'
 local attach = require'nvim-treesitter.textobjects.attach'
-local api = vim.api
 
 local M = {}
 
@@ -9,18 +8,7 @@ function M.goto_adjacent(query_string, forward, start, same_parent, overlapping_
   local bufnr, _, node = shared.textobject_at_point(query_string)
   local adjacent = shared.get_adjacent(forward, node,  query_string, same_parent, overlapping_range_ok, bufnr)
 
-  if adjacent then
-    utils.set_jump()
-
-    local adjacent_textobject_range = {adjacent:range()}
-    local position
-    if start then
-      position = { adjacent_textobject_range[1] + 1, adjacent_textobject_range[2] }
-    else
-      position = { adjacent_textobject_range[3] + 1, adjacent_textobject_range[4] }
-    end
-    api.nvim_win_set_cursor(api.nvim_get_current_win(), position)
-  end
+  ts_utils.goto_node(adjacent, not start)
 end
 
 -- luacheck: push ignore 631

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -276,4 +276,24 @@ function M.swap_nodes(node_or_range1, node_or_range2, bufnr, cursor_to_second)
   end
 end
 
+function M.goto_node(node, goto_end, avoid_set_jump)
+  if not node then return end
+  if not avoid_set_jump then
+    utils.set_jump()
+  end
+  local range = {node:range()}
+  local position
+  if not goto_end then
+    position = { range[1], range[2] }
+  else
+    -- ranges are exclusive: -1 character!
+    if range[4] == 0 then
+      position = { range[3] - 1, -1 }
+    else
+      position = { range[3], range[4] - 1 }
+    end
+  end
+  api.nvim_win_set_cursor(0, { position[1] + 1, position[2] })
+end
+
 return M

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -71,4 +71,12 @@ function M.set_jump()
   vim.cmd "normal! m'"
 end
 
+function M.index_of(tbl, obj)
+  for i, o in ipairs(tbl) do
+    if o == obj then
+      return i
+    end
+  end
+end
+
 return M


### PR DESCRIPTION
I like `*` and `#` to consider only other usages of the identifier under cursor (if it's an identifier). Overwriting the default mappings is however not a good idea. Any suggestion what default key mapping we could use for this? We could also not set any default mappings.

TODO:

 - [x] docs