### PR TITLE
fix ocaml highlights

### DIFF
--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -38,8 +38,12 @@
 [(value_name) (type_variable)] @variable
 
 (let_binding pattern: (value_pattern) @variable)
+(let_binding pattern: (tuple_pattern (value_pattern) @variable))
 
-(value_pattern) @parameter
+(let_binding (parameter (label_name) @parameter))
+(let_binding (parameter (value_pattern) @parameter))
+(let_binding (parameter (typed_pattern (value_pattern) @parameter)))
+(function_type (typed_label (label_name) @parameter))
 
 ; Application
 ;------------
@@ -55,7 +59,7 @@
   (#eq? @operator "|>"))
 
 (application_expression
-  function: (value_path (value_name)) @function)
+  function: (value_path (value_name) @function))
 
 (
   (value_name) @function.builtin
@@ -140,7 +144,7 @@
 (object_type ["<" ">"] @punctuation.bracket)
 
 [
-  "," "." ";" ":" "=" "|" "~" "?" "+" "-" "!" ">" "&"
+  "," "." ";" ":" "=" "|" "~" "?" "!" ">" "&"
   "->" ";;" ":>" "+=" ":=" ".."
 ] @punctuation.delimiter
 


### PR DESCRIPTION
Function matching was wrongly parenthesized, parameter detection was too
eager and it was wrongly matching all + and - as delimiters.
Now it marks tuple values as variables when they are being defined