### PR TITLE
fix(javascript): fix constant variable highlight

### DIFF
--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -17,14 +17,14 @@
 
 (identifier) @variable
 
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
+
 ((identifier) @constant
  (#vim-match? @constant "^[A-Z_][A-Z\\d_]+$"))
 
 ((shorthand_property_identifier) @constant
  (#vim-match? @constant "^[A-Z_][A-Z\\d_]+$"))
-
-((identifier) @constructor
- (#match? @constructor "^[A-Z]"))
 
 ((identifier) @variable.builtin
  (#vim-match? @variable.builtin "^(arguments|module|console|window|document)$"))


### PR DESCRIPTION
Hey!

I found that in JavaScript, the `@constant` query gets overwritten by the `@constructor` query. They both query for variables starting with an uppercase letter, but the `@constant` query took effect first.

Here's how it looks like:

**Before:**

<img width="312" alt="image" src="https://user-images.githubusercontent.com/9450943/97044330-9e3f2b00-157c-11eb-8b8c-d94dfab74978.png">

**After:**

<img width="316" alt="image" src="https://user-images.githubusercontent.com/9450943/97044401-bb73f980-157c-11eb-975d-428b59681d50.png">