### PR TITLE
Add support for locals in (system)verilog and some highlight fixes

### DIFF
--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -15,6 +15,10 @@
   "endclass"
   "return"
   "default"
+  "break"
+  "interface"
+  "endinterface"
+  "modport"
 ] @keyword
 
 [

--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -19,7 +19,19 @@
   "interface"
   "endinterface"
   "modport"
+  "package"
+  "endpackage"
+  "fork"
+  "join"
+  "join_none"
+  "join_any"
+  "assert"
 ] @keyword
+
+[
+  "begin"
+  "end"
+] @label
 
 [
   (always_keyword)
@@ -28,6 +40,7 @@
   "foreach"
   "repeat"
   "forever"
+  "initial"
   "while"
 ] @repeat
 
@@ -37,15 +50,6 @@
   "case"
   "endcase"
 ] @conditional
-
-[
-  "begin"
-  "end"
-  "fork"
-  "join"
-  "join_none"
-  "join_any"
-] @label
 
 (comment) @comment
 
@@ -65,9 +69,12 @@
  (package_identifier
   (simple_identifier) @constant))
 
-(module_ansi_header
- (parameter_port_list
-  "#" @constructor))
+(package_declaration
+ (package_identifier
+  (simple_identifier) @constant))
+
+(parameter_port_list
+ "#" @constructor)
 
 [
   "="
@@ -140,7 +147,10 @@
 (net_port_type1
  (simple_identifier) @type)
 
-(double_quoted_string) @string
+[
+  (double_quoted_string)
+  (string_literal)
+] @string
 
 [
   (include_compiler_directive)
@@ -227,6 +237,14 @@
   (data_type ["packed"] @label))
 
 (struct_union) @type
+
+[
+  "enum"
+] @type
+
+(enum_name_declaration
+ (enum_identifier
+  (simple_identifier) @constant))
 
 (type_declaration
  (simple_identifier) @type)

--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -14,6 +14,7 @@
   "class"
   "endclass"
   "return"
+  "default"
 ] @keyword
 
 [
@@ -29,6 +30,8 @@
 [
   "if"
   "else"
+  "case"
+  "endcase"
 ] @conditional
 
 [
@@ -45,6 +48,7 @@
 (include_compiler_directive) @constant.macro
 (package_import_declaration
  "import" @include)
+
 (package_import_declaration
  (package_import_item
   (package_identifier
@@ -56,6 +60,10 @@
 (package_scope
  (package_identifier
   (simple_identifier) @constant))
+
+(module_ansi_header
+ (parameter_port_list
+  "#" @constructor))
 
 [
   "="
@@ -97,8 +105,6 @@
 
 (edge_identifier) @attribute
 
-";" @punctuation.delimiter
-
 (port_direction) @label
 (port_identifier
  (simple_identifier) @variable)
@@ -120,6 +126,16 @@
 (method_call_body
   (method_identifier) @field)
 
+(interface_identifier
+ (simple_identifier) @type)
+
+(modport_identifier
+ (modport_identifier
+  (simple_identifier) @field))
+
+(net_port_type1
+ (simple_identifier) @type)
+
 (double_quoted_string) @string
 
 [
@@ -128,12 +144,18 @@
   (timescale_compiler_directive)
 ] @constant.macro
 
+; begin/end label
 (seq_block
  (simple_identifier) @comment)
 
 [
-  "::"
+ ";"
+ "::"
+ ","
+ "."
 ] @punctuation.delimiter
+
+
 (default_nettype_compiler_directive
  (default_nettype_value) @string)
 
@@ -189,12 +211,17 @@
   (system_tf_call
    (system_tf_identifier) @function.builtin)))
 
+(task_identifier
+ (task_identifier
+  (simple_identifier) @method))
+
 (assignment_pattern_expression
  (assignment_pattern
   (parameter_identifier) @field))
 
 (type_declaration
-  (data_type) @label)
+  (data_type ["packed"] @label))
+
 (struct_union) @type
 
 (type_declaration
@@ -223,3 +250,12 @@
  (simple_identifier) @type)
 
 (generate_block_identifier) @comment
+
+[
+  "["
+  "]"
+  "("
+  ")"
+] @punctuation.bracket
+
+(ERROR) @error

--- a/queries/verilog/locals.scm
+++ b/queries/verilog/locals.scm
@@ -1,0 +1,60 @@
+[
+  (loop_generate_construct)
+  (loop_statement)
+  (conditional_statement)
+  (case_item)
+  (function_declaration)
+  (always_construct)
+  (module_declaration)
+] @scope
+
+(data_declaration
+ (list_of_variable_decl_assignments
+  (variable_decl_assignment
+   (simple_identifier) @definition.var)))
+
+(genvar_initialization
+ (genvar_identifier
+  (simple_identifier) @definition.var))
+
+(for_initialization
+ (for_variable_declaration
+  (simple_identifier) @definition.var))
+
+(net_declaration
+ (list_of_net_decl_assignments
+  (net_decl_assignment
+   (simple_identifier) @definition.var)))
+
+(ansi_port_declaration
+ (port_identifier
+  (simple_identifier) @definition.var))
+
+(parameter_declaration
+ (list_of_param_assignments
+  (param_assignment
+   (parameter_identifier
+    (simple_identifier) @definition.parameter))))
+
+(local_parameter_declaration
+ (list_of_param_assignments
+  (param_assignment
+   (parameter_identifier
+    (simple_identifier) @definition.parameter))))
+
+(function_declaration
+ (function_identifier
+  (simple_identifier) @definition.function))
+
+(function_declaration
+ (function_body_declaration
+  (function_identifier
+   (function_identifier
+    (simple_identifier) @definition.function))))
+
+(tf_port_item1
+ (port_identifier
+  (simple_identifier) @definition.parameter))
+
+; too broad, now includes types etc
+(simple_identifier) @reference


### PR DESCRIPTION
Adds some scope and definition queries for systemverilog code.

I still have an issue with the `reference` query.
In the tree-sitter parser, everything that is not a keyword or constant is ultimately parsed into a `simple_identifier`.
This also includes defined types.

I am currently using the `simple_identifier` as a reference, but that means that the refactor plugin also highlights other mentions of the type when the cursor is on one.
Is there a way to exclude certain matches through a query or would I need to list all more cases to exclude these? 

For example, I have a variable defined with a custom type:

``` systemverilog
some_type_t some_variable;    
```
Which parses as:
```
block_item_declaration [124, 4] - [124, 38]                  // line
  data_declaration [124, 4] - [124, 38]             
    data_type_or_implicit1 [124, 4] - [124, 19]
      data_type [124, 4] - [124, 19]
        simple_identifier [124, 4] - [124, 19]               // this is the data type: some_type_t
    list_of_variable_decl_assignments [124, 22] - [124, 37]
      variable_decl_assignment [124, 22] - [124, 37]
        simple_identifier [124, 22] - [124, 37]              // this is the variable: some_variable
```

The instances of the variable can be parsed in many different ways, depending on the location, and the list becomes quite long.


So, is there a way to define `(simple_identifier)` as `@reference` but exclude `(data_type (simple_identifier))`?