### PR TITLE
Add `selection_mode` argument to `ts_utils.update_selection()`

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -131,7 +131,8 @@ function M.highlight_range(range, buf, hl_namespace, hl_group)
 end
 
 -- Set visual selection to node
--- @param selection_mode One of "charwise" (default), "linewise", "blockwise"
+-- @param selection_mode One of "charwise" (default) or "v", "linewise" or "V",
+--   "blockwise" or "<C-v>" (as a string with 5 characters or a single character)
 function M.update_selection(buf, node, selection_mode)
   selection_mode = selection_mode or "charwise"
   local start_row, start_col, end_row, end_col = M.get_node_range(node)
@@ -152,10 +153,10 @@ function M.update_selection(buf, node, selection_mode)
   local v_table = {charwise = "v", linewise = "V", blockwise = "<C-v>"}
   ---- Call to `nvim_replace_termcodes()` is needed for sending appropriate
   ---- command to enter blockwise mode
-  local command = vim.api.nvim_replace_termcodes(
-    "normal! " .. v_table[selection_mode], true, true, true
+  local mode_string = vim.api.nvim_replace_termcodes(
+    v_table[selection_mode] or selection_mode, true, true, true
   )
-  vim.cmd(command)
+  vim.cmd("normal! " .. mode_string)
 
   -- Convert exclusive end position to inclusive
   if end_col == 1 then

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -131,7 +131,9 @@ function M.highlight_range(range, buf, hl_namespace, hl_group)
 end
 
 -- Set visual selection to node
-function M.update_selection(buf, node)
+-- @param selection_mode One of "charwise" (default), "linewise", "blockwise"
+function M.update_selection(buf, node, selection_mode)
+  selection_mode = selection_mode or "charwise"
   local start_row, start_col, end_row, end_col = M.get_node_range(node)
 
   if end_row == vim.fn.line('$') then
@@ -145,7 +147,15 @@ function M.update_selection(buf, node)
   end_col = end_col + 1
 
   vim.fn.setpos(".", { buf, start_row, start_col, 0 })
-  vim.fn.nvim_exec("normal! v", false)
+
+  -- Start visual selection in appropriate mode
+  local v_table = {charwise = "v", linewise = "V", blockwise = "<C-v>"}
+  ---- Call to `nvim_replace_termcodes()` is needed for sending appropriate
+  ---- command to enter blockwise mode
+  local command = vim.api.nvim_replace_termcodes(
+    "normal! " .. v_table[selection_mode], true, true, true
+  )
+  vim.cmd(command)
 
   -- Convert exclusive end position to inclusive
   if end_col == 1 then


### PR DESCRIPTION
This update allows setting a visual selection mode when calling `ts_utils.update_selection()`. Essentially, behavior is equivalent to the following steps: go to start position of the node, invoke certain visual selection mode, go to end position of the node.

Note for possible update: for blockwise mode select block not from start to end positions, but block containing the whole node. The drawback is that it will not be aligned with default Vim's behavior: after selecting region, user can change selection mode (by typing `v`, `V`, or `<C-v>`). So with current approach two actions are equivalent: `update_selection(..., "blockwise")` and `update_selection(..., "charwise")` followed by `<C-v>`.

Related PR: nvim-treesitter/nvim-treesitter-textobjects/pull/37