### PR TITLE
Add Kotlin parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [jsdoc](https://github.com/tree-sitter/tree-sitter-jsdoc) (maintained by @steelsojka)
 - [x] [json](https://github.com/tree-sitter/tree-sitter-json) (maintained by @steelsojka)
 - [ ] [julia](https://github.com/tree-sitter/tree-sitter-julia)
+- [ ] [kotlin](https://github.com/QthCN/tree-sitter-kotlin)
 - [x] [lua](https://github.com/nvim-treesitter/tree-sitter-lua) (maintained by @vigoux)
 - [x] [nix](https://github.com/cstrahan/tree-sitter-nix) (maintained by @leo60228)
 - [x] [ocaml](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -111,6 +111,13 @@ list.java = {
   maintainers = {"@p00f"},
 }
 
+list.kotlin = {
+  install_info = {
+    url = "https://github.com/QthCN/tree-sitter-kotlin",
+    files = {"src/parser.c"}
+  }
+}
+
 list.html = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-html",


### PR DESCRIPTION
https://github.com/QthCN/tree-sitter-kotlin is a fork of https://github.com/fwcd/tree-sitter-kotlin with some recent updates. The parser is working quite well on all the files that I tried. Thought, that it you be a nice task for Hacktober fest to add some queries.

fwcd made a Kotlin language server and a debug adapter for Kotlin.
Probably, the language server is using this parser.