### PR TITLE
parser: only use parse to get a tree

### DIFF
--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -43,7 +43,7 @@ local function select_incremental(get_parent)
     local csrow, cscol, cerow, cecol = visual_selection_range()
     -- Initialize incremental selection with current selection
     if not nodes or #nodes == 0 or not range_matches(nodes[#nodes]) then
-      local root = parsers.get_parser().tree:root()
+      local root = parsers.get_parser():parse():root()
       local node = root:named_descendant_for_range(csrow, cscol, cerow, cecol)
       ts_utils.update_selection(buf, node)
       if nodes and #nodes > 0 then

--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -235,7 +235,7 @@ function M.find_usages(node, scope_node, bufnr)
 
   if not node_text or #node_text < 1 then return {} end
 
-  local scope_node = scope_node or parsers.get_parser(bufnr).tree:root()
+  local scope_node = scope_node or parsers.get_parser(bufnr):parse():root()
   local usages = {}
 
   for match in M.iter_locals(bufnr, scope_node) do

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -397,7 +397,7 @@ end
 function M.get_tree_root(bufnr)
   local bufnr = bufnr or api.nvim_get_current_buf()
 
-  return M.get_parser(bufnr).tree:root()
+  return M.get_parser(bufnr):parse():root()
 end
 
 -- get language of given buffer

--- a/lua/nvim-treesitter/tsrange.lua
+++ b/lua/nvim-treesitter/tsrange.lua
@@ -57,7 +57,7 @@ end
 
 function TSRange:parent(range)
   local parser = parsers.get_parser(self.buf, parsers.get_buf_lang(range))
-  local root = parser.tree:root()
+  local root = parser:parse():root()
   return root:named_descendant_for_range(self.start_pos[1], self.start_pos[2], self.end_pos[1], self.end_pos[2])
 end
 


### PR DESCRIPTION
This will avoid using internal data. And maybe avoid crashes when https://github.com/neovim/neovim/pull/13219 will be merged.