### PR TITLE
feat(smart_rename): set cursor to start of renamed code after renaming

### DIFF
--- a/lua/nvim-treesitter/refactor/smart_rename.lua
+++ b/lua/nvim-treesitter/refactor/smart_rename.lua
@@ -43,6 +43,7 @@ function M.smart_rename(bufnr)
     table.insert(edits, text_edit)
   end
   vim.lsp.util.apply_text_edits(edits, bufnr)
+  ts_utils.goto_node(node_at_point, false, true)
 end
 
 function M.attach(bufnr)


### PR DESCRIPTION
Sometimes when I'm shorting a identifier with smart rename, my cursor will be on some of the nodes after the identifier. So I was wondering whether we should set the cursor to start of renamed node after renaming, or should this be configurable?

![Peek 2020-08-31 23-16](https://user-images.githubusercontent.com/7189118/91769817-605b0180-ebe0-11ea-97d0-6efec33d7a7d.gif)
If I would not change the cursor position, my cursor would be on the next argument or even the closing parenthesis.