### PR TITLE
Address #1067: check whether lockfile exists

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -33,7 +33,8 @@ end
 
 local function get_revision(lang)
   if #lockfile == 0 then
-    lockfile = vim.fn.json_decode(vim.fn.readfile(utils.join_path(utils.get_package_path(), 'lockfile.json')))
+    local filename = utils.join_path(utils.get_package_path(), 'lockfile.json')
+    lockfile = vim.fn.filereadable(filename) == 1 and vim.fn.json_decode(vim.fn.readfile(filename)) or {}
   end
   return (lockfile[lang] and lockfile[lang].revision)
 end


### PR DESCRIPTION
@richban could you try which path this function actually returns on your machine: https://github.com/theHamsta/nvim-treesitter/blob/b8c2128e7954fd7916c2004d92aa831b8f2d9c32/lua/nvim-treesitter/utils.lua#L40-L46 ?

This PR should at least allow you to use nvim-treesitter without lockfile when it does not exist.