### PR TITLE
Allow configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,19 @@ EOF
 You can also skip step 2 and use `:TSInstallFromGrammar zimbu` to install directly from a `grammar.js` in the top-level directory specified by `url`.
 Once the parser is installed, you can update it (from the latest revision of the `main` branch if `url` is a Github repository) with `:TSUpdate zimbu`.
 
+## Update parsers used_by
+
+Sometimes needs to use some parser for different filetype.
+
+Add the following snippet to your `init.vim`:
+
+```vim
+lua <<EOF
+local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
+parser_config.typescript.used_by = "javascriptflow"
+EOF
+```
+
 ## Adding queries
 
 Queries are what `nvim-treesitter` uses to extract informations from the syntax tree; they are


### PR DESCRIPTION
Trying to use typescript for **flow typed** [issue related](https://github.com/nvim-treesitter/nvim-treesitter/issues/31) I set up as describes Readme file but as this lines 

https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/parsers.lua#L344-L354 

runs at require, any new setup has no effect because `ft_to_parsername` is not repopulated, and any `used_by` value is not used.