### PR TITLE
Syntax plus treesitter

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -22,7 +22,8 @@ local builtin_modules = {
     enable = false,
     disable = {'markdown'}, -- FIXME(vigoux): markdown highlighting breaks everything for now
     custom_captures = {},
-    is_supported = queries.has_highlights
+    is_supported = queries.has_highlights,
+    additional_vim_regex_highlighting = false,
   },
   incremental_selection = {
     module_path = 'nvim-treesitter.incremental_selection',

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -104,7 +104,9 @@ function M.attach(bufnr, lang)
   end
 
   ts.highlighter.new(parser, {})
-  if config.additional_vim_regex_highlighting then
+
+  local is_table = type(config.additional_vim_regex_highlighting) == 'table'
+  if config.additional_vim_regex_highlighting and (not is_table or config.additional_vim_regex_highlighting[lang]) then
     api.nvim_buf_set_option(bufnr, 'syntax', 'ON')
   end
 end

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -104,6 +104,9 @@ function M.attach(bufnr, lang)
   end
 
   ts.highlighter.new(parser, {})
+  if config.additional_vim_regex_highlighting then
+    api.nvim_buf_set_option(bufnr, 'syntax', 'ON')
+  end
 end
 
 function M.detach(bufnr)


### PR DESCRIPTION
I thought this is a better solution than giving an option to `ts.highlighter` (the culprit that deactivates syntax) because it seems to handle also the case no syntax was loaded (though in a weird way by deactivating syntax and then checking whether it's deactivated).

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/959

 @sperezconesa can you check whether this works?

You would add the option `additional_vim_regex_highlighting = true` to you setup call of nvim-treesitter in the highlight section.
