### PR TITLE
add treesitter version in checkhealth

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -12,6 +12,16 @@ local M = {}
 
 local function install_health()
   health_start('Installation')
+  if fn.executable('tree-sitter') == 0 then
+    health_error('`tree-sitter` executable not found')
+  else
+    local handle = io.popen('tree-sitter  -V')
+    local result = handle:read("*a")
+    handle:close()
+    local version = vim.split(result,'\n')[1]:match('[^tree%psitter].*')
+    health_ok('`tree-sitter` version '..version)
+  end
+
   if fn.executable('git') == 0 then
     health_error('`git` executable not found.', {
       'Install it with your package manager.',

--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -19,7 +19,7 @@ local function install_health()
     local result = handle:read("*a")
     handle:close()
     local version = vim.split(result,'\n')[1]:match('[^tree%psitter].*')
-    health_ok('`tree-sitter` version '..version)
+    health_ok('`tree-sitter` found '..version .. '(parser generator, used for :TSInstallFromGrammar)')
   end
 
   if fn.executable('git') == 0 then


### PR DESCRIPTION
 cc @vigoux @theHamsta   treesitter 0.19 has some problem with neovim,so add the version in checkhealth will be useful. it works like this

![image](https://user-images.githubusercontent.com/41671631/110124071-9f227c00-7dfc-11eb-8d6d-7d7d03e5156d.png)
