### PR TITLE
fix: ocaml highlight

### DIFF
--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -69,9 +69,8 @@
 
 (comment) @comment
 
-[(string) (quoted_string)] @string
+[(string) (quoted_string) (conversion_specification)] @string
 (escape_sequence) @string.escape
-(conversion_specification) @string.special
 
 (infix_operator) @operator
 


### PR DESCRIPTION
The string.special group was removed from highlight.lua, replace its
uses by the string group.

The issue was detected in https://github.com/nvim-treesitter/nvim-treesitter/issues/387