### PR TITLE
javascript: Add operator to / for division

### DIFF
--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -180,6 +180,7 @@
   "%="
 ] @operator
 
+(binary_expression "/" @operator)
 (ternary_expression ["?" ":"] @operator)
 
 "(" @punctuation.bracket


### PR DESCRIPTION
This currently has no highlights for `/` in division.

This adds `/` for division punctuation. https://tc39.es/ecma262/#prod-DivPunctuator

![2020-11-23-115514_4480x1440_scrot](https://user-images.githubusercontent.com/15027/99991368-ef605b80-2d82-11eb-9938-39bf92cdcff5.png)

And doesn't match for `/` in tags (jsx/tsx)

![2020-11-23-115555_4480x1440_scrot](https://user-images.githubusercontent.com/15027/99991415-fedfa480-2d82-11eb-9785-f5b4b4123513.png)

