### PR TITLE
Remove SKIP_LOCKFILE_UPDATES_FOR_LANGS

### DIFF
--- a/.github/workflows/update-parsers-pr.yml
+++ b/.github/workflows/update-parsers-pr.yml
@@ -27,8 +27,6 @@ jobs:
           ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter/start
 
       - name: Update parsers
-        env:
-          SKIP_LOCKFILE_UPDATE_FOR_LANGS: clojure
         run: |
           ./nvim.appimage --headless -c "luafile ./scripts/write-lockfile.lua" -c "q"
           # Pretty print


### PR DESCRIPTION
This is an attempt to attend to: https://github.com/nvim-treesitter/nvim-treesitter/pull/1037#discussion_r595484547
as tree-sitter-clojure's master branch now has changes for upgrading to 0.19.x on it.

@theHamsta How's this?