### PR TITLE
c/cpp: fix field and initializer highlights

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -122,6 +122,11 @@
 (((field_expression
      (field_identifier) @property)) @_parent
  (#not-has-parent? @_parent template_method function_declarator call_expression))
+
+(((field_identifier) @property)
+ (#has-ancestor? @property field_declaration)
+ (#not-has-ancestor? @property function_declarator))
+
 (statement_identifier) @label
 
 [

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -27,6 +27,12 @@
      (field_identifier) @method)) @_parent
  (#has-parent? @_parent template_method function_declarator call_expression))
 
+(field_initializer
+ (field_identifier) @property)
+
+(function_declarator
+  declarator: (field_identifier) @method)
+
 (template_function
   name: (scoped_identifier
     name: (identifier) @function))


### PR DESCRIPTION
After a recent fix for #446, declarations in class/struct definitions stopped being marked as properties or methods. This fix will add property highlights to field declarations, and method highlight to field function declarations.
