### PR TITLE
indent: fix wrong line number passed to descendant_for_range

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -60,7 +60,7 @@ function M.get_indent(lnum)
   -- and if the node is an indent node, we should set the indent level as the indent_size
   -- and we set the node as the first child of this wrapper node or the wrapper itself
   if not node then
-    local wrapper = root:descendant_for_range(lnum, 0, lnum, -1)
+    local wrapper = root:descendant_for_range(lnum-1, 0, lnum-1, -1)
     node = wrapper:child(0) or wrapper
     if indents[node_fmt(wrapper)] ~= nil and wrapper ~= root then
       indent = indent_size


### PR DESCRIPTION
Currently the number passed is 1-based, but `descendant_for_range` expects 0-based number. It's most likely due to the fact that this piece of code was previously inside the `get_node_at_line` which receives `lnum - 1`.