### PR TITLE
Feat/graphql support

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ List of currently supported languages:
 - [ ] [elm](https://github.com/razzeee/tree-sitter-elm)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)
 - [x] [go](https://github.com/tree-sitter/tree-sitter-go) (maintained by @theHamsta, @WinWisely268)
+- [x] [graphql](https://github.com/dralletje/tree-sitter-graphql) (maintained by @kyazdani42)
 - [ ] [haskell](https://github.com/tree-sitter/tree-sitter-haskell)
 - [x] [html](https://github.com/tree-sitter/tree-sitter-html) (maintained by @TravonteD)
 - [x] [java](https://github.com/tree-sitter/tree-sitter-java) (maintained by @p00f)

--- a/ftdetect/graphql.vim
+++ b/ftdetect/graphql.vim
@@ -1,0 +1,1 @@
+autocmd BufEnter,BufNewFile *.gql,*.graphql setlocal ft=graphql

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -320,6 +320,14 @@ list.query = {
   maintainers = {"@steelsojka"},
 }
 
+list.graphql = {
+  install_info = {
+    url = "https://github.com/dralletje/tree-sitter-graphql",
+    files = { "src/parser.c"}
+  },
+  maintainers = {"@kyazdani42"},
+}
+
 local M = {
   list = list
 }

--- a/queries/graphql/highlights.scm
+++ b/queries/graphql/highlights.scm
@@ -1,0 +1,6 @@
+(Type) @type
+(Variable) @variable
+
+(OperationDefinition
+    (OperationType) @type
+    (Name) @function)

--- a/queries/javascript/injections.scm
+++ b/queries/javascript/injections.scm
@@ -1,2 +1,8 @@
 ((comment) @injection
  (#set! "lang" "jsdoc"))
+
+(call_expression
+  function: ((identifier) @matches
+             (#eq? @matches "gql"))
+  arguments: (template_string) @injection
+   (#set! "lang" "graphql"))


### PR DESCRIPTION
- finish highlight
- ask the maintainer if it expects upgrading the parser to 2020 spec or fork the parser
- remove template substitution from injection (should not highlight ${...} stuff)
- maybe make a plugin to add injection support in this case as it's mostly framework related (and its still a little niche)