### PR TITLE
ci: check capture names in queries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,19 +84,20 @@ are optional and will not have any effect for now.
 ```
 @embedded
 @injection
-  language
-  content
+@injection.language
+@injection.content
 ```
 
 #### Constants
 
 ```
 @constant
-  builtin
-  macro
+@constant.builtin
+@constant.macro
 @string
-  regex
-  escape
+@string.regex
+@string.escape
+@string.special
 @character
 @number
 @boolean
@@ -107,13 +108,13 @@ are optional and will not have any effect for now.
 
 ```
 @function
-  builtin
-  macro
+@function.builtin
+@function.macro
 @parameter
-  reference references to parameters
 
 @method
-@field or @property
+@field
+@property
 
 @constructor
 ```
@@ -126,19 +127,20 @@ are optional and will not have any effect for now.
 @label for C/Lua-like labels
 @operator
 @keyword
-  function
+@keyword.function
 @exception
 @include keywords for including modules (e.g. import/from in Python)
 
 @type
-    builtin
+@type.builtin
 @structure
+@attribute for e.g. Python decorators
 ```
 
 #### Variables
 ```
 @variable
-  builtin
+@variable.builtin
 ```
 
 #### Text
@@ -158,15 +160,19 @@ Mainly for markup languages.
 ### Locals
 ```
 @definition for various definitions
-  function
-  method
-  var
-  macro
-  type
-  field
-  namespace for modules or C++ namespaces
-  import for imported names
-  doc for documentation adjacent to a definition. E.g.
+@definition.function
+@definition.method
+@definition.var
+@definition.parameter
+@definition.macro
+@definition.type
+@definition.field
+@definition.enum
+@definition.namespace for modules or C++ namespaces
+@definition.import for imported names
+
+@definition.associated to determine the type of a variable
+@definition.doc for documentation adjacent to a definition. E.g.
 ```
 
 ```scheme
@@ -178,6 +184,7 @@ Mainly for markup languages.
 ```
 @scope
 @reference
