### PR TITLE
Use function keyword highlight group for Rust's fn

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -140,7 +140,6 @@
 "dyn"
 "enum"
 "extern"
-"fn"
 "impl"
 "let"
 "macro_rules!"
@@ -164,6 +163,8 @@
 (attribute_item)
 (inner_attribute_item)
  ] @keyword
+
+"fn" @keyword.function
 
 (use_list (self) @keyword)
 (scoped_use_list (self) @keyword)


### PR DESCRIPTION
The Rust grammar doesn't have a special token for fn, so it has to remain hardcoded, but that's still an improvement.