### PR TITLE
Support for R language

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [python](https://github.com/tree-sitter/tree-sitter-python) (maintained by @stsewd, @theHamsta)
 - [x] [ql](https://github.com/tree-sitter/tree-sitter-ql) (maintained by @pwntester)
 - [x] [Tree-sitter query language](https://github.com/nvim-treesitter/tree-sitter-query) (maintained by @steelsojka)
+- [x] [r](https://github.com/r-lib/tree-sitter-r) (maintained by @jimhester)
 - [x] [regex](https://github.com/tree-sitter/tree-sitter-regex) (maintained by @theHamsta)
 - [x] [rst](https://github.com/stsewd/tree-sitter-rst) (maintained by @stsewd)
 - [x] [ruby](https://github.com/tree-sitter/tree-sitter-ruby) (maintained by @TravonteD)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -466,6 +466,14 @@ list.svelte = {
   maintainers = { "@elianiva" },
 }
 
+list.r = {
+  install_info = {
+    url = "https://github.com/r-lib/tree-sitter-r",
+    files = { "src/parser.c" }
+  },
+  maintainers = { "@jimhester" },
+}
+
 local M = {
   list = list
 }

--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -1,0 +1,86 @@
+; highlights.scm
+
+(call function: (identifier) @function)
+(namespace_get function: (identifier) @function.method)
+(namespace_get_internal function: (identifier) @function.method)
+
+; Literals
+
+(integer) @number
+
+(float) @number
+
+(complex) @number
+
+(string) @string
+
+(comment) @comment
+
+(formal_parameters (identifier) @variable.parameter)
+
+(identifier) @variable
+
+; Operators
+[
+ "="
+ "<-"
+ "<<-"
+ "->"
+] @operator
+
+(unary operator: [
+  "-"
+  "+"
+  "!"
+  "~"
+] @operator)
+
+(binary operator: [
+  "-"
+  "+"
+  "*"
+  "/"
+  "^"
+  "<"
+  ">"
+  "<="
+  ">="
+  "=="
+  "!="
+  "||"
+  "|"
+  "&&"
+  "&"
+  ":"
+  "~"
+] @operator)
+
+(special) @operator
+
+[
+ "("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+] @punctuation.bracket
+
+[
+ "while"
+ "if"
+ "else"
+ "function"
+ "repeat"
+ "for"
+ "in"
+ (dots)
+ (true)
+ (false)
+ (break)
+ (next)
+ (inf)
+ (nan)
+ (na)
+ (null)
+] @keyword

--- a/queries/r/locals.scm
+++ b/queries/r/locals.scm
@@ -1,0 +1,11 @@
+; locals.scm
+
+(function_definition) @local.scope
+
+(formal_parameters (identifier) @local.definition)
+
+(left_assignment name: (identifier) @local.definition)
+(equals_assignment name: (identifier) @local.definition)
+(right_assignment name: (identifier) @local.definition)
+
+(identifier) @local.reference


### PR DESCRIPTION
This PR adds support for R language. Maintainer of r-lib/tree-sitter-r, @jimhester, agreed to add it to the list here (see r-lib/tree-sitter-r#7). Queries are taken in their current state from repository.