### PR TITLE
fix(CI): don't let update-parsers fail if no change is necessary

### DIFF
--- a/.github/workflows/update-parsers-pr.yml
+++ b/.github/workflows/update-parsers-pr.yml
@@ -40,7 +40,7 @@ jobs:
           git config user.name "GitHub"
           git config user.email "noreply@github.com"
           git add lockfile.json
-          git commit -m "Update lockfile.json"
+          git commit -m "Update lockfile.json" || echo 'No commit necessary!'
           git clean -xf
 
       - name: Create Pull Request


### PR DESCRIPTION
Currently, this workflow fails if there are no changes to commit.