### PR TITLE
Python: inject rst in docstrings

### DIFF
--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -4,3 +4,21 @@
   arguments: (argument_list (string) @regex))
  (#eq? @_re "re")
  (#match? @regex "^r.*"))
+
+; Module docstring
+((module . (expression_statement (string) @rst))
+ (#offset! @rst 0 3 0 -3))
+
+; Class docstring
+((class_definition
+  body: (block . (expression_statement (string) @rst)))
+ (#offset! @rst 0 3 0 -3))
+
+; Function/method docstring
+((function_definition
+  body: (block . (expression_statement (string) @rst)))
+ (#offset! @rst 0 3 0 -3))
+
+; Attribute docstring
+(((expression_statement (assignment)) . (expression_statement (string) @rst))
+ (#offset! @rst 0 3 0 -3))


### PR DESCRIPTION
Since hasn't been much discussion around https://github.com/nvim-treesitter/nvim-treesitter/issues/806.
I'm just porting the injection queries, if you want to merge it. RST is a very popular format used in dosctrings, but certainly isn't the only format used.
 
I've been using this for a while now.Things I've noticed:

- Due that rst uses indentation for its syntax,
  everything is treated as an block quote (but it looks good).
  This can be solved by having a predicate like `#dedent!`.
- Looks like there is a bug in how the injected content is extracted

  ```
  def foo():
      """Foo bar"""
  ```

  That is parsed as a section for some reason,
  but it's a paragraph.

  In rst it would be a section if the content was:

  ```
  """
  Foo bar
  """
  ```

  If the content is

  ```
  """Foo bar"""
  ```

  That's just a paragraph.

  (also, note that it shouldn't even parse the `"""` since I'm using the offset predicate!)

I'll try to debug that from the neovim side next week or so.