### PR TITLE
fixes to bash highlighting

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -29,6 +29,7 @@
  "|"
  "||"
  "="
+ "=~"
  "=="
  "!="
  ] @operator
@@ -117,3 +118,5 @@
 
 (case_item
   value: (word) @parameter)
+
+(regex) @string.regex

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -70,13 +70,13 @@
 (special_variable_name) @constant
 
 ((word) @constant.builtin
- (#vim-match? @constant.builtin "SIG(INT|TERM|QUIT|TIN|TOU|STP|HUP)"))
+ (#match? @constant.builtin "^SIG(INT|TERM|QUIT|TIN|TOU|STP|HUP)$"))
 
 ((word) @boolean
-  (#vim-match? @boolean "true|false"))
+  (#match? @boolean "^(true|false)$"))
 
 ((word) @number
-  (#vim-match? @number "^\d*$"))
+  (#match? @number "^[0-9]+$"))
 
 (comment) @comment
 (test_operator) @string
@@ -96,10 +96,12 @@
 (command
   argument: [
              (word) @parameter
-             ((word) @number
-              (#vim-match? @number "^\d*$"))
              (concatenation (word) @parameter)
              ])
+
+(command
+  argument: ((word) @number
+             (#match? @number "^[0-9]+$")))
 
 (file_redirect
   descriptor: (file_descriptor) @operator
@@ -115,5 +117,3 @@
 
 (case_item
   value: (word) @parameter)
-
-(concatenation (word) @parameter)

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -76,9 +76,6 @@
 ((word) @boolean
   (#match? @boolean "^(true|false)$"))
 
-((word) @number
-  (#match? @number "^[0-9]+$"))
-
 (comment) @comment
 (test_operator) @string
 
@@ -100,9 +97,8 @@
              (concatenation (word) @parameter)
              ])
 
-(command
-  argument: ((word) @number
-             (#match? @number "^[0-9]+$")))
+((word) @number
+  (#match? @number "^[0-9]+$"))
 
 (file_redirect
   descriptor: (file_descriptor) @operator


### PR DESCRIPTION
Various fixes to the bash highlighting:

- top and tail matches with `^` and `$` so that they don't match more than intended
- switch to lua matches - are these faster? - not sure that this matters
- move capture of number parameters to a separate block: not that I know what I'm doing, but this seems to work where the original did not
- remove a redundant capture (which I suspect may have been compensating for the non-workingness per the other change)

Before:

![before](https://user-images.githubusercontent.com/875184/102699188-c96f8f00-423a-11eb-8cd2-ecbacfd08bfc.png)

- `3` is not recognized as a number
- all of `bar=false` is treated as a boolean
- only `baz="baz"` is highlighted as expected

After:

![after](https://user-images.githubusercontent.com/875184/102699206-eefc9880-423a-11eb-834d-785e668603ee.png)

