### PR TITLE
readme: add nvim-treesitter-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Other modules can be installed as plugins.
 - [refactor](https://github.com/nvim-treesitter/nvim-treesitter-refactor) - Refactoring and definition modules
 - [textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) - Textobjects defined by tree-sitter queries
 - [playground](https://github.com/nvim-treesitter/playground) - Treesitter integrated playground
+- [context](https://github.com/romgrk/nvim-treesitter-context) - Show parent code context in a popover
+
 
 # Extra features
 


### PR DESCRIPTION
Basic alternative to [context.vim](https://github.com/wellle/context.vim) with `nvim-treesitter`: https://github.com/romgrk/nvim-treesitter-context

![demo](https://raw.githubusercontent.com/romgrk/nvim-treesitter-context/master/static/demo.gif)