### PR TITLE
Do not use builtin tar on Windows

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -109,7 +109,8 @@ function M.select_mv_cmd(from, to, cwd)
 end
 
 function M.select_download_commands(repo, project_name, cache_folder, revision)
-  if vim.fn.executable('tar') == 1 and vim.fn.executable('curl') == 1 and repo.url:find("github.com", 1, true) and not fn.hs('win32') then
+  local has_tar = vim.fn.executable('tar') == 1 and not fn.hs('win32')
+  if has_tar and vim.fn.executable('curl') == 1 and repo.url:find("github.com", 1, true) then
 
     revision = revision or repo.branch or "master"
     local path_sep = utils.get_path_sep()

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -109,7 +109,7 @@ function M.select_mv_cmd(from, to, cwd)
 end
 
 function M.select_download_commands(repo, project_name, cache_folder, revision)
-  if vim.fn.executable('tar') == 1 and vim.fn.executable('curl') == 1 and repo.url:find("github.com", 1, true) then
+  if vim.fn.executable('tar') == 1 and vim.fn.executable('curl') == 1 and repo.url:find("github.com", 1, true) and not fn.hs('win32') then
 
     revision = revision or repo.branch or "master"
     local path_sep = utils.get_path_sep()

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -155,13 +155,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
       M.select_install_rm_cmd(cache_folder, project_name..'-tmp')
     }
   else
-    local git_folder
-    if is_windows then
-      git_folder = cache_folder ..'\\'.. project_name
-    else
-      git_folder = cache_folder ..'/'.. project_name
-    end
-
+    local git_folder = utils.join_path(cache_folder, project_name)
     local clone_error = 'Error during download, please verify your internet connection'
     if is_windows then
       clone_error = clone_error .. ". If on Windows you may need to enable Developer mode"

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -109,7 +109,7 @@ function M.select_mv_cmd(from, to, cwd)
 end
 
 function M.select_download_commands(repo, project_name, cache_folder, revision)
-  local has_tar = vim.fn.executable('tar') == 1 and not fn.hs('win32')
+  local has_tar = vim.fn.executable('tar') == 1 and fn.hs('win32') ~= 1
   if has_tar and vim.fn.executable('curl') == 1 and repo.url:find("github.com", 1, true) then
 
     revision = revision or repo.branch or "master"


### PR DESCRIPTION
Several parsers ([typescript](https://github.com/tree-sitter/tree-sitter-typescript/blob/master/tsx/corpus/common) and [ocaml](https://github.com/tree-sitter/tree-sitter-ocaml/blob/master/interface/corpus/module-items.txt) specifically) contain symlinks in their repo. The tar that comes with Windows cannot handle them.

So, on Windows just use git to download parsers.


Once I got this settled everything else worked fine when compiling with clang.