### PR TITLE
Query: set commenstring

### DIFF
--- a/after/ftplugin/query.vim
+++ b/after/ftplugin/query.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=;\ %s


### PR DESCRIPTION
Otherwise the default is `/*%s*/`