### PR TITLE
fix(highlights): Add TSNamespace highlight

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ are optional and will not have any effect for now.
 
 @type
 @type.builtin
-@structure
+@namespace for identifiers referring to namespaces
 @attribute for e.g. Python decorators
 ```
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ List of currently supported languages:
 - [x] [rust](https://github.com/tree-sitter/tree-sitter-rust) (maintained by @vigoux)
 - [ ] [scala](https://github.com/tree-sitter/tree-sitter-scala)
 - [ ] [swift](https://github.com/tree-sitter/tree-sitter-swift)
+- [x] [teal](https://github.com/euclidianAce/tree-sitter-teal) (maintained by @euclidianAce)
 - [x] [toml](https://github.com/ikatyang/tree-sitter-toml) (maintained by @tk-shirasaka)
 - [ ] [tsx](https://github.com/tree-sitter/tree-sitter-typescript)
 - [x] [typescript](https://github.com/tree-sitter/tree-sitter-typescript) (maintained by @steelsojka)

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -570,9 +570,9 @@ For types.
                                                             *hl-TSTypeBuiltin*
 For builtin types (you guessed it, right ?).
 
-`TSStructure`
-                                                              *hl-TSStructure*
-This is left as an exercise for the reader.
+`TSNamespace`
+                                                              *hl-TSNamespace*
+For identifiers referring to modules and namespaces.
 
 `TSInclude`
                                                                 *hl-TSInclude*

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -30,6 +30,7 @@ hlmap["boolean"] = "TSBoolean"
 hlmap["float"] = "TSFloat"
 hlmap["annotation"] = "TSAnnotation"
 hlmap["attribute"] = "TSAttribute"
+hlmap["namespace"] = "TSNamespace"
 
 -- Functions
 hlmap["function"] = "TSFunction"

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -41,6 +41,7 @@ highlight default link TSProperty Identifier
 highlight default link TSConstructor Special
 highlight default link TSAnnotation PreProc
 highlight default link TSAttribute PreProc
+highlight default link TSNamespace Include
 
 highlight default link TSConditional Conditional
 highlight default link TSRepeat Repeat
@@ -53,7 +54,6 @@ highlight default link TSException Exception
 
 highlight default link TSType Type
 highlight default link TSTypeBuiltin Type
-highlight default link TSStructure Structure
 highlight default link TSInclude Include
 
 highlight default link TSVariable TSNone

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -28,14 +28,16 @@
   name: (scoped_identifier
     name: (identifier) @function))
 
-(namespace_identifier) @constant
 
 ((identifier) @type (#match? @type "^[A-Z]"))
 
+(namespace_identifier) @namespace
 ((namespace_identifier) @type
                         (#match? @type "^[A-Z]"))
 ((namespace_identifier) @constant
                         (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+(namespace_definition
+  name: (identifier) @namespace)
 
 (destructor_name
   name: (_) @function)

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -90,6 +90,11 @@
   (rest_parameter
     (identifier) @parameter))
 
+; Variables
+;----------
+(namespace_import
+  (identifier) @namespace)
+
 ; Literals
 ;---------
 

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -1,7 +1,7 @@
 ; Modules
 ;--------
 
-[(module_name) (module_type_name)] @structure
+[(module_name) (module_type_name)] @namespace
 
 ; Types
 ;------

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -13,11 +13,15 @@
 (type_identifier) @type
 (primitive_type) @type.builtin
 (field_identifier) @field
-
+(mod_item
+ name: (identifier) @namespace)
 
 ; Function calls
 (call_expression
   function: (identifier) @function)
+(call_expression
+  function: (scoped_identifier 
+              (identifier) @function .))
 (call_expression
   function: (field_expression
     field: (field_identifier) @function))
@@ -36,6 +40,16 @@
  (#match? @constant "^[A-Z]"))
 
 ; Assume that uppercase names in paths are types
+(scoped_identifier
+  path: (identifier) @namespace)
+(scoped_identifier
+ (scoped_identifier
+  name: (identifier) @namespace))
+(scoped_type_identifier
+  path: (identifier) @namespace)
+(scoped_type_identifier
+ (scoped_identifier
+  name: (identifier) @namespace))
 ((scoped_identifier
   path: (identifier) @type)
  (#match? @type "^[A-Z]"))
@@ -43,6 +57,13 @@
     name: (identifier) @type)
  (#match? @type "^[A-Z]"))
 
+(crate) @namespace
+(scoped_use_list
+  path: (identifier) @namespace)
+(scoped_use_list
+  path: (scoped_identifier
+            (identifier) @namespace))
+(use_list (scoped_identifier (identifier) @namespace . (_)))
 (use_list (identifier) @type (#match? @type "^[A-Z]"))
 (use_as_clause alias: (identifier) @type (#match? @type "^[A-Z]"))
 
@@ -60,8 +81,10 @@
   (#eq? @type "derive"))
 
 (macro_invocation
-  macro: (identifier) @function.macro
-  "!" @function.macro)
+  macro: (identifier) @function.macro)
+(macro_invocation
+  macro: (scoped_identifier
+           (identifier) @function.macro .))
 
 ; Function definitions
 
@@ -100,6 +123,11 @@
 (self) @variable.builtin
 
 [
+ "use"
+ "mod"
+] @include
+
+[
 "break"
 "const"
 "default"
@@ -111,7 +139,6 @@
 "let"
 "macro_rules!"
 "match"
-"mod"
 "move"
 "pub"
 "ref"
@@ -124,7 +151,6 @@
 "unsafe"
 "async"
 "await"
-"use"
 "where"
 (mutable_specifier)
 (super)


### PR DESCRIPTION
Start adding highlights for
     - C++
     - Rust (including other scoped_identifier/scoped_type_identifier fixes)
     - JS (only namespace_import)

Addresses #516

Vim has no dedicated hl-group for modules/namespace continued to use Constant (open for better suggestions)

#453 could be useful for Rust highlights. In the queries it can almost always be `scoped_identifier` or `scoped_type_identifier` as a parent.