### PR TITLE
Highlights: use underlined for TSURI

### DIFF
--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -66,4 +66,4 @@ highlight default TSEmphasis term=italic cterm=italic gui=italic
 highlight default TSUnderline term=underline cterm=underline gui=underline
 highlight default link TSTitle Title
 highlight default link TSLiteral String
-highlight default link TSURI Identifier
+highlight default link TSURI Underlined


### PR DESCRIPTION
Neovim uses this hl group `:h group-name`

> 	*Underlined	text that stands out, HTML links

Let me know what you think