### PR TITLE
add scanner.c to fennel compilation

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -245,7 +245,7 @@ list.rst = {
 list.fennel = {
   install_info = {
     url = "https://github.com/travonted/tree-sitter-fennel",
-    files = { "src/parser.c" },
+    files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = {'@TravonteD'},
 }


### PR DESCRIPTION
I added a `scanner.c` to tree-sitter-fennel, so I'm updating things here so that it compiles correctly.