### PR TITLE
Add fix for vim.fn.executable(vim.NIL)

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -50,7 +50,7 @@ function M.select_rm_file_cmd(file, info_msg)
 end
 
 function M.select_executable(executables)
-  return vim.tbl_filter(function(c) return fn.executable(c) == 1 end, executables)[1]
+  return vim.tbl_filter(function(c) return c ~= vim.NIL and fn.executable(c) == 1 end, executables)[1]
 end
 
 function M.select_compiler_args(repo)


### PR DESCRIPTION
This might be a hard error in future:
https://github.com/neovim/neovim/issues/13485
https://github.com/vim/vim/commit/7bb4e74c38642682cfdd0cb4052adfa5efdd7dd1

Avoids: https://github.com/nvim-treesitter/nvim-treesitter/issues/744

We might have similar problems in other parts of the code.