### PR TITLE
show [nvim-treesitter] during install

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -27,7 +27,7 @@ local function reset_progress_counter()
 end
 
 local function get_job_status()
-  return "["..finished_commands.."/"..started_commands
+  return "[nvim-treesitter] ["..finished_commands.."/"..started_commands
             ..(failed_commands > 0 and ", failed: "..failed_commands or "").."]"
 end
 


### PR DESCRIPTION
it can be disturbing on startup when treesitter is updating, you don't really know which plugin is printing the [Compiling], so i added [nvim-treesitter] to inform users treesitter parser is being updated/installed.