### PR TITLE
RFC: C/C++ macro injections

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -114,9 +114,11 @@
 (preproc_function_def
   name: (identifier) @function.macro)
 [
- (preproc_arg)
  (preproc_defined)
 ]  @function.macro
+
+
+ ;(preproc_arg)
 ; TODO (preproc_arg)  @embedded
 
 (((field_expression

--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -1,0 +1,1 @@
+(preproc_arg) @c

--- a/queries/cpp/injections.scm
+++ b/queries/cpp/injections.scm
@@ -1,0 +1,1 @@
+(preproc_arg) @cpp


### PR DESCRIPTION
With injections, it would be possible to self-inject C into macros
![image](https://user-images.githubusercontent.com/7189118/100012404-894ff480-2dd3-11eb-878c-d74a2208074a.png)
or C++
![image](https://user-images.githubusercontent.com/7189118/100012435-94a32000-2dd3-11eb-9d1a-b5cf95775ff5.png)

It would be good to have some kind of background highlighting to signalize the use that this is macro code (how to do this for all colorschemes?). The advantage of the current highlighting is that it makes clear were macro code starts and were it ends.
![image](https://user-images.githubusercontent.com/7189118/100012651-e481e700-2dd3-11eb-90cc-59e731ecd0ec.png)
