### PR TITLE
Add devicetree parser with queries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Each of these `scheme` files contains a *tree-sitter query* for a given purpose.
 Before going any further, we highly suggest that you [read more about tree-sitter queries](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries).
 
 Each query has an appropriate name, which is then used by modules to extract data from the syntax tree.
-For now the following types of queries are used by `nvim-treesitter`:
+For now two types of queries are used by `nvim-treesitter`:
 
 - `highlights.scm`: used for syntax highlighting, using the `highlight` module.
 - `locals.scm`: used to extract keyword definitions, scopes, references, etc, using the `locals` module.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Each of these `scheme` files contains a *tree-sitter query* for a given purpose.
 Before going any further, we highly suggest that you [read more about tree-sitter queries](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries).
 
 Each query has an appropriate name, which is then used by modules to extract data from the syntax tree.
-For now two types of queries are used by `nvim-treesitter`:
+For now the following types of queries are used by `nvim-treesitter`:
 
 - `highlights.scm`: used for syntax highlighting, using the `highlight` module.
 - `locals.scm`: used to extract keyword definitions, scopes, references, etc, using the `locals` module.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [cpp](https://github.com/tree-sitter/tree-sitter-cpp) (maintained by @theHamsta)
 - [x] [css](https://github.com/tree-sitter/tree-sitter-css) (maintained by @TravonteD)
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @Akin909)
-- [ ] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree)
+- [x] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree) (maintained by @jedrzejboczar)
 - [ ] [elm](https://github.com/razzeee/tree-sitter-elm)
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [cpp](https://github.com/tree-sitter/tree-sitter-cpp) (maintained by @theHamsta)
 - [x] [css](https://github.com/tree-sitter/tree-sitter-css) (maintained by @TravonteD)
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @Akin909)
+- [ ] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree)
 - [ ] [elm](https://github.com/razzeee/tree-sitter-elm)
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -416,6 +416,15 @@ list.turtle = {
   maintainers = { "@bonabeavis" },
 }
 
+list.devicetree = {
+  install_info = {
+    url = "https://github.com/joelspadin/tree-sitter-devicetree",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  filetype = 'dts',
+}
+
 local M = {
   list = list
 }

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -423,6 +423,7 @@ list.devicetree = {
     branch = "main",
   },
   filetype = 'dts',
+  maintainers = { "@jedrzejboczar" },
 }
 
 local M = {

--- a/queries/devicetree/folds.scm
+++ b/queries/devicetree/folds.scm
@@ -1,0 +1,1 @@
+(node) @fold

--- a/queries/devicetree/highlights.scm
+++ b/queries/devicetree/highlights.scm
@@ -1,0 +1,40 @@
+(comment) @comment
+
+[
+  (preproc_include)
+  (dtsi_include)
+] @include
+
+[
+  (preproc_def)
+] @constant.macro
+
+[
+  (preproc_function_def)
+] @function.macro
+
+[
+  (memory_reservation)
+  (file_version)
+] @annotation
+
+[
+  (string_literal)
+  (byte_string_literal)
+  (system_lib_string)
+] @string
+
+(integer_literal) @number
+
+(identifier) @variable
+(node (identifier) @attribute)
+(property (identifier) @property)
+(labeled_item (identifier) @label)
+(call_expression (identifier) @function.macro)
+
+(reference) @attribute
+(unit_address) @constant
+
+[ "=" ] @operator
+[ "(" ")" "[" "]" "{" "}" "<" ">" ] @punctuation.bracket
+[ ";" ":" "," "@" ] @punctuation.delimiter

--- a/queries/devicetree/highlights.scm
+++ b/queries/devicetree/highlights.scm
@@ -5,18 +5,13 @@
   (dtsi_include)
 ] @include
 
-[
-  (preproc_def)
-] @constant.macro
-
-[
-  (preproc_function_def)
-] @function.macro
+(preproc_def) @constant.macro
+(preproc_function_def) @function.macro
 
 [
   (memory_reservation)
   (file_version)
-] @annotation
+] @attribute
 
 [
   (string_literal)
@@ -27,12 +22,12 @@
 (integer_literal) @number
 
 (identifier) @variable
-(node (identifier) @attribute)
+(node (identifier) @namespace)
 (property (identifier) @property)
 (labeled_item (identifier) @label)
 (call_expression (identifier) @function.macro)
 
-(reference) @attribute
+(reference) @label ; referencing labeled_item.identifier
 (unit_address) @constant
 
 [ "=" ] @operator

--- a/queries/devicetree/indents.scm
+++ b/queries/devicetree/indents.scm
@@ -1,0 +1,14 @@
+[
+  (node)
+  (property)
+  (integer_cells)
+] @indent
+
+[
+  "}"
+  ">"
+] @branch
+
+[
+  (comment)
+] @ignore

--- a/queries/devicetree/locals.scm
+++ b/queries/devicetree/locals.scm
@@ -1,0 +1,4 @@
+[
+  (node)
+  (integer_cells)
+]@scope


### PR DESCRIPTION
This adds Linux [Device Tree](https://www.kernel.org/doc/html/latest/devicetree/usage-model.html) files parser (https://github.com/joelspadin/tree-sitter-devicetree).

Fold queries are straightforward. For highlights I'm not entirely sure of the captures that should be used, I tried to select the ones that seemed sensible (and to end up with roughly similar colors as with vim's `syntax/dts.vim`, at least for gruvbox). I am not really sure what `locals.scm` are, maybe someone could check/improve/remove these queries. Indents work fine for me, there is some issue with indenting the first node in the file, but couldn't find what causes it.

Some `.dts`/`.dtsi` files to test these queries can be found e.g. [here](https://github.com/torvalds/linux/tree/master/arch/arm/boot/dts).