### PR TITLE
Dart highlights: Reset highlight in interpolation

### DIFF
--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -11,7 +11,7 @@ let g:loaded_nvim_treesitter = 1
 
 lua require'nvim-treesitter'.setup()
 
-highlight default TSNone term=none cterm=none gui=none guifg=none guibg=none
+highlight default TSNone term=NONE cterm=NONE gui=NONE
 
 highlight default link TSError TSNone
 

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -19,7 +19,7 @@
   "$" @punctuation.special
   "{" @punctuation.special
   "}" @punctuation.special
-) @embedded
+) @none
 
 [
  "@"

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -5,7 +5,7 @@
 (identifier) @variable
 
 ; Reset highlighing in f-string interpolations
-(interpolation) @Normal
+(interpolation) @none
 
 ;; Identifier naming conventions
 ((identifier) @type


### PR DESCRIPTION
Seeing the screenshot of @akinsho (https://github.com/neovim/neovim/issues/12967#issuecomment-702701918), I had the idea that we could reset highlight in Dart string interpolations similar to how we treat Python f-strings.

If someone can tell me what to change that it works with `TSNone` we would not have to change it to `@Normal`.
