### PR TITLE
Fix TSType and TSPunctuationSpecial

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -80,7 +80,8 @@
                          (constant) @constant
                          ])
 
-(class name: (constant) @constant)
+(class name: (constant) @type)
+(module name: (constant) @type)
 
 ; Identifiers
 [
@@ -144,8 +145,8 @@
  ] @boolean
 
 (interpolation
-  "#{" @punctuation.bracket
-  "}" @punctuation.bracket) @embedded
+  "#{" @punctuation.special
+  "}" @punctuation.special) @embedded
 
 (comment) @comment
 


### PR DESCRIPTION
Move class and module names to `@type` to be consistent with the other languages. (fixes #448)

Use `@punction.special` for interpolation brackets. (fixes #449)
