### PR TITLE
Simplify configs.setup

### DIFF
--- a/lua/nvim-treesitter/refactor/highlight_current_scope.lua
+++ b/lua/nvim-treesitter/refactor/highlight_current_scope.lua
@@ -37,8 +37,8 @@ function M.attach(bufnr)
 end
 
 function M.detach(bufnr)
-  M.clear_usage_highlights(bufnr)
-  cmd(string.format('autocmd! NvimTreesitterCurrentScope_%d CursorHold', bufnr))
+  M.clear_highlights(bufnr)
+  cmd(string.format('autocmd! NvimTreesitterCurrentScope_%d CursorMoved', bufnr))
   cmd(string.format('autocmd! NvimTreesitterCurrentScope_%d BufLeave', bufnr))
 end
 


### PR DESCRIPTION
This PR tries to simplify `configs.setup` to avoid a few problems. The main problem: attach/detach should be strictly inverse to each other and if they are not it shouldn't cause a problem for disabled modules.

- try to avoid enabling modules just to disable them afterwards for languages in `disable`. This could avoid problems when attach/detach of certain modules are not inverse to each other
- make attach/detach of `highlight_current_scope` inverse to each other
- avoid calling `enable_all` with disable/enable data that is actually for a different module

This solves the bug that executing this lua file (once all modules are loaded) automatically activates `highlight_current_scope` though it's deactivated. Happens with every top-level module set to true.

```lua
    require "nvim-treesitter.configs".setup(
        {
            highlight = {
                enable = true, -- false will disable the whole extension
                disable = {"html", "lua"} -- list of language that will be disabled
            },
            refactor = {
                highlight_current_scope = {
                    enable = false,
                    inverse_highlighting = true,
                    disable = {"python", "markdown"}
                },
                highlight_definitions = {
                    enable = true,
                    disable = {"markdown"}
                },
            },
            ensure_installed = "all",
        }
    )
```

This is still a draft. There were a few bugs that I discovered on the way. I found the function how it was before very confusing and I could not understand it fully. So please handle those changes with care.
