### PR TITLE
C++ highlights: Fix destructor highlighting

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -51,7 +51,7 @@
   name: (identifier) @namespace)
 
 (destructor_name
-  name: (_) @function)
+  (identifier) @method)
 
 (function_declarator
       declarator: (scoped_identifier


### PR DESCRIPTION
Field is not "name"

or should the highlight be "constructor" or stay "function"?