### PR TITLE
Fix readme setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ All modules are disabled by default,
 so you'll need to activate them by putting this in your `init.vim` file:
 
 ```lua
+lua <<EOF
 require'nvim-treesitter.configs'.setup {
   ensure_installed = "maintained", -- one of "all", "maintained" (parsers with maintainers), or a list of languages
   highlight = {
@@ -112,6 +113,7 @@ require'nvim-treesitter.configs'.setup {
     disable = { "c", "rust" },  -- list of language that will be disabled
   },
 }
+EOF
 ```
 
 Check [`:h nvim-treesitter-modules`](doc/nvim-treesitter.txt)
@@ -175,7 +177,6 @@ Other modules can be installed as plugins.
 - [playground](https://github.com/nvim-treesitter/playground) - Treesitter integrated playground
 - [context](https://github.com/romgrk/nvim-treesitter-context) - Show parent code context in a popover
 
-
 # Extra features
 
 ## Syntax based code folding
@@ -219,6 +220,7 @@ List of currently supported languages:
 
 <!--This section of the README is automatically updated by a CI job-->
 <!--parserinfo-->
+
 - [x] [bash](https://github.com/tree-sitter/tree-sitter-bash) (maintained by @TravonteD)
 - [x] [c](https://github.com/tree-sitter/tree-sitter-c) (maintained by @vigoux)
 - [x] [c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) (maintained by @svermeulen)
@@ -327,6 +329,7 @@ located in the `queries/{lang}/*` runtime directories (like the `queries` folder
 
 This hybrid approach is the most standard way, and according to that, here is some ideas on how to
 use is :
+
 - If you want to rewrite (or write) a query, don't use `after/queries`.
 - If you want to override a part of a query (only one match for example), use the `after/queries`
   directory.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ And now you should be ready to use every functionality `nvim-treesitter` provide
 All modules are disabled by default,
 so you'll need to activate them by putting this in your `init.vim` file:
 
-```lua
+```vim
 lua <<EOF
 require'nvim-treesitter.configs'.setup {
   ensure_installed = "maintained", -- one of "all", "maintained" (parsers with maintainers), or a list of languages
@@ -125,7 +125,8 @@ for a list of available modules and its options.
 
 Consistent syntax highlighting.
 
-```lua
+```vim
+lua <<EOF
 require'nvim-treesitter.configs'.setup {
   highlight = {
     enable = true,
@@ -136,13 +137,15 @@ require'nvim-treesitter.configs'.setup {
     },
   },
 }
+EOF
 ```
 
 ## Incremental selection
 
 Incremental selection based on the named nodes from the grammar.
 
-```lua
+```vim
+lua <<EOF
 require'nvim-treesitter.configs'.setup {
   incremental_selection = {
     enable = true,
@@ -154,18 +157,21 @@ require'nvim-treesitter.configs'.setup {
     },
   },
 }
+EOF
 ```
 
 ## Indentation
 
 Treesitter based indentation (`=` vim behavior)
 
-```lua
+```vim
+lua <<EOF
 require'nvim-treesitter.config'.setup {
   indent = {
     enable = true
   }
 }
+EOF
 ```
 
 # External modules
@@ -280,7 +286,8 @@ Users and plugin authors can take advantage of modules by creating their own. Mo
 
 You can use the `define_modules` function to define one or more modules or module groups.
 
-```lua
+```vim
+lua <<EOF
 require'nvim-treesitter'.define_modules {
   my_cool_plugin = {
     attach = function(bufnr, lang)
@@ -294,6 +301,7 @@ require'nvim-treesitter'.define_modules {
     end
   }
 }
+EOF
 ```
 
 Modules can consist of the following properties:


### PR DESCRIPTION
The setup example in README.md is not precise as is in [:h nvim-treesitter-modules](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/doc/nvim-treesitter.txt) which could mislead new neovim users.