### PR TITLE
Update ocaml parser to latest master

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -75,10 +75,10 @@
     "revision": "a6bae0619126d70c756c11e404d8f4ad5108242f"
   },
   "ocaml": {
-    "revision": "4ec9ee414dadc2b6e7325a9f8124d02f6cd8c250"
+    "revision": "785ab1fe61c91f7ed4c4457af790b24fe57d8305"
   },
   "ocaml_interface": {
-    "revision": "4ec9ee414dadc2b6e7325a9f8124d02f6cd8c250"
+    "revision": "785ab1fe61c91f7ed4c4457af790b24fe57d8305"
   },
   "ocamllex": {
     "revision": "ac1d5957e719d49bd6acd27439b79843e4daf8ed"

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -68,7 +68,7 @@
 ; Constants
 ;----------
 
-(boolean) @constant
+[(boolean) (unit)] @constant
 
 [(number) (signed_number)] @number
 
@@ -80,7 +80,10 @@
 
 (escape_sequence) @string.escape
 
-(conversion_specification) @punctuation.special
+[
+  (conversion_specification)
+  (pretty_printing_indication)
+] @punctuation.special
 
 ; Operators
 ;----------

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -85,30 +85,6 @@
   (pretty_printing_indication)
 ] @punctuation.special
 
-; Operators
-;----------
-
-(match_expression (match_operator) @keyword)
-
-(value_definition [(let_operator) (and_operator)] @keyword)
-
-[
-  (prefix_operator)
-  (infix_operator)
-  (indexing_operator)
-  (let_operator)
-  (and_operator)
-  (match_operator)
-] @operator
-
-(prefix_operator "!" @operator)
-
-(infix_operator ["&" "+" "-" "=" ">" "|" "%"] @operator)
-
-(signed_number ["+" "-"] @operator)
-
-["*" "#" "::" "<-"] @operator
-
 ; Keywords
 ;---------
 
@@ -149,6 +125,30 @@
   "," "." ";" ":" "=" "|" "~" "?" "+" "-" "!" ">" "&"
   "->" ";;" ":>" "+=" ":=" ".."
 ] @punctuation.delimiter
+
+; Operators
+;----------
+
+[
+  (prefix_operator)
+  (infix_operator)
+  (indexing_operator)
+  (let_operator)
+  (and_operator)
+  (match_operator)
+] @operator
+
+(match_expression (match_operator) @keyword)
+
+(value_definition [(let_operator) (and_operator)] @keyword)
+
+(prefix_operator "!" @operator)
+
+(infix_operator ["&" "+" "-" "=" ">" "|" "%"] @operator)
+
+(signed_number ["+" "-"] @operator)
+
+["*" "#" "::" "<-"] @operator
 
 ; Attributes
 ;-----------


### PR DESCRIPTION
Now quoted strings can contain other nodes. Also change the order of highlight captures to adapt to neovim's order and added a couple of captures more.