### PR TITLE
Improve startuptime

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -332,8 +332,7 @@ end
 M.reset_cache()
 
 function M.has_parser(lang)
-  local buf = api.nvim_get_current_buf()
-  local lang = lang or M.get_buf_lang(buf)
+  local lang = lang or M.get_buf_lang(api.nvim_get_current_buf())
 
   if not lang or #lang == 0 then return false end
   return #parser_files[lang] > 0
@@ -369,5 +368,3 @@ function M.get_buf_lang(bufnr)
 end
 
 return M
-
-


### PR DESCRIPTION
- Don't load everything at startup
- Don't define an autocomand for each module and for each supported lang
  (this creates nxm autocomands!). Just define one per module.

Still need to test this more, but here are some numbers :D

### Before

```
044.113: sourcing .../nvim-treesitter/plugin/nvim-treesitter.vim
```

### After

```
000.632: sourcing .../nvim-treesitter/plugin/nvim-treesitter.vim
```