### PR TITLE
feat: use @ignore for comments and multiline strings

### DIFF
--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -14,3 +14,8 @@
   "{"
   "}"
 ] @branch
+
+[
+  (comment)
+  (preproc_function_def)
+] @ignore

--- a/queries/cpp/indents.scm
+++ b/queries/cpp/indents.scm
@@ -14,3 +14,5 @@
   "{"
   "}"
 ] @branch
+
+(comment) @ignore

--- a/queries/css/indents.scm
+++ b/queries/css/indents.scm
@@ -7,3 +7,4 @@
   "}"
 ] @branch
 
+(comment) @ignore

--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -20,3 +20,5 @@
   "{"
   "}"
 ] @branch
+
+(comment) @ignore

--- a/queries/html/indents.scm
+++ b/queries/html/indents.scm
@@ -7,3 +7,5 @@
   ">"
   "/>"
 ] @branch
+
+(comment) @ignore

--- a/queries/java/indents.scm
+++ b/queries/java/indents.scm
@@ -18,3 +18,5 @@
   "["
   "]"
 ] @branch
+
+(comment) @ignore

--- a/queries/javascript/indents.scm
+++ b/queries/javascript/indents.scm
@@ -25,3 +25,8 @@
   "["
   "]"
 ] @branch
+
+[
+  (comment)
+  (template_string)
+] @ignore

--- a/queries/jsonc/indents.scm
+++ b/queries/jsonc/indents.scm
@@ -1,1 +1,3 @@
 ; inherits: json
+
+(comment) @ignore

--- a/queries/lua/indents.scm
+++ b/queries/lua/indents.scm
@@ -27,3 +27,5 @@
   (else)
   (elseif)
 ] @branch
+
+(comment) @ignore

--- a/queries/ruby/indents.scm
+++ b/queries/ruby/indents.scm
@@ -10,3 +10,5 @@
   (elsif)
   "end"
 ] @branch
+
+(comment) @ignore

--- a/queries/rust/indents.scm
+++ b/queries/rust/indents.scm
@@ -26,3 +26,8 @@
   "{"
   "}"
 ] @branch
+
+[
+  (line_comment)
+  (raw_string_literal)
+] @ignore

--- a/queries/svelte/indents.scm
+++ b/queries/svelte/indents.scm
@@ -14,3 +14,5 @@
   ">"
   "/>"
 ] @branch
+
+(comment) @ignore


### PR DESCRIPTION
It doesn't work 100% though, for example this jsdoc comment
```javascript
// Original
/**
 * Some description
 * @param {string} foo - bar
 * @return foo
 */
const foo = (foo: string): string => foo

// Without this PR
/**
* Some description
* @param {string} foo - bar
* @return foo
*/
const foo = (foo: string): string => foo

// After this PR (incorrect)
/**
 * Some description
 * @param {string} foo - bar
 * @return foo
*/
const foo = (foo: string): string => foo

// Shouldn't get affected by the indent rule (correct)
/**
 * Some description
 * @param {string} foo - bar
 * @return foo
 */
const foo = (foo: string): string => foo
```