### PR TITLE
Remove debug print statement

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -98,7 +98,6 @@ end
 --- This function is meant for an autocommand and not to be used. Only use if file is a query file.
 function M.reload_file_cache_on_write(fname)
   local fnamemodify = vim.fn.fnamemodify
-  print('reloading cache')
   M.reload_file_cache(fnamemodify(fname, ':p:h:t'), fnamemodify(fname, ':t:r'))
 end
 


### PR DESCRIPTION
The message does not even provide any context where it's coming from
and what it is exactly doing and has to be acknowledged when printed in
conjunction with the "wrote xxx bytes message"
