### PR TITLE
fix(python): use `@Normal` again for f-strings `@none` is not aggressive enough

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -5,7 +5,7 @@
 (identifier) @variable
 
 ; Reset highlighing in f-string interpolations
-(interpolation) @none
+(interpolation) @Normal
 
 ;; Identifier naming conventions
 ((identifier) @type


### PR DESCRIPTION
We really want to reset all potential highlighting from the string here.

An alternative would be to add explicit highlighting of `@variable` but this wouldn't reset potential background highlighting of the string.