+@constructor
 ```
 
 #### Definition Scope
@@ -208,7 +215,11 @@ Possible scope values are:
 
 ### Folds
 
-You can define folds for a given language by adding a `fold.scm` query.
-The `@fold` capture is used to fold a node.
+You can define folds for a given language by adding a `fold.scm` query :
+
+```
+@fold
+```
+
 If the `fold.scm` query is not present, this will fallback to the `@scope` captures in the `locals`
 query.

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -96,12 +96,12 @@
   destination: (word) @parameter)
 
 
-("$" (variable_name)) @identifier
+("$" (variable_name)) @variable
 
 (expansion
   [ "${" "}" ] @punctuation.bracket)
 
-(variable_name) @identifier
+(variable_name) @variable
 
 (case_item
   value: (word) @parameter)

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -124,6 +124,6 @@
 
 ; Annotations (not fully supported by parser)
 
-((ERROR) @annotation 
-         (vim-match? @annotation  "\[?\[.*\]\]?.*$"))
-(attribute) @annotation
+((ERROR) @attribute
+         (vim-match? @attribute  "\[?\[.*\]\]?.*$"))
+(attribute) @attribute

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -8,9 +8,9 @@
 
 ; Annotations
 (annotation
-  name: (identifier) @annotation)
+  name: (identifier) @attribute)
 (marker_annotation
-  name: (identifier) @annotation)
+  name: (identifier) @attribute)
 
 ; Operators and Tokens
 
@@ -123,7 +123,7 @@
     name: (identifier) @parameter)
 
 (named_argument
-  (label (identifier) @variable.parameter))
+  (label (identifier) @parameter))
 
 ; Literals
 
@@ -136,7 +136,7 @@
     ; (hex_floating_point_literal)
 ] @number
 
-(symbol_literal) @string.special.symbol
+(symbol_literal) @string.special
 (string_literal) @string
 (true) @boolean
 (false) @boolean

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -121,7 +121,7 @@
 (interpreted_string_literal) @string
 (raw_string_literal) @string
 (rune_literal) @string
-(escape_sequence) @escape
+(escape_sequence) @string.escape
 
 (int_literal) @number
 (float_literal) @float

--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -41,24 +41,24 @@
 
 ;; Call references
 ((call_expression
-   function: (identifier) @reference) @call
+   function: (identifier) @reference)
  (set! reference.kind "call" ))
 
 ((call_expression
     function: (selector_expression
-                field: (field_identifier) @reference)) @call
+                field: (field_identifier) @reference))
  (set! reference.kind "call" ))
 
 
 ((call_expression
     function: (parenthesized_expression
-                (identifier) @reference)) @call
+                (identifier) @reference))
  (set! reference.kind "call" ))
 
 ((call_expression
    function: (parenthesized_expression
                (selector_expression
-                 field: (field_identifier) @reference))) @call
+                 field: (field_identifier) @reference)))
  (set! reference.kind "call" ))
 
 ;; Scopes

--- a/queries/java/locals.scm
+++ b/queries/java/locals.scm
@@ -35,15 +35,14 @@
 ; Functions
 
 (constructor_declaration) @scope
-(method_declaration
-  name: (identifier) @definition.scope) @scope
+(method_declaration) @scope
 
 
 ; DEFINITIONS
 (package_declaration
   (identifier) @definition.namespace)
 (class_declaration
-  name: (identifier) @definition.class)
+  name: (identifier) @definition.type)
 (enum_declaration
   name: (identifier) @definition.enum)
 (method_declaration

--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -9,4 +9,4 @@
 (jsx_opening_element name: (identifier) @variable.builtin)
 (jsx_self_closing_element name: (identifier) @variable.builtin)
 
-(jsx_text) @none
+(jsx_text) @Normal

--- a/queries/php/locals.scm
+++ b/queries/php/locals.scm
@@ -32,10 +32,10 @@
 
 (namespace_use_clause
   (qualified_name
-    (name) @definition.class))
+    (name) @definition.type))
 
 (class_declaration
-  name: (name) @definition.class)
+  name: (name) @definition.type)
 
 ; References
 ;------------

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -67,11 +67,11 @@
     (identifier) @type)) ; type subscript: Tuple[int]
 
 ((call
-  function: (identifier) @isinstance
+  function: (identifier) @_isinstance
   arguments: (argument_list
     (_)
     (identifier) @type))
- (#eq? @isinstance "isinstance"))
+ (#eq? @_isinstance "isinstance"))
 
 ; Normal parameters
 (parameters

--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -24,6 +24,6 @@
  (end_assertion)
  (boundary_assertion)
  (non_boundary_assertion)
-] @escape
+] @string.escape
 
 [ "*" "+" "|" "=" "<=" "!" "<!" ] @operator

--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -1,13 +1,47 @@
 -- Execute as `nvim --headless -c "luafile ./scripts/check-queries.lua"`
+
+local function extract_captures()
+  local lines = vim.fn.readfile("CONTRIBUTING.md")
+  local captures = {}
+  local current_query
+
+  for _, line in ipairs(lines) do
+    if vim.startswith(line, "### ") then
+      current_query = vim.fn.tolower(line:sub(5))
+    elseif vim.startswith(line, "@") and current_query then
+      if not captures[current_query] then
+        captures[current_query] = {}
+      end
+
+      table.insert(captures[current_query], vim.split(line:sub(2), " ", true)[1])
+    end
+  end
+
+  return captures
+end
+
 local function do_check()
   local parsers = require 'nvim-treesitter.parsers'.available_parsers()
   local queries = require 'nvim-treesitter.query'
   local query_types = queries.built_in_query_groups
 
+  local captures = extract_captures()
+
   for _, lang in pairs(parsers) do
     for _, query_type in pairs(query_types) do
       print('Checking '..lang..' '..query_type)
-      queries.get_query(lang, query_type)
+      local query = queries.get_query(lang, query_type)
+
+      if query then
+        for _, capture in ipairs(query.captures) do
+          if not vim.startswith(capture, "_") -- We ignore things like _helper
+            and captures[query_type]
+            and not capture:find("^[A-Z]") -- Highlight groups
+            and not vim.tbl_contains(captures[query_type], capture) then
+            error(string.format("Invalid capture @%s in %s for %s.", capture, query_type, lang))
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This will avoid using invalid captures in queries, and avoid typos.
