### PR TITLE
fix(checkhealth): use pcall to check for syntax errors in query files

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -34,7 +34,13 @@ local function install_health()
 end
 
 local function query_health(lang, query_group)
-  if not queries.get_query(lang, query_group) then
+  local ok, found_query = pcall(queries.get_query, lang, query_group)
+  if not ok then
+    health_error("Error in `"..query_group..".scm` query found for "..lang..'\n'..found_query, {
+      "Try `:TSUpdate "..lang.."` (queries might have been adapted for a upstream parser change)",
+      "Try to find the syntax error/invalid node type in above file."
+    })
+  elseif not found_query then
     health_warn("No `"..query_group..".scm` query found for " .. lang, {
       "Open an issue at https://github.com/nvim-treesitter/nvim-treesitter"
     })


### PR DESCRIPTION
Before:

```
health#nvim_treesitter#check
========================================================================
  - ERROR: Failed to run healthcheck for "nvim_treesitter" plugin. Exception:
    function health#check[21]..health#nvim_treesitter#check, line 1
    Vim(lua):E5108: Error executing lua /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:20: query: invalid node type at position 170

... output of checkhealth stops
```


After:
```
## c parser healthcheck
  - OK: c parser found.
  - ERROR: Error in `highlights.scm` query found for c
    /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:20: query: invalid node type at position 170
    - ADVICE:
      - Try `:TSUpdate` (queries might have been adapted for a upstream parser change)
      - Try to find the syntax error/invalid node type in above file.
  - OK: `locals.scm` found.
  - OK: `textobjects.scm` found.
  - OK: `folds.scm` found.
```