### PR TITLE
Add case builtin for dart

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -29,6 +29,7 @@ hlmap["number"] = "TSNumber"
 hlmap["boolean"] = "TSBoolean"
 hlmap["float"] = "TSFloat"
 hlmap["annotation"] = "TSAnnotation"
+hlmap["attribute"] = "TSAttribute"
 
 -- Functions
 hlmap["function"] = "TSFunction"

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -38,6 +38,7 @@ highlight default link TSField Identifier
 highlight default link TSProperty Identifier
 highlight default link TSConstructor Special
 highlight default link TSAnnotation PreProc
+highlight default link TSAttribute PreProc
 
 highlight default link TSConditional Conditional
 highlight default link TSRepeat Repeat

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -8,14 +8,13 @@
 
 ; Annotations
 (annotation
-  name: (identifier) @attribute)
+  name: (identifier) @annotation)
 (marker_annotation
-  name: (identifier) @attribute)
+  name: (identifier) @annotation)
 
 ; Operators and Tokens
 
-; FIXME: nodes not accessible and ranges
-; currently incorrect
+; FIXME: nodes not accessible and ranges currently incorrect
 ; (template_substitution
 ;   "${" @punctuation.special
 ;   "}" @punctuation.special) @embedded
@@ -103,6 +102,8 @@
 ((identifier) @type
  (#match? @type "^[A-Z]"))
 
+("Function" @type)
+
 ; properties
 ; TODO: add method/call_expression to grammar and
 ; distinguish method call from variable access
@@ -151,9 +152,9 @@
 
 ; Reserved words (cannot be used as identifiers)
 ; TODO: "rethrow" @keyword
-
 [
     ; "assert"
+    (case_builtin)
     "class"
     "enum"
     "extends"
@@ -178,7 +179,6 @@
     "dynamic"
     "external"
     "factory"
-    "Function"
     "get"
     "implements"
     "interface"

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -8,9 +8,9 @@
 
 ; Annotations
 (annotation
-  name: (identifier) @annotation)
+  name: (identifier) @attribute)
 (marker_annotation
-  name: (identifier) @annotation)
+  name: (identifier) @attribute)
 
 ; Operators and Tokens
 


### PR DESCRIPTION
Based on https://github.com/UserNobody14/tree-sitter-dart/pull/10 to unhide the `case` node
This PR also shows `Function` as a type rather than a keyword. `Function` is used as a type annotation but I've previously incorrectly included it as a keyword which isn't correct.

Lastly switch to using the existing annotation highlight for annotations (duh) rather than the no longer existing `attribute` annotation