### PR TITLE
RST: update parser and queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -93,7 +93,7 @@
     "revision": "be2e415b5716615530234d179dc27c32b7a1d86b"
   },
   "rst": {
-    "revision": "aa61d0e2930de134089326973686ac547cca9e03"
+    "revision": "226196277df51e5222f3113a3c814dd8b17e70e7"
   },
   "ruby": {
     "revision": "bb572f60e9538bd11fbde95a54f97522073f1e06"

--- a/queries/rst/highlights.scm
+++ b/queries/rst/highlights.scm
@@ -19,21 +19,20 @@
 
 ((directive
   name: (type) @include)
- (#match? @include "^include::$"))
+ (#eq? @include "include"))
 
 ((directive
    name: (type) @function.builtin)
- (#vim-match?
+ (#match?
   @function.builtin
   ; https://docutils.sourceforge.io/docs/ref/rst/directives.html
-  "^(attention|caution|danger|error|hint|important|note|tip|warning|admonition)|(image|figure)|(topic|sidebar|line-block|parsed-literal|code|math|rubric|epigraph|highlights|pull-quote|compound|container)|(table|csv-table|list-table)|(contents|sectnum|section-numbering|header|footer)|(target-notes)|(meta)|(replace|unicode|date)|(raw|class|role|default-role|title|restructuredtext-test-directive)::$"))
+  "^(attention|caution|danger|error|hint|important|note|tip|warning|admonition)|(image|figure)|(topic|sidebar|line-block|parsed-literal|code|math|rubric|epigraph|highlights|pull-quote|compound|container)|(table|csv-table|list-table)|(contents|sectnum|section-numbering|header|footer)|(target-notes)|(meta)|(replace|unicode|date)|(raw|class|role|default-role|title|restructuredtext-test-directive)$"))
 
 ;; Blocks
 
 [
   (literal_block)
   (line_block)
-  (doctest_block)
 ] @text.literal
 
 (block_quote
@@ -50,7 +49,7 @@
 
 (target
   name: (name)? @constant
-  link: (_) @text.literal)
+  link: (_)? @text.literal)
 
 ;; Lists
 
@@ -73,10 +72,15 @@
 (role) @function
 
 ((role) @function.builtin
- (#vim-match?
+ (#match?
   @function.builtin
   ; https://docutils.sourceforge.io/docs/ref/rst/roles.html
   "^:(emphasis|literal|code|math|pep-reference|PEP|rfc-reference|RFC|strong|subscript|sub|superscript|sup|title-reference|title|t|raw):$"))
+
+[
+ "interpreted_text"
+  (literal)
+] @text.literal
 
 ; Prefix role
 ((interpreted_text
@@ -89,7 +93,12 @@
   "interpreted_text" @text.strong)
  (#eq? @_role ":strong:"))
 
-; Sufix role
+((interpreted_text
+  (role) @_role
+  "interpreted_text" @none)
+ (#eq? @_role ":math:"))
+
+; Suffix role
 ((interpreted_text
   "interpreted_text" @text.emphasis
   (role) @_role)
@@ -100,10 +109,10 @@
   (role) @_role)
  (#eq? @_role ":strong:"))
 
-[
- "interpreted_text"
-  (literal)
-] @text.literal
+((interpreted_text
+  "interpreted_text" @none
+  (role) @_role)
+ (#eq? @_role ":math:"))
 
 [
   (inline_target)

--- a/queries/rst/injections.scm
+++ b/queries/rst/injections.scm
@@ -1,0 +1,47 @@
+(doctest_block) @python
+
+;; Directives with nested content
+
+((directive
+   name: (type) @_type
+   body: (body) @rst)
+ (#match?
+  @_type
+  "^(attention|caution|danger|error|hint|important|note|tip|warning|admonition)|(image|figure)|(topic|sidebar|line-block|parsed-literal|rubric|epigraph|highlights|pull-quote|compound|container)|(table|list-table)|(contents|sectnum|section-numbering|header|footer)|(target-notes)|(meta)|(replace|unicode|date)|(include|class|role|default-role|title|restructuredtext-test-directive)$"))
+
+;; Special directives
+
+;; TODO: using @language and @content on the same capture raises an error.
+;; ((directive
+;;    name: (type) @_type
+;;    body: (body) @language @content)
+;;  (#eq? @_type "code"))
+
+;; ((directive
+;;    name: (type) @_type
+;;    body: (body) @language @content)
+;;  (#eq? @_type "raw"))
+
+((directive
+   name: (type) @_type
+   body: (body) @latex)
+ (#eq? @_type "math"))
+
+((directive
+   name: (type) @_type
+   body: (body) @csv)
+ (#eq? @_type "csv-table"))
+
+;; Special roles - prefix
+
+((interpreted_text
+  (role) @_role
+  "interpreted_text" @latex)
+ (#eq? @_role ":math:"))
+
+;; Special roles - suffix
+
+((interpreted_text
+  "interpreted_text" @latex
+  (role) @_role)
+ (#eq? @_role ":math:"))

--- a/queries/rst/locals.scm
+++ b/queries/rst/locals.scm
@@ -27,7 +27,7 @@
 ((directive
   name: (type) @_type
   body: (body) @definition)
- (#match? @_type "role::"))
+ (#eq? @_type "role"))
 
 ;; References
 


### PR DESCRIPTION
- The directive type does not longer includes `::`.
- The content of the directives is not longer interpreted as rst,
  but it uses language injection for it.
- Fix a query to allow capturing targets without link.
- Reset the content of the math role, so it can be highlighted by the
  injection instead.

Problems I found:

- Capturing the same node with `@language` and `@content` will raise an
  error.

  ```
  Error detected while processing FileType Autocommands for "*":
  E5108: Error executing lua /usr/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:331: table index is nil
  ```

  Harcoding the language works, Using the offset predicate doesn't work
  either `(#offset! 0 0 1 0)` nor `(#offset! 0 0 0 5)`

- Generating the grammar using `tree-sitter-cli@0.17.x` breaks
  nvim-treesitter, `@0.16.9` works.