### PR TITLE
css: add indent support

### DIFF
--- a/queries/css/indents.scm
+++ b/queries/css/indents.scm
@@ -1,0 +1,9 @@
+[
+  (block)
+  (declaration)
+] @indent
+
+[
+  "}"
+] @branch
+


### PR DESCRIPTION
When you enter a new line after `{` or new line `o` in command mode, it'll enter a new line with auto indent. For example:

```
a {< enter
  |
}
```

The indent when enter a new line after properties declaration is also support:

```
a {
  color: black;< enter
  |
}
```

NOTE: `|` is a cursor.