### PR TITLE
Typescript Delimiter Highlights & | : ? 

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -27,6 +27,12 @@
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
 
+(union_type 
+  "|" @punctuation.delimiter)
+
+(intersection_type 
+  "&" @punctuation.delimiter)
+
 (type_annotation
   ":" @punctuation.delimiter)
 
@@ -34,6 +40,9 @@
   ":" @punctuation.delimiter)
 
 (unary_expression) @punctuation.special
+
+(property_signature 
+  "?" @punctuation.special)
 
 ; Variables
 

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -15,14 +15,30 @@
 ] @keyword
 
 (readonly) @keyword
+
+; types
+
 (type_identifier) @type
 (predefined_type) @type.builtin
+
+; punctuation
 
 (type_arguments
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
 
+(type_annotation
+  ":" @punctuation.delimiter)
+
+(pair
+  ":" @punctuation.delimiter)
+
+(unary_expression) @punctuation.special
+
 ; Variables
+
+(shorthand_property_identifier) @variable
+(undefined) @variable.builtin
 
 (required_parameter (identifier) @parameter)
 (optional_parameter (identifier) @parameter)


### PR DESCRIPTION
Updated highlight groups to handle more of the typescript delimiters and some other small changes.

![2020-11-14-191200_4480x1440_scrot](https://user-images.githubusercontent.com/15027/99159732-5314c580-26ad-11eb-91b7-84a7a3e22ed8.png)

Test code in typescript. Note `&`, `|`, `:`, `?` and argument arguments should now be properly setting the correct group. 

```
type Red = 'red'
type Blue = 'blue

type Colors = Red & Blue

type ColorOpts = Red | Blue

type X = {
  y?: undefined
}

const yo = ({y}: X): void => {
  return;
}
```