### PR TITLE
fix: readme link to nvim-treesitter-textobjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ EOF
 Other modules can be installed as plugins.
 
 - [refactor](https://github.com/nvim-treesitter/nvim-treesitter-refactor) - Refactoring and definition modules
-- [textobjects](https://github.com/nvim-treesitter/nvim-treesitter-refactor) - Textobjects defined by tree-sitter queries
+- [textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) - Textobjects defined by tree-sitter queries
 - [playground](https://github.com/nvim-treesitter/playground) - Treesitter integrated playground
 
 # Extra features


### PR DESCRIPTION
Hey! Really interesting work going on here, been following and updating regularly. Saw that `textobjects` was moved to a new module and found a small typo while updating my dotfiles.