### PR TITLE
C++ highlights: highlight all kinds of optional parameters

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -14,10 +14,10 @@
 ; function(Foo ...foo)
 (variadic_parameter_declaration
   declarator: (variadic_declarator
-                (identifier) @parameter))
+                (_) @parameter))
 ; int foo = 0
 (optional_parameter_declaration
-    declarator: (identifier) @parameter)
+    declarator: (_) @parameter)
 
 ;(field_expression) @parameter ;; How to highlight this?
 (template_function


### PR DESCRIPTION
declarator can be a identifier, a reference or a pointer

This is a intended mirco-improvement to highlight parameters like `foo(TypeT* t = nullptr)` except that it doesn't.

All reference, pointer and member highlights (`m_foo`) do not work on my machine for a longer time. I don't understand why.