### PR TITLE
Add folding for local functions in lua

### DIFF
--- a/queries/lua/fold.scm
+++ b/queries/lua/fold.scm
@@ -3,6 +3,7 @@
  (for_statement)
  (if_statement)
  (function_definition)
+ (local_function)
  (function)
  (while_statement)
  (table)


### PR DESCRIPTION
I noticed that local functions weren't folding with the current head, so I poked around a bit and came up with this.