### PR TITLE
lua: Remove shebang highlight

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -132,7 +132,6 @@
 (string) @string
 (number) @number
 (label_statement) @label
-(shebang) @comment
 
 ;; Error
 (ERROR) @error


### PR DESCRIPTION
This line was breaking highlighting in my fill and breaking playground working to find the highlight.

```
E5108: Error executing lua /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:119: query: invalid node type at positio
n 1483
```

File it was happening on: https://github.com/nvim-lua/lsp_extensions.nvim/blob/master/lua/lsp_extensions/inlay_hints.lua

Removing this line fixes these issues but I do not know why it would even break things.