### PR TITLE
Improve python/indents.scm

### DIFF
--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -1,16 +1,38 @@
 [
-  (function_definition)
+  (list)
+  (tuple)
+  (dictionary)
+  (set)
+
   (if_statement)
+  (for_statement)
+  (while_statement)
   (with_statement)
   (try_statement)
-  (for_statement)
-  (for_in_clause)
+  (import_from_statement)
+
+  (parenthesized_expression)
+  (generator_expression)
+  (list_comprehension)
+  (set_comprehension)
+  (dictionary_comprehension)
+
+  (tuple_pattern)
+  (list_pattern)
+  (argument_list)
+  (parameters)
+  (binary_operator)
+
+  (function_definition)
   (class_definition)
 ] @indent
 
 [
-  "elif"
-  "else"
-  "finally"
-  "except"
+  ")"
+  "]"
+  "}"
+  (elif_clause)
+  (else_clause)
+  (except_clause)
+  (finally_clause)
 ] @branch


### PR DESCRIPTION
I was testing https://github.com/nvim-treesitter/nvim-treesitter/pull/772 but it does not seem to work well on my machine (nvim-treesitter on master, did `TSUpdate`). It didn't really indent the blocks "else", "elseif", etc. properly. It also missed the indentation of collections (lists, dictionaries, ...). I used https://github.com/nvim-treesitter/playground (especially the query linter) and it seems that e.g. literal "else" matches only the text part. `indent.lua` didn't go through that node and so it didn't apply `@branch`. 

This PR adds the groups that I could find. I tested the changes on the following file: [test-indent.zip](https://github.com/nvim-treesitter/nvim-treesitter/files/5720888/test-indent.zip). I indented the file manually and I'm just testing with `gg=G`. Most of the file is indented correctly. If someone could test it and confirm I would be grateful.

I still have some issues, but they would probably require changes in `indent.lua`. The main issues I still see are:

1) The `\` character for line continuation - I don't really now if it's possible to match that with treesitter. The query `(binary_operator)` that I added in this PR somehow helps, but I'm not sure if it should really be used, or maybe better remove it for now?

2) Parameters alignment as defined in https://www.python.org/dev/peps/pep-0008/#indentation. For example, now `aligned_indent` is not possible:
```python
def aligned_indent(arg1,
                   arg2):
    pass

def hanging_indent(
        arg1, arg2):
    pass
```

3) Indentation after you press enter on start of a block, e.g. when you write `def foo():` then hit enter. Treesitter does not consider the next line as part of function body, so it indents to 0. It would be nice if after hitting enter we could get proper indentation (only that first line after declaration). This is actually the case for whenever you add new line past the current block. Is there a good solution using treesitter? Or maybe it shouldn't be supported in this plugin?

My first idea for 2. was to add something like:
```
[
  (function_definition
    (parameters "(" @target) @params
    (#not-lua-match? @params "^%(\n"))
] @align
```
And (in https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/indent.lua#L39) to first check if we go through `@align` node. If so, then we search for `@target` in node's children, and then force `ind` to end column of `@target`. This also requires multi-line Lua matches (https://github.com/neovim/neovim/blob/master/runtime/lua/vim/treesitter/query.lua#L136-L154). I did initial implementation of multi-line matching and may add a PR with that to neovim later.