### PR TITLE
c highlights: fix define/undef arguments

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -143,6 +143,15 @@
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z0-9_]+$"))
 
+;; Preproc def / undef
+(preproc_def
+  name: (_) @constant)
+(preproc_call
+  directive: (preproc_directive) @_u
+  argument: (_) @constant
+  (#eq? @_u "#undef"))
+
+
 (comment) @comment
 
 ;; Parameters


### PR DESCRIPTION
This bugged me for a while, the fix is a bit strange, but it'll do the trick hopefully