### PR TITLE
highlights(rust): Highlight dereferenced closure parameters

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -125,7 +125,7 @@
  ] @punctuation.delimiter
 
 (parameter (identifier) @parameter)
-(closure_parameters (identifier) @parameter)
+(closure_parameters (_) @parameter)
 
 (lifetime (identifier) @label)
 


### PR DESCRIPTION
The closure parameters can be de-referenced and then they are no longer identifier but ref_patterns.

```rust
vec.iter().fold(0, |acc, &m| acc + m)
```

Before:
![image](https://user-images.githubusercontent.com/7189118/112232423-d4bac800-8c38-11eb-80f9-1cfe54318ca5.png)


After:
![image](https://user-images.githubusercontent.com/7189118/112232397-c5d41580-8c38-11eb-8e5e-2cf5e0d2d6f3.png)
