### PR TITLE
javascript: : in pairs as punctuation.delimiter

### DIFF
--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -49,6 +49,8 @@
   key: (property_identifier) @method
   value: (arrow_function))
 
+(pair ":" @punctuation.delimiter)
+
 (assignment_expression
   left: (member_expression
     property: (property_identifier) @method)

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -49,8 +49,6 @@
   key: (property_identifier) @method
   value: (arrow_function))
 
-(pair ":" @punctuation.delimiter)
-
 (assignment_expression
   left: (member_expression
     property: (property_identifier) @method)
@@ -151,6 +149,8 @@
 ";" @punctuation.delimiter
 "." @punctuation.delimiter
 "," @punctuation.delimiter
+
+(pair ":" @punctuation.delimiter)
 
 [
   "--"

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -49,7 +49,7 @@
   key: (property_identifier) @method
   value: (arrow_function))
 
-(pair ":" @punctuation.delimiter)
+(pair ":" @operator)
 
 (assignment_expression
   left: (member_expression

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -49,7 +49,7 @@
   key: (property_identifier) @method
   value: (arrow_function))
 
-(pair ":" @operator)
+(pair ":" @punctuation.delimiter)
 
 (assignment_expression
   left: (member_expression


### PR DESCRIPTION
Set : to be operator in javascript.

![punctuation.delimiter](https://user-images.githubusercontent.com/15027/99910644-2ec47480-2cbd-11eb-9025-fa5179b744fd.png)

[old-operator-example](https://user-images.githubusercontent.com/15027/99914664-e6ad4e00-2ccc-11eb-8640-df957f6d3a62.png)


