### PR TITLE
[Ruby highlighting] Revert @include highlighting for require

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -45,8 +45,8 @@
 
 ; Function calls
 
-((identifier) @include
- (#vim-match? @include "^(require|require_relative|load)$"))
+((identifier) @function
+ (#eq? @function "require"))
 
 "defined?" @function
 


### PR DESCRIPTION
In #463 I advocated that require/require_relative & load should be
highlighted as `@include`.

Turns out that is not a good idea.

require is not a keyword, it is an actual function, and it can be
overriden as a class method.

For example in Rails strong params is invoked via a require method, an
example:

```ruby
  def album_params
    params.require(:album).permit(:title, :genre_id, :year, :track_list,
                                  :cover, :cover_cache)
  end
```

With the PR #477 the the require above would be highlighted as
TSInclude, not what we want.

In the end it is best to stay with the original function highlighting
for require.

I apologize for needlessly going down this rabbit hole.