### PR TITLE
CSS: Move property_name, feature_name to @field

### DIFF
--- a/queries/css/highlights.scm
+++ b/queries/css/highlights.scm
@@ -49,11 +49,13 @@
  (class_name)
  (id_name)
  (namespace_name)
- (property_name)
- (feature_name)
  (attribute_name)
  ] @property
 
+[
+ (property_name)
+ (feature_name)
+ ] @field
 
 ((property_name) @type
                  (#match? @type "^--"))


### PR DESCRIPTION
Move property_name and feature_name to @field

I feel this is a more appropriate location and allows better distinction. 

My colors (sorry for the very slight color change, I can adjust if necessary)
![2020-11-15-141903_4480x1440_scrot](https://user-images.githubusercontent.com/15027/99194503-bc4c1580-274d-11eb-948c-4f68e0b52db2.png)
