### PR TITLE
Ecma: Highlight single-argument callback parameter

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -110,6 +110,10 @@
     value: (arrow_function
       parameter: (identifier) @parameter))
 
+; (a => null)
+(arrow_function
+    parameter: (identifier) @parameter)
+
 ; optional parameters
 (formal_parameters
   (assignment_pattern

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -4,6 +4,7 @@
 
 ; Identifier conventions
 
+(identifier) @variable
 ; Assume all-caps names are constants
 ((identifier) @constant
  (#vim-match? @constant "^[A-Z][A-Z\\d_]+$'"))
@@ -123,6 +124,7 @@
  ] @punctuation.delimiter
 
 (parameter (identifier) @parameter)
+(closure_parameters (identifier) @parameter)
 
 (lifetime (identifier) @label)
 


### PR DESCRIPTION
(File shown is Javascript (.js))
Before: Parameter in callback function highlighted as TSVariable (white)
![before](https://user-images.githubusercontent.com/64917719/111018787-f12d4980-8388-11eb-8e77-b5066c60e48e.png)
After: Parameter highlighted as TSParameter
![after](https://user-images.githubusercontent.com/64917719/111018790-f4283a00-8388-11eb-86e4-5098b5cdd04a.png)
(TSParameter colour is pink italic, TSVariable is white)
Arrow functions taking a single parameter with brackets omitted were not having their function arguments highlighted when they were passed as an argument.
