### PR TITLE
Enable automatic parser updateing with a hack (skip typescript for now)

### DIFF
--- a/.github/workflows/update-parsers-pr.yml
+++ b/.github/workflows/update-parsers-pr.yml
@@ -27,6 +27,8 @@ jobs:
           ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter/start
 
       - name: Update parsers
+        env:
+          SKIP_LOCKFILE_UPDATE_FOR_LANGS: tsx,typescript,javascript # HACK: remove as soon tsx,typescript get updated
         run: |
           ./nvim.appimage --headless -c "luafile ./scripts/write-lockfile.lua" -c "q"
           # Pretty print

--- a/lockfile.json
+++ b/lockfile.json
@@ -24,7 +24,7 @@
     "revision": "cbec3e4afbf4376bd3a1c0aa9c21009de6013752"
   },
   "erlang": {
-    "revision": "1648ac4095a410570c9d91aa9d99a202c5a1c5bf"
+    "revision": "97e4f3d3790f19a7fe3cfe09737c5ea5b12d2d11"
   },
   "fennel": {
     "revision": "5aad9d1f490b7fc8a847a5b260f23396c56024f5"
@@ -105,10 +105,10 @@
     "revision": "a22fa5e19bae50098e2252ea96cba3aba43f4c58"
   },
   "teal": {
-    "revision": "59f90be8d211f9abd63ee68ca1ff65096d7d0b2a"
+    "revision": "b6b6363e7ee82150f2cf7c1242423f7b6f74a4c5"
   },
   "toml": {
-    "revision": "02e774c911d123ea3fbe5273cf9d987fa88dd3fb"
+    "revision": "084da152d85cb8c4bbbe0ab5f3f1f9e5bfb77d3c"
   },
   "tsx": {
     "revision": "73afadbd117a8e8551758af9c3a522ef46452119"
@@ -123,6 +123,6 @@
     "revision": "ac0829b5f7aa4234c149c23fc12d09a7c3477d4a"
   },
   "yaml": {
-    "revision": "258751d666d31888f97ca6188a686f36fadf6c43"
+    "revision": "da23114377ac32e844eb82e96bdcf830e874c451"
   }
 }

--- a/lockfile.json
+++ b/lockfile.json
@@ -24,7 +24,7 @@
     "revision": "cbec3e4afbf4376bd3a1c0aa9c21009de6013752"
   },
   "erlang": {
-    "revision": "53725641da5624a5066c4d01cdb27d7b05cb2810"
+    "revision": "1648ac4095a410570c9d91aa9d99a202c5a1c5bf"
   },
   "fennel": {
     "revision": "5aad9d1f490b7fc8a847a5b260f23396c56024f5"

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -323,8 +323,11 @@ function M.uninstall(lang)
   end
 end
 
-function M.write_lockfile(verbose)
+function M.write_lockfile(verbose, skip_langs)
   local sorted_parsers = {}
+  -- Load previous lockfile
+  get_revision()
+  skip_langs = skip_langs or {}
 
   for k, v in pairs(parsers.get_parser_configs()) do
     table.insert(sorted_parsers, {name = k, parser = v})
@@ -333,11 +336,16 @@ function M.write_lockfile(verbose)
   table.sort(sorted_parsers, function(a, b) return a.name < b.name end)
 
   for _, v in ipairs(sorted_parsers) do
-    -- I'm sure this can be done in aync way with iter_cmd
-    local sha = vim.split(vim.fn.systemlist('git ls-remote '..v.parser.install_info.url)[1], '\t')[1]
-    lockfile[v.name] = { revision = sha }
-    if verbose then
-      print(v.name..': '..sha)
+
+    if not vim.tbl_contains(skip_langs, v.name) then
+      -- I'm sure this can be done in aync way with iter_cmd
+      local sha = vim.split(vim.fn.systemlist('git ls-remote '..v.parser.install_info.url)[1], '\t')[1]
+      lockfile[v.name] = { revision = sha }
+      if verbose then
+        print(v.name..': '..sha)
+      end
+    else
+      print('Skipping '..v.name)
     end
   end
 

--- a/scripts/write-lockfile.lua
+++ b/scripts/write-lockfile.lua
@@ -1,3 +1,10 @@
 -- Execute as `nvim --headless -c "luafile ./scripts/write-lockfile.lua"`
-require 'nvim-treesitter.install'.write_lockfile('verbose')
+local skip_langs = vim.fn.getenv('SKIP_LOCKFILE_UPDATE_FOR_LANGS')
+if skip_langs == vim.NIL then
+  skip_langs = {}
+else
+  skip_langs = vim.fn.split(skip_langs, ',')
+end
+print("Skipping languages: "..vim.inspect(skip_langs))
+require 'nvim-treesitter.install'.write_lockfile('verbose', skip_langs)
 vim.cmd('q')


### PR DESCRIPTION
When we skip javascript/typescript it should be possible to update the parsers automatically.

This is a lazier solution than updating all parsers one after another and test with another nvim instance whether this causes a break.