### PR TITLE
Highlight top-level 'require' as TSInclude (fix #463)

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -49,9 +49,6 @@
 
 ; Function calls
 
-((identifier) @include
- (#vim-match? @include "^(require|require_relative|load)$"))
-
 "defined?" @function
 
 (call
@@ -71,6 +68,11 @@
             (constant)
             ] @function
    ])
+
+(program
+ (method_call
+  (identifier) @include)
+ (#vim-match? @include "^(require|require_relative|load)$"))
 
 ; Function definitions
 


### PR DESCRIPTION
This enhancement, provided by @theHamsta in [this comment](https://github.com/nvim-treesitter/nvim-treesitter/issues/463#issuecomment-695357859) fixes issue #463 

Top level `require` / `require_relative` / `load` will be highlighted as `TSInclude`, however other usages of those functions, such as Rails strong-params will be highlighted as Method/Function instead.