### PR TITLE
Fix jsdoc: play nice with the comment parser

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -1,4 +1,5 @@
-((comment) @comment @jsdoc)
+(comment) @jsdoc
+(comment) @comment
 
 ((regex_pattern) @regex)
 

--- a/queries/jsdoc/highlights.scm
+++ b/queries/jsdoc/highlights.scm
@@ -1,3 +1,2 @@
-(_) @comment
 (tag_name) @keyword
 (type) @type


### PR DESCRIPTION
Using separate queries makes it work as expected.
Also, for the comment parser to be able to override the other tokens
we need to remove the comment from highlights (this shouldn't be a
problem since that section is already highlighted as a comment).

And, the order of the captures matter,
having jsdoc first will have more priority over `@param`.

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1069

![Screenshot from 2021-03-26 14-25-43](https://user-images.githubusercontent.com/4975310/112683210-30ef3900-8e3f-11eb-9e37-2ae688588740.png)
