### PR TITLE
Only update outdated_parsers on TSUpdate

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -30,6 +30,7 @@ jobs:
           git config user.email "actions@github"
           git config user.name "Github Actions"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          ./nvim.appimage --headless -c "luafile ./scripts/update-readme.lua" -c "q" || git add README.md
+          ./nvim.appimage --headless -c "luafile ./scripts/update-readme.lua" -c "q" || echo "Needs update"
+          git add README.md
           # Only commit and push if we have changes
           git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin HEAD:${GITHUB_REF})

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 doc/tags
 .luacheckcache
 /tags
+nvim.appimage

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ List of currently supported languages:
 
 <!--This section of the README is automatically updated by a CI job-->
 <!--parserinfo-->
-
 - [x] [bash](https://github.com/tree-sitter/tree-sitter-bash) (maintained by @TravonteD)
 - [x] [c](https://github.com/tree-sitter/tree-sitter-c) (maintained by @vigoux)
 - [x] [c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) (maintained by @svermeulen)

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -68,9 +68,10 @@ end
 -- "site" dir from "runtimepath". "site" dir will be created if it doesn't
 -- exist. Using only the package dir won't work when the plugin is installed
 -- with Nix, since the "/nix/store" is read-only.
-function M.get_parser_install_dir()
+function M.get_parser_install_dir(folder_name)
+  folder_name = folder_name or "parser"
   local package_path = M.get_package_path()
-  local package_path_parser_dir = M.join_path(package_path, "parser")
+  local package_path_parser_dir = M.join_path(package_path, folder_name)
 
   -- If package_path is read/write, use that
   if luv.fs_access(package_path_parser_dir, 'RW') then
@@ -79,7 +80,7 @@ function M.get_parser_install_dir()
 
   local site_dir = M.get_site_dir()
   local path_sep = M.get_path_sep()
-  local parser_dir = M.join_path(site_dir, path_sep, 'parser')
+  local parser_dir = M.join_path(site_dir, path_sep, folder_name)
 
   -- Try creating and using parser_dir if it doesn't exist
   if not luv.fs_stat(parser_dir) then
@@ -99,6 +100,10 @@ function M.get_parser_install_dir()
   -- package_path isn't read/write, parser_dir exists but isn't read/write
   -- either, give up
   return nil, join_space('Invalid cache rights,', package_path, 'or', parser_dir, 'should be read/write')
+end
+
+function M.get_parser_info_dir()
+  return M.get_parser_install_dir('parser-info')
 end
 
 -- Gets a property at path

--- a/parser-info/.gitignore
+++ b/parser-info/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
I have no idea why Github decided to close #640 but here is an updated version. It should now also work when `lockfile.json` changed after a plugin update and when `parser-info` is not writable.

Please also test. E.g. by

-  `:TSUpdate` (now it should write all installed parser revisions, will run for all parsers a last time)
- Change `lockfile.json` (only one revision -> should only update that parser on TSUpdate, or execute `write-lockfile.json` -> :TSUpdate should  update all parsers with new revision available)