### PR TITLE
Ensure that updated files are replaced w/o warning

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -104,7 +104,7 @@ local function select_mv_cmd(compile_location, parser_lib_name)
     return {
       cmd = 'cmd',
       opts = {
-        args = { '/C', 'move', compile_location..'\\parser.so', parser_lib_name },
+        args = { '/C', 'move', '/Y', compile_location..'\\parser.so', parser_lib_name },
       }
     }
   else


### PR DESCRIPTION
This should ensure that `:TSUpdate` replaces already existing files when moving the compiled libraries.