### PR TITLE
[highlights] Add TSSymbol highlight group

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @type
 @type.builtin
 @namespace for identifiers referring to namespaces
+@symbol for identifiers referring to symbols
 @attribute for e.g. Python decorators
 ```
 

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -560,6 +560,10 @@ For regexes.
                                                            *hl-TSStringEscape*
 For escape characters within a string.
 
+`TSSymbol`
+                                                                 *hl-TSSymbol*
+For identifiers referring to symbols or atoms.
+
 `TSTag`
                                                                    *hl-TSTag*
 Tags like html tag names.

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -71,6 +71,8 @@ hlmap["string"] = "TSString"
 hlmap["string.regex"] = "TSStringRegex"
 hlmap["string.escape"] = "TSStringEscape"
 
+hlmap["symbol"] = "TSSymbol"
+
 hlmap["tag"] = "TSTag"
 hlmap["tag.delimiter"] = "TSTagDelimiter"
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -54,6 +54,7 @@ highlight default link TSConstructor Special
 highlight default link TSAnnotation PreProc
 highlight default link TSAttribute PreProc
 highlight default link TSNamespace Include
+highlight default link TSSymbol Identifier
 
 highlight default link TSConditional Conditional
 highlight default link TSRepeat Repeat

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -144,7 +144,7 @@
     ; (hex_floating_point_literal)
 ] @number
 
-(symbol_literal) @string.special
+(symbol_literal) @symbol
 (string_literal) @string
 (true) @boolean
 (false) @boolean

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -63,9 +63,8 @@
     (parameterized_identifier) @type))
 
 ;; Symbol expressions (:my-wanna-be-lisp-keyword)
-;; Same highlight as in clojure
 (quote_expression
- (identifier)) @type
+ (identifier)) @symbol
 
 ;; Parsing error! foo (::Type) get's parsed as two quote expressions
 (argument_list 

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -144,7 +144,7 @@
  (simple_symbol)
  (delimited_symbol)
  (hash_key_symbol)
- ] @property
+ ] @symbol
 
 (pair key: (hash_key_symbol) ":" @constant)
 (regex) @string.regex


### PR DESCRIPTION
Addresses issue #892

Ruby and Dart literal symbols will now be highlighted by the new
TSSymbol highlight group, which itself will, by default, link to the Vim
Identifier highlight group. Vim theme authors can then set their
TSSymbol colors.

Symbol highlighting can apply to a number of languages as noted in the
following Wikipedia page: https://en.wikipedia.org/wiki/Symbol_(programming)

Not just for Ruby and Dart.

Closes #892