### PR TITLE
fix: support shiftwidth for indents.

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -50,11 +50,12 @@ function M.get_indent(lnum)
     node = node:parent()
   end
 
+  local ind_size = vim.bo.softtabstop < 0 and vim.bo.shiftwidth or vim.bo.tabstop
   local ind = 0
   while node do
     node = node:parent()
     if indents[tostring(node)] then
-      ind = ind + vim.bo.tabstop
+      ind = ind + ind_size
     end
   end
 


### PR DESCRIPTION
Uses `shiftwidth` for indentation size if `softtabstop` is set to a negative value.

Is there anything more involved to [resolving this issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/704) than this?