### PR TITLE
feat(config): add global disable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ so you'll need to activate them by putting this in your `init.vim` file:
 lua <<EOF
 require'nvim-treesitter.configs'.setup {
   ensure_installed = "all"      -- one of "all", "language", or a list of languages
+  disable = {"markdown"},       -- a list of languages to disable for all modules (only enable manually)
   highlight = {
     enable = true,              -- false will disable the whole extension
     disable = { "c", "rust" },  -- list of language that will be disabled

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -37,6 +37,7 @@ To enable supported features, put this in your `init.vim` file:
   lua <<EOF
   require'nvim-treesitter.configs'.setup {
     ensure_installed = "all"      -- one of "all", "language", or a list of languages
+    disable = {"markdown"},       -- a list of languages to disable for all modules (only enable manually)
     highlight = {
       enable = true,              -- false will disable the whole extension
       disable = { "c", "rust" },  -- list of language that will be disabled

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -300,17 +300,22 @@ function M.setup(user_data)
       config.ensure_installed = data
       require'nvim-treesitter.install'.ensure_installed(data)
     else
+      data.disable = data.disable or {}
+      for _, lang in ipairs(user_data.disable or {}) do
+        if not vim.tbl_contains(data.disable, lang) then
+          table.insert(data.disable, lang)
+        end
+      end
       config.modules[name] = vim.tbl_deep_extend('force', config.modules[name] or {}, data)
 
       recurse_modules(function(_, _, new_path)
         if data.enable then
           enable_all(new_path)
         end
-
-        for _, lang in ipairs(data.disable or {}) do
+        for _, lang in ipairs(config.modules[name].disable) do
           disable_mod_conf_autocmd(new_path, lang)
         end
-      end, config.modules)
+      end, config.modules[name])
     end
   end
 end


### PR DESCRIPTION
Add option to disable parsers for all modules. (Should we remove the markdown parser for it's SEGFAULTs?)

TODO:

- [x] docs
- [ ] how does disable work for submodules?
