### PR TITLE
fix get_package_path function for paths with trailing slash

### DIFF
--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -20,8 +20,7 @@ end
 function M.get_package_path()
   for _, path in pairs(api.nvim_list_runtime_paths()) do
     local last_segment = vim.fn.fnamemodify(path, ":p:h:t")
-    local penultimate_segment = vim.fn.fnamemodify(path, ":p:h:t:t")
-    if last_segment == "nvim-treesitter" or (last_segment == "" and penultimate_segment == "nvim-treesitter") then
+    if last_segment == "nvim-treesitter" then
       return path
     end
   end

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -19,8 +19,8 @@ end
 
 function M.get_package_path()
   for _, path in pairs(api.nvim_list_runtime_paths()) do
-    local last_segment = vim.fn.fnamemodify(path, ":t")
-    local penultimate_segment = vim.fn.fnamemodify(path, ":t:t")
+    local last_segment = vim.fn.fnamemodify(path, ":p:h:t")
+    local penultimate_segment = vim.fn.fnamemodify(path, ":p:h:t:t")
     if last_segment == "nvim-treesitter" or (last_segment == "" and penultimate_segment == "nvim-treesitter") then
       return path
     end


### PR DESCRIPTION
This function is not working with paths with trailing slash

so the :p modifier will add path serparator in the end (if missing) but only if directory exists
:h modifier will remove trailing path serparator