### PR TITLE
go locals: remove unused strip! directive

### DIFF
--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -2,14 +2,12 @@
     (comment)* @definition.doc
     (function_declaration
         name: (identifier) @definition.function) ;@function 
-    (#strip! @definition.doc "^//\\s*") ; <- does nothing at the moment
 )
 
 (
     (comment)* @definition.doc
     (method_declaration
         name: (field_identifier) @definition.method); @method
-    (#strip! @definition.doc "^//\\s*") ; <- does nothing at the moment
 )
 
 (short_var_declaration 


### PR DESCRIPTION
The unused `#strip!` now causes an error.