### PR TITLE
rust: treat `,` as a punctuation delimiter

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -121,6 +121,7 @@
 "::"
 "."
 ";"
+","
  ] @punctuation.delimiter
 
 (parameter (identifier) @parameter)


### PR DESCRIPTION
Treat `,` as a punctuation delimiter for `Rust`.