### PR TITLE
Add warning about required Neovim version

### DIFF
--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -1,9 +1,15 @@
+--TODO(theHamsta): remove once stabilized!
+if not pcall(require,"vim.treesitter.query") then
+  error("nvim-treesitter requires a more recent Neovim nightly version!")
+end
+
 local install = require'nvim-treesitter.install'
 local utils = require'nvim-treesitter.utils'
 local ts_utils = require'nvim-treesitter.ts_utils'
 local info = require'nvim-treesitter.info'
 local configs = require'nvim-treesitter.configs'
 local parsers = require'nvim-treesitter.parsers'
+
 
 -- Registers all query predicates
 require"nvim-treesitter.query_predicates"


### PR DESCRIPTION
I am not sure how to tackle #322 since `lua-match?` will introduce the next breaking change. But maybe we can catch with this people who try the plugin with Neovim stable. 