### PR TITLE
Add more ruby built-in constants

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -101,7 +101,7 @@
  ] @label
 
 ((identifier) @constant.builtin
- (#vim-match? @constant.builtin "^__(FILE|LINE|ENCODING)__$"))
+ (#vim-match? @constant.builtin "^__(callee|dir|id|method|send|ENCODING|FILE|LINE)__$"))
 
 ((constant) @constant.macro
  (#vim-match? @constant.macro "^[A-Z\\d_]+$"))


### PR DESCRIPTION
Add the follow ruby builtins:

- [__callee__](https://ruby-doc.org/core-2.7.2/Kernel.html#__callee__-method)
- [__dir__](https://ruby-doc.org/core-2.7.2/Kernel.html#__dir__-method)
- [__method__](https://ruby-doc.org/core-2.7.2/Kernel.html#__method__-method)
- [__id__](https://ruby-doc.org/core-2.7.2/BasicObject.html#__id__-method)
- [__method__](https://ruby-doc.org/core-2.7.2/Kernel.html#__method__-method)
- [__send__](https://ruby-doc.org/core-2.7.2/BasicObject.html#__send__-method)