### PR TITLE
Add Windows support (mingw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ so you'll need to activate them by putting this in your `init.vim` file:
 ```lua
 lua <<EOF
 require'nvim-treesitter.configs'.setup {
-  ensure_installed = "all"      -- one of "all", "language", or a list of languages
+  ensure_installed = "all",     -- one of "all", "language", or a list of languages
   highlight = {
     enable = true,              -- false will disable the whole extension
     disable = { "c", "rust" },  -- list of language that will be disabled

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -36,7 +36,7 @@ To enable supported features, put this in your `init.vim` file:
 >
   lua <<EOF
   require'nvim-treesitter.configs'.setup {
-    ensure_installed = "all"      -- one of "all", "language", or a list of languages
+    ensure_installed = "all",     -- one of "all", "language", or a list of languages
     highlight = {
       enable = true,              -- false will disable the whole extension
       disable = { "c", "rust" },  -- list of language that will be disabled

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -58,6 +58,10 @@ local function iter_cmd_sync(cmd_list)
   return true
 end
 
+local function select_executable(executables)
+  return vim.tbl_filter(function(c) return fn.executable(c) == 1 end, executables)[1]
+end
+
 local function run_install(cache_folder, package_path, lang, repo, with_sync)
   parsers.reset_cache()
 
@@ -66,6 +70,10 @@ local function run_install(cache_folder, package_path, lang, repo, with_sync)
   -- compile_location only needed for typescript installs.
   local compile_location = cache_folder..'/'..(repo.location or project_name)
   local parser_lib_name = package_path.."/parser/"..lang..".so"
+
+  local cc = select_executable({ "cc", "gcc" })
+  local win32 = fn.has('win32') == 1
+
   local command_list = {
     {
       cmd = 'rm',
@@ -83,7 +91,7 @@ local function run_install(cache_folder, package_path, lang, repo, with_sync)
       },
     },
     {
-      cmd = 'cc',
+      cmd = cc,
       info = 'Compiling...',
       err = 'Error during compilation',
       opts = {
@@ -152,7 +160,7 @@ end
 local function install(with_sync, ask_reinstall)
   return function (...)
     if fn.has('win32') == 1 then
-      return api.nvim_err_writeln('This command is not available on windows at the moment.')
+      --return api.nvim_err_writeln('This command is not available on windows at the moment.')
     end
 
     if fn.executable('git') == 0 then

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -19,7 +19,7 @@ end
 
 function M.get_package_path()
   for _, path in pairs(api.nvim_list_runtime_paths()) do
-    if string.match(path, '.*/nvim%-treesitter') then
+    if string.match(path, '.*/nvim%-treesitter') or string.match(path, '.*\\nvim%-treesitter') then
       return path
     end
   end
@@ -29,7 +29,14 @@ end
 
 function M.get_cache_dir()
   local home = fn.get(fn.environ(), 'HOME')
-  local xdg_cache = fn.get(fn.environ(), 'XDG_CACHE_HOME')
+
+  local xdg_cache
+  if fn.has("win32") then
+    xdg_cache = fn.get(fn.environ(), 'LOCALAPPDATA')
+  else
+    xdg_cache = fn.get(fn.environ(), 'XDG_CACHE_HOME')
+  end
+
 
   if xdg_cache == 0 then
     xdg_cache = home .. '/.cache'


### PR DESCRIPTION
This PR adds Windows support for parser installation.

What did I do?

- install git
- open powershell (admin)
- install chocoletey
```
Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
```
- open powershell (admin)
- run `choco install mingw`
- `refreshenv`
- run Nvim-qt from nightly neovim releases
- google how to install vim plug
- `TSInstall cpp` installs stuff. *.so is loaded and plugin functionality works (highlighting, go to definition, list locals).

It was a lot of pain to program this on Windows. Will fix lua style on Linux :stuck_out_tongue_closed_eyes: 

#6 helps to compile the parsers using the mingw toolchain. TODO: MSVC (CL.EXE)