### PR TITLE
fix(#620): Fall into the "update-all" branch if lang is "all"

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -208,7 +208,7 @@ end
 
 function M.update(lang)
   reset_progress_counter()
-  if lang then
+  if lang and lang ~= 'all' then
     install(false, 'force')(lang)
   else
     local installed = info.installed_parsers()


### PR DESCRIPTION
Pretty much what it says on the tin.

If the language specified in the `TSUpdate` command is `all`, then the plugin should update all installed parsers.