### PR TITLE
Find package path based on the Lua source file

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -200,9 +200,7 @@ local function install(with_sync, ask_reinstall)
       return api.nvim_err_writeln('Git is required on your system to run this command')
     end
 
-    local package_path, err = utils.get_package_path()
-    if err then return api.nvim_err_writeln(err) end
-
+    local package_path = utils.get_package_path()
     local cache_folder, err = utils.get_cache_dir()
     if err then return api.nvim_err_writeln(err) end
 
@@ -267,11 +265,7 @@ function M.uninstall(lang)
       M.uninstall(lang)
     end
   elseif lang then
-    local package_path, err = utils.get_package_path()
-    if err then
-      print(err)
-      return
-    end
+    local package_path = utils.get_package_path()
     local parser_lib = package_path..path_sep.."parser"..path_sep..lang..".so"
 
     local command_list = {

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -18,14 +18,11 @@ function M.setup_commands(mod, commands)
 end
 
 function M.get_package_path()
-  for _, path in pairs(api.nvim_list_runtime_paths()) do
-    local last_segment = vim.fn.fnamemodify(path, ":p:h:t")
-    if last_segment == "nvim-treesitter" then
-      return path
-    end
-  end
+  -- Path to this source file, removing the leading '@'
+  local source = string.sub(debug.getinfo(1, 'S').source, 2)
 
-  return nil, 'Plugin runtime path not found.'
+  -- Path to the package root
+  return fn.fnamemodify(source, ":p:h:h:h")
 end
 
 function M.get_cache_dir()


### PR DESCRIPTION
This is more robust compared to the previous method where we walked
up the tree and matched on the directory name, which also required
that the repository was cloned in a directory named `nvim-treesitter`.

Also see previous discussion at https://github.com/nvim-treesitter/nvim-treesitter/issues/363#issuecomment-687211730