### PR TITLE
editorconfig: set tab_width to 2 for lua files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 
+[*.lua]
+tab_width = 2
+
 [{Makefile,**/Makefile,runtime/doc/*.txt}]
 indent_style = tab
 indent_size = 8


### PR DESCRIPTION
I found an issue that lua files in the project got indent incorrectly when enabled nvim-treesitter indent. The root cause is that editorconfig set `tab_width` to `8` for every file. I fix that by specific only lua files to be `2`. 