### PR TITLE
Add support for JSONC

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -303,6 +303,13 @@ list.vue = {
   }
 }
 
+list.jsonc = {
+  install_info = {
+    url = "https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git",
+    files = { "src/parser.c" },
+  }
+}
+
 list.elm = {
   install_info = {
     url = "https://github.com/elm-tooling/tree-sitter-elm",

--- a/queries/jsonc/folds.scm
+++ b/queries/jsonc/folds.scm
@@ -1,0 +1,1 @@
+; inherits: json

--- a/queries/jsonc/highlights.scm
+++ b/queries/jsonc/highlights.scm
@@ -1,0 +1,3 @@
+; inherits: json
+
+(comment) @comment

--- a/queries/jsonc/indents.scm
+++ b/queries/jsonc/indents.scm
@@ -1,0 +1,1 @@
+; inherits: json

--- a/queries/jsonc/locals.scm
+++ b/queries/jsonc/locals.scm
@@ -1,0 +1,1 @@
+; inherits: json


### PR DESCRIPTION
`jsonc` is basically JSON with inline comments. It's used a lot for configuring desktop apps, including `waybar`, `coc`, `vscode` and others.

I've written a parser which is about 95% based on the `json` parser, with comment support added on top. The parser itself has some tests, as well as some manual testing on file I have lying around.