### PR TITLE
Health error

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [verilog](https://github.com/tree-sitter/tree-sitter-verilog) (maintained by @zegervdv)
 - [x] [vue](https://github.com/ikatyang/tree-sitter-vue) (maintained by @WhyNotHugo)
 - [ ] [yaml](https://github.com/ikatyang/tree-sitter-yaml)
-- [ ] [zig](https://github.com/Himujjal/tree-sitter-zig)
+- [x] [zig](https://github.com/Himujjal/tree-sitter-zig) (maintained by @Himujjal)
 <!--parserinfo-->
 
 

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -66,27 +66,27 @@ do
   --- Same as `vim.treesitter.query` except will return cached values
   function M.get_query(lang, query_name)
     if cache[lang][query_name] == nil then
-      M.reload_file_cache(lang, query_name)
+      cache[lang][query_name] = tsq.get_query(lang, query_name)
     end
 
     return cache[lang][query_name]
   end
 
-  --- Reloads the query file cache.
+  --- Invalidates the query file cache.
   --- If lang and query_name is both present, will reload for only the lang and query_name.
   --- If only lang is present, will reload all query_names for that lang
   --- If none are present, will reload everything
-  function M.reload_file_cache(lang, query_name)
+  function M.invalidate_query_cache(lang, query_name)
     if lang and query_name then
-      cache[lang][query_name] = tsq.get_query(lang, query_name)
+      cache[lang][query_name] = nil
     elseif lang and not query_name then
       for query_name, _ in pairs(cache[lang]) do
-        M.reload_file_cache(lang, query_name)
+        M.invalidate_query_cache(lang, query_name)
       end
     elseif not lang and not query_name then
       for lang, _ in pairs(cache) do
         for query_name, _ in pairs(cache[lang]) do
-          M.reload_file_cache(lang, query_name)
+          M.invalidate_query_cache(lang, query_name)
         end
       end
     else
@@ -96,9 +96,9 @@ do
 end
 
 --- This function is meant for an autocommand and not to be used. Only use if file is a query file.
-function M.reload_file_cache_on_write(fname)
+function M.invalidate_query_file(fname)
   local fnamemodify = vim.fn.fnamemodify
-  M.reload_file_cache(fnamemodify(fname, ':p:h:t'), fnamemodify(fname, ':t:r'))
+  M.invalidate_query_cache(fnamemodify(fname, ':p:h:t'), fnamemodify(fname, ':t:r'))
 end
 
 function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -7,7 +7,7 @@ endif
 augroup NvimTreesitter
   " on every query file write we want to set an autocommand that will reload the cache
   autocmd FileType query
-      \ autocmd! NvimTreesitter BufWritePost <buffer> call v:lua.require('nvim-treesitter.query').reload_file_cache_on_write(expand('%:p'))
+      \ autocmd! NvimTreesitter BufWritePost <buffer> call v:lua.require('nvim-treesitter.query').invalidate_query_file(expand('%:p'))
 augroup END
 
 let g:loaded_nvim_treesitter = 1


### PR DESCRIPTION
Recently we don't get the actual error message due to compact health check. At least when we have errors we should not be too compact. Also really do the health check and don't rely on previously cached query loads.

![image](https://user-images.githubusercontent.com/7189118/112208716-f4da8f00-8c18-11eb-84ba-e2ae278126d4.png)
