### PR TITLE
feat: added more indent queries

### DIFF
--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -1,0 +1,16 @@
+[
+  (init_declarator)
+  (compound_statement)
+  (preproc_arg)
+  (field_declaration_list)
+  (case_statement)
+] @indent
+
+
+[
+  "#define"
+  "#ifdef"
+  "#endif"
+  "{"
+  "}"
+] @branch

--- a/queries/cpp/indents.scm
+++ b/queries/cpp/indents.scm
@@ -1,0 +1,16 @@
+[
+  (enumerator_list)
+  (struct_specifier)
+  (compound_statement)
+  (case_statement)
+  (condition_clause)
+  (conditional_expression)
+] @indent
+
+[
+  (statement_identifier)
+  "#ifdef"
+  "#endif"
+  "{"
+  "}"
+] @branch

--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -1,0 +1,17 @@
+[
+  (import_declaration)
+  (function_declaration)
+  (const_declaration)
+  (var_declaration)
+  (type_declaration)
+  (composite_literal)
+  (func_literal)
+  (block)
+] @indent
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+] @branch

--- a/queries/graphql/indents.scm
+++ b/queries/graphql/indents.scm
@@ -1,0 +1,9 @@
+[
+  (definition)
+  (selection)
+] @indent
+
+[
+  "{"
+  "}"
+] @branch

--- a/queries/html/indents.scm
+++ b/queries/html/indents.scm
@@ -1,0 +1,9 @@
+[
+  (element)
+] @indent
+
+[
+  (end_tag)
+  ">"
+  "/>"
+] @branch

--- a/queries/javascript/indents.scm
+++ b/queries/javascript/indents.scm
@@ -1,0 +1,26 @@
+; inherits: (jsx)
+
+[
+  (object)
+  (array)
+  (arguments)
+  (statement_block)
+  (object_pattern)
+  (class_body)
+  (method_definition)
+  (named_imports)
+  (binary_expression)
+  (return_statement)
+  (template_substitution)
+  (expression_statement (call_expression))
+  (export_clause)
+] @indent
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @branch

--- a/queries/json/indents.scm
+++ b/queries/json/indents.scm
@@ -1,0 +1,9 @@
+[
+  (object)
+  (array)
+] @indent
+
+[
+  "}"
+  "]"
+] @branch

--- a/queries/jsx/indents.scm
+++ b/queries/jsx/indents.scm
@@ -1,0 +1,10 @@
+[
+  (jsx_fragment)
+  (jsx_element)
+  (jsx_self_closing_element)
+] @indent
+
+[
+  (jsx_closing_element)
+  ">"
+] @branch

--- a/queries/ruby/indents.scm
+++ b/queries/ruby/indents.scm
@@ -1,0 +1,12 @@
+[
+  (class)
+  (method)
+  (module)
+  (call)
+  (if)
+] @indent
+
+[
+  (elsif)
+  "end"
+] @branch

--- a/queries/rust/indents.scm
+++ b/queries/rust/indents.scm
@@ -1,0 +1,26 @@
+[
+  (mod_item)
+  (struct_item)
+  (enum_item)
+  (impl_item)
+  (for_expression)
+  (struct_expression)
+  (match_expression)
+  (match_arm)
+  (if_let_expression)
+  (call_expression)
+  (assignment_expression)
+  (arguments)
+  (block)
+  (where_clause)
+] @indent
+
+[
+  "where"
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @branch

--- a/queries/teal/indents.scm
+++ b/queries/teal/indents.scm
@@ -1,0 +1,20 @@
+[
+  (record_declaration)
+  (record_entry)
+  (anon_function)
+  (function_body)
+  (table_constructor)
+  (if_statement)
+  (for_statement)
+  (return_statement)
+  (while_statement)
+] @indent
+
+[
+  "{"
+  "}"
+  "("
+  ")"
+  "end"
+  "then"
+] @branch

--- a/queries/toml/indents.scm
+++ b/queries/toml/indents.scm
@@ -1,0 +1,8 @@
+[
+  (array)
+  (table_array_element)
+] @indent
+
+[
+  "]"
+] @branch

--- a/queries/tsx/indents.scm
+++ b/queries/tsx/indents.scm
@@ -1,0 +1,1 @@
+; inherits: typescript,jsx

--- a/queries/typescript/indents.scm
+++ b/queries/typescript/indents.scm
@@ -1,0 +1,6 @@
+; inherits: javascript
+
+[
+  (interface_declaration)
+  (object_type)
+] @indent

--- a/queries/yaml/indents.scm
+++ b/queries/yaml/indents.scm
@@ -1,0 +1,3 @@
+[
+  (block_mapping_pair)
+] @indent


### PR DESCRIPTION
I've added indent queries for some languages but I might have not covered some cases, would be awesome if anyone would try it and give some advice :)

List of languages that I've added
- HTML
- JSON
- YAML
- TOML
- Javascript
- Typescript
- JSX
- TSX
- Go
- Ruby
- GraphQL
- Rust
- Teal
- C
- C++

Known issues: 
- Last `/>` on self closing HTML tag doesn't get outdented properly **(Fixed after #837)**
- Last `</>` on jsx fragment doesn't get outdented properly
- Last `}` on Rust `else_clause` doesn't get outdented properly **(Fixed)**
- Last `end` on Teal sometimes doesn't get outdented properly. e.g if you use anonymous function for an argument.
- Some block doesn't get indented properly when you press `o` on the first line of the block to add a new line. Hopefully these illustrations make it clearer.
```javascript
return(| <- if you press `o` here
| <- your cursor will go here
  | <- instead of here, notice the indentation 
)
```
another case is the Rust's else clause
```rust
} else {| <- if you press `o` here
| <- it will go here, no indent
  println!("something");| <- if you press `o` here
  | <- it will go here, the indentation is correct
}
```

note: this branch will only receives force push commits