### PR TITLE
feat: Respect user queries

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -270,6 +270,7 @@ end
 -- @param user_data module overrides
 function M.setup(user_data)
   config.modules = vim.tbl_deep_extend('force', config.modules, user_data)
+  config.parsers = user_data.parsers or {}
 
   local ensure_installed = user_data.ensure_installed or {}
   if #ensure_installed > 0 then
@@ -409,6 +410,10 @@ end
 
 function M.get_update_strategy()
   return config.update_strategy
+end
+
+function M.get_parsers_config()
+  return config.parsers
 end
 
 return M

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -97,11 +97,13 @@ function M.attach(bufnr, lang)
     hlmap[k] = v
   end
 
-  local opts = {}
+  local opts = nil
   if config.queries then
     if config.queries[lang] then
-      opts.queries = {
-        [lang] = config.queries[lang]
+      opts = {
+        queries = {
+          [lang] = config.queries[lang]
+        }
       }
     end
   end

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -97,7 +97,16 @@ function M.attach(bufnr, lang)
     hlmap[k] = v
   end
 
-  ts.highlighter.new(parser, {})
+  local opts = {}
+  if config.queries then
+    if config.queries[lang] then
+      opts.queries = {
+        [lang] = config.queries[lang]
+      }
+    end
+  end
+
+  ts.highlighter.new(parser, opts)
 end
 
 function M.detach(bufnr)


### PR DESCRIPTION
Now you can do this:

```lua
local read_query = function(filename)
  return table.concat(vim.fn.readfile(vim.fn.expand(filename)), "\n")
end

require('nvim-treesitter.configs').setup {
  -- ensure_installed = {'lua'}, -- one of 'all', 'language', or a list of languages
  ensure_installed = { 'go', 'rust', 'toml', 'query', },

  parsers = {
    lua = {
      injections = read_query("~/plugins/tree-sitter-lua/queries/lua/injections.scm"),
    }
  },

  highlight = {
    enable = enabled, -- false will disable the whole extension
    use_languagetree = false,
    disable = {"json"},
    custom_captures = custom_captures,
    queries = {
      lua  = read_query("~/plugins/tree-sitter-lua/queries/lua/highlights.scm"),
      rust = read_query("~/.config/nvim/queries/rust/highlights.scm"),
    }
  },
}