### PR TITLE
Fix indent size

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -39,10 +39,6 @@ local get_indents = utils.memoize_by_buf_tick(function(bufnr)
   }
 end)
 
-local function get_indent_size()
-  return vim.bo.softtabstop > 0 and vim.bo.shiftwidth or vim.bo.tabstop
-end
-
 function M.get_indent(lnum)
   local parser = parsers.get_parser()
   if not parser or not lnum then return -1 end
@@ -52,7 +48,7 @@ function M.get_indent(lnum)
   local node = get_node_at_line(root, lnum-1)
 
   local indent = 0
-  local indent_size = get_indent_size()
+  local indent_size = vim.fn.shiftwidth()
 
   -- to get corret indetation when we land on an empty line (for instance by typing `o`), we try
   -- to use indentation of previous nonblank line, this solves the issue also for languages that


### PR DESCRIPTION
The current implementation can make indent_size zero if shiftwidth is zero which results in no indentation for any line. With normal vim auto-indent shiftwidth is always used for indent size, unless it's zero in which case tabstop is used instead. The `vim.fn.shiftwidth()` function returns shiftwidth if it's non-zero and tabstop otherwise.