### PR TITLE
Add lacked Javascript operators

### DIFF
--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -151,6 +151,7 @@
 ";" @punctuation.delimiter
 "." @punctuation.delimiter
 "," @punctuation.delimiter
+"?." @punctuation.delimiter
 
 (pair ":" @punctuation.delimiter)
 
@@ -181,6 +182,21 @@
   "||"
   "%"
   "%="
+  "*"
+  "**"
+  ">>>"
+  "&"
+  "|"
+  "^"
+  "??"
+  "*="
+  ">>="
+  ">>>="
+  "^="
+  "|="
+  "&&="
+  "||="
+  "??="
 ] @operator
 
 (binary_expression "/" @operator)


### PR DESCRIPTION
Added operators described in [Expressions and operators - JavaScript | MDN][doc].

[doc]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators

```javascript
2 * 3
2 ** 3
2 >>> 3
2 & 3
2 | 3
2 ^ 3
2 ?? 3
let a *= 2
let a >>= 2
let a >>>= 2
let a ^= 2
let a |= 2
let a &&= 2
let a ||= 2
let a ??= 2
a?.b
```

| before | after |
|---|---|
| <img width="102" alt="スクリーンショット 0002-12-21 11 14 15" src="https://user-images.githubusercontent.com/1239245/102732502-40fa0700-437e-11eb-9d66-44dc0c403a85.png"> | <img width="101" alt="スクリーンショット 0002-12-21 11 15 47" src="https://user-images.githubusercontent.com/1239245/102732512-46575180-437e-11eb-9993-9991fba0274d.png"> |

