### PR TITLE
Fix java constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [javascript](https://github.com/tree-sitter/tree-sitter-javascript) (maintained by @steelsojka)
 - [x] [jsdoc](https://github.com/tree-sitter/tree-sitter-jsdoc) (maintained by @steelsojka)
 - [x] [json](https://github.com/tree-sitter/tree-sitter-json) (maintained by @steelsojka)
+- [x] [JSON with comments](https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git) (maintained by @WhyNotHugo)
 - [x] [julia](https://github.com/tree-sitter/tree-sitter-julia) (maintained by @mroavi, @theHamsta)
 - [x] [kotlin](https://github.com/QthCN/tree-sitter-kotlin) (maintained by @tormodatt)
 - [x] [ledger](https://github.com/cbarrete/tree-sitter-ledger) (maintained by @cbarrete)
@@ -178,7 +179,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [turtle](https://github.com/BonaBeavis/tree-sitter-turtle) (maintained by @bonabeavis)
 - [x] [typescript](https://github.com/tree-sitter/tree-sitter-typescript) (maintained by @steelsojka)
 - [x] [verilog](https://github.com/tree-sitter/tree-sitter-verilog) (maintained by @zegervdv)
-- [ ] [vue](https://github.com/ikatyang/tree-sitter-vue)
+- [x] [vue](https://github.com/ikatyang/tree-sitter-vue) (maintained by @WhyNotHugo)
 - [ ] [yaml](https://github.com/ikatyang/tree-sitter-yaml)
 <!--parserinfo-->
 

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -19,6 +19,9 @@
 (catch_formal_parameter
   name: (identifier) @parameter)
 
+(spread_parameter
+ (variable_declarator) @parameter) ; int... foo
+
 ;; Lambda parameter
 (inferred_parameters (identifier) @parameter) ; (x,y) -> ...
 (lambda_expression
@@ -105,7 +108,7 @@
 ; Variables
 
 ((identifier) @constant
-  (#vim-match? @constant "^[A-Z_][A-Z\d_]+$"))
+  (#match? @constant "^[A-Z_][A-Z\d_]+$"))
 
 (this) @variable.builtin
 
@@ -205,6 +208,7 @@
 [
 ";"
 "."
+"..."
 ","
 ] @punctuation.delimiter
 

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -105,7 +105,7 @@
 ; Variables
 
 ((identifier) @constant
-  (#vim-match? @constant "^_*[A-Z][A-Z\d_]+"))
+  (#vim-match? @constant "^[A-Z_][A-Z\d_]+$"))
 
 (this) @variable.builtin
 


### PR DESCRIPTION
Currently, something would be highlighted as a constant even if it has starts with only two uppercase letters, e.g. IOException