### PR TITLE
Text objects: check for query files first

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -87,7 +87,7 @@ local builtin_modules = {
       enable = false,
       disable = {},
       is_supported = function(lang)
-        return has_some_textobject_mapping(lang) or queries.has_textobjects(lang)
+        return queries.has_textobjects(lang) or has_some_textobject_mapping(lang)
       end,
       keymaps = {},
     },


### PR DESCRIPTION
The first function is faster and more common.