### PR TITLE
Bash: update highlights

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -57,13 +57,10 @@
  "unset"
  ] @keyword
 
-[
- (special_variable_name)
- ("$" (special_variable_name))
- ] @constant
+(special_variable_name) @constant
 
-((word) @constant
-  (#vim-match? @constant "SIG(INT|TERM|QUIT|TIN|TOU|STP|HUP)"))
+((word) @constant.builtin
+ (#vim-match? @constant.builtin "SIG(INT|TERM|QUIT|TIN|TOU|STP|HUP)"))
 
 ((word) @boolean
   (#vim-match? @boolean "true|false"))
@@ -81,7 +78,10 @@
 (function_definition
   name: (word) @function)
 
-(command_name (word)) @function
+(command_name (word) @function)
+
+((command_name (word) @function.builtin)
+ (#match? @function.builtin "^(cd|echo|eval|exit|getopts|pushd|popd|return|set|shift)$"))
 
 (command
   argument: [
@@ -102,6 +102,9 @@
   [ "${" "}" ] @punctuation.bracket)
 
 (variable_name) @variable
+
+((variable_name) @constant
+ (#match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 (case_item
   value: (word) @parameter)


### PR DESCRIPTION
Following some of our conventions and some bits from atom
https://github.com/atom/language-shellscript/blob/master/grammars/tree-sitter-bash.cson:

- Uppercase var are constants
- `$` is a special symbol, not part of the name
- Builtin constants and functions

Closes https://github.com/nvim-treesitter/nvim-treesitter/issues/444