### PR TITLE
Implement inheritance using in-file modelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,18 @@ Here are some global advices :
 - Examples of queries can be found in [queries/](queries/)
 - Matches in the bottom will override queries that are above of them.
 
+If your language is an extension of a language (TypeScript is an extension of JavaScript for
+example), you can include the queries from your base language by adding the following _as the first
+line of your file_.
+
+```scheme
+; inherits: lang1,(optionallang)
+```
+
+If you want to include a language for a given query, but don't want for the queries including the
+query you qre writing to include it too, you can mark the language as optional (by putting it
+between parenthesis).
+
 ### Highlights
 
 As languages differ quite a lot, here is a set of captures available to you when building a `highlights.scm` query.

--- a/queries/cpp/folds.scm
+++ b/queries/cpp/folds.scm
@@ -1,3 +1,5 @@
+; inherits: c
+
 [
  (for_range_loop)
  (class_specifier)

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -1,3 +1,5 @@
+; inherits: c
+
 ((identifier) @field
  (#match? @field "^_"))
 

--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -1,3 +1,5 @@
+; inherits: c
+
 ;; Parameters
 (variadic_parameter_declaration
   declarator: (variadic_declarator

--- a/queries/javascript/folds.scm
+++ b/queries/javascript/folds.scm
@@ -1,3 +1,4 @@
+; inherits: (jsx)
 [
   (for_in_statement)
   (for_statement)

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -1,3 +1,4 @@
+; inherits: (jsx)
 ; Types
 
 ; Javascript

--- a/queries/javascript/locals.scm
+++ b/queries/javascript/locals.scm
@@ -1,3 +1,5 @@
+; inherits: (jsx)
+
 ; Scopes
 ;-------
 

--- a/queries/ocaml_interface/folds.scm
+++ b/queries/ocaml_interface/folds.scm
@@ -1,0 +1,1 @@
+; inherits: ocaml

--- a/queries/ocaml_interface/highlights.scm
+++ b/queries/ocaml_interface/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: ocaml

--- a/queries/ocaml_interface/locals.scm
+++ b/queries/ocaml_interface/locals.scm
@@ -1,0 +1,1 @@
+; inherits: ocaml

--- a/queries/tsx/folds.scm
+++ b/queries/tsx/folds.scm
@@ -1,0 +1,1 @@
+; inherits: typescript,jsx

--- a/queries/tsx/highlights.scm
+++ b/queries/tsx/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: typescript,jsx

--- a/queries/tsx/locals.scm
+++ b/queries/tsx/locals.scm
@@ -1,0 +1,1 @@
+; inherits: typescript,jsx

--- a/queries/typescript/folds.scm
+++ b/queries/typescript/folds.scm
@@ -1,3 +1,5 @@
+; inherits: javascript
+
 [
   (interface_declaration)
   (internal_module)

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -1,3 +1,4 @@
+; inherits: javascript
 [
 "abstract"
 "declare"

--- a/queries/typescript/locals.scm
+++ b/queries/typescript/locals.scm
@@ -1,2 +1,4 @@
+; inherits: javascript
+
 (required_parameter (identifier) @definition)
 (optional_parameter (identifier) @definition)


### PR DESCRIPTION
This implements neovim/neovim#13059 (comment)

This behaves like modelines and remove the use of the base_language map.
Also, this allows to fine-tune what we actually want to include per
query, which is better IMO.

One other thing to note to is that using this mechanism, one can just write queries for his language, without knowing anything about lua, which is great.

I would really like everyone's approval on this, to be sure I don't break anything.