### PR TITLE
yaml: improve highlights and locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [typescript](https://github.com/tree-sitter/tree-sitter-typescript) (maintained by @steelsojka)
 - [x] [verilog](https://github.com/tree-sitter/tree-sitter-verilog) (maintained by @zegervdv)
 - [ ] [vue](https://github.com/ikatyang/tree-sitter-vue)
-- [ ] [yaml](https://github.com/ikatyang/tree-sitter-yaml)
+- [x] [yaml](https://github.com/ikatyang/tree-sitter-yaml) (maintained by @stsewd)
 <!--parserinfo-->
 
 

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -314,7 +314,8 @@ list.yaml = {
   install_info = {
     url = "https://github.com/ikatyang/tree-sitter-yaml",
     files = { "src/parser.c", "src/scanner.cc" },
-  }
+  },
+  maintainers = {"@stsewd"},
 }
 
 list.nix = {

--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -1,9 +1,9 @@
-(block_mapping_pair key: (_) @field)
-(flow_mapping (_ key: (_) @field))
 (boolean_scalar) @boolean
 (null_scalar) @constant.builtin
 (double_quote_scalar) @string
 (single_quote_scalar) @string
+(block_scalar) @string
+(string_scalar) @string
 (escape_sequence) @string.escape
 (integer_scalar) @number
 (float_scalar) @number
@@ -13,17 +13,36 @@
 (tag) @type
 (yaml_directive) @keyword
 (ERROR) @error
+
+(block_mapping_pair key: (_) @field)
+(block_mapping_pair
+  key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @field))
+(block_mapping_pair
+  key: (flow_node (plain_scalar (string_scalar) @field)))
+
+(flow_mapping key: (_) @field)
+(flow_mapping
+  (_ key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @field)))
+(flow_mapping
+  (_ key: (flow_node (plain_scalar (string_scalar) @field))))
+
 [
-","
-"-"
-":"
-">"
-"?"
-"|"
+ ","
+ "-"
+ ":"
+ ">"
+ "?"
+ "|"
 ] @punctuation.delimiter
+
 [
-"["
-"]"
-"{"
-"}"
+ "["
+ "]"
+ "{"
+ "}"
 ] @punctuation.bracket
+
+[
+ "---"
+ "..."
+] @punctuation.special

--- a/queries/yaml/locals.scm
+++ b/queries/yaml/locals.scm
@@ -1,1 +1,5 @@
-(document) @scope
+[
+ (stream)
+ (document)
+ (block_node)
+] @scope


### PR DESCRIPTION
- More scopes
- Highlight strings as strings
- Recognize more keys/fields

Improvements can be seen with this weird yaml:

```yaml
{ foo: bar }
---
{a: [b, c], [d, e]: f}

---
- { single line, a: b}
- { multi
  line, a: b}
---

"fooo": bar
'foo': bar
one: |
   I'm a multi line
```