### PR TITLE
Fix: avoid overwriting tables in insert_to_path

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -85,8 +85,8 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
       for id, node in pairs(match) do
         local name = query.captures[id] -- name of the capture in the query
         if name ~= nil then
-          local path = split(name)
-          insert_to_path(prepared_match, path, { node=node })
+          local path = split(name..'.node')
+          insert_to_path(prepared_match, path, node)
         end
       end
 


### PR DESCRIPTION
The following query will result in matches with only one node though it
requires two nodes to be a match.

```scheme
(function_definition
 (comment) @function.inner.start
  body: (block) @function.inner)
```
Why? First `insert_to_path` is called for `@function.inner.start` which
will result int the following table.

```lua
{ function = { inner = { start = { node =  <userdata1>} } } }
```
`insert_to_path` will overwrite the result
```lua
{ function = { inner = { node = <userdata2>  } } }
```
instead of having
```
{ function = { inner = { start = { node =  <userdata1>}, node = <userdata2>} } }
```
This can either be solved by avoiding to insert tables (this PR) or by trying to perform a `tbl_merge`
```
    if type(curr_obj[path[#path]]) == 'table' and type(value) == 'table' then
      curr_obj[path[#path]] = vim.tbl_extend('force', curr_obj[path[#path]], value)
    else
      curr_obj[path[#path]] = value
    end
```

Related #552