### PR TITLE
make graphql injection also works with `graphql`

### DIFF
--- a/queries/javascript/injections.scm
+++ b/queries/javascript/injections.scm
@@ -9,6 +9,6 @@
 
 (call_expression
   function: ((identifier) @_name
-             (#eq? @_name "gql"))
+             (#match? @_name "^(gql|graphql)$"))
   arguments: ((template_string) @graphql
               (#offset! @graphql 0 1 0 -1)))


### PR DESCRIPTION
If anyone doesn't want to make an alias to make injection works. Gatsby uses `graphql` by default as the function name and maybe someone doesn't want to change that on every places if they want injection or if they prefer using `graphql` instead of `gql`.