### PR TITLE
Add a "Performance" section to docs

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -755,11 +755,12 @@ the cursor.
                                                             *hl-TSCurrentScope*
 Used by refactor.highlight_current_scope to highlight the current scope.
 
-vim:tw=78:ts=8:expandtab:noet:ft=help:norl:
-
 ==============================================================================
 PERFORMANCE                                      *nvim-treesitter-performance*
 
 `nvim-treesitter` checks the 'runtimepath' on startup in order to discover
-available parsers and install them. As a consequence, a very long
+available parsers and queries and install them. As a consequence, a very long
 'runtimepath' might result in delayed startup times.
+
+
+vim:tw=78:ts=8:expandtab:noet:ft=help:norl:

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -756,3 +756,10 @@ the cursor.
 Used by refactor.highlight_current_scope to highlight the current scope.
 
 vim:tw=78:ts=8:expandtab:noet:ft=help:norl:
+
+==============================================================================
+PERFORMANCE                                      *nvim-treesitter-performance*
+
+`nvim-treesitter` checks the 'runtimepath' on startup in order to discover
+available parsers and install them. As a consequence, a very long
+'runtimepath' might result in delayed startup times.

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -759,7 +759,7 @@ Used by refactor.highlight_current_scope to highlight the current scope.
 PERFORMANCE                                      *nvim-treesitter-performance*
 
 `nvim-treesitter` checks the 'runtimepath' on startup in order to discover
-available parsers and queries and install them. As a consequence, a very long
+available parsers and queries and index them. As a consequence, a very long
 'runtimepath' might result in delayed startup times.
 
 


### PR DESCRIPTION
This pull request adds a "Performance" section to docs stating that the way nvim-treesitter checks `rtp` might result in slow startup times.