### PR TITLE
Lua: highlight all `{}` as bracket

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -133,7 +133,6 @@
   (identifier) @parameter)
 
 ;; Nodes
-(table ["{" "}"] @constructor)
 (comment) @comment
 (string) @string
 (number) @number


### PR DESCRIPTION
 For example

![Screenshot from 2021-02-05 01-10-33](https://user-images.githubusercontent.com/4975310/106996422-f7f3eb80-674e-11eb-82b0-0fe3f9ffb77c.png)

Otherwise everything is white

![Screenshot from 2021-02-05 01-11-24](https://user-images.githubusercontent.com/4975310/106996484-15c15080-674f-11eb-827b-c21748fb3b0c.png)

I'm not really sure if `{}` should be highlighted as constructor at all, but I'm not that deep with lua