### PR TITLE
first draft of YAML highlighting

### DIFF
--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -1,5 +1,5 @@
-(block_mapping_pair key: (flow_node) @field)
-(flow_pair key: (flow_node) @field) ; This one doesn't seem to work, no idea what's wrong with it.
+(block_mapping_pair key: (_) @field)
+(flow_mapping (_ key: (_) @field))
 (boolean_scalar) @boolean
 (null_scalar) @constant.builtin
 (double_quote_scalar) @string

--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -15,7 +15,6 @@
 (yaml_directive) @keyword
 (ERROR) @error
 [
-; "+" ; including this causes "invalid node type" errors?!?
 ","
 "-"
 ":"

--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -4,8 +4,7 @@
 (null_scalar) @constant.builtin
 (double_quote_scalar) @string
 (single_quote_scalar) @string
-(double_quote_scalar (escape_sequence)) @string.escape
-(single_quote_scalar (escape_sequence)) @string.escape
+(escape_sequence) @string.escape
 (integer_scalar) @number
 (float_scalar) @number
 (comment) @comment

--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -1,0 +1,31 @@
+(block_mapping_pair key: (flow_node) @field)
+(flow_pair key: (flow_node) @field) ; This one doesn't seem to work, no idea what's wrong with it.
+(boolean_scalar) @boolean
+(null_scalar) @constant.builtin
+(double_quote_scalar) @string
+(single_quote_scalar) @string
+(double_quote_scalar (escape_sequence)) @string.escape
+(single_quote_scalar (escape_sequence)) @string.escape
+(integer_scalar) @number
+(float_scalar) @number
+(comment) @comment
+(anchor) @type
+(alias) @type
+(tag) @type
+(yaml_directive) @keyword
+(ERROR) @error
+[
+; "+" ; including this causes "invalid node type" errors?!?
+","
+"-"
+":"
+">"
+"?"
+"|"
+] @punctuation.delimiter
+[
+"["
+"]"
+"{"
+"}"
+] @punctuation.bracket


### PR DESCRIPTION
A first draft of highlighting for YAML.  

Some comments:

- This is my first time with treesitter, I've very likely done things wrong, corrections welcome!
 
- In particular there are a couple of things that aren't working, in ways that I don't understand.

First:
```
(flow_pair key: (flow_node) @field)
```
is supposed to catch the `foo` in `mapping: { foo: bar }`, but seems to have no effect.  I don't see how this is different from the handling of `block_mapping_pair`, which seems to work fine

Second, including `"+"` in the list of punctuation characters causes errors.  I've no idea how this is different from the other punctuation characters.

- I have treated keys as `field`, whereas the JSON highlighter treats them as `label`.  IMO `field` makes more sense both here and in JSON, but if you have considered this possibility in the JSON context, and decided otherwise, and value consistency, perhaps we should go `label` here too.

- YAML is complicated and has some obscure corners and I wouldn't be at all surprised to find that I've missed some of them.