### PR TITLE
RFC: Auto sync lockfile

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -11,6 +11,7 @@ local config = {
   modules = {},
   ensure_installed = {},
   update_strategy = 'lockfile',
+  auto_sync_lockfile = true,
 }
 -- List of modules that need to be setup on initialization.
 local queued_modules_defs = {}
@@ -232,6 +233,14 @@ function M.setup(user_data)
   local ensure_installed = user_data.ensure_installed or {}
   if #ensure_installed > 0 then
     require'nvim-treesitter.install'.ensure_installed(ensure_installed)
+  end
+
+  for _, setting in pairs({'auto_sync_lockfile', 'update_strategy'}) do
+    config[setting] = user_data[setting] ~= nil and user_data[setting] or config[setting]
+  end
+
+  if config.auto_sync_lockfile and config.update_strategy == 'lockfile' then
+    require'nvim-treesitter.install'.sync_lockfile()
   end
 
   config.modules.ensure_installed = nil

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -45,13 +45,17 @@ local function get_installed_revision(lang)
   end
 end
 
-local function needs_update(lang)
-  return not get_revision(lang) or get_revision(lang) ~= get_installed_revision(lang)
+local function needs_update(lang, pinned_only)
+  if pinned_only then
+    return get_revision(lang) and get_revision(lang) ~= get_installed_revision(lang)
+  else
+    return not get_revision(lang) or get_revision(lang) ~= get_installed_revision(lang)
+  end
 end
 
-local function outdated_parsers()
+local function outdated_parsers(pinned_only)
   return vim.tbl_filter(function(lang)
-    return needs_update(lang)
+    return needs_update(lang, pinned_only)
   end,
   info.installed_parsers())
 end
@@ -291,6 +295,15 @@ function M.update(lang)
     for _, lang in pairs(parsers_to_update) do
       install(false, 'force')(lang)
     end
+  end
+end
+
+function M.sync_lockfile()
+  M.lockfile = {}
+  reset_progress_counter()
+  local parsers_to_update = outdated_parsers('pinned only')
+  for _, lang in pairs(parsers_to_update) do
+    install(false, 'force')(lang)
   end
 end
 


### PR DESCRIPTION
This PR is on top of #718 

It checks whether the installed parsers are still in sync with the lockfile (opt-out possible).

Make this default on or default off? (It will implicitly check installed_parsers, but this could also be avoided if necessary). Also added a hint to README.md to do `:TSUpdate` on update (maybe this is enough?).

At the moment I have rather the tendency to prefer to just recommend `:TSUpdate` on update. So just to close this PR.

