### PR TITLE
feat(ocamllex): use injections for ocaml

### DIFF
--- a/queries/ocamllex/highlights.scm
+++ b/queries/ocamllex/highlights.scm
@@ -3,10 +3,12 @@
 
 (lexer_entry_name) @function
 
-["as" "let" "parse" "rule"] @keyword
+["as" "let" "and" "parse" "rule"] @keyword
 
 [(eof) (character)] @character
 (string) @string
+
+(ocaml) @none
 
 (character_range "-" @operator)
 (character_set "^" @operator)
@@ -16,7 +18,7 @@
 (regexp_repetition ["*"] @operator)
 (regexp_strict_repetition ["+"] @operator)
 
-(action ["{" "}"] @punctuation.special) @embedded
+(action ["{" "}"] @punctuation.special)
 (character_set ["[" "]"] @punctuation.bracket)
 (parenthesized_regexp ["(" ")"] @punctuation.bracket)
 

--- a/queries/ocamllex/injections.scm
+++ b/queries/ocamllex/injections.scm
@@ -1,0 +1,2 @@
+((ocaml) @injection
+ (#set! "lang" "ocaml"))


### PR DESCRIPTION
This allows the big blocks of ocaml code to be highlighted correctly.

Example:
![before](https://user-images.githubusercontent.com/578125/96515677-a423cc00-125d-11eb-8f3a-8108bae5443b.png)

![after](https://user-images.githubusercontent.com/578125/96515618-8d7d7500-125d-11eb-9b0b-abeeeb8b7bef.png)
