### PR TITLE
feat(C++ highlights): highlight operator_name as function

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -48,6 +48,8 @@
         name: (identifier) @constructor))
  (#match? @constructor "^[A-Z]"))
 
+(operator_name) @function
+
 (call_expression
   function: (scoped_identifier
               name: (identifier) @function))


### PR DESCRIPTION
when you're overloading operators...