### PR TITLE
Python: highlight builtin functions as identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ List of currently supported languages:
 - [x] [rust](https://github.com/tree-sitter/tree-sitter-rust) (maintained by @vigoux)
 - [ ] [scala](https://github.com/tree-sitter/tree-sitter-scala)
 - [ ] [swift](https://github.com/tree-sitter/tree-sitter-swift)
+- [x] [teal](https://github.com/euclidianAce/tree-sitter-teal) (maintained by @euclidianAce)
 - [x] [toml](https://github.com/ikatyang/tree-sitter-toml) (maintained by @tk-shirasaka)
 - [ ] [tsx](https://github.com/tree-sitter/tree-sitter-typescript)
 - [x] [typescript](https://github.com/tree-sitter/tree-sitter-typescript) (maintained by @steelsojka)

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -54,8 +54,7 @@
 
 ;; Builtin functions
 
-((call
-  function: (identifier) @function.builtin)
+((identifier) @function.builtin
  (vim-match? @function.builtin
              "^(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|exec|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__)$"))
 


### PR DESCRIPTION
This can be used without being called (`map(int, ...)`)