### PR TITLE
do not highlight jsx_text as normal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,8 @@ effect on highlighting. We will work on improving highlighting in the near futur
 
 ```
 @comment
-@error for error (ERROR` nodes.
+@error for error `ERROR` nodes.
+@none to disable completely the highlight
 @punctuation.delimiter for `;` `.` `,`
 @punctuation.bracket for `()` or `{}`
 @punctuation.special for symbols with special meaning like `{}` in string interpolation.

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -68,6 +68,8 @@ hlmap["text.title"] = "TSTitle"
 hlmap["text.literal"] = "TSLiteral"
 hlmap["text.uri"] = "TSURI"
 
+hlmap["none"] = "TSNone"
+
 function M.attach(bufnr, lang)
   local lang = lang or parsers.get_buf_lang(bufnr)
   local config = configs.get_module('highlight')

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -67,3 +67,5 @@ highlight default TSUnderline term=underline cterm=underline gui=underline
 highlight default link TSTitle Title
 highlight default link TSLiteral String
 highlight default link TSURI Underlined
+
+highlight default TSNone term=none cterm=none gui=none guifg=none guibg=none

--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -8,3 +8,5 @@
 (jsx_closing_element name: (identifier) @variable.builtin)
 (jsx_opening_element name: (identifier) @variable.builtin)
 (jsx_self_closing_element name: (identifier) @variable.builtin)
+
+(jsx_text) @none

--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -8,5 +8,3 @@
 (jsx_closing_element name: (identifier) @variable.builtin)
 (jsx_opening_element name: (identifier) @variable.builtin)
 (jsx_self_closing_element name: (identifier) @variable.builtin)
-
-(jsx_text) @Normal

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -2,7 +2,7 @@
 ; Copyright (c) 2016 Max Brunsfeld
 
 ; Reset highlighing in f-string interpolations
-(interpolation) @Normal
+(interpolation) @none
 
 ;; Identifier naming conventions
 ((identifier) @type


### PR DESCRIPTION
highlighting with `@Normal` is conflicting with other groups, because normal also highlights the background color.
What happens then is that the CursorLine don't get properly highlighted on nodes where `@Normal` is applied.