### PR TITLE
Query: highlight modeline

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -18,3 +18,6 @@
   "("
   ")"
 ] @punctuation.bracket
+
+((program . (comment) @include)
+ (#match? @include "^;\ +inherits\ *:"))


### PR DESCRIPTION
Matches the first comment and the beginning from the pattern
https://github.com/neovim/neovim/blob/52397aaa0d1e2d4ce1320c73761cf316fc608ffb/runtime/lua/vim/treesitter/query.lua#L25