### PR TITLE
README: Explain how to add unsupported parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,22 +70,25 @@ $ git clone https://github.com/nvim-treesitter/nvim-treesitter.git
 ## Adding parsers
 
 Treesitter uses a different _parser_ for every language, which needs to be generated via `tree-sitter-cli` from a `grammar.js` file, then compiled to a `.so` library that needs to be placed in neovim's `runtimepath` (typically under `parser/{lang}.so`). To simplify this, `nvim-treesitter`
-provides commands to automate this process:
+provides commands to automate this process. If the language is already [supported by `nvim-treesitter`](#supported), you can install it with
+```vim
+:TSInstall {language}
+```
+This command supports tab expansion. You can also get a list of all available languages and their installation status with `:TSInstallInfo`.
 
-- `TSInstall {language}` to install one or more parsers from a generated `c` file. (This requires a `C` compiler in your path.)
-- `TSInstallFromGrammar {language}` to install one or more parsers from the original `grammar.js`. (In addition to a `C` compiler, this requires the `tree-sitter-cli` executable in your path; see https://tree-sitter.github.io/tree-sitter/creating-parsers#installation for installation instructions.)
+If you update `nvim-treesitter` and want to make sure the parser is at the latest compatible version (as specified in `nvim-treesitter`'s `lockfile.json`), use `:TSUpdate {language}`. To update all parsers unconditionally, use `:TSUpdate all` or just `:TSUpdate`.
 
-`TSInstall <tab>` and `TSInstallFromGrammar <tab>` will give you a list of supported languages; you can also use `TSInstall all` to install every parser on the list. To show which languages are available together with their installation status, use `TSInstallInfo`.
+### Adding unsupported parsers
 
-If your language is not yet included in this list, you can add it locally as follows:
+If you have a parser that is not on the list (either from a repository on Github or a local directory), you can add it manually for use by `nvim-treesitter` as follows:
 
-1. Clone the repository or [create a new project](https://tree-sitter.github.io/tree-sitter/creating-parsers#project-setup) in, say, `~/projects/tree-sitter-zimbu`.
-2. Run `tree-sitter generate` in this directory (followed by `tree-sitter test`, for good measure).
+1. Clone the repository or [create a new project](https://tree-sitter.github.io/tree-sitter/creating-parsers#project-setup) in, say, `~/projects/tree-sitter-zimbu`. Make sure that the `tree-sitter-cli` executable is installed and in your path; see https://tree-sitter.github.io/tree-sitter/creating-parsers#installation for installation instructions.
+2. Run `tree-sitter generate` in this directory (followed by `tree-sitter test` for good measure).
 3. Add the following snippet to your `init.vim`:
 
 ```vim
 lua <<EOF
-local parser_config =  require "nvim-treesitter.parsers".get_parser_configs()
+local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
 parser_config.zimbu = {
   install_info = {
     url = "~/projects/tree-sitter-zimbu", -- local path or git repo
@@ -94,13 +97,14 @@ parser_config.zimbu = {
   filetype = "zu", -- if filetype does not agrees with parser name
   used_by = {"bar", "baz"} -- additional filetypes that use this parser
 }
+EOF
 ```
 
-4. Start `nvim` and run `TSInstall zimbu` (or `TSInstallFromGrammar zimbu` if you skipped step 2).
+4. Start `nvim` and `:TSInstall zimbu`.
+
+You can also skip step 2 and use `:TSInstallFromGrammar zimbu` to install straight from `grammar.js`. Once the parser is installed, you can update it (from the latest revision of the `main` branch if `url` is a Github repository) with `:TSUpdate zimbu`.
 
 Note that this only installs the parser itself; using it for, e.g., highlighting also requires corresponding queries that need to be written and placed in the appropriate directory (e.g., as `queries/zimbu/highlights.scm`).
-
-Once a parser is installed, you can update it via `TSUpdate {language}`. If the parser is supported, this will checkout and install the revision specified in `nvim-treesitter`'s `lockfile.json`; otherwise it will use the latest revision of the repo or directory given in the `url` field above. Like `TSInstall`, you can get a list of possible arguments with `TSUpdate <tab>` or update every installed parser with `TSUpdate all` (or just `TSUpdate` for short).
 
 ## Setup
 
@@ -217,7 +221,7 @@ Each feature can be enabled or disabled by different means:
 
 Check [`:h nvim-treesitter-commands`](doc/nvim-treesitter.txt) for a list of all available commands.
 
-# Supported Languages
+# <a name="supported"></a>Supported Languages
 
 For `nvim-treesitter` to work, we need to use query files such as those you can find in
 `queries/{lang}/{locals,highlights,textobjects}.scm`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   </p>
 </div>
 
-The goal of `nvim-treesitter` is both to provide a simple and easy way to use the interface for [tree-sitter](https://github.com/tree-sitter/tree-sitter) in Neovim and to provide some basic functionality such as highlighting based on on it:
+The goal of `nvim-treesitter` is both to provide a simple and easy way to use the interface for [tree-sitter](https://github.com/tree-sitter/tree-sitter) in Neovim and to provide some basic functionality such as highlighting based on it:
 
 ![cpp example](assets/example-cpp.png)
 
@@ -41,7 +41,22 @@ Please consider the experience with this plug-in as experimental until Neovim 0.
 You can find the current roadmap [here](https://github.com/nvim-treesitter/nvim-treesitter/projects/1).
 The roadmap and all features of this plugin are open to change, and any suggestion will be highly appreciated!**
 
-Nvim-treesitter is based on three interlocking features: [**language parsers**](#parsers), [**queries**](#queries), and [**modules**](#modules), where *modules* provide features -- such as highlighting -- based on *queries* for syntax objects specified by language *parsers*. Users will generally only need to interact with parsers and modules as explained in the next section. For more detailed information on setting these up, see ["Advanced setup"](#advanced).
+Nvim-treesitter is based on three interlocking features: [**language parsers**](#language-parsers), [**queries**](#adding-queries), and [**modules**](#available-modules), where *modules* provide features – e.g., highlighting – based on *queries* for syntax objects extracted from a given buffer by *language parsers*.
+Users will generally only need to interact with parsers and modules as explained in the next section.
+For more detailed information on setting these up, see ["Advanced setup"](#advanced-setup).
+
+---
+
+### Table of contents
+
+* [Quickstart](#quickstart)
+* [Supported languages](#supported-languages)
+* [Available modules](#available-modules)
+* [Advanced setup](#advanced-setup)
+* [Extra features](#extra-features)
+* [Troubleshooting](#troubleshooting)
+
+---
 
 # Quickstart
 
@@ -63,20 +78,24 @@ Plug 'nvim-treesitter/nvim-treesitter'
 
 ## Language parsers
 
-Treesitter uses a different _parser_ for every language, which needs to be generated via `tree-sitter-cli` from a `grammar.js` file, then compiled to a `.so` library that needs to be placed in neovim's `runtimepath` (typically under `parser/{lang}.so`). To simplify this, `nvim-treesitter`
-provides commands to automate this process. If the language is already [supported by `nvim-treesitter`](#supported), you can install it with
+Treesitter uses a different _parser_ for every language, which needs to be generated via `tree-sitter-cli` from a `grammar.js` file, then compiled to a `.so` library that needs to be placed in neovim's `runtimepath` (typically under `parser/{language}.so`).
+To simplify this, `nvim-treesitter` provides commands to automate this process.
+If the language is already [supported by `nvim-treesitter`](#supported-languages), you can install it with
 ```vim
 :TSInstall {language}
 ```
-This command supports tab expansion. You can also get a list of all available languages and their installation status with `:TSInstallInfo`. Parsers not on this list can be added manually by following the steps described under ["Adding unsupported parsers"](#unsupported) below.
+This command supports tab expansion.
+You can also get a list of all available languages and their installation status with `:TSInstallInfo`.
+Parsers not on this list can be added manually by following the steps described under ["Adding parsers"](#adding-parsers) below.
 
-If you update `nvim-treesitter` and want to make sure the parser is at the latest compatible version (as specified in `nvim-treesitter`'s `lockfile.json`), use `:TSUpdate {language}`. To update all parsers unconditionally, use `:TSUpdate all` or just `:TSUpdate`.
+If you update `nvim-treesitter` and want to make sure the parser is at the latest compatible version (as specified in `nvim-treesitter`'s `lockfile.json`), use `:TSUpdate {language}`.
+To update all parsers unconditionally, use `:TSUpdate all` or just `:TSUpdate`.
 
 ## Modules
 
-Each modules provide a distinct feature based on treesitter such as [highlighting](#highlighting), [indentation](#indentation), or [folding](#folding); see [`:h nvim-treesitter-modules`](doc/nvim-treesitter.txt) or see ["Modules"](#modules) below for a list of available modules and their options.
+Each module provides a distinct tree-sitter-based feature such as [highlighting](#highlight), [indentation](#indentation), or [folding](#folding); see [`:h nvim-treesitter-modules`](doc/nvim-treesitter.txt) or ["Available modules"](#available-modules) below for a list of modules and their options.
 
-All modules are disabled by default and need to be activated explicitly in your `init.vim`:
+All modules are disabled by default and need to be activated explicitly in your `init.vim`, e.g., via
 
 ```vim
 lua <<EOF
@@ -100,11 +119,12 @@ Each module can also be enabled or disabled interactively through the following 
 :TSModuleInfo [{module}] " list information about modules state for each filetype
 ```
 
-Check [`:h nvim-treesitter-commands`](doc/nvim-treesitter.txt) for a list of all available commands. It may be necessary to reload the buffer (e.g., via `:e`) after enabling a module.
+Check [`:h nvim-treesitter-commands`](doc/nvim-treesitter.txt) for a list of all available commands.
+It may be necessary to reload the buffer (e.g., via `:e`) after enabling a module interactively.
 
-# <a name="supported"></a>Supported languages
+# Supported languages
 
-For `nvim-treesitter` to support a specific feature for a specific language requires both a parser for this language and an appropriate query file for that language and that feature.
+For `nvim-treesitter` to support a specific feature for a specific language requires both a parser for that language and an appropriate language-specific query file for that feature.
 
 The following is a list of languages for which a parser can be installed through `:TSInstall`; a checked box means that `nvim-treesitter` also contains queries at least for the `highlight` module.
 
@@ -154,15 +174,14 @@ We are looking for maintainers to add more parsers and to write query files for 
 <!--parserinfo-->
 
 
-# <a name="modules"></a> Available modules
+# Available modules
 
-Modules provide the top-level features of `nvim-treesitter`. These can be implemented either as part of `nvim-treesitter` or as an external plugin.
+Modules provide the top-level features of `nvim-treesitter`.
+The following is a list of modules included in `nvim-treesitter` and their configuration via `init.vim` (where multiple modules can be combined in a single call to `setup`).
+Note that not all modules work for all languages (depending on the queries available for them).
+Additional modules can be provided as [external plugins](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Extra-modules-and-plugins).
 
-## Included modules
-
-The following is a list of modules included in `nvim-treesitter`. Note that not all modules work for all languages (depending on the queries available for them).
-
-#### <a name="highlighting"></a> Highlight
+#### Highlight
 
 Consistent syntax highlighting.
 
@@ -200,9 +219,9 @@ require'nvim-treesitter.configs'.setup {
 EOF
 ```
 
-#### <a name="indentation"></a> Indentation
+#### Indentation
 
-Treesitter based indentation (`=` vim behavior)
+Tree-sitter based indentation.
 
 ```vim
 lua <<EOF
@@ -214,7 +233,9 @@ require'nvim-treesitter.config'.setup {
 EOF
 ```
 
-#### <a name="folding"></a> Folding
+#### Folding
+
+Tree-sitter based folding.
 
 ```vim
 set foldmethod=expr
@@ -223,23 +244,13 @@ set foldexpr=nvim_treesitter#foldexpr()
 
 This will respect your `foldnestmax` setting.
 
-## External modules
+# Advanced setup
 
-Other modules can be installed as plugins, such as
+## Adding parsers
 
-- [refactor](https://github.com/nvim-treesitter/nvim-treesitter-refactor) - Refactoring and definition modules
-- [textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) - Textobjects defined by tree-sitter queries
-- [playground](https://github.com/nvim-treesitter/playground) - Treesitter integrated playground
-- [context](https://github.com/romgrk/nvim-treesitter-context) - Show parent code context in a popover
+If you have a parser that is not on the list of supported languages (either as a repository on Github or in a local directory), you can add it manually for use by `nvim-treesitter` as follows:
 
-
-# <a name="advanced"></a> Advanced setup
-
-## <a name="unsupported"></a> Adding parsers
-
-If you have a parser that is not on this list (either from a repository on Github or a local directory), you can add it manually for use by `nvim-treesitter` as follows:
-
-1. Clone the repository or [create a new project](https://tree-sitter.github.io/tree-sitter/creating-parsers#project-setup) in, say, `~/projects/tree-sitter-zimbu`. Make sure that the `tree-sitter-cli` executable is installed and in your path; see https://tree-sitter.github.io/tree-sitter/creating-parsers#installation for installation instructions.
+1. Clone the repository or [create a new project](https://tree-sitter.github.io/tree-sitter/creating-parsers#project-setup) in, say, `~/projects/tree-sitter-zimbu`. Make sure that the `tree-sitter-cli` executable is installed and in your path; see <https://tree-sitter.github.io/tree-sitter/creating-parsers#installation> for installation instructions.
 2. Run `tree-sitter generate` in this directory (followed by `tree-sitter test` for good measure).
 3. Add the following snippet to your `init.vim`:
 
@@ -259,14 +270,16 @@ EOF
 
 4. Start `nvim` and `:TSInstall zimbu`.
 
-You can also skip step 2 and use `:TSInstallFromGrammar zimbu` to install straight from `grammar.js`. Once the parser is installed, you can update it (from the latest revision of the `main` branch if `url` is a Github repository) with `:TSUpdate zimbu`.
+You can also skip step 2 and use `:TSInstallFromGrammar zimbu` to install directly from a `grammar.js` in the top-level directory specified by `url`.
+Once the parser is installed, you can update it (from the latest revision of the `main` branch if `url` is a Github repository) with `:TSUpdate zimbu`.
 
-## <a name="queries"></a> Adding queries
+## Adding queries
 
 Queries are what `nvim-treesitter` uses to extract informations from the syntax tree; they are
-located in the `queries/{language}/*` runtime directories (like the `queries` folder of this plugin), e.g., `queries/{language}/{locals,highlights,textobjects}.scm`. Other modules may require additional queries such as `folding.scm`.
+located in the `queries/{language}/*` runtime directories (like the `queries` folder of this plugin), e.g., `queries/{language}/{locals,highlights,textobjects}.scm`.
+Other modules may require additional queries such as `folding.scm`.
 
-`nvim-treesitter` considers queries as any runtime file (see `:h rtp`), that is :
+`nvim-treesitter` considers queries as any runtime file (see `:h rtp`), i.e.,
 
 - if the file is in any `after/queries/` folder, then it will be used to extend the already defined
   queries.
@@ -307,14 +320,14 @@ require'nvim-treesitter'.define_modules {
 EOF
 ```
 
-with the following properties
+with the following properties:
 
-- `module_path`: A require path (string) that exports a module with an `attach` and `detach` function. This is not required if the functions are on this definition.
-- `enable`: Determines if the module is enabled by default. This is usually overridden by the user.
-- `disable`: A list of languages that this module is disabled for. This is usually overridden by the user.
-- `is_supported`: A function that takes a language and determines if this module supports that language.
-- `attach`: A function that attaches to a buffer. This is required if `module_path` is not provided.
-- `detach`: A function that detaches from a buffer. This is required if `module_path` is not provided.
+- `module_path` specifies a require path (string) that exports a module with an `attach` and `detach` function. This is not required if the functions are on this definition.
+- `enable` determines if the module is enabled by default. This is usually overridden by the user.
+- `disable` takes a list of languages that this module is disabled for. This is usually overridden by the user.
+- `is_supported` takes a function that takes a language and determines if this module supports that language.
+- `attach` takes a function that attaches to a buffer. This is required if `module_path` is not provided.
+- `detach` takes a function that detaches from a buffer. This is required if `module_path` is not provided.
 
 # Extra features
 
@@ -337,40 +350,41 @@ Check [`:h nvim-treesitter-utils`](doc/nvim-treesitter.txt) for more information
 
 # Troubleshooting
 
-Before doing anything make sure you have the latest version of this plugin and run `:checkhealth nvim_treesitter`. It can also help to update the parsers via `:TSUpdate`.
-This will help you find where the bug might come from.
+Before doing anything, make sure you have the latest version of this plugin and run `:checkhealth nvim_treesitter`.
+It can also help to update the parsers via `:TSUpdate`.
 
-* **Feature `X` does not work for `{language}`...**
+#### Feature `X` does not work for `{language}`...
 
-First, check the `## {language} parser healthcheck` section of `:checkhealth` if you have any warning.
-If you do, it's highly possible that this is the cause of the problem.
+First, check the `## {language} parser healthcheck` section of `:checkhealth` for any warning.
+If there is one, it's highly likely that this is the cause of the problem.
 If everything is okay, then it might be an actual error.
 
-In both cases, feel free to [open an issue here](https://github.com/nvim-treesitter/nvim-treesitter/issues/new/choose).
+In that case, feel free to [open an issue here](https://github.com/nvim-treesitter/nvim-treesitter/issues/new/choose).
 
-* **I get `module 'vim.treesitter.query' not found`**
+#### I get `module 'vim.treesitter.query' not found`
 
 Make sure you have the latest nightly version of Neovim.
 
-* **I get `Error detected while processing .../plugin/nvim-treesitter.vim` every time I open Neovim**
+#### I get `Error detected while processing .../plugin/nvim-treesitter.vim` every time I open Neovim
 
 This is probably due to a change in a parser's grammar or its queries.
 Try updating the parser that you suspect has changed (`:TSUpdate {language}`) or all of them (`:TSUpdate`).
 If the error persists after updating all parsers,
 please [open an issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/new/choose).
 
-* **I experience weird highlighting issues similar to [#78](https://github.com/nvim-treesitter/nvim-treesitter/issues/78)**
+#### I experience weird highlighting issues similar to [#78](https://github.com/nvim-treesitter/nvim-treesitter/issues/78)
 
-This is a well known issue, which arise when the tree and the buffer are getting out of sync.
-As this issue comes from upstream, we don't have any finite fix. To get around this, you can force reparsing the buffer with this command:
+This is a well known issue, which arises when the tree and the buffer have gotten out of sync.
+As this is an upstream issue, we don't have any definite fix.
+To get around this, you can force reparsing the buffer with
 
 ```vim
 :write | edit | TSBufEnable highlight
 ```
 
-This will save, restore and enable highlighting for the current buffer, fixing the issue.
+This will save, restore and enable highlighting for the current buffer.
 
-* **I experience bugs when using `nvim-treesitter`'s `foldexpr` similar to [#194](https://github.com/nvim-treesitter/nvim-treesitter/issues/194)**
+#### I experience bugs when using `nvim-treesitter`'s `foldexpr` similar to [#194](https://github.com/nvim-treesitter/nvim-treesitter/issues/194)
 
-This might happen, and is known to happen with `vim-clap`, to avoid those kind of errors, please use
-`setlocal` instead of `set` for the appropriate filetypes.
+This might happen, and is known to happen, with `vim-clap`.
+To avoid these kind of errors, please use `setlocal` instead of `set` for the respective filetypes.

--- a/README.md
+++ b/README.md
@@ -75,11 +75,10 @@ provides commands to automate this process:
 - `TSInstallInfo` to know which parsers are available and installed.
 - `TSInstall {language}` to install one or more parsers from a generated `c` file. (This requires a `C` compiler in your path.)
 - `TSInstallFromGrammar {language}` to install one or more parsers from the original `grammar.js`. (In addition to a `C` compiler, this requires the `tree-sitter-cli` executable in your path; see https://tree-sitter.github.io/tree-sitter/creating-parsers#installation for installation instructions.)
-- `TSUpdate` to update already installed parsers
 
-`TSInstall <tab>`, `TSInstallFromGrammar <tab>`, and `TSUpdate <tab>` will give you a list of supported languages, or select `all` to install/update them all.
+`TSInstall <tab>` and `TSInstallFromGrammar <tab>` will give you a list of supported languages; you can also use `TSInstall all` to install every parser on the list.
 
-If your language is not yet included in the supported list, you can add it locally as follows:
+If your language is not yet included in this list, you can add it locally as follows:
 
 1. Clone the repository or [create a new project](https://tree-sitter.github.io/tree-sitter/creating-parsers#project-setup) in, say, `~/projects/tree-sitter-zimbu`.
 2. Run `tree-sitter generate` in this directory (followed by `tree-sitter test`, for good measure).
@@ -101,6 +100,8 @@ parser_config.zimbu = {
 4. Start `nvim` and run `TSInstall zimbu` (or `TSInstallFromGrammar zimbu` if you skipped step 2).
 
 Note that this only installs the parser itself; using it for, e.g., highlighting also requires corresponding queries that need to be written and placed in the appropriate directory (e.g., as `queries/zimbu/highlights.scm`).
+
+Once a parser is installed, you can update it via `TSUpdate {language}`. If the parser is supported, this will checkout and install the revision specified in `nvim-treesitter`'s `lockfile.json`; otherwise it will use the latest revision of the repo or directory given in the `url` field above. Like `TSInstall`, you can get a list of possible arguments with `TSUpdate <tab>` or update every installed parser with `TSUpdate all` (or just `TSUpdate` for short).
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -74,37 +74,9 @@ provides commands to automate this process. If the language is already [supporte
 ```vim
 :TSInstall {language}
 ```
-This command supports tab expansion. You can also get a list of all available languages and their installation status with `:TSInstallInfo`.
+This command supports tab expansion. You can also get a list of all available languages and their installation status with `:TSInstallInfo`. Parsers not on this list can be added manually by following the steps described under ["Adding unsupported parsers"](#unsupported) below.
 
 If you update `nvim-treesitter` and want to make sure the parser is at the latest compatible version (as specified in `nvim-treesitter`'s `lockfile.json`), use `:TSUpdate {language}`. To update all parsers unconditionally, use `:TSUpdate all` or just `:TSUpdate`.
-
-### Adding unsupported parsers
-
-If you have a parser that is not on the list (either from a repository on Github or a local directory), you can add it manually for use by `nvim-treesitter` as follows:
-
-1. Clone the repository or [create a new project](https://tree-sitter.github.io/tree-sitter/creating-parsers#project-setup) in, say, `~/projects/tree-sitter-zimbu`. Make sure that the `tree-sitter-cli` executable is installed and in your path; see https://tree-sitter.github.io/tree-sitter/creating-parsers#installation for installation instructions.
-2. Run `tree-sitter generate` in this directory (followed by `tree-sitter test` for good measure).
-3. Add the following snippet to your `init.vim`:
-
-```vim
-lua <<EOF
-local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
-parser_config.zimbu = {
-  install_info = {
-    url = "~/projects/tree-sitter-zimbu", -- local path or git repo
-    files = {"src/parser.c"}
-  },
-  filetype = "zu", -- if filetype does not agrees with parser name
-  used_by = {"bar", "baz"} -- additional filetypes that use this parser
-}
-EOF
-```
-
-4. Start `nvim` and `:TSInstall zimbu`.
-
-You can also skip step 2 and use `:TSInstallFromGrammar zimbu` to install straight from `grammar.js`. Once the parser is installed, you can update it (from the latest revision of the `main` branch if `url` is a Github repository) with `:TSUpdate zimbu`.
-
-Note that this only installs the parser itself; using it for, e.g., highlighting also requires corresponding queries that need to be written and placed in the appropriate directory (e.g., as `queries/zimbu/highlights.scm`).
 
 ## Setup
 
@@ -272,6 +244,34 @@ List of currently supported languages:
 - [ ] [vue](https://github.com/ikatyang/tree-sitter-vue)
 - [ ] [yaml](https://github.com/ikatyang/tree-sitter-yaml)
 <!--parserinfo-->
+
+## <a name="unsupported"></a> Parsers for other languages
+
+If you have a parser that is not on this list (either from a repository on Github or a local directory), you can add it manually for use by `nvim-treesitter` as follows:
+
+1. Clone the repository or [create a new project](https://tree-sitter.github.io/tree-sitter/creating-parsers#project-setup) in, say, `~/projects/tree-sitter-zimbu`. Make sure that the `tree-sitter-cli` executable is installed and in your path; see https://tree-sitter.github.io/tree-sitter/creating-parsers#installation for installation instructions.
+2. Run `tree-sitter generate` in this directory (followed by `tree-sitter test` for good measure).
+3. Add the following snippet to your `init.vim`:
+
+```vim
+lua <<EOF
+local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
+parser_config.zimbu = {
+  install_info = {
+    url = "~/projects/tree-sitter-zimbu", -- local path or git repo
+    files = {"src/parser.c"}
+  },
+  filetype = "zu", -- if filetype does not agrees with parser name
+  used_by = {"bar", "baz"} -- additional filetypes that use this parser
+}
+EOF
+```
+
+4. Start `nvim` and `:TSInstall zimbu`.
+
+You can also skip step 2 and use `:TSInstallFromGrammar zimbu` to install straight from `grammar.js`. Once the parser is installed, you can update it (from the latest revision of the `main` branch if `url` is a Github repository) with `:TSUpdate zimbu`.
+
+Note that this only installs the parser itself; using it for, e.g., highlighting also requires corresponding queries that need to be written and placed in the appropriate directory (e.g., as `queries/zimbu/highlights.scm`).
 
 # Roadmap
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,19 @@
   </p>
 </div>
 
+The goal of `nvim-treesitter` is both to provide a simple and easy way to use the interface for [tree-sitter](https://github.com/tree-sitter/tree-sitter) in Neovim and to provide some basic functionality such as highlighting based on on it:
+
 ![cpp example](assets/example-cpp.png)
 
 Traditional highlighting (left) vs Treesitter-based highlighting (right).
-See more examples in [our gallery](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Gallery).
+More examples can be found in [our gallery](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Gallery).
 
-**Warning: Treesitter and Treesitter highlighting are an experimental feature of nightly versions of Neovim.
-Please consider the experience with this plug-in as experimental until Neovim 0.5 is released!**
+**Warning: Treesitter and nvim-treesitter highlighting are an experimental feature of nightly versions of Neovim.
+Please consider the experience with this plug-in as experimental until Neovim 0.5 is released!
+You can find the current roadmap [here](https://github.com/nvim-treesitter/nvim-treesitter/projects/1).
+The roadmap and all features of this plugin are open to change, and any suggestion will be highly appreciated!**
+
+Nvim-treesitter is based on three interlocking features: [**language parsers**](#parsers), [**queries**](#queries), and [**modules**](#modules), where *modules* provide features -- such as highlighting -- based on *queries* for syntax objects specified by language *parsers*. Users will generally only need to interact with parsers and modules as explained in the next section. For more detailed information on setting these up, see ["Advanced setup"](#advanced).
 
 # Quickstart
 
@@ -47,27 +53,15 @@ Please consider the experience with this plug-in as experimental until Neovim 0.
 
 ## Installation
 
-You can install `nvim-treesitter` with your favorite package manager, or using the default `pack` feature of Neovim!
+You can install `nvim-treesitter` with your favorite package manager (or using the native `package` feature of vim, see `:h packages`).
 
-### Using a package manager
-
-If you are using [vim-plug](https://github.com/junegunn/vim-plug), put this in your `init.vim` file:
+E.g., if you are using [vim-plug](https://github.com/junegunn/vim-plug), put this in your `init.vim` file:
 
 ```vim
 Plug 'nvim-treesitter/nvim-treesitter'
 ```
 
-### Using Neovim `pack` feature
-
-We highly recommend reading `:h packages` to learn more about this feature, but you can still follow these steps:
-
-```sh
-$ mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
-$ cd ~/.local/share/nvim/site/pack/nvim-treesitter/start
-$ git clone https://github.com/nvim-treesitter/nvim-treesitter.git
-```
-
-## Adding parsers
+## Language parsers
 
 Treesitter uses a different _parser_ for every language, which needs to be generated via `tree-sitter-cli` from a `grammar.js` file, then compiled to a `.so` library that needs to be placed in neovim's `runtimepath` (typically under `parser/{lang}.so`). To simplify this, `nvim-treesitter`
 provides commands to automate this process. If the language is already [supported by `nvim-treesitter`](#supported), you can install it with
@@ -78,10 +72,11 @@ This command supports tab expansion. You can also get a list of all available la
 
 If you update `nvim-treesitter` and want to make sure the parser is at the latest compatible version (as specified in `nvim-treesitter`'s `lockfile.json`), use `:TSUpdate {language}`. To update all parsers unconditionally, use `:TSUpdate all` or just `:TSUpdate`.
 
-## Setup
+## Modules
 
-All modules are disabled by default,
-so you'll need to activate them by putting this in your `init.vim` file:
+Each modules provide a distinct feature based on treesitter such as [highlighting](#highlighting), [indentation](#indentation), or [folding](#folding); see [`:h nvim-treesitter-modules`](doc/nvim-treesitter.txt) or see ["Modules"](#modules) below for a list of available modules and their options.
+
+All modules are disabled by default and need to be activated explicitly in your `init.vim`:
 
 ```vim
 lua <<EOF
@@ -95,93 +90,7 @@ require'nvim-treesitter.configs'.setup {
 EOF
 ```
 
-Check [`:h nvim-treesitter-modules`](doc/nvim-treesitter.txt)
-for a list of available modules and its options.
-
-# Available modules
-
-## Highlight
-
-Consistent syntax highlighting.
-
-```vim
-lua <<EOF
-require'nvim-treesitter.configs'.setup {
-  highlight = {
-    enable = true,
-    custom_captures = {
-      -- Highlight the @foo.bar capture group with the "Identifier" highlight group.
-      ["foo.bar"] = "Identifier",
-    },
-  },
-}
-EOF
-```
-
-## Incremental selection
-
-Incremental selection based on the named nodes from the grammar.
-
-```vim
-lua <<EOF
-require'nvim-treesitter.configs'.setup {
-  incremental_selection = {
-    enable = true,
-    keymaps = {
-      init_selection = "gnn",
-      node_incremental = "grn",
-      scope_incremental = "grc",
-      node_decremental = "grm",
-    },
-  },
-}
-EOF
-```
-
-## Indentation
-
-Treesitter based indentation (`=` vim behavior)
-
-```vim
-lua <<EOF
-require'nvim-treesitter.config'.setup {
-  indent = {
-    enable = true
-  }
-}
-EOF
-```
-
-# External modules
-
-Other modules can be installed as plugins.
-
-- [refactor](https://github.com/nvim-treesitter/nvim-treesitter-refactor) - Refactoring and definition modules
-- [textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) - Textobjects defined by tree-sitter queries
-- [playground](https://github.com/nvim-treesitter/playground) - Treesitter integrated playground
-- [context](https://github.com/romgrk/nvim-treesitter-context) - Show parent code context in a popover
-
-# Extra features
-
-## Syntax based code folding
-
-```vim
-set foldmethod=expr
-set foldexpr=nvim_treesitter#foldexpr()
-```
-
-This will respect your `foldnestmax` setting.
-
-## Statusline indicator
-
-```vim
-echo nvim_treesitter#statusline(90)  " 90 can be any length
-module->expression_statement->call->identifier
-```
-
-# Commands
-
-Each feature can be enabled or disabled by different means:
+Each module can also be enabled or disabled interactively through the following commands:
 
 ```vim
 :TSBufEnable {module} " enable module on current buffer
@@ -191,16 +100,15 @@ Each feature can be enabled or disabled by different means:
 :TSModuleInfo [{module}] " list information about modules state for each filetype
 ```
 
-Check [`:h nvim-treesitter-commands`](doc/nvim-treesitter.txt) for a list of all available commands.
+Check [`:h nvim-treesitter-commands`](doc/nvim-treesitter.txt) for a list of all available commands. It may be necessary to reload the buffer (e.g., via `:e`) after enabling a module.
 
-# <a name="supported"></a>Supported Languages
+# <a name="supported"></a>Supported languages
 
-For `nvim-treesitter` to work, we need to use query files such as those you can find in
-`queries/{lang}/{locals,highlights,textobjects}.scm`
+For `nvim-treesitter` to support a specific feature for a specific language requires both a parser for this language and an appropriate query file for that language and that feature.
 
-We are looking for maintainers to write query files for their languages.
+The following is a list of languages for which a parser can be installed through `:TSInstall`; a checked box means that `nvim-treesitter` also contains queries at least for the `highlight` module.
 
-List of currently supported languages:
+We are looking for maintainers to add more parsers and to write query files for their languages.
 
 <!--This section of the README is automatically updated by a CI job-->
 <!--parserinfo-->
@@ -245,7 +153,89 @@ List of currently supported languages:
 - [ ] [yaml](https://github.com/ikatyang/tree-sitter-yaml)
 <!--parserinfo-->
 
-## <a name="unsupported"></a> Parsers for other languages
+
+# <a name="modules"></a> Available modules
+
+Modules provide the top-level features of `nvim-treesitter`. These can be implemented either as part of `nvim-treesitter` or as an external plugin.
+
+## Included modules
+
+The following is a list of modules included in `nvim-treesitter`. Note that not all modules work for all languages (depending on the queries available for them).
+
+#### <a name="highlighting"></a> Highlight
+
+Consistent syntax highlighting.
+
+```vim
+lua <<EOF
+require'nvim-treesitter.configs'.setup {
+  highlight = {
+    enable = true,
+    custom_captures = {
+      -- Highlight the @foo.bar capture group with the "Identifier" highlight group.
+      ["foo.bar"] = "Identifier",
+    },
+  },
+}
+EOF
+```
+
+#### Incremental selection
+
+Incremental selection based on the named nodes from the grammar.
+
+```vim
+lua <<EOF
+require'nvim-treesitter.configs'.setup {
+  incremental_selection = {
+    enable = true,
+    keymaps = {
+      init_selection = "gnn",
+      node_incremental = "grn",
+      scope_incremental = "grc",
+      node_decremental = "grm",
+    },
+  },
+}
+EOF
+```
+
+#### <a name="indentation"></a> Indentation
+
+Treesitter based indentation (`=` vim behavior)
+
+```vim
+lua <<EOF
+require'nvim-treesitter.config'.setup {
+  indent = {
+    enable = true
+  }
+}
+EOF
+```
+
+#### <a name="folding"></a> Folding
+
+```vim
+set foldmethod=expr
+set foldexpr=nvim_treesitter#foldexpr()
+```
+
+This will respect your `foldnestmax` setting.
+
+## External modules
+
+Other modules can be installed as plugins, such as
+
+- [refactor](https://github.com/nvim-treesitter/nvim-treesitter-refactor) - Refactoring and definition modules
+- [textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) - Textobjects defined by tree-sitter queries
+- [playground](https://github.com/nvim-treesitter/playground) - Treesitter integrated playground
+- [context](https://github.com/romgrk/nvim-treesitter-context) - Show parent code context in a popover
+
+
+# <a name="advanced"></a> Advanced setup
+
+## <a name="unsupported"></a> Adding parsers
 
 If you have a parser that is not on this list (either from a repository on Github or a local directory), you can add it manually for use by `nvim-treesitter` as follows:
 
@@ -271,25 +261,33 @@ EOF
 
 You can also skip step 2 and use `:TSInstallFromGrammar zimbu` to install straight from `grammar.js`. Once the parser is installed, you can update it (from the latest revision of the `main` branch if `url` is a Github repository) with `:TSUpdate zimbu`.
 
-Note that this only installs the parser itself; using it for, e.g., highlighting also requires corresponding queries that need to be written and placed in the appropriate directory (e.g., as `queries/zimbu/highlights.scm`).
+## <a name="queries"></a> Adding queries
 
-# Roadmap
+Queries are what `nvim-treesitter` uses to extract informations from the syntax tree; they are
+located in the `queries/{language}/*` runtime directories (like the `queries` folder of this plugin), e.g., `queries/{language}/{locals,highlights,textobjects}.scm`. Other modules may require additional queries such as `folding.scm`.
 
-The goal of `nvim-treesitter` is both to provide a simple and easy way to use the interface for Treesitter in Neovim,
-but also to add some functionalities to it.
+`nvim-treesitter` considers queries as any runtime file (see `:h rtp`), that is :
 
-You can find the roadmap [here](https://github.com/nvim-treesitter/nvim-treesitter/projects/1).
-The roadmap and all features of this plugin are open to change, and any suggestion will be highly appreciated!
+- if the file is in any `after/queries/` folder, then it will be used to extend the already defined
+  queries.
+- Otherwise, it will be used as a base to define the query, the first query found (with the highest
+  priority) will be the only one to be used.
 
-# Defining Modules
+This hybrid approach is the most standard way; in this case
 
-Users and plugin authors can take advantage of modules by creating their own. Modules provide:
+- if you want to rewrite (or write) a query, don't use `after/queries`;
+- if you want to override a part of a query (only one match for example), use the `after/queries`
+  directory.
 
-- Treesitter language detection support
-- Attach and detach to buffers
-- Works with all nvim-treesitter commands
+## Adding modules
 
-You can use the `define_modules` function to define one or more modules or module groups.
+If you wish you write your own module, you need to support
+
+- tree-sitter language detection support;
+- attaching and detaching to buffers;
+- all nvim-treesitter commands.
+
+At the top level, you can use the `define_modules` function to define one or more modules or module groups:
 
 ```vim
 lua <<EOF
@@ -309,7 +307,7 @@ require'nvim-treesitter'.define_modules {
 EOF
 ```
 
-Modules can consist of the following properties:
+with the following properties
 
 - `module_path`: A require path (string) that exports a module with an `attach` and `detach` function. This is not required if the functions are on this definition.
 - `enable`: Determines if the module is enabled by default. This is usually overridden by the user.
@@ -318,7 +316,16 @@ Modules can consist of the following properties:
 - `attach`: A function that attaches to a buffer. This is required if `module_path` is not provided.
 - `detach`: A function that detaches from a buffer. This is required if `module_path` is not provided.
 
-# Utils
+# Extra features
+
+### Statusline indicator
+
+```vim
+echo nvim_treesitter#statusline(90)  " 90 can be any length
+module->expression_statement->call->identifier
+```
+
+### Utilities
 
 You can get some utility functions with
 
@@ -328,31 +335,12 @@ local ts_utils = require 'nvim-treesitter.ts_utils'
 
 Check [`:h nvim-treesitter-utils`](doc/nvim-treesitter.txt) for more information.
 
-# User Query Extensions
-
-Queries are what `nvim-treesitter` uses to extract informations from the syntax tree, and they are
-located in the `queries/{lang}/*` runtime directories (like the `queries` folder of this plugin).
-
-`nvim-treesitter` considers queries as any runtime file (see `:h rtp`), that is :
-
-- if the file is in any `after/queries/` folder, then it will be used to extend the already defined
-  queries.
-- Otherwise, it will be used as a base to define the query, the first query found (with the highest
-  priority) will be the only one to be used.
-
-This hybrid approach is the most standard way, and according to that, here is some ideas on how to
-use is :
-
-- If you want to rewrite (or write) a query, don't use `after/queries`.
-- If you want to override a part of a query (only one match for example), use the `after/queries`
-  directory.
-
 # Troubleshooting
 
-Before doing anything make sure you have the latest version of this plugin and run `:checkhealth nvim_treesitter`.
+Before doing anything make sure you have the latest version of this plugin and run `:checkhealth nvim_treesitter`. It can also help to update the parsers via `:TSUpdate`.
 This will help you find where the bug might come from.
 
-## Feature `X` does not work for `{language}`...
+* **Feature `X` does not work for `{language}`...**
 
 First, check the `## {language} parser healthcheck` section of `:checkhealth` if you have any warning.
 If you do, it's highly possible that this is the cause of the problem.
@@ -360,18 +348,18 @@ If everything is okay, then it might be an actual error.
 
 In both cases, feel free to [open an issue here](https://github.com/nvim-treesitter/nvim-treesitter/issues/new/choose).
 
-## I get `module 'vim.treesitter.query' not found`
+* **I get `module 'vim.treesitter.query' not found`**
 
 Make sure you have the latest nightly version of Neovim.
 
-## I get `Error detected while processing .../plugin/nvim-treesitter.vim` every time I open Neovim
+* **I get `Error detected while processing .../plugin/nvim-treesitter.vim` every time I open Neovim**
 
 This is probably due to a change in a parser's grammar or its queries.
 Try updating the parser that you suspect has changed (`:TSUpdate {language}`) or all of them (`:TSUpdate`).
 If the error persists after updating all parsers,
 please [open an issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/new/choose).
 
-## I experience weird highlighting issues similar to [#78](https://github.com/nvim-treesitter/nvim-treesitter/issues/78)
+* **I experience weird highlighting issues similar to [#78](https://github.com/nvim-treesitter/nvim-treesitter/issues/78)**
 
 This is a well known issue, which arise when the tree and the buffer are getting out of sync.
 As this issue comes from upstream, we don't have any finite fix. To get around this, you can force reparsing the buffer with this command:
@@ -382,7 +370,7 @@ As this issue comes from upstream, we don't have any finite fix. To get around t
 
 This will save, restore and enable highlighting for the current buffer, fixing the issue.
 
-## I experience bugs when using `nvim-treesitter`'s `foldexpr` similar to [#194](https://github.com/nvim-treesitter/nvim-treesitter/issues/194)
+* **I experience bugs when using `nvim-treesitter`'s `foldexpr` similar to [#194](https://github.com/nvim-treesitter/nvim-treesitter/issues/194)**
 
 This might happen, and is known to happen with `vim-clap`, to avoid those kind of errors, please use
 `setlocal` instead of `set` for the appropriate filetypes.

--- a/README.md
+++ b/README.md
@@ -72,11 +72,10 @@ $ git clone https://github.com/nvim-treesitter/nvim-treesitter.git
 Treesitter uses a different _parser_ for every language, which needs to be generated via `tree-sitter-cli` from a `grammar.js` file, then compiled to a `.so` library that needs to be placed in neovim's `runtimepath` (typically under `parser/{lang}.so`). To simplify this, `nvim-treesitter`
 provides commands to automate this process:
 
-- `TSInstallInfo` to know which parsers are available and installed.
 - `TSInstall {language}` to install one or more parsers from a generated `c` file. (This requires a `C` compiler in your path.)
 - `TSInstallFromGrammar {language}` to install one or more parsers from the original `grammar.js`. (In addition to a `C` compiler, this requires the `tree-sitter-cli` executable in your path; see https://tree-sitter.github.io/tree-sitter/creating-parsers#installation for installation instructions.)
 
-`TSInstall <tab>` and `TSInstallFromGrammar <tab>` will give you a list of supported languages; you can also use `TSInstall all` to install every parser on the list.
+`TSInstall <tab>` and `TSInstallFromGrammar <tab>` will give you a list of supported languages; you can also use `TSInstall all` to install every parser on the list. To show which languages are available together with their installation status, use `TSInstallInfo`.
 
 If your language is not yet included in this list, you can add it locally as follows:
 


### PR DESCRIPTION
This adds a brief explanation how to add unsupported parsers to nvim-treesitter (assuming the grammar is already written) via the snippet @theHamsta provided on Gitter.

It might be good to also add more details how to add the corresponding queries; I've left this vague since I don't know the details myself (is it enough to have a `queries` directory somewhere in `rtp`?)