### PR TITLE
rewrite lua queries to match the updated lua parser

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -7,8 +7,8 @@
 [
   "if" 
   "then"
-  "end"
 ] @conditional)
+(if_statement (end_keyword) @conditional)
 
 [
   "else"
@@ -19,35 +19,36 @@
 [
   "for"
   "do"
-  "end"
 ] @repeat)
+(for_statement (end_keyword) @repeat)
 
 (for_in_statement
 [
   "for"
   "do"
-  "end"
 ] @repeat)
+(for_in_statement (end_keyword) @repeat)
 
 (while_statement
 [
   "while"
   "do"
-  "end"
 ] @repeat)
+(while_statement (end_keyword) @repeat)
 
 (repeat_statement
 [
   "repeat"
   "until"
 ] @repeat)
+(repeat_statement (end_keyword) @repeat)
 
 [
  "in"
- "local"
  "return"
- (break_statement)
  "goto"
+ (local_keyword)
+ (break_statement)
 ] @keyword
 
 ;; Operators
@@ -99,10 +100,16 @@
 (nil) @constant.builtin
 (spread) @constant ;; "..."
 
+; (function_keyword) @keyword.function
+
 ;; Functions
-("function" @keyword.function
- [(function_name) (identifier)] @function
- "end" @keyword.function)
+(function [(function_keyword) (end_keyword)] @keyword.function)
+(function [(function_name) (identifier)] @function)
+
+(local_function [(function_keyword) (end_keyword)] @keyword.function)
+(local_function [(function_name) (identifier)] @function)
+
+(function_definition [(function_keyword) (end_keyword)] @keyword.function)
 
 (property_identifier) @property
 (method) @method

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -7,8 +7,8 @@
 [
   "if" 
   "then"
+  (_end_keyword)
 ] @conditional)
-(if_statement (end_keyword) @conditional)
 
 [
   "else"
@@ -19,35 +19,35 @@
 [
   "for"
   "do"
+  (_end_keyword)
 ] @repeat)
-(for_statement (end_keyword) @repeat)
 
 (for_in_statement
 [
   "for"
   "do"
+  (_end_keyword)
 ] @repeat)
-(for_in_statement (end_keyword) @repeat)
 
 (while_statement
 [
   "while"
   "do"
+  (_end_keyword)
 ] @repeat)
-(while_statement (end_keyword) @repeat)
 
 (repeat_statement
 [
   "repeat"
   "until"
+  (_end_keyword)
 ] @repeat)
-(repeat_statement (end_keyword) @repeat)
 
 [
  "in"
  "return"
  "goto"
- (local_keyword)
+ (_local_keyword)
  (break_statement)
 ] @keyword
 
@@ -100,16 +100,16 @@
 (nil) @constant.builtin
 (spread) @constant ;; "..."
 
-; (function_keyword) @keyword.function
+; (_function_keyword) @keyword.function
 
 ;; Functions
-(function [(function_keyword) (end_keyword)] @keyword.function)
+(function [(_function_keyword) (_end_keyword)] @keyword.function)
 (function [(function_name) (identifier)] @function)
 
-(local_function [(function_keyword) (end_keyword)] @keyword.function)
+(local_function [(_function_keyword) (_end_keyword)] @keyword.function)
 (local_function [(function_name) (identifier)] @function)
 
-(function_definition [(function_keyword) (end_keyword)] @keyword.function)
+(function_definition [(_function_keyword) (_end_keyword)] @keyword.function)
 
 (property_identifier) @property
 (method) @method


### PR DESCRIPTION
lua highlighting now works perfectly with [this PR](https://github.com/nvim-treesitter/tree-sitter-lua/pull/2) and the updated version of the query file. I didn't take time to look at the other lua files, i'll do it tomorrow. 
Basically the fix for lua highlighting is to declared function and end as keywords because `function` is an identifier but also the keyword `"function"` that we had to match literally. This was messing up the parser badly.