### PR TITLE
Support the glimmer parser when the `hbs` template literal tag is used

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -296,6 +296,7 @@ list.glimmer = {
   install_info = {
     url = "https://github.com/alexlafroscia/tree-sitter-glimmer",
     files = { "src/parser.c", "src/scanner.c" },
+    branch = 'main',
   },
   readme_name = "Glimmer and Ember",
   maintainers = { "@alexlafroscia" },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -292,6 +292,16 @@ list.toml = {
   maintainers = {"@tk-shirasaka"},
 }
 
+list.glimmer = {
+  install_info = {
+    url = "https://github.com/alexlafroscia/tree-sitter-glimmer",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  readme_name = "Glimmer and Ember",
+  maintainers = { "@alexlafroscia" },
+  filetype = "handlebars"
+}
+
 list.vue = {
   install_info = {
     url = "https://github.com/ikatyang/tree-sitter-vue",

--- a/queries/glimmer/highlights.scm
+++ b/queries/glimmer/highlights.scm
@@ -14,7 +14,7 @@
 ; == Mustache Statements ===
 
 ; Hightlight the whole statement, to color brackets and separators
-(mustache_statement) @tag
+(mustache_statement) @tag.delimiter
 
 ; Generic identifiers are variables
 (identifier) @variable
@@ -33,4 +33,4 @@
   ">"
   "</"
   "/>"
-] @tag
+] @tag.delimiter

--- a/queries/glimmer/highlights.scm
+++ b/queries/glimmer/highlights.scm
@@ -1,3 +1,7 @@
+;; By @alexlafroscia (https://github.com/alexlafroscia/tree-sitter-glimmer)
+;; Licensed under MIT
+;; Modified for nvim-treesitter
+
 ; Tags that start with a lower case letter are HTML tags
 ((tag_name) @tag
   (#match? @tag "^[a-z]"))

--- a/queries/glimmer/highlights.scm
+++ b/queries/glimmer/highlights.scm
@@ -1,0 +1,36 @@
+; Tags that start with a lower case letter are HTML tags
+((tag_name) @tag
+  (#match? @tag "^[a-z]"))
+; Tags that start with a capital letter are Glimmer components
+((tag_name) @constructor
+  (#match? @constructor "^[A-Z]"))
+
+(attribute_name) @property
+
+(string_literal) @string
+(number_literal) @number
+(boolean_literal) @boolean
+
+; == Mustache Statements ===
+
+; Hightlight the whole statement, to color brackets and separators
+(mustache_statement) @tag
+
+; Generic identifiers are variables
+(identifier) @variable
+; Helpers are functions
+(helper_identifier) @function
+
+(comment_statement) @comment
+
+(attribute_node "=" @operator)
+
+(block_params "as" @keyword)
+(block_params "|" @operator)
+
+[
+  "<"
+  ">"
+  "</"
+  "/>"
+] @tag

--- a/queries/javascript/injections.scm
+++ b/queries/javascript/injections.scm
@@ -12,3 +12,9 @@
              (#eq? @_name "gql"))
   arguments: ((template_string) @graphql
               (#offset! @graphql 0 1 0 -1)))
+
+(call_expression
+  function: ((identifier) @_name
+             (#eq? @_name "hbs"))
+  arguments: ((template_string) @glimmer
+              (#offset! @glimmer 0 1 0 -1)))


### PR DESCRIPTION
Idk if this is correct, but I know that gql usage is similar:
```js
const query = gql`
 query stuff
`;
```
so I copy-pasted that for glimmer, which looks like

```js
cost template = hbs`
  <glimmer-stuff />
  <html-like />
`;  
```

Here is the WIP syntax support for glimmer: https://github.com/alexlafroscia/tree-sitter-glimmer