### PR TITLE
Fix #591: Add verilog parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ List of currently supported languages:
 - [x] [toml](https://github.com/ikatyang/tree-sitter-toml) (maintained by @tk-shirasaka)
 - [ ] [tsx](https://github.com/tree-sitter/tree-sitter-typescript)
 - [x] [typescript](https://github.com/tree-sitter/tree-sitter-typescript) (maintained by @steelsojka)
+- [ ] [verilog](https://github.com/tree-sitter/tree-sitter-verilog)
 - [ ] [vue](https://github.com/ikatyang/tree-sitter-vue)
 - [ ] [yaml](https://github.com/ikatyang/tree-sitter-yaml)
 <!--parserinfo-->

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -285,6 +285,13 @@ list.ql = {
   maintainers = {'@pwntester'},
 }
 
+list.verilog = {
+  install_info = {
+    url = "https://github.com/tree-sitter/tree-sitter-verilog",
+    files = { "src/parser.c" },
+  },
+}
+
 -- Parsers for injections
 list.regex = {
   install_info = {


### PR DESCRIPTION
@medwatt have you tested which of the parsers is better. I could not make the other parser working with nvim-treesitter though I re-generated the grammar from source. The official parsers had some parsing errors on the next best file I tested.

The other one had even more errors. Are they parsing different dialects of Verilog?