### PR TITLE
Bash highlights: reset highlighting in expansion

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -1,3 +1,7 @@
+(simple_expansion) @none
+(expansion
+  "${" @punctuation.special
+  "}" @punctuation.special) @none
 [
  "("
  ")"


### PR DESCRIPTION
Reset highlighting in expansion regions

![image](https://user-images.githubusercontent.com/7189118/101986941-63f72d80-3c91-11eb-8fa8-a4aa0d381864.png)

@TravonteD 
