### PR TITLE
Indent improvements

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -60,7 +60,7 @@ function M.get_indent(lnum)
   -- and if the node is an indent node, we should set the indent level as the indent_size
   -- and we set the node as the first child of this wrapper node or the wrapper itself
   if not node then
-    local wrapper = root:descendant_for_range(lnum, 0, lnum, -1)
+    local wrapper = root:descendant_for_range(lnum-1, 0, lnum-1, -1)
     node = wrapper:child(0) or wrapper
     if indents[node_fmt(wrapper)] ~= nil and wrapper ~= root then
       indent = indent_size

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -36,3 +36,9 @@
   (except_clause)
   (finally_clause)
 ] @branch
+
+[
+  (return_statement)
+  (pass_statement)
+  (raise_statement)
+] @return

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -42,3 +42,7 @@
   (pass_statement)
   (raise_statement)
 ] @return
+
+[
+  (string)
+] @ignore


### PR DESCRIPTION
This PR adds some improvements to indent functionality.
Note that it includes the commit from https://github.com/nvim-treesitter/nvim-treesitter/pull/835.

00a63f0 Uses `vim.fn.prevnonblank` to match indentation of preceding non-blank line after moving to new line with operations like `o` in normal mode or `<cr>` in insert mode. Without this change `root:descendant_for_range` was being used to get the wrapper node. This worked for languages with braces like C, but failed in e.g. Python (now `root:descendant_for_range` is still used as a fallback in some situations, see comments in code).

Following commits add `@return` capture that can be used to mark "last" nodes in a block. It differs from `@branch` in that the `@return` node itself keeps indentation of its block, but when it is the node found by the "prevnonblank" step, than the previous indentation won't be kept. 

I added example `@return` queries for Python. However particularly for Python, it has a corner case, when this won't work when `@return` is in the first line of a block. 
E.g. here `@return` won't be applied (after hitting `o` on the line with "return"):
```python
def foo():
    return
```
This is because `get_node_at_line` will find `block` instead of `return_statement`, because they both start on the same line.
However `@return` will be applied correctly in the following example:
```python
def foo():
    x = 1
    return
```

But I was also able to test `@return` for C in code like:
```c
if (1)
    return;
```
and it worked.
But in C on the other hand I experience an issue with `else` clauses (`@branch` doesn't work properly with `else`). I'm not including any indent queries for C/C++ because they are not really usable with this issue.

The final commits add another capture called `@ignore` which can be used for things like multi-line strings and multi-line comments. When an `@ignore` node is encountered when moving up the tree, no indentation will be performed.

I would be grateful if someone could test if these changes do not introduce any regressions. I was mainly testing on Python, Lua and C++ (with my `indents.scm`) and it seemed ok aside from the things mentioned above.