### PR TITLE
go: add builtin types

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -103,6 +103,12 @@
 "var" @keyword
 
 
+;; Builtin types
+
+((type_identifier) @type.builtin
+ (#match? @type.builtin "^(bool|byte|complex128|complex64|error|float32|float64|int|int16|int32|int64|int8|rune|string|uint|uint16|uint32|uint64|uint8|uintptr)$"))
+
+
 ;; Builtin functions
 
 ((identifier) @function.builtin


### PR DESCRIPTION
As same as https://github.com/nvim-treesitter/nvim-treesitter/pull/1034 which adds built-in functions, this PR adds built-in `types`.
ref: https://golang.org/pkg/builtin/