### PR TITLE
feat(dart): add indents

### DIFF
--- a/queries/dart/indents.scm
+++ b/queries/dart/indents.scm
@@ -1,0 +1,27 @@
+[
+  (class_body)
+  (function_body)
+  (function_expression_body)
+  (declaration (initializers))
+  (switch_block)
+  (if_statement)
+  (formal_parameter_list)
+  (formal_parameter)
+  (list_literal)
+  (return_statement)
+  (arguments)
+] @indent
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @branch
+
+; this one is for dedenting the else block
+(if_statement (block) @branch)
+
+(comment) @ignore


### PR DESCRIPTION
The `case` block can't be indented because the query doesn't group them (same with Java). Also, there's this scenario because I couldn't define *how many* it should get indented using the query.

```dart
// correct
static Future<Nvim> spawn(
    {String nvimBinary = 'nvim',
    List<String> commandArgs = const ['--embed'],
    NvimHandler onNotify,
    NvimHandler onRequest}) async {
  var nvim = Nvim._spawn(nvimBinary, commandArgs);
  nvim._nvim = await nvim._nvimFut;
  // ....
}

// after indenting
static Future<Nvim> spawn(
  {String nvimBinary = 'nvim',
  List<String> commandArgs = const ['--embed'],
  NvimHandler onNotify,
  NvimHandler onRequest}) async {
  var nvim = Nvim._spawn(nvimBinary, commandArgs);
  nvim._nvim = await nvim._nvimFut;
  // ....
}
```

ps: the code was stolen from [smolck's dart-nvim-api](https://github.com/smolck/dart-nvim-api/blob/master/lib/src/neovim.dart)