### PR TITLE
fix(cpp highlights): Use `@include` for preproc_include

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -37,9 +37,10 @@
   "#else"
   "#elif"
   "#endif"
-  "#include"
   (preproc_directive)
 ] @keyword
+
+"#include" @include
 
 [
   "="


### PR DESCRIPTION
Fix #445 