### PR TITLE
go: Add package_identifier as variable

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -7,6 +7,7 @@
 (type_identifier) @type
 (field_identifier) @property
 (identifier) @variable
+(package_identifier) @variable
 
 (parameter_declaration (identifier) @parameter)
 (variadic_parameter_declaration (identifier) @parameter)


### PR DESCRIPTION
This adds `package_identifier` as `@variable`. Previously had no highlights.

![2020-12-10-174826_4480x1440_scrot](https://user-images.githubusercontent.com/15027/101839244-05ef0c80-3b10-11eb-9039-6d6ba652b7d9.png)

