### PR TITLE
treesitter indentation

### DIFF
--- a/autoload/nvim_treesitter.vim
+++ b/autoload/nvim_treesitter.vim
@@ -17,3 +17,7 @@ endfunction
 function! nvim_treesitter#available_modules(arglead, cmdline, cursorpos) abort
   return join(luaeval("require'nvim-treesitter.configs'.available_modules()"), "\n")
 endfunction
+
+function! nvim_treesitter#indent() abort
+	return luaeval(printf('require"nvim-treesitter.indent".get_indent(%d)', v:lnum))
+endfunction

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -40,7 +40,7 @@ local builtin_modules = {
     module_path = 'nvim-treesitter.indent',
     enable = false,
     disable = {},
-    is_supported = queries.has_locals
+    is_supported = queries.has_indents
   }
 }
 

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -36,6 +36,12 @@ local builtin_modules = {
     },
     is_supported = queries.has_locals
   },
+  indent = {
+    module_path = 'nvim-treesitter.indent',
+    enable = false,
+    disable = {},
+    is_supported = queries.has_locals
+  }
 }
 
 local attached_buffers_by_module = caching.create_buffer_cache()

--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -1,0 +1,69 @@
+-- TODO: logic not working properly
+-- need to find a better way to get the indent from a line
+-- it almosts works though
+local api = vim.api
+local utils = require'nvim-treesitter.ts_utils'
+local query = require'nvim-treesitter.query'
+local parsers = require'nvim-treesitter.parsers'
+local utils = require'nvim-treesitter.ts_utils'
+local locals = require'nvim-treesitter.locals'
+
+local M = {}
+
+local function get_node_at_line(lnum)
+  local node = utils.get_node_at_cursor()
+  local srow = node:range()
+
+  if srow+1 < lnum then
+    for n in node:iter_children() do
+      local row = n:range()
+      if row+1 == lnum then
+        node = n
+        break
+      end
+    end
+  end
+
+  return node
+end
+
+function M.get_indent(lnum)
+  if not parsers.has_parser() or not lnum then return -1 end
+
+  local node = get_node_at_line(lnum)
+  local srow, scol, erow, ecol = node:range()
+
+  local parent = locals.containing_scope(node:parent() or node)
+  local parent_row, pscol, perow, pecol = parent:range()
+  local parent_indent = vim.fn.indent(parent_row+1)
+
+  if (parent_row == srow and pscol == scol) or (perow == erow and pecol == ecol) then
+    node = parent
+    srow = node:range()
+    node_indent = vim.fn.indent(srow+1)
+
+    parent = locals.containing_scope(parent:parent() or parent) 
+    parent_row = parent:range()
+    parent_indent = vim.fn.indent(parent_row+1)
+
+    if node_indent == 0 and parent_indent == 0 then
+      return 0
+    end
+  end
+
+  local tabstop = vim.bo.tabstop
+  return parent_indent + tabstop
+end
+
+local indent_funcs = {}
+
+function M.attach(bufnr)
+  indent_funcs[bufnr] = vim.bo.indentexpr
+  vim.bo.indentexpr = 'nvim_treesitter#indent()'
+end
+
+function M.detach(bufnr)
+  vim.bo.indentexpr = indent_funcs[bufnr]
+end
+
+return M

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -8,7 +8,7 @@ local M = {}
 
 local query_cache = caching.create_buffer_cache()
 
-M.built_in_query_groups = {'highlights', 'locals', 'textobjects', 'folds'}
+M.built_in_query_groups = {'highlights', 'locals', 'textobjects', 'folds', 'indents'}
 
 -- Creates a function that checks whether a given query exists
 -- for a specific language.

--- a/queries/lua/indents.scm
+++ b/queries/lua/indents.scm
@@ -1,0 +1,23 @@
+[
+  (function_definition)
+  (local_function)
+  (function)
+  (if_statement)
+  (for_statement)
+  (for_in_statement)
+  (repeat_statement)
+  (while_statement)
+  (table)
+  (arguments)
+] @indent
+
+[
+  "end"
+  "{"
+  "}"
+  "("
+  ")"
+  "then"
+  (else)
+  (elseif)
+] @branch


### PR DESCRIPTION
fixes #332.
This is the first indent draft for nvim-treesitter, we might need to look for more in depth edge cases in next implementations.

I also changed the memoize_by_buf_tick function to use the on_changedtick callback for the nvim_buf_attach callbacks.