### PR TITLE
Remove @definition.doc captures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,7 @@ Mainly for markup languages.
 ```
 
 ### Locals
+
 ```
 @definition for various definitions
 @definition.function
@@ -174,15 +175,7 @@ Mainly for markup languages.
 
 @definition.associated to determine the type of a variable
 @definition.doc for documentation adjacent to a definition. E.g.
-```
 
-```scheme
-  (comment)* @definition.doc
-    (method_declaration
-        name: (field_identifier) @definition.method)
-```
-
-```
 @scope
 @reference
 @constructor

--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -1,11 +1,9 @@
 (
-    (comment)* @definition.doc
     (function_declaration
         name: (identifier) @definition.function) ;@function 
 )
 
 (
-    (comment)* @definition.doc
     (method_declaration
         name: (field_identifier) @definition.method); @method
 )

--- a/queries/python/locals.scm
+++ b/queries/python/locals.scm
@@ -45,8 +45,7 @@
 
 ; Function defines function and scope
 ((function_definition
-  name: (identifier) @definition.function
-  body: (block (expression_statement (string) @definition.doc)?)) @scope
+  name: (identifier) @definition.function) @scope
  (#set! definition.function.scope "parent"))
 
 


### PR DESCRIPTION
These aren't really definitions and are being show in the definitions
list. We aren't using them at the moment, we could use another group or
query file.