### PR TITLE
fix(indent): set b:did_indent variable on attach

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -65,6 +65,7 @@ local indent_funcs = {}
 
 function M.attach(bufnr)
   indent_funcs[bufnr] = vim.bo.indentexpr
+  vim.b.did_indent = 1
   vim.bo.indentexpr = 'nvim_treesitter#indent()'
 end
 


### PR DESCRIPTION
This will better conform to vim indent plugin standards.

Fixes #630.