### PR TITLE
Fold: don't hide the first line from the node

### DIFF
--- a/lua/nvim-treesitter/fold.lua
+++ b/lua/nvim-treesitter/fold.lua
@@ -23,6 +23,8 @@ local folds_levels = utils.memoize_by_buf_tick(function(bufnr)
 
   for _, node in ipairs(matches) do
     local start, _, stop, stop_col = node.node:range()
+    -- Don't hide the first line
+    start = start + 1
 
     if stop_col > 0 then
       stop = stop + 1

--- a/queries/python/fold.scm
+++ b/queries/python/fold.scm
@@ -1,13 +1,13 @@
-(function_definition (block) @fold)
-(class_definition (block) @fold)
-
-(while_statement (block) @fold)
-(for_statement (block) @fold)
-(if_statement (block) @fold)
-(with_statement (block) @fold)
-(try_statement (block) @fold)
-
 [
+  (function_definition)
+  (class_definition)
+
+  (while_statement)
+  (for_statement)
+  (if_statement)
+  (with_statement)
+  (try_statement)
+
   (import_from_statement)
   (parameters)
   (argument_list)


### PR DESCRIPTION
Currently, the fold will hide the function name,
this makes it hard to have context over the fold.

Leaving the first line visible makes it easy to read.
In python, I captured the `block` node as a workaround, but it doesn't work for all nodes/grammars.