### PR TITLE
Ruby highlights: reset highlight on interpolation

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -1,5 +1,8 @@
 ; Variables
 (identifier) @variable
+(interpolation
+  "#{" @punctuation.special
+  "}" @punctuation.special) @none
 
 ; Keywords
 


### PR DESCRIPTION
@TravonteD

Before:
![image](https://user-images.githubusercontent.com/7189118/95655589-c5234900-0b08-11eb-9fb5-262d9ef34dff.png)


After:
![image](https://user-images.githubusercontent.com/7189118/95655569-ab820180-0b08-11eb-891f-5e3b658337c3.png)

May require #567 
