### PR TITLE
feat: add missing golang indent queries

### DIFF
--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -6,6 +6,10 @@
   (type_declaration)
   (composite_literal)
   (func_literal)
+  (literal_value)
+  (expression_case)
+  (argument_list)
+  (default_case)
   (block)
 ] @indent
 


### PR DESCRIPTION
didn't notice this in my previous PR