### PR TITLE
Initial support for Vue files

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -300,7 +300,8 @@ list.vue = {
   install_info = {
     url = "https://github.com/ikatyang/tree-sitter-vue",
     files = { "src/parser.c", "src/scanner.cc" },
-  }
+  },
+  maintainers = {"@WhyNotHugo"},
 }
 
 list.jsonc = {

--- a/queries/vue/folds.scm
+++ b/queries/vue/folds.scm
@@ -1,0 +1,6 @@
+[
+  (element)
+  (template_element)
+  (script_element)
+  (style_element)
+] @fold

--- a/queries/vue/highlights.scm
+++ b/queries/vue/highlights.scm
@@ -1,0 +1,38 @@
+[
+  (component)
+  (template_element)
+  (start_tag)
+  (tag_name)
+  (directive_attribute)
+  (directive_dynamic_argument)
+  (directive_dynamic_argument_value)
+  (component)
+  (end_tag)
+] @tag
+
+(erroneous_end_tag_name) @error
+(attribute_name) @property
+(attribute_value) @string
+(quoted_attribute_value) @string
+(comment) @comment
+
+(text) @none
+(element) @string
+(interpolation) @punctuation.special
+(interpolation
+  (raw_text) @none)
+
+[
+  (directive_modifier)
+  (directive_name)
+  (directive_argument)
+] @method
+
+"=" @operator
+
+[
+ "<"
+ ">"
+ "</"
+ "/>"
+ ] @tag.delimiter

--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -1,0 +1,19 @@
+((style_element
+  (raw_text) @css))
+
+; There's no queries for less, sass nor postcss.
+
+((script_element
+  (raw_text) @javascript))
+
+(
+  (script_element
+    (start_tag
+      (attribute
+        (quoted_attribute_value (attribute_value) @_lang)))
+    (raw_text) @typescript)
+  (#match? @_lang "(ts|typescript)")
+)
+
+((interpolation
+  (raw_text) @javascript))


### PR DESCRIPTION
Due to limitations in tree-sitter-vue, TypeScript and JavaScript are indistinguishable. Since the former is a superset of the latter, always treating them as TypeScript should result in valid highlighting in all
cases.

Support for LESS and other formats requires support from the tree-sitter itself.

Closes #936