### PR TITLE
fix: js indent for object inside arguments

### DIFF
--- a/queries/javascript/indents.scm
+++ b/queries/javascript/indents.scm
@@ -17,6 +17,7 @@
 ] @indent
 
 [
+  (arguments (object))
   "("
   ")"
   "{"


### PR DESCRIPTION
Fixes a scenario when we have this.
```javascript
doSomething("foo", {
  default: false,
  }) <- not indented properly
  // rest of the lines after this one got messed up
```