### PR TITLE
fix(highlights): fix ts parameter highlights

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -23,5 +23,5 @@
 
 ; Variables
 
-(required_parameter (identifier) @variable.parameter)
-(optional_parameter (identifier) @variable.parameter)
+(required_parameter (identifier) @parameter)
+(optional_parameter (identifier) @parameter)


### PR DESCRIPTION
This fixes an error that's thrown when highlighting TS files, since `variable.parameter` is not an actual capture. 