### PR TITLE
Add folds for Go

### DIFF
--- a/queries/go/folds.scm
+++ b/queries/go/folds.scm
@@ -1,0 +1,13 @@
+[
+ (const_declaration)
+ (expression_switch_statement)
+ (for_statement)
+ (func_literal)
+ (function_declaration)
+ (if_statement)
+ (import_declaration)
+ (method_declaration)
+ (type_declaration)
+ (var_declaration)
+] @fold
+


### PR DESCRIPTION
The default behavior in which `@scope` captures were folded resulted in
toplevel fold for an entire source file, which was mildly irritating.

related: #597