### PR TITLE
highlights(rst): Reset highlights in doctest_block

### DIFF
--- a/queries/rst/highlights.scm
+++ b/queries/rst/highlights.scm
@@ -12,6 +12,10 @@
   (transition)
 ] @punctuation.special
 
+;; Resets for injection
+
+(doctest_block) @none
+
 ;; Directives
 
 (directive


### PR DESCRIPTION
This resets the string highlight in `doctest_block`s to better contrast the code highlight with the rest of the documentation

![image](https://user-images.githubusercontent.com/7189118/107988097-92fe8800-6fcf-11eb-8ea5-4635c2ace364.png)

before:
![image](https://user-images.githubusercontent.com/7189118/107988295-fb4d6980-6fcf-11eb-8771-12e5a6ff9db5.png)

