### PR TITLE
Fixes Issue #597.

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -8,7 +8,7 @@ local M = {}
 
 local query_cache = caching.create_buffer_cache()
 
-M.built_in_query_groups = {'highlights', 'locals', 'folds', 'indents'}
+M.built_in_query_groups = {'highlights', 'locals', 'folds'}
 
 -- Creates a function that checks whether a given query exists
 -- for a specific language.


### PR DESCRIPTION
Since, the [nvim-treesitter-textobject](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) has been moved to another repository. The checkhealth script needs to be updated so it doesn't check for indent.scm.