### PR TITLE
Installation of maintained parsers only

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ so you'll need to activate them by putting this in your `init.vim` file:
 ```lua
 lua <<EOF
 require'nvim-treesitter.configs'.setup {
-  ensure_installed = "all",     -- one of "all", "language", or a list of languages
+  ensure_installed = "maintained", -- one of "all", "maintained" (parsers with maintainers), or a list of languages
   highlight = {
     enable = true,              -- false will disable the whole extension
     disable = { "c", "rust" },  -- list of language that will be disabled

--- a/autoload/nvim_treesitter.vim
+++ b/autoload/nvim_treesitter.vim
@@ -7,11 +7,11 @@ function! nvim_treesitter#foldexpr() abort
 endfunction
 
 function! nvim_treesitter#installable_parsers(arglead, cmdline, cursorpos) abort
-  return join(luaeval("require'nvim-treesitter.parsers'.available_parsers()") + ['all'], "\n")
+  return join(luaeval("require'nvim-treesitter.parsers'.available_parsers()") + ['all', 'maintained'], "\n")
 endfunction
 
 function! nvim_treesitter#installed_parsers(arglead, cmdline, cursorpos) abort
-  return join(luaeval("require'nvim-treesitter.info'.installed_parsers()") + ['all'], "\n")
+  return join(luaeval("require'nvim-treesitter.info'.installed_parsers()") + ['all', 'maintained'], "\n")
 endfunction
 
 function! nvim_treesitter#available_modules(arglead, cmdline, cursorpos) abort

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -36,7 +36,7 @@ To enable supported features, put this in your `init.vim` file:
 >
   lua <<EOF
   require'nvim-treesitter.configs'.setup {
-    ensure_installed = "all",     -- one of "all", "language", or a list of languages
+    ensure_installed = "maintained", -- one of "all", "maintained" (parsers with maintainers), or a list of languages
     highlight = {
       enable = true,              -- false will disable the whole extension
       disable = { "c", "rust" },  -- list of language that will be disabled

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -329,6 +329,9 @@ local function install(with_sync, ask_reinstall)
     if ... == 'all' then
       languages = parsers.available_parsers()
       ask = false
+    elseif ... == 'maintained' then
+      languages = parsers.maintained_parsers()
+      ask = false
     else
       languages = vim.tbl_flatten({...})
       ask = ask_reinstall
@@ -362,9 +365,13 @@ function M.uninstall(lang)
     path_sep = '\\'
   end
 
-  if lang == 'all' then
+  if vim.tbl_contains({'all', 'maintained'}, lang) then
     reset_progress_counter()
     local installed = info.installed_parsers()
+    if lang == "maintained" then
+      local maintained = parsers.maintained_parsers()
+      installed = vim.tbl_filter(function(l) return vim.tbl_contains(maintained, l) end, installed)
+    end
     for _, lang in pairs(installed) do
       M.uninstall(lang)
     end

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -324,6 +324,10 @@ function M.available_parsers()
   return vim.tbl_keys(M.list)
 end
 
+function M.maintained_parsers()
+  return vim.tbl_filter(function(lang) return M.list[lang].maintainers end, M.available_parsers())
+end
+
 function M.get_parser_configs()
   return M.list
 end


### PR DESCRIPTION
Unmaintained parsers only give users little benefit but take sometimes a
a long time to install (e.g. Markdown, Julia, Haskell parser). We could
recommend to only install maintained parsers by default.

So instead of `ensure_installed = 'all'` or `:TSInstall all` you can now also install `'maintained'` parsers only.

This PR is on top of #351 