### PR TITLE
Lua: update highlights

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -61,7 +61,7 @@
  ] @operator
 
 ;; Punctuation
-[ "," "." ] @punctuation.delimiter
+[ "," "." ":"] @punctuation.delimiter
 
 ;; Brackets
 [
@@ -85,6 +85,12 @@
 ("function" @keyword.function
  [(function_name) (identifier)] @function
  "end" @keyword.function)
+
+(property_identifier) @property
+(method) @method
+
+(function_call (identifier) @function . (arguments))
+(function_call (field_expression (property_identifier) @function) . (arguments))
 
 ;; Nodes
 (table ["{" "}"] @constructor)


### PR DESCRIPTION
Function calls were missing. The grammar identifies the whole node as a function call, but we only care about the "final call", so that's why `. (arguments)`