### PR TITLE
feat: add parser for ocaml interface files

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ List of currently supported languages:
 - [ ] [markdown](https://github.com/ikatyang/tree-sitter-markdown)
 - [ ] [nix](https://github.com/cstrahan/tree-sitter-nix)
 - [x] [ocaml](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
+- [x] [ocaml_interface](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
 - [x] [php](https://github.com/tree-sitter/tree-sitter-php) (maintained by @tk-shirasaka)
 - [x] [python](https://github.com/tree-sitter/tree-sitter-python) (maintained by @stsewd, @theHamsta)
 - [x] [Tree-sitter query language](https://github.com/nvim-treesitter/tree-sitter-query) (maintained by @steelsojka)

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -49,9 +49,10 @@ local function iter_cmd_sync(cmd_list)
       print(cmd.info)
     end
 
-    vim.fn.system(get_command(cmd))
+    local ret = vim.fn.system(get_command(cmd))
     if vim.v.shell_error ~= 0 then
-      api.nvim_err_writeln(cmd.err or ("Failed to execute the following command:\n"..vim.inspect(cmd)))
+      print(ret)
+      api.nvim_err_writeln((cmd.err..'\n' or '').."Failed to execute the following command:\n"..vim.inspect(cmd))
       return false
     end
 

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -135,6 +135,16 @@ list.ocaml = {
   maintainers = {'@undu'},
 }
 
+list.ocaml_interface = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-ocaml",
+    files = { "src/parser.c", "src/scanner.cc" },
+    location = "tree-sitter-ocaml_interface/interface"
+  },
+  maintainers = {'@undu'},
+  filetype = 'ocamlinterface'
+}
+
 list.swift = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-swift",

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -15,6 +15,7 @@ M.base_language_map = {
   typescript = {'javascript'},
   javascript = {'jsx'},
   tsx = {'typescript', 'javascript', 'jsx'},
+  ocaml_interface = {'ocaml'},
 }
 
 M.built_in_query_groups = {'highlights', 'locals', 'textobjects', 'folds'}

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -40,9 +40,8 @@
 (let_binding pattern: (value_pattern) @variable)
 (let_binding pattern: (tuple_pattern (value_pattern) @variable))
 
-(let_binding (parameter (label_name) @parameter))
-(let_binding (parameter (value_pattern) @parameter))
-(let_binding (parameter (typed_pattern (value_pattern) @parameter)))
+(value_pattern) @parameter
+(parameter (label_name) @parameter)
 (function_type (typed_label (label_name) @parameter))
 
 ; Application
@@ -76,7 +75,7 @@
 
 (boolean) @constant
 
-(number) @number
+[(number) (signed_number)] @number
 
 [(string) (character)] @string
 
@@ -106,6 +105,8 @@
 
 (infix_operator ["&" "+" "-" "=" ">" "|" "%"] @operator)
 
+(signed_number ["+" "-"] @operator)
+
 ["*" "#" "::" "<-"] @operator
 
 ; Keywords
@@ -126,6 +127,7 @@
 ["include" "open"] @include
 
 ["for" "to" "downto" "while" "do" "done"] @repeat
+
 ; Punctuation
 ;------------
 
@@ -144,7 +146,7 @@
 (object_type ["<" ">"] @punctuation.bracket)
 
 [
-  "," "." ";" ":" "=" "|" "~" "?" "!" ">" "&"
+  "," "." ";" ":" "=" "|" "~" "?" "+" "-" "!" ">" "&"
   "->" ";;" ":>" "+=" ":=" ".."
 ] @punctuation.delimiter
 

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -19,16 +19,16 @@
 ;----------
 
 (let_binding
-  pattern: (value_pattern) @function
+  pattern: (value_name) @function
   (parameter))
 
 (let_binding
-  pattern: (value_pattern) @function
+  pattern: (value_name) @function
   body: [(fun_expression) (function_expression)])
 
 (value_specification (value_name) @function)
 
-(external (value_pattern) @function)
+(external (value_name) @function)
 
 (method_name) @method
 
@@ -36,9 +36,6 @@
 ;----------
 
 [(value_name) (type_variable)] @variable
-
-(let_binding pattern: (value_pattern) @variable)
-(let_binding pattern: (tuple_pattern (value_pattern) @variable))
 
 (value_pattern) @parameter
 (parameter (label_name) @parameter)


### PR DESCRIPTION
Currently ocaml interface files (.mli) are interpreted as standard ml files, which generates erroneous trees.

This PR activates the correct parsing of mli files when using the filetype `ocamlinterface`. This filetype does not exist in vim or neovim out of the box. The filetyppe can be manually set, there is a branch of [vim-ocaml](https://github.com/undu/vim-ocaml/tree/ocaml_interface) sets it out of the box.

Some upstream changes for the ocaml highlights are included. These currently don't provide the best highlighting possible because captures rule precedence in neovim doesn't work the same way as treesitter assumes.

I'd like to get some comments on what do people think it's the best approach for adding a new parser that neovim doesn't support out of the box because parser selection is more granular than existing filetypes.