### PR TITLE
Python locals.scm: variables -> left_hand_side

### DIFF
--- a/queries/python/locals.scm
+++ b/queries/python/locals.scm
@@ -61,7 +61,7 @@
 ;;; Loops
 ; not a scope!
 (for_statement
-  left: (variables
+  left: (left_hand_side
           (identifier) @definition.var))
 
 ; not a scope!
@@ -69,7 +69,7 @@
 
 ; for in list comprehension
 (for_in_clause
-  left: (variables
+  left: (left_hand_side
           (identifier) @definition.var))
 
 (dictionary_comprehension) @scope


### PR DESCRIPTION
This shouldn't be merged yet! The commits that require this change come after the update runtime commit of the Python repository which currently makes the Python parser unusable.