### PR TITLE
handle jsx components with dot in them

### DIFF
--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -18,19 +18,19 @@
  (#match? @type "^[A-Z]")))
 
 ; Handle the dot operator effectively - <My.Component>
-(jsx_opening_element ((nested_identifier (identifier) @type (identifier) @type)))
+(jsx_opening_element ((nested_identifier (identifier) @tag (identifier) @type)))
 
 (jsx_closing_element ((identifier) @type
  (#match? @type "^[A-Z]")))
 
 ; Handle the dot operator effectively - </My.Component>
-(jsx_closing_element ((nested_identifier (identifier) @type (identifier) @type)))
+(jsx_closing_element ((nested_identifier (identifier) @tag (identifier) @type)))
 
 (jsx_self_closing_element ((identifier) @type
  (#match? @type "^[A-Z]")))
 
 ; Handle the dot operator effectively - <My.Component />
-(jsx_self_closing_element ((nested_identifier (identifier) @type (identifier) @type)))
+(jsx_self_closing_element ((nested_identifier (identifier) @tag (identifier) @type)))
 
 (variable_declarator ((identifier) @type
  (#match? @type "^[A-Z]")))

--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -11,17 +11,26 @@
 (jsx_closing_element
   name: (identifier) @tag)
 
-(jsx_self_closing_element 
+(jsx_self_closing_element
   name: (identifier) @tag)
 
 (jsx_opening_element ((identifier) @type
  (#match? @type "^[A-Z]")))
 
+; Handle the dot operator effectively - <My.Component>
+(jsx_opening_element ((nested_identifier (identifier) @type (identifier) @type)))
+
 (jsx_closing_element ((identifier) @type
  (#match? @type "^[A-Z]")))
 
+; Handle the dot operator effectively - </My.Component>
+(jsx_closing_element ((nested_identifier (identifier) @type (identifier) @type)))
+
 (jsx_self_closing_element ((identifier) @type
  (#match? @type "^[A-Z]")))
+
+; Handle the dot operator effectively - <My.Component />
+(jsx_self_closing_element ((nested_identifier (identifier) @type (identifier) @type)))
 
 (variable_declarator ((identifier) @type
  (#match? @type "^[A-Z]")))


### PR DESCRIPTION
I noticed some issues with components that had `.` in them - SUI React has a lot of components defined in this way, such as [Table](https://react.semantic-ui.com/collections/table/) etc.
 
Before:
![image](https://user-images.githubusercontent.com/6155705/96613781-5ba3f700-12cd-11eb-8db2-776c9e6fa1f0.png)

After:
![image](https://user-images.githubusercontent.com/6155705/96613904-7f673d00-12cd-11eb-8e88-bc90b228eb8e.png)
