### PR TITLE
Navigation: improve list_definitions and implement list_definitions_toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ require'nvim-treesitter.configs'.setup {
       keymaps = {
         goto_definition = "gnd",
         list_definitions = "gnD",
+	    list_definitions_toc = "gO",
         goto_next_usage = "<a-*>",
         goto_previous_usage = "<a-#>",
       },

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -254,6 +254,9 @@ Supported options:
     No default mapping
   - list_definitions: list all definitions from the current file.
     Defaults to `gnD`.
+  - list_definitions_toc: list all definitions from the current file like a
+    table of contents (similar to the one you see when pressing |gO| in help files).
+    Defaults to `gO`.
   - goto_next_usage: go to next usage of identifier under the cursor.
     Defaults to `<a-*>`.
   - goto_previous_usage: go to previous usage of identifier.
@@ -268,6 +271,7 @@ Supported options:
         keymaps = {
           goto_definition = "gnd",
           list_definitions = "gnD",
+	  list_definitions_toc = "gO",
           goto_next_usage = "<a-*>",
           goto_previous_usage = "<a-#>",
         },

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -76,6 +76,7 @@ local builtin_modules = {
       keymaps = {
         goto_definition = "gnd",
         list_definitions = "gnD",
+        list_definitions_toc = "gO",
         goto_next_usage = "<a-*>",
         goto_previous_usage = "<a-#>",
       }

--- a/lua/nvim-treesitter/refactor/navigation.lua
+++ b/lua/nvim-treesitter/refactor/navigation.lua
@@ -33,22 +33,74 @@ function M.list_definitions(bufnr)
 
   local qf_list = {}
 
-  for _, def in ipairs(definitions) do
-    locals.recurse_local_nodes(def, function(_, node, _, match)
-      local lnum, col, _ = node:start()
-
-      table.insert(qf_list, {
-        bufnr = bufnr,
-        lnum = lnum + 1,
-        col = col + 1,
-        text = ts_utils.get_node_text(node)[1] or "",
-        kind = match and match:sub(1, 1) or ""
-      })
-    end)
+  for _, node in ipairs(definitions) do
+    local lnum, col, _ = node.node:start()
+    local type = string.upper(node.type:sub(1, 1))
+    local text = ts_utils.get_node_text(node.node)[1] or ""
+    table.insert(qf_list, {
+      bufnr = bufnr,
+      lnum = lnum + 1,
+      col = col + 1,
+      text = text,
+      type = type,
+    })
   end
 
   vim.fn.setqflist(qf_list, 'r')
   api.nvim_command('copen')
+end
+
+function M.list_definitions_toc(bufnr)
+  local winnr = api.nvim_get_current_win()
+  local bufnr = api.nvim_win_get_buf(winnr)
+  local definitions = locals.get_definitions(bufnr)
+
+  if #definitions < 1 then return end
+
+  local loc_list = {}
+
+  -- Force some types to act like they are parents
+  -- instead of neighbors of the next nodes.
+  local containers = {
+    ['function'] = true,
+    ['type'] = true,
+    ['method'] = true,
+  }
+  local parents = {}
+
+  for _, def in ipairs(definitions) do
+    -- Get indentation level by putting all parents in a stack.
+    -- The length of the stack minus one is the current level of indentation.
+    local n = #parents
+    for i=1, n do
+      local index = n + 1 - i
+      local parent_def = parents[index]
+      if ts_utils.is_parent(parent_def.node, def.node)
+          or (containers[parent_def.type] and ts_utils.is_parent(parent_def.node:parent(), def.node)) then
+        break
+      else
+        parents[index] = nil
+      end
+    end
+    parents[#parents + 1] = def
+
+    local lnum, col, _ = def.node:start()
+    local type = string.upper(def.type:sub(1, 1))
+    local text = ts_utils.get_node_text(def.node)[1] or ""
+    table.insert(loc_list, {
+      bufnr = bufnr,
+      lnum = lnum + 1,
+      col = col + 1,
+      text = string.rep('  ', #parents - 1) .. text,
+      type = type,
+    })
+  end
+
+  vim.fn.setloclist(winnr, loc_list, 'r')
+  -- The title needs to end with `TOC`,
+  -- so Neovim displays it like a TOC instead of an error list.
+  vim.fn.setloclist(winnr, {}, 'a', {title = 'Definitions TOC'})
+  api.nvim_command('lopen')
 end
 
 function M.goto_adjacent_usage(bufnr, delta)


### PR DESCRIPTION
Fix a couple of bugs with the current list_definitions:

- List by order of appearance
- Remove duplicates (like nodes could match a function and a method, last one takes priority)
- Use type instead of kind in the qf list

Implement list_definitions_toc, this basically mimics the TOC that
you see in the help/Man files when you type `gO`.


### TODO

- [x] docs
- [x] docstrings
- [x] set indentation level for nested nodes