### PR TITLE
RST: update injection queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -93,7 +93,7 @@
     "revision": "be2e415b5716615530234d179dc27c32b7a1d86b"
   },
   "rst": {
-    "revision": "a2ef2b3fae0c5b07f7c386c6397d4812275ea4e5"
+    "revision": "b3cdb27d3da6f48bec8533ea92a0f54a39679ebb"
   },
   "ruby": {
     "revision": "bb572f60e9538bd11fbde95a54f97522073f1e06"

--- a/queries/rst/highlights.scm
+++ b/queries/rst/highlights.scm
@@ -17,6 +17,9 @@
 (directive
   name: (type) @function)
 
+(directive
+  body: (body (arguments) @parameter))
+
 ((directive
   name: (type) @include)
  (#eq? @include "include"))

--- a/queries/rst/injections.scm
+++ b/queries/rst/injections.scm
@@ -1,35 +1,48 @@
 (doctest_block) @python
 
-;; Directives with nested content
-
+;; Directives with nested content without arguments nor options
 ((directive
    name: (type) @_type
    body: (body) @rst)
  (#match?
   @_type
-  "^(attention|caution|danger|error|hint|important|note|tip|warning|admonition)|(image|figure)|(topic|sidebar|line-block|parsed-literal|rubric|epigraph|highlights|pull-quote|compound|container)|(table|list-table)|(contents|sectnum|section-numbering|header|footer)|(target-notes)|(meta)|(replace|unicode|date)|(include|class|role|default-role|title|restructuredtext-test-directive)$"))
+  "^(attention|caution|danger|error|hint|important|note|tip|warning|admonition)|(line-block|parsed-literal|epigraph|highlights|pull-quote|compound)|(header|footer)|(meta)|(replace)$"))
+
+;; Directives with nested content without arguments, but with options
+((directive
+   name: (type) @_type
+   body: (body (options) (content) @rst))
+ (#match?
+  @_type
+  "^(attention|caution|danger|error|hint|important|note|tip|warning|admonition)|(line-block|parsed-literal|compound)$"))
+
+;; Directives with nested content with arguments and options
+((directive
+   name: (type) @_type
+   body: (body (content) @rst))
+ (#match?
+  @_type
+  "^(figure)|(topic|sidebar|container)|(table|list-table)|(class|role|restructuredtext-test-directive)$"))
 
 ;; Special directives
-
-;; TODO: using @language and @content on the same capture raises an error.
-;; ((directive
-;;    name: (type) @_type
-;;    body: (body) @language @content)
-;;  (#eq? @_type "code"))
-
-;; ((directive
-;;    name: (type) @_type
-;;    body: (body) @language @content)
-;;  (#eq? @_type "raw"))
+((directive
+   name: (type) @_type
+   body: (body (arguments) @language (content) @content))
+ (#eq? @_type "code"))
 
 ((directive
    name: (type) @_type
-   body: (body) @latex)
+   body: (body (arguments) @language (content) @content))
+ (#eq? @_type "raw"))
+
+((directive
+   name: (type) @_type
+   body: (body (content) @latex))
  (#eq? @_type "math"))
 
 ((directive
    name: (type) @_type
-   body: (body) @csv)
+   body: (body (content) @csv))
  (#eq? @_type "csv-table"))
 
 ;; Special roles - prefix

--- a/queries/rst/locals.scm
+++ b/queries/rst/locals.scm
@@ -26,7 +26,7 @@
 ; The role directive can define a new role
 ((directive
   name: (type) @_type
-  body: (body) @definition)
+  body: (body (arguments) @definition))
  (#eq? @_type "role"))
 
 ;; References


### PR DESCRIPTION
Finally, highlight for code blocks.

Some directives have the option to interpret the whole body as they want, so that's why some capture `(body)` and others `(content)`