### PR TITLE
Rust locals: Make `const_block` a scope

### DIFF
--- a/queries/rust/locals.scm
+++ b/queries/rust/locals.scm
@@ -100,5 +100,6 @@
  (struct_item)
  (enum_item)
  (impl_item)
+ (const_block)
 ] @scope
 


### PR DESCRIPTION
Requires #828