### PR TITLE
Add an alternative implementation to find definitions

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -94,7 +94,7 @@ query.add_predicate('is-fast?', function(match, pattern, bufnr, pred)
 
   if not node then return true end
 
-  local found = locals.find_definition_fast(bufnr, node)
+  local found = locals.find_definition_fast(node, bufnr)
 
   return found and found.type and type == found.type
 end)

--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -84,6 +84,21 @@ query.add_predicate("is?", function(match, pattern, bufnr, pred)
   return vim.tbl_contains(types, kind)
 end)
 
+query.add_predicate('is-fast?', function(match, pattern, bufnr, pred)
+  if not valid_args("is-fast?", pred, 2) then return end
+
+  -- Avoid circular dependencies
+  local locals = require"nvim-treesitter.locals"
+  local node = match[pred[2]]
+  local type =pred[3]
+
+  if not node then return true end
+
+  local found = locals.find_definition_fast(bufnr, node)
+
+  return found and found.type and type == found.type
+end)
+
 query.add_predicate("has-type?", function(match, pattern, bufnr, pred)
   if not valid_args(pred[1], pred, 2) then
     return

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -103,6 +103,10 @@
 ;; Normal parameters
 (parameters
   (identifier) @parameter)
+
+((identifier) @parameter
+(#is-fast? @parameter "definition.parameter"))
+
 ;; Lambda parameters
 (lambda_parameters
   (identifier) @parameter)


### PR DESCRIPTION
I made an alternative implementation to resolve definitions. I hope it's faster. I did not measure it. So it might be a lie. But when I tested it on larger Python files I didn't encounter any typing problems.

The current implementation does not take advantage of incremental parsing and never releases memory. Incremental updating could be done easily by updating the new region. There is no need to evict old entries so eventually garbage will aggregate in the scope tree and we could do a garbage collection from time to time or just delete the whole tree.

~~EDIT: I think it still has bug. Not all definitions are correct.~~
EDIT: not all local query files are correct :smile: 