### PR TITLE
Python (folds): allow to fold strings

### DIFF
--- a/queries/python/folds.scm
+++ b/queries/python/folds.scm
@@ -22,4 +22,6 @@
   (list)
   (set)
   (dictionary)
+
+  (string)
 ] @fold


### PR DESCRIPTION
Mostly useful for folding docstrings