### PR TITLE
feat: added more fold queries

### DIFF
--- a/queries/css/folds.scm
+++ b/queries/css/folds.scm
@@ -1,0 +1,3 @@
+[
+  (rule_set)
+] @fold

--- a/queries/json/folds.scm
+++ b/queries/json/folds.scm
@@ -1,0 +1,4 @@
+[
+  (object)
+  (array)
+] @fold

--- a/queries/toml/folds.scm
+++ b/queries/toml/folds.scm
@@ -1,0 +1,4 @@
+[
+  (table)
+  (array)
+] @fold

--- a/queries/yaml/folds.scm
+++ b/queries/yaml/folds.scm
@@ -1,0 +1,3 @@
+[
+  (block_mapping_pair)
+] @fold


### PR DESCRIPTION
Added fold queries for several simple languages. I didn't add HTML because I find it quite inconsistence. Here's an example.

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <title>Something</title>
  </head>
  <body>
    <div>  <- cursor on this line
      <span>somethin</span>
    </div>
  </body>
</html>
```

If you try to fold the `div`, it will fold up until the last `</html>`.  But this won't happend if you expand `<span>` tag to this.

```html
<span>
  somethin
</span>
```

There might be some stuff that hasn't been covered yet so any advice would be appreciated :)