### PR TITLE
Fixes #630: Indentexpr reverts to runtime specified

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -114,6 +114,7 @@ local indent_funcs = {}
 function M.attach(bufnr)
   indent_funcs[bufnr] = vim.bo.indentexpr
   vim.bo.indentexpr = 'nvim_treesitter#indent()'
+  vim.api.nvim_command("au Filetype "..vim.bo.filetype.." setlocal indentexpr=nvim_treesitter#indent()")
 end
 
 function M.detach(bufnr)


### PR DESCRIPTION
fixes #630 
Sets a filetype autocmd to set indentexpr when enabled by default. Fixes issue when using telescope or any plugin that runs doautocmd.