### PR TITLE
Update README requirements for parser download/compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Please consider the experience with this plug-in as experimental until Neovim 0.
 ## Requirements
 
 - Neovim [nightly](https://github.com/neovim/neovim#install-from-source)
-- `git` in your path.
-- A C compiler in your path ([Windows users please read this!](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Windows-support)).
+- `tar` and `curl` in your path (or alternativly `git`)
+- A C compiler in your path and libstdc++ installed ([Windows users please read this!](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Windows-support)).
 
 ## Installation
 


### PR DESCRIPTION
https://www.reddit.com/r/neovim/comments/jbsfx2/cant_install_treesitter_error_during_compilation/

At the moment we require `libstdc++` I guess it's easier to stay with this dependency than to say only some parsers may require C++.

Also updated the Windows wiki that git is not required on up-to-date Windows 10.