### PR TITLE
Add CI and Windows support for cl.exe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: Parser compilation and tests
+
+on: [push, pull_request]
+
+jobs:
+  check_compilation_unix_like:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        cc: [ gcc, clang ]
+        exclude:
+          - os: macos-latest
+            cc: gcc
+
+        include:
+          - os: windows-latest
+            cc: cl
+
+          - os: macos-latest
+            cc: gcc-10
+
+    name: Parser compilation
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ilammy/msvc-dev-cmd@v1.5.0
+
+      - name: Install and prepare Neovim
+        run: |
+          bash ./scripts/ci-install-${{ matrix.os }}.sh
+
+      - name: Compile parsers Unix like
+        if: matrix.os != 'windows-latest'
+        run: |
+          nvim --headless -c "TSInstallSync all" -c "q"
+
+      - name: Compile parsers Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          C:\\tools\\neovim\\Neovim\\bin\\nvim.exe --headless -c "TSInstallSync all" -c "q"
+
+      - name: Post compile Windows
+        if: matrix.os == 'windows-latest'
+        run: cp -r ~/AppData/Local/nvim/pack/nvim-treesitter/start/nvim-treesitter/parser/* parser
+        shell: bash
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: parsers-${{ matrix.os }}-${{ matrix.cc }}-x86_64
+          path: parser/*
+

--- a/scripts/ci-install-macos-latest.sh
+++ b/scripts/ci-install-macos-latest.sh
@@ -1,0 +1,4 @@
+brew install neovim --HEAD
+mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
+ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter/start
+

--- a/scripts/ci-install-ubuntu-latest.sh
+++ b/scripts/ci-install-ubuntu-latest.sh
@@ -1,0 +1,9 @@
+sudo apt-get update
+sudo add-apt-repository universe
+wget https://github.com/neovim/neovim/releases/download/nightly/nvim.appimage
+chmod u+x nvim.appimage
+mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
+ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter/start
+sudo cp ./nvim.appimage /usr/bin/nvim
+sudo chmod uog+rwx /usr/bin/nvim
+

--- a/scripts/ci-install-windows-latest.sh
+++ b/scripts/ci-install-windows-latest.sh
@@ -1,0 +1,5 @@
+choco install neovim --pre
+mkdir -p ~/AppData/Local/nvim/pack/nvim-treesitter/start
+mkdir -p ~/AppData/Local/nvim-data
+cp -r $(pwd) ~/AppData/Local/nvim/pack/nvim-treesitter/start
+


### PR DESCRIPTION
I tried #347 and changes were looking fine(`cd` does not like `;`), but since the branch was too old I decided to do it this way.

Changes are working tested on windows machine. Also to make this work `nvim` has to be started from `Developer Command Prompt` (`cl.exe` has some environmental needs)