### PR TITLE
feat(install): ignore parser install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ All modules are disabled by default and need to be activated explicitly in your 
 lua <<EOF
 require'nvim-treesitter.configs'.setup {
   ensure_installed = "maintained", -- one of "all", "maintained" (parsers with maintainers), or a list of languages
+  ignore_install = { "javascript" }, -- List of parsers to ignore installing
   highlight = {
     enable = true,              -- false will disable the whole extension
     disable = { "c", "rust" },  -- list of language that will be disabled

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -37,6 +37,7 @@ To enable supported features, put this in your `init.vim` file:
   lua <<EOF
   require'nvim-treesitter.configs'.setup {
     ensure_installed = "maintained", -- one of "all", "maintained" (parsers with maintainers), or a list of languages
+    ignore_install = { "javascript" }, -- List of parsers to ignore installing
     highlight = {
       enable = true,              -- false will disable the whole extension
       disable = { "c", "rust" },  -- list of language that will be disabled

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -10,6 +10,7 @@ local M = {}
 local config = {
   modules = {},
   ensure_installed = {},
+  ignore_install = {},
   update_strategy = 'lockfile',
 }
 -- List of modules that need to be setup on initialization.
@@ -271,6 +272,7 @@ end
 -- @param user_data module overrides
 function M.setup(user_data)
   config.modules = vim.tbl_deep_extend('force', config.modules, user_data)
+  config.ignore_install = user_data.ignore_install or {}
 
   local ensure_installed = user_data.ensure_installed or {}
   if #ensure_installed > 0 then
@@ -410,6 +412,10 @@ end
 
 function M.get_update_strategy()
   return config.update_strategy
+end
+
+function M.get_ignored_parser_installs()
+  return config.ignore_install or {}
 end
 
 return M

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -141,4 +141,29 @@ function M.index_of(tbl, obj)
   end
 end
 
+-- Filters a list based on the given predicate
+-- @param tbl The list to filter
+-- @param predicate The predicate to filter with
+function M.filter(tbl, predicate)
+  local result = {}
+
+  for i, v in ipairs(tbl) do
+    if predicate(v, i) then
+      table.insert(result, v)
+    end
+  end
+
+  return result
+end
+
+-- Returns a list of all values from the first list
+-- that are not present in the second list.
+-- @params tbl1 The first table
+-- @params tbl2 The second table
+function M.difference(tbl1, tbl2)
+  return M.filter(tbl1, function(v)
+    return not vim.tbl_contains(tbl2, v)
+  end)
+end
+
 return M


### PR DESCRIPTION
This allows a list of parsers to be ignored from install. This is useful when you want 'all' parsers except maybe one that may be having issues or that you just don't want. For example, my scenario, three parsers fail to compile on macos so I want to exclude them.