### PR TITLE
feat(c/cpp highlights): highlight pointer/reference parameters

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -134,6 +134,9 @@
 (parameter_declaration
   declarator: (identifier) @parameter)
 
+(parameter_declaration
+  declarator: (pointer_declarator) @parameter)
+
 (preproc_params
   (identifier)) @parameter
 

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -7,6 +7,8 @@
 ((identifier) @field
  (#match? @field "_$"))
 
+(parameter_declaration
+  declarator: (reference_declarator) @parameter)
 ; function(Foo ...foo)
 (variadic_parameter_declaration
   declarator: (variadic_declarator


### PR DESCRIPTION
This highlights `void foo(int* a);` and `int& a`, `int&&&& a` as parameters.