### PR TITLE
Update ruby parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -90,7 +90,7 @@
     "revision": "aa61d0e2930de134089326973686ac547cca9e03"
   },
   "ruby": {
-    "revision": "4ba96497dd5911d5dc8856943eabafb2c493921d"
+    "revision": "694f81cbc552d2c2e928d909652544e0a2d60613"
   },
   "rust": {
     "revision": "8746bd4b584b8063ee8e445bf31015e887417d33"

--- a/lockfile.json
+++ b/lockfile.json
@@ -90,7 +90,7 @@
     "revision": "aa61d0e2930de134089326973686ac547cca9e03"
   },
   "ruby": {
-    "revision": "b92e1f80e5a838aa78f19faab6350157beb6fcd6"
+    "revision": "4ba96497dd5911d5dc8856943eabafb2c493921d"
   },
   "rust": {
     "revision": "8746bd4b584b8063ee8e445bf31015e887417d33"


### PR DESCRIPTION
Includes fixes for float rationals and keyword parameters

I guess it would be nice to have a highlight for rational.

![image](https://user-images.githubusercontent.com/7189118/101410433-9c88b700-38df-11eb-8d9e-06c19b809fd2.png)

Maybe operator?
![image](https://user-images.githubusercontent.com/7189118/101410480-b1fde100-38df-11eb-9ce1-acc2416d4bfa.png)

fyi: @TravonteD 

