### PR TITLE
JS optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ List of currently supported languages:
 - [x] [bash](https://github.com/tree-sitter/tree-sitter-bash) (maintained by @TravonteD)
 - [x] [c](https://github.com/tree-sitter/tree-sitter-c) (maintained by @vigoux)
 - [x] [c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) (maintained by @svermeulen)
+- [x] [clojure](https://github.com/sogaiu/tree-sitter-clojure) (maintained by @sogaiu)
 - [x] [cpp](https://github.com/tree-sitter/tree-sitter-cpp) (maintained by @theHamsta)
 - [x] [css](https://github.com/tree-sitter/tree-sitter-css) (maintained by @TravonteD)
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @Akin909)

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -112,6 +112,11 @@
     value: (arrow_function                                                                                                                                                                                    
       parameter: (identifier) @parameter))
 
+; optional parameters
+(formal_parameters
+  (assignment_pattern
+    (shorthand_property_identifier) @parameter))
+
 ; Variables
 ;----------
 (namespace_import

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -144,6 +144,7 @@
 (template_substitution
   "${" @punctuation.special
   "}" @punctuation.special) @embedded
+"..." @punctuation.special
 
 ";" @punctuation.delimiter
 "." @punctuation.delimiter


### PR DESCRIPTION
I have no idea how to write a function in JS but googling told me that you can have optional parameters that are not highlighted right now https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/19#pullrequestreview-523806600

```javascript
(function connect(hostname = "localhost",
                 port = 80,
                 method = "HTTP") {

})
```
The dots of `rest_pattern` `...` are not highlighted right now. How could the be highlighted. Punctuation? Parameter?