### PR TITLE
feat(js): add jsdoc lang injection

### DIFF
--- a/queries/javascript/injections.scm
+++ b/queries/javascript/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection
+ (#set! "lang" "jsdoc"))

--- a/queries/jsdoc/highlights.scm
+++ b/queries/jsdoc/highlights.scm
@@ -1,0 +1,3 @@
+(_) @comment
+(tag_name) @keyword
+(type) @type

--- a/queries/typescript/injections.scm
+++ b/queries/typescript/injections.scm
@@ -1,0 +1,1 @@
+; inherits: javascript


### PR DESCRIPTION
Add jsdoc highlight injections for javascript and typescript.

![Screen Shot 2020-10-27 at 7 36 15 AM](https://user-images.githubusercontent.com/2062154/97303530-812e8480-1828-11eb-961f-6322cfbb461f.png)
