### PR TITLE
Add Windows support (mingw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please consider the experience with this plug-in as experimental until Neovim 0.
 
 - Neovim [nightly](https://github.com/neovim/neovim#install-from-source)
 - `git` in your path.
-- A C compiler in your path.
+- A C compiler in your path ([Windows users please read this!](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Windows-support)).
 
 ## Installation
 

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -19,7 +19,9 @@ end
 
 function M.get_package_path()
   for _, path in pairs(api.nvim_list_runtime_paths()) do
-    if string.match(path, '.*/nvim%-treesitter') then
+    local last_segment = vim.fn.fnamemodify(path, ":t")
+    local penultimate_segment = vim.fn.fnamemodify(path, ":t:t")
+    if last_segment == "nvim-treesitter" or (last_segment == "" and penultimate_segment == "nvim-treesitter") then
       return path
     end
   end
@@ -28,20 +30,15 @@ function M.get_package_path()
 end
 
 function M.get_cache_dir()
-  local home = fn.get(fn.environ(), 'HOME')
-  local xdg_cache = fn.get(fn.environ(), 'XDG_CACHE_HOME')
+  local cache_dir = fn.stdpath('data')
 
-  if xdg_cache == 0 then
-    xdg_cache = home .. '/.cache'
-  end
-
-  if luv.fs_access(xdg_cache, 'RW') then
-    return xdg_cache
+  if luv.fs_access(cache_dir, 'RW') then
+    return cache_dir
   elseif luv.fs_access('/tmp', 'RW') then
     return '/tmp'
   end
 
-  return nil, 'Invalid cache rights, $XDG_CACHE_HOME or /tmp should be read/write'
+  return nil, 'Invalid cache rights, '..fn.stdpath('data')..' or /tmp should be read/write'
 end
 
 -- Gets a property at path


### PR DESCRIPTION
This PR adds Windows support for parser installation.

What did I do?

 -   install git
 -  open powershell (admin)
 -   install chocoletey by pasting the following line

```
Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
```

 - open powershell (admin)
 - run `choco install mingw`
 - `refreshenv`
 - run Nvim-qt from nightly neovim releases
  - google how to install vim plug
  - `TSInstall cpp` installs stuff. *.so is loaded and plugin functionality works (highlighting, go to definition, list locals).

It was a lot of pain to program this on Windows. Will fix lua style on Linux :stuck_out_tongue_closed_eyes:

#6 helps to compile the parsers using the mingw toolchain. TODO: MSVC (CL.EXE)