### PR TITLE
fix: indent on new line

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -67,7 +67,7 @@ function M.get_indent(lnum)
     if prevnonblank ~= lnum then
       local prev_node = get_node_at_line(root, prevnonblank-1)
       -- get previous node in any case to avoid erroring
-      while not prev_node do
+      while not prev_node and prevnonblank-1 > 0 do
         prevnonblank = vim.fn.prevnonblank(prevnonblank-1)
         prev_node = get_node_at_line(root, prevnonblank-1)
       end

--- a/queries/jsx/indents.scm
+++ b/queries/jsx/indents.scm
@@ -4,6 +4,8 @@
   (jsx_self_closing_element)
 ] @indent
 
+(parenthesized_expression) @indent
+
 [
   (jsx_closing_element)
   ">"


### PR DESCRIPTION
Fixes #1019
Fixes #1074
Fixes #802

One issue with this PR is that python is still not working as expected.
I'm not sure why but python behaves quite strangely:
typing `def a():` gives a node without errors (although it's an empty function) thus indenting like the function start row
typing
```python
def a():
    print(1)
    |
    |
```
it will indent on every new line (not sure if this is expected behavior.
I'm pretty sure the singularity of the python language makes it hard to make it work with other languages. (EDIT: maybe this could be solved with more advanced indent queries)
If someone has an idea on how to fix that, i'd be happy to hear them.

@jedrzejboczar i'd like your input on this. Newline indent is working super well with this PR, but for python i did not manage to make it work properly. 

EDIT: i've found some strange behaviors in HTML indents just by nesting divs.