### PR TITLE
Fix some missing highlight and add placeholder in docs

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -506,6 +506,10 @@ For labels: `label:` in C and `:label:` in Lua.
                                                                *hl-TSOperator*
 For any operator: `+`, but also `->` and `*` in C.
 
+`TSKeywordOperator`
+                                                               *hl-TSKeywordOperator*
+Same as the |hl-TSOperator|
+
 `TSKeyword`
                                                                 *hl-TSKeyword*
 For keywords that don't fall in previous categories.
@@ -539,6 +543,10 @@ in Lua.
                                                              *hl-TSAnnotation*
 For C++/Dart attributes, annotations that can be attached to the code to
 denote some kind of meta information.
+
+`TSAttribute`
+                                                             *hl-TSAttribute*
+TODO: Add missing description.
 
 `TSText`
                                                                    *hl-TSText*
@@ -576,6 +584,14 @@ Any variable name that does not have another highlight.
 `TSVariableBuiltin`
                                                         *hl-TSVariableBuiltin*
 Variable names that are defined by the languages, like `this` or `self`.
+
+`TSTag`
+                                                               *hl-TSTag*
+TODO: Add missing description.
+
+`TSTagDelimiter`
+                                                        *hl-TSTagDelimiter*
+TODO: Add missing description.
 
 ==============================================================================
 PERFORMANCE                                      *nvim-treesitter-performance*

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -23,6 +23,7 @@ let cterm_normal = s:has_attr('fg', 'cterm') ? 'fg' : 'NONE'
 let gui_normal = s:has_attr('fg', 'gui') ? 'foreground' : 'NONE'
 
 execute 'highlight default TSNone term=NONE cterm=NONE gui=NONE guifg='.gui_normal.' ctermfg='.cterm_normal
+highlight default link TSError ErrorMsg
 
 highlight default link TSPunctDelimiter Delimiter
 highlight default link TSPunctBracket Delimiter
@@ -65,6 +66,7 @@ highlight default link TSType Type
 highlight default link TSTypeBuiltin Type
 highlight default link TSInclude Include
 
+highlight default link TSVariable Special
 highlight default link TSVariableBuiltin Special
 
 highlight default link TSText TSNone


### PR DESCRIPTION
This is a little blind fix, I found there was missing highlight for TSVariable and digging deeper I found missing documentation for some other highlight too. I just fix it as I could with placeholders in documentation. @theHamsta could you review it, I same that you are mostly author of this part of plugin.