### PR TITLE
parsers: change repo link of Elm parser to the new official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [cpp](https://github.com/tree-sitter/tree-sitter-cpp) (maintained by @theHamsta)
 - [x] [css](https://github.com/tree-sitter/tree-sitter-css) (maintained by @TravonteD)
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @Akin909)
-- [ ] [elm](https://github.com/razzeee/tree-sitter-elm)
+- [ ] [elm](https://github.com/elm-tooling/tree-sitter-elm)
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by not @tjdevries)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -295,7 +295,7 @@ list.vue = {
 
 list.elm = {
   install_info = {
-    url = "https://github.com/razzeee/tree-sitter-elm",
+    url = "https://github.com/elm-tooling/tree-sitter-elm",
     files = { "src/parser.c", "src/scanner.cc" },
   }
 }


### PR DESCRIPTION
Follow https://github.com/tree-sitter/tree-sitter/pull/907
and change the link of the Elm parser to the elm-tooling namespace.