### PR TITLE
Ruby constants highlighted as Type

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -45,7 +45,7 @@
  "while"
  ] @repeat
 
-(constant) @constant
+(constant) @type
 
 ((identifier) @keyword
  (#vim-match? @keyword "^(private|protected|public)$"))
@@ -82,12 +82,12 @@
 
 (method name: [
                (identifier) @function
-               (constant) @constant
+               (constant) @type
                ])
 
 (singleton_method name: [
                          (identifier) @function
-                         (constant) @constant
+                         (constant) @type
                          ])
 
 (class name: (constant) @type)
@@ -103,8 +103,8 @@
 ((identifier) @constant.builtin
  (#vim-match? @constant.builtin "^__(callee|dir|id|method|send|ENCODING|FILE|LINE)__$"))
 
-((constant) @constant.macro
- (#vim-match? @constant.macro "^[A-Z\\d_]+$"))
+((constant) @type
+ (#vim-match? @type "^[A-Z\\d_]+$"))
 
 [
  (self)


### PR DESCRIPTION
## Problem

Currently nvim-treesitter is highlighting ruby constants and types differently, but in ruby they are basically the same thing

## Solution

Based on [vim-ruby highlight](https://github.com/vim-ruby/vim-ruby/blob/master/syntax/ruby.vim#L502), highlight most ruby constants as types.

| before | after |
| --- | --- |
| <img width="396" alt="_private_tmp_a_rb" src="https://user-images.githubusercontent.com/120483/102622819-78c43d00-4139-11eb-9cff-0e2dd0ea94a6.png"> | <img width="406" alt="_private_tmp_a_rb" src="https://user-images.githubusercontent.com/120483/102622846-84afff00-4139-11eb-986c-40696ab27163.png"> |


#### vim-ruby (for reference)

<img width="386" alt="_private_tmp_a_rb" src="https://user-images.githubusercontent.com/120483/102623121-ee300d80-4139-11eb-8ec2-a82317309c21.png">


