### PR TITLE
Update svelte parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -460,7 +460,7 @@ list.devicetree = {
 list.svelte = {
   install_info = {
     url = "https://github.com/Himujjal/tree-sitter-svelte",
-    files = { "src/parser.c", "src/scanner.cc" },
+    files = { "src/parser.c", "src/scanner.c" },
     branch = "master",
   },
   maintainers = { "@elianiva" },


### PR DESCRIPTION
Make svelte parser depend on `src/scanner.c` instead of `src/scanner.cc` because of https://github.com/Himujjal/tree-sitter-svelte/commit/43817cfe3e936859959a897fce411e3982fd2273