### PR TITLE
Add ocamllex highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ List of currently supported languages:
 - [ ] [nix](https://github.com/cstrahan/tree-sitter-nix)
 - [x] [ocaml](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
 - [x] [ocaml_interface](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
+- [x] [ocamllex](https://github.com/atom-ocaml/tree-sitter-ocamllex) (maintained by @undu)
 - [x] [php](https://github.com/tree-sitter/tree-sitter-php) (maintained by @tk-shirasaka)
 - [x] [python](https://github.com/tree-sitter/tree-sitter-python) (maintained by @stsewd, @theHamsta)
 - [x] [ql](https://github.com/tree-sitter/tree-sitter-ql) (maintained by @pwntester)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -145,6 +145,14 @@ list.ocaml_interface = {
   filetype = 'ocamlinterface'
 }
 
+list.ocamllex = {
+  install_info = {
+    url = "https://github.com/atom-ocaml/tree-sitter-ocamllex",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  maintainers = {'@undu'},
+}
+
 list.swift = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-swift",

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -72,7 +72,9 @@
 
 [(number) (signed_number)] @number
 
-[(string) (character)] @string
+(character) @character
+
+(string) @string
 
 (quoted_string "{" @string "}" @string) @string
 

--- a/queries/ocamllex/highlights.scm
+++ b/queries/ocamllex/highlights.scm
@@ -1,0 +1,27 @@
+
+[(lexer_argument) (regexp_name) (any)] @type
+
+(lexer_entry_name) @function
+
+["as" "let" "parse" "rule"] @keyword
+
+[(eof) (character)] @character
+(string) @string
+
+(character_range "-" @operator)
+(character_set "^" @operator)
+(regexp_alternative ["|"] @operator)
+(regexp_difference ["#"] @operator)
+(regexp_option ["?"] @operator)
+(regexp_repetition ["*"] @operator)
+(regexp_strict_repetition ["+"] @operator)
+
+(action ["{" "}"] @punctuation.special) @embedded
+(character_set ["[" "]"] @punctuation.bracket)
+(parenthesized_regexp ["(" ")"] @punctuation.bracket)
+
+["="] @punctuation.delimiter
+(lexer_entry "|" @punctuation.delimiter)
+
+(comment) @comment
+(ERROR) @error


### PR DESCRIPTION
The parser emits opaque `ocaml` nodes, since these are not yet handled to the ocaml parser they remain unhighlighted. The ocaml nodes appear inside action nodes. I've tagged those with `@embedded` since that's how it seems to be handled in other scm files. is this how it's supposed to be used?
 
I've added the hash to the lockfile, although it's not clear in the diff since it's all in the same line.

Like it happens to highlight mli files, this PR is needed: https://github.com/ocaml/vim-ocaml/pull/61 (or set manually the filetype to ocamllex)