### PR TITLE
Fix ruby include highlights

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -72,8 +72,12 @@
 
 (program
  (call
-  (identifier) @include)
- (#vim-match? @include "^(require|require_relative|load)$"))
+   (identifier) @include)
+   (#vim-match? @include "^(require|require_relative|load)$"))
+
+ (call
+   (identifier) @include
+   (#vim-match? @include "^(include|extend|prepend)$"))
 
 ; Function definitions
 


### PR DESCRIPTION
Fix `require`, `require_relative`, `load` and `include`, `extend`, `preprend` to the includes group.

| before | after | vim-ruby for reference |
| --- | --- | --- |
| <img width="400" alt="_HOME_src_ruby-highlight_rb" src="https://user-images.githubusercontent.com/120483/102637209-90a5bc00-414d-11eb-963f-e7a9930a6277.png"> | <img width="400" alt="_HOME_src_ruby-highlight_rb" src="https://user-images.githubusercontent.com/120483/102637308-b5019880-414d-11eb-84a6-a3d086d1eab1.png"> | <img width="400" alt="_HOME_src_ruby-highlight_rb" src="https://user-images.githubusercontent.com/120483/102637348-c5197800-414d-11eb-85ff-78e88e1c0bcb.png"> |




