### PR TITLE
Add inline html comments highlighting for markdown

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -17,3 +17,5 @@
   (strong_emphasis)
 ] @text.emphasis
 (link_destination) @text.uri
+
+(html_comment) @comment


### PR DESCRIPTION
This enables highlighting of inline html comments in markdown (see #976 )