### PR TITLE
Update js ts

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -105,10 +105,10 @@
     "revision": "02e774c911d123ea3fbe5273cf9d987fa88dd3fb"
   },
   "tsx": {
-    "revision": "73afadbd117a8e8551758af9c3a522ef46452119"
+    "revision": "ada1521cecdb81a9430f2dd73d662f6cee4efc5f"
   },
   "typescript": {
-    "revision": "73afadbd117a8e8551758af9c3a522ef46452119"
+    "revision": "ada1521cecdb81a9430f2dd73d662f6cee4efc5f"
   },
   "verilog": {
     "revision": "ad551aae2649da56582bc0557478a7dc979c0be3"

--- a/lockfile.json
+++ b/lockfile.json
@@ -42,7 +42,7 @@
     "revision": "f7b62ac33d63bea56ce202ace107aaa4285e50af"
   },
   "javascript": {
-    "revision": "852f11b394804ac2a8986f8bcaafe77753635667"
+    "revision": "3f8b62f9befd3cb3b4cb0de22f6595a0aadf76ca"
   },
   "jsdoc": {
     "revision": "77e7785739ad3e90c3de8ed5a55418a5fd2b8225"

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -86,37 +86,10 @@
 ; Variables
 ;----------
 
-(formal_parameters (identifier) @parameter)
-
-(formal_parameters
-  (rest_parameter
-    (identifier) @parameter))
-
-; ({ a }) => null
-(formal_parameters
-  (object_pattern
-    (shorthand_property_identifier) @parameter))
-
-; ({ a: b }) => null
-(formal_parameters
-  (object_pattern
-    (pair
-      value: (identifier) @parameter)))
-
-; ([ a ]) => null
-(formal_parameters
-  (array_pattern
-    (identifier) @parameter))
-
 ; a => null
 (variable_declarator                                                                                                                                                                                        
     value: (arrow_function                                                                                                                                                                                    
       parameter: (identifier) @parameter))
-
-; optional parameters
-(formal_parameters
-  (assignment_pattern
-    (shorthand_property_identifier) @parameter))
 
 ; Variables
 ;----------

--- a/queries/javascript/locals.scm
+++ b/queries/javascript/locals.scm
@@ -18,10 +18,6 @@
 (formal_parameters
   (identifier) @definition.parameter)
 
-(formal_parameters
-  (object_pattern
-    (identifier) @definition.parameter))
-
 ; function(arg = []) {
 (formal_parameters
   (assignment_pattern
@@ -30,6 +26,11 @@
 ; x => x
 (arrow_function
   parameter: (identifier) @definition.parameter)
+
+(formal_parameters
+  (object_pattern
+    (pair
+      value: (identifier) @definition.parameter)))
 
 (formal_parameters
   (object_pattern

--- a/queries/typescript/locals.scm
+++ b/queries/typescript/locals.scm
@@ -1,4 +1,37 @@
-; inherits: javascript
+; inherits: (jsx)
 
-(required_parameter (identifier) @definition)
-(optional_parameter (identifier) @definition)
+; Scopes
+;-------
+
+(statement_block) @scope
+(function) @scope
+(arrow_function) @scope
+(function_declaration) @scope
+(method_definition) @scope
+(for_statement) @scope
+(for_in_statement) @scope
+(catch_clause) @scope
+
+; Definitions
+;------------
+
+(variable_declarator
+  name: (identifier) @definition.var)
+
+(import_specifier
+  (identifier) @definition.import)
+
+(namespace_import
+  (identifier) @definition.import)
+
+(function_declaration
+  ((identifier) @definition.var)
+   (#set! definition.var.scope parent))
+
+; References
+;------------
+
+(identifier) @reference
+(shorthand_property_identifier) @reference
+(required_parameter (identifier) @definition.parameter)
+(optional_parameter (identifier) @definition.parameter)


### PR DESCRIPTION
PR just for reference.

Problem:

typescript does not inherit the parameter rule from JS. So all `@definition.parameter` queries will not be accepted by the typescript parser.

How to continue? 

- Not let typescript inherit from JS
- Let both JS and TS inherit from a common subset
- Update JS only (does not harm old TS parser)

@steelsojka  