### PR TITLE
fix(install): account for NIL executables

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -50,7 +50,9 @@ function M.select_rm_file_cmd(file, info_msg)
 end
 
 function M.select_executable(executables)
-  return vim.tbl_filter(function(c) return fn.executable(c) == 1 end, executables)[1]
+  return vim.tbl_filter(function(c)
+    return c ~= vim.NIL and fn.executable(c) == 1
+  end, executables)[1]
 end
 
 function M.select_compiler_args(repo)


### PR DESCRIPTION
This occured when trying to add a parser  with a plugin. On my system at least, this list contained a `vim.NIL` which caused an error during install.