### PR TITLE
fix(markdown): disable highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ List of currently supported languages:
 - [x] [json](https://github.com/tree-sitter/tree-sitter-json) (maintained by @steelsojka)
 - [ ] [julia](https://github.com/tree-sitter/tree-sitter-julia)
 - [x] [lua](https://github.com/nvim-treesitter/tree-sitter-lua) (maintained by @vigoux)
-- [ ] [markdown](https://github.com/ikatyang/tree-sitter-markdown)
 - [ ] [nix](https://github.com/cstrahan/tree-sitter-nix)
 - [x] [ocaml](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
 - [x] [ocaml_interface](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -20,7 +20,7 @@ local builtin_modules = {
   highlight = {
     module_path = 'nvim-treesitter.highlight',
     enable = false,
-    disable = {},
+    disable = {'markdown'}, -- FIXME(vigoux): markdown highlighting breaks everything for now
     custom_captures = {},
     is_supported = queries.has_highlights
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -202,12 +202,13 @@ list.haskell = {
   }
 }
 
-list.markdown = {
-  install_info = {
-    url = "https://github.com/ikatyang/tree-sitter-markdown",
-    files = { "src/parser.c", "src/scanner.cc" },
-  }
-}
+-- FIXME(vigoux): markdown is broken for now
+-- list.markdown = {
+--   install_info = {
+--     url = "https://github.com/ikatyang/tree-sitter-markdown",
+--     files = { "src/parser.c", "src/scanner.cc" },
+--   }
+-- }
 
 list.toml = {
   install_info = {


### PR DESCRIPTION
The markdown scanner errors out far too often to be usable, disabling it
by default would avoid many issues until those assertion errors are
fixed.

I know it is sad to come to such solutions, but I think everybody agrees that this is just too buggy.

Partialy fixes #602 