### PR TITLE
Remove usages of `@embedded` in highlights

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,16 +96,6 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @punctuation.special for symbols with special meaning like `{}` in string interpolation.
 ```
 
-Some captures are related to language injection (like markdown code blocks). As this is not supported by neovim yet, these
-are optional and will not have any effect for now.
-
-```
-@embedded
-@injection
-@injection.language
-@injection.content
-```
-
 #### Constants
 
 ```
@@ -245,3 +235,18 @@ You can define folds for a given language by adding a `folds.scm` query :
 
 If the `fold.scm` query is not present, this will fallback to the `@scope` captures in the `locals`
 query.
+
+### Injections
+
+Some captures are related to language injection (like markdown code blocks). They are used in `injections.scm`.
+You can directly use the name of the language that you want to inject (e.g. `@html` to inject html).
+
+If you want to dynamically detect the language (e.g. for Markdown blocks) use the `@language` to capture
+the node describing the language and `@content` to describe the injection region.
+
+```
+@{language} ; e.g. @html to describe a html region
+
+@language ; dynamic detection of the injection language (i.e. the text of the captured node describes the language)
+@content ; region for the dynamically detected language
+```

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -117,7 +117,6 @@
  (preproc_arg)
  (preproc_defined)
 ]  @function.macro
-; TODO (preproc_arg)  @embedded
 
 (((field_expression
      (field_identifier) @property)) @_parent

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -144,7 +144,7 @@
 
 (template_substitution
   "${" @punctuation.special
-  "}" @punctuation.special) @embedded
+  "}" @punctuation.special) @none
 
 "..." @punctuation.special
 

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -204,7 +204,7 @@
 
 (interpolation
   "{" @punctuation.special
-  "}" @punctuation.special) @embedded
+  "}" @punctuation.special)
 
 ["," "." ":" (ellipsis)] @punctuation.delimiter
 

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -153,10 +153,6 @@
  (false)
  ] @boolean
 
-(interpolation
-  "#{" @punctuation.special
-  "}" @punctuation.special) @embedded
-
 (comment) @comment
 
 ; Operators


### PR DESCRIPTION
We have now language injection. No need to have those queries in `highlights.scm`. We could rename `@none` to `@embedded` though.

Also resets the interpolation highlighting in JS.

![image](https://user-images.githubusercontent.com/7189118/103717159-0ec6e700-4fc5-11eb-8a8f-ee9acc8c9cf8.png)
