### PR TITLE
Add background and foreground colors to TSNone

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ List of currently supported languages:
 - [x] [rust](https://github.com/tree-sitter/tree-sitter-rust) (maintained by @vigoux)
 - [ ] [scala](https://github.com/tree-sitter/tree-sitter-scala)
 - [ ] [swift](https://github.com/tree-sitter/tree-sitter-swift)
+- [x] [teal](https://github.com/euclidianAce/tree-sitter-teal) (maintained by @euclidianAce)
 - [x] [toml](https://github.com/ikatyang/tree-sitter-toml) (maintained by @tk-shirasaka)
 - [ ] [tsx](https://github.com/tree-sitter/tree-sitter-typescript)
 - [x] [typescript](https://github.com/tree-sitter/tree-sitter-typescript) (maintained by @steelsojka)

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -11,7 +11,7 @@ let g:loaded_nvim_treesitter = 1
 
 lua require'nvim-treesitter'.setup()
 
-highlight default TSNone term=NONE cterm=NONE gui=NONE guifg=foreground guibg=background ctermfg=fg ctermbg=bg
+highlight default TSNone term=NONE cterm=NONE gui=NONE guifg=foreground ctermfg=fg
 
 highlight default link TSError TSNone
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -11,17 +11,18 @@ let g:loaded_nvim_treesitter = 1
 
 lua require'nvim-treesitter'.setup()
 
-function s:has_attr(attr)
-  return strlen(synIDattr(hlID('Normal'), a:attr)) > 0
+function s:has_attr(attr, mode)
+  let norm_color = synIDattr(hlID('Normal'), a:attr, a:mode)
+  return strlen(norm_color) > 0
 endfunction
 
 " if the ctermfg or guifg is not known by nvim then using the
 " fg or foreground highlighting value will cause an E419 error
-if s:has_attr('fg')
-  highlight default TSNone term=NONE cterm=NONE gui=NONE guifg=foreground ctermfg=fg
-else
-  highlight default TSNone term=NONE cterm=NONE gui=NONE
-endif
+" so we check to see if either highlight has been set if not default to NONE
+let cterm_normal = s:has_attr('fg', 'cterm') ? 'fg' : 'NONE'
+let gui_normal = s:has_attr('fg', 'gui') ? 'foreground' : 'NONE'
+
+execute 'highlight default TSNone term=NONE cterm=NONE gui=NONE guifg='.gui_normal.' ctermfg='.cterm_normal
 
 highlight default link TSError TSNone
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -11,7 +11,7 @@ let g:loaded_nvim_treesitter = 1
 
 lua require'nvim-treesitter'.setup()
 
-highlight default TSNone term=NONE cterm=NONE gui=NONE guifg=foreground guibg=background ctermfg=foreground ctermbg=background
+highlight default TSNone term=NONE cterm=NONE gui=NONE guifg=foreground guibg=background ctermfg=fg ctermbg=bg
 
 highlight default link TSError TSNone
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -11,7 +11,7 @@ let g:loaded_nvim_treesitter = 1
 
 lua require'nvim-treesitter'.setup()
 
-highlight default TSNone term=NONE cterm=NONE gui=NONE
+highlight default TSNone term=NONE cterm=NONE gui=NONE guifg=foreground guibg=background ctermfg=foreground ctermbg=background
 
 highlight default link TSError TSNone
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -11,7 +11,17 @@ let g:loaded_nvim_treesitter = 1
 
 lua require'nvim-treesitter'.setup()
 
-highlight default TSNone term=NONE cterm=NONE gui=NONE guifg=foreground ctermfg=fg
+function s:has_attr(attr)
+  return strlen(synIDattr(hlID('Normal'), a:attr)) > 0
+endfunction
+
+" if the ctermfg or guifg is not known by nvim then using the
+" fg or foreground highlighting value will cause an E419 error
+if s:has_attr('fg')
+  highlight default TSNone term=NONE cterm=NONE gui=NONE guifg=foreground ctermfg=fg
+else
+  highlight default TSNone term=NONE cterm=NONE gui=NONE
+endif
 
 highlight default link TSError TSNone
 


### PR DESCRIPTION
This fixes the issue where colors highlighted as TSNone were not
reverting to the background and foreground color. It follow us up #551.