### PR TITLE
Make make-range! more relaxed (one of the arguments may be nil)

### DIFF
--- a/lua/nvim-treesitter/tsrange.lua
+++ b/lua/nvim-treesitter/tsrange.lua
@@ -26,8 +26,8 @@ end
 
 function TSRange.from_nodes(buf, start_node, end_node)
   TSRange.__index = TSRange
-  local start_pos = {start_node:start()}
-  local end_pos = {end_node:end_()}
+  local start_pos = start_node and {start_node:start()} or {end_node:start()}
+  local end_pos = end_node and {end_node:end_()} or {start_node:end_()}
   return setmetatable(
     {
       start_pos = {start_pos[1], start_pos[2], start_pos[3]},


### PR DESCRIPTION
This lets you write queries with an optional end/start node that gets appended if it's there. 

```
((lambda_parameters
  [(identifier)
   (tuple)
   (typed_parameter)
   (default_parameter)
   (typed_default_parameter)
   (list_splat)
   (dictionary_splat)] @parameter.inner
   . ","? @_end)
  (make-range! "parameter.outer" @parameter.inner @_end))
```
In this example `@parameter,outer` will include a following ",". If there is no comma after the parameter then `@parameter.outer` == `@parameter.inner`. This would greatly simplify the logic of including possible attributes and decoration to captures that may be there but not in all cases.

Related: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/22