### PR TITLE
Support TSInstall on Windows with Clang

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -100,7 +100,7 @@ local function select_install_rm_cmd(cache_folder, project_name)
     return {
       cmd = 'rm',
       opts = {
-        args = { 'rf', cache_folder..'/'..project_name },
+        args = { '-rf', cache_folder..'/'..project_name },
       }
     }
   end
@@ -134,7 +134,6 @@ local function run_install(cache_folder, package_path, lang, repo, with_sync)
   end
 
   local project_name = 'tree-sitter-'..lang
-  local project_repo = cache_folder..path_sep..project_name
   -- compile_location only needed for typescript installs.
   local compile_location = cache_folder..path_sep..(repo.location or project_name)
   local parser_lib_name = package_path..path_sep.."parser"..path_sep..lang..".so"

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -73,7 +73,7 @@ local function select_args(repo)
         '-lstdc++',
   }
   if fn.has('win32') == 0 then
-    table.insert('-fPIC')
+    table.insert(args, '-fPIC')
   end
   return args
 end

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -72,14 +72,14 @@ local function select_args(repo)
         '-Os',
         '-lstdc++',
   }
-  if not fn.has('win32') then
+  if fn.has('win32') == 0 then
     table.insert('-fPIC')
   end
   return args
 end
 
 local function select_install_rm_cmd(cache_folder, project_name)
-  if fn.has('win32') then
+  if fn.has('win32') == 1 then
     local dir = cache_folder ..'\\'.. project_name
     return {
       cmd = 'cmd',
@@ -98,7 +98,7 @@ local function select_install_rm_cmd(cache_folder, project_name)
 end
 
 local function select_mv_cmd(compile_location, parser_lib_name)
-  if fn.has('win32') then
+  if fn.has('win32') == 1 then
     return {
       cmd = 'cmd',
       opts = {
@@ -119,7 +119,7 @@ local function run_install(cache_folder, package_path, lang, repo, with_sync)
   parsers.reset_cache()
 
   local path_sep = '/'
-  if fn.has('win32') then
+  if fn.has('win32') == 1 then
     path_sep = '\\'
   end
 
@@ -234,7 +234,7 @@ function M.update(lang)
 end
 
 local function select_uninstall_rm_cmd(lang, parser_lib)
-  if fn.has('win32') then
+  if fn.has('win32') == 1 then
     return {
       cmd = 'cmd',
       opts = {
@@ -257,7 +257,7 @@ end
 
 function M.uninstall(lang)
   local path_sep = '/'
-  if fn.has('win32') then
+  if fn.has('win32') == 1 then
     path_sep = '\\'
   end
 

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -89,7 +89,7 @@ end
 
 local function select_install_rm_cmd(cache_folder, project_name)
   if fn.has('win32') then
-    dir = cache_folder ..'\\'.. project_name
+    local dir = cache_folder ..'\\'.. project_name
     return {
       cmd = 'cmd',
       opts = {

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -63,28 +63,19 @@ local function select_executable(executables)
 end
 
 local function select_args(repo)
-  if fn.has('win32') then
-    return {
-      '-o',
-      'parser.so',
-      '-I./src',
-      repo.files,
-      '-shared',
-      '-Os',
-      '-lstdc++',
-    }
-  else
-    return {
-      '-o',
-      'parser.so',
-      '-I./src',
-      repo.files,
-      '-shared',
-      '-Os',
-      '-lstdc++',
-      '-fPIC'
-    }
+  local args = {
+        '-o',
+        'parser.so',
+        '-I./src',
+        repo.files,
+        '-shared',
+        '-Os',
+        '-lstdc++',
+  }
+  if not fn.has('win32') then
+    table.insert('-fPIC')
   end
+  return args
 end
 
 local function select_install_rm_cmd(cache_folder, project_name)
@@ -122,7 +113,6 @@ local function select_mv_cmd(compile_location, parser_lib_name)
       }
     }
   end
-
 end
 
 local function run_install(cache_folder, package_path, lang, repo, with_sync)


### PR DESCRIPTION
I've made some changes to the install script so tree sitter languages can be installed on Windows with the clang compiler installed. I had some trouble getting #347 to work I think due to the cl compiler being quite a bit different from the gcc/clang counterparts. With clang most commands remain the same only some considerations have to be made like path separators atleast when using cmd.exe. Maybe it'd be preferable to write the command_list changes with powershell instead, not sure. 

Either way this PR works on my Windows 10 machine.