### PR TITLE
Python regex injection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,7 @@ are optional and will not have any effect for now.
 @constant.macro
 @string
 @string.regex
+@string.regex-classchar
 @string.escape
 @string.special
 @character

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,6 @@ are optional and will not have any effect for now.
 @constant.macro
 @string
 @string.regex
-@string.regex-classchar
 @string.escape
 @string.special
 @character

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -1,0 +1,6 @@
+((call
+  function: (attribute
+	  object: (identifier) @_re)
+  arguments: (argument_list (string) @regex))
+ (#eq? @_re "re")
+ (#match? @regex "^r.*"))

--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -15,6 +15,10 @@
 
 (group_name) @property
 
+;; These are escaped special characters that lost their special meaning
+;; -> no special highlighting
+; (identity_escape)
+
 [
  (identity_escape)
  (control_letter_escape)

--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -17,10 +17,11 @@
 
 ;; These are escaped special characters that lost their special meaning
 ;; -> no special highlighting
-; (identity_escape)
+(identity_escape) @string.regex
+
+(class_character) @constant
 
 [
- (identity_escape)
  (control_letter_escape)
  (character_class_escape)
  (control_escape)

--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -26,4 +26,4 @@
  (non_boundary_assertion)
 ] @string.escape
 
-[ "*" "+" "|" "=" "<=" "!" "<!" ] @operator
+[ "*" "+" "?" "|" "=" "<=" "!" "<!" ] @operator


### PR DESCRIPTION
This add regex injections for Python expression of type `re.regex_function(r"regex-string")`

Additionally for regex highlighting:

- Give unescaped regex characters normal highlighting. In a normal string escape means special meaning. In regex escaping a special characters means it removes the special meaning and should thus be highlighted with normal regex highlights. This gives the escaped chars a different highlight as normal special chars.
- Give class_character constant highlighting to have a some colors in regexes for different kinds of chars
- add "?" operator