### PR TITLE
Make :TSInstall work in Nix by adding a second module installation target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/tags
 .luacheckcache
+/tags

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -33,9 +33,9 @@ function M.generate_join(separator)
   end
 end
 
-M.join_path = M.generate_join(M.get_path_sep())
+local join_path = M.generate_join(M.get_path_sep())
 
-M.join_space = M.generate_join(" ")
+local join_space = M.generate_join(" ")
 
 function M.get_package_path()
   -- Path to this source file, removing the leading '@'
@@ -54,14 +54,14 @@ function M.get_cache_dir()
     return '/tmp'
   end
 
-  return nil, M.join_space('Invalid cache rights,', fn.stdpath('data'), 'or /tmp should be read/write')
+  return nil, join_space('Invalid cache rights,', fn.stdpath('data'), 'or /tmp should be read/write')
 end
 
 -- Returns $XDG_DATA_HOME/nvim/site, but could use any directory that is in
 -- runtimepath
 function M.get_site_dir()
   local path_sep = M.get_path_sep()
-  return M.join_path(fn.stdpath('data'), path_sep, 'site')
+  return join_path(fn.stdpath('data'), path_sep, 'site')
 end
 
 -- Try the package dir of the nvim-treesitter plugin first, followed by the
@@ -70,7 +70,7 @@ end
 -- with Nix, since the "/nix/store" is read-only.
 function M.get_parser_install_dir()
   local package_path = M.get_package_path()
-  local package_path_parser_dir = M.join_path(package_path, "parser")
+  local package_path_parser_dir = join_path(package_path, "parser")
 
   -- If package_path is read/write, use that
   if luv.fs_access(package_path_parser_dir, 'RW') then
@@ -79,13 +79,13 @@ function M.get_parser_install_dir()
 
   local site_dir = M.get_site_dir()
   local path_sep = M.get_path_sep()
-  local parser_dir = M.join_path(site_dir, path_sep, 'parser')
+  local parser_dir = join_path(site_dir, path_sep, 'parser')
 
   -- Try creating and using parser_dir if it doesn't exist
   if not luv.fs_stat(parser_dir) then
     local ok, error = pcall(vim.fn.mkdir, parser_dir, "p", "0755")
     if not ok then
-      return nil, M.join_space('Couldn\'t create parser dir', parser_dir, ':', error)
+      return nil, join_space('Couldn\'t create parser dir', parser_dir, ':', error)
     end
 
     return parser_dir
@@ -98,7 +98,7 @@ function M.get_parser_install_dir()
 
   -- package_path isn't read/write, parser_dir exists but isn't read/write
   -- either, give up
-  return nil, M.join_space('Invalid cache rights,', package_path, 'or', parser_dir, 'should be read/write')
+  return nil, join_space('Invalid cache rights,', package_path, 'or', parser_dir, 'should be read/write')
 end
 
 -- Gets a property at path

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -70,10 +70,11 @@ end
 -- with Nix, since the "/nix/store" is read-only.
 function M.get_parser_install_dir()
   local package_path = M.get_package_path()
+  local package_path_parser_dir = M.join_path(package_path, "parser")
 
   -- If package_path is read/write, use that
-  if luv.fs_access(package_path, 'RW') then
-    return package_path
+  if luv.fs_access(package_path_parser_dir, 'RW') then
+    return package_path_parser_dir
   end
 
   local site_dir = M.get_site_dir()


### PR DESCRIPTION
_Disclaimer: I'm a Lua beginner and new to this repository_

This PR solves #436 by adding more logic to determine the correct installation directory for `*.so` files with `:TSInstall`. The logic is to first try the package directory (the way it was before) and then try `$XDG_DATA_HOME/nvim/site/parser/*.so`. The `site` folder will be created if it doesn't exist. The reason I chose this folder is that it is already in `runtimepath`

I also added this logic for the `:TSUninstall` command.

So far I tested the PR in two ways:
1. Follow the install instructions by running `git clone` and using the native packages feature. The expected result is for the `*.so` files to appear in `$XDG_DATA_HOME/site/pack/nvim-treesitter/start/nvim-treesitter/parser/*.so`
2. Install `nvim-treesitter` with Nix. The expected result is for the `*.so` files to appear in `$XDG_DATA_HOME/nvim/site/parser/*.so`

I also made sure that `:TSUninstall` work and that `:TSInstallInfo` shows the modules as installed.

Tested only on Linux so far, but I can also test on MacOS.

Looking forward for very honest feedback :waffle: 

PS: I also included one commit which adds `/tags` to `.gitignore`