### PR TITLE
Add node requirement

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -84,7 +84,7 @@
     "revision": "ea43db6830632fd3531b9cbc34a93502b0d4339a"
   },
   "ledger": {
-    "revision": "609d5e5ab5955823b3faeaec8d2afc91860c639a"
+    "revision": "d4a37df03a51e6949256773f43091cb8388eb6b2"
   },
   "lua": {
     "revision": "b6d4e9e10ccb7b3afb45018fbc391b4439306b23"

--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -25,6 +25,17 @@ local function install_health()
     health_ok('`tree-sitter` found '..version..' (parser generator, only needed for :TSInstallFromGrammar)')
   end
 
+  if fn.executable('node') == 0 then
+    health_warn('`node` executable not found (only needed for :TSInstallFromGrammar,'..
+                ' not required for :TSInstall)')
+  else
+    local handle = io.popen('node --version')
+    local result = handle:read("*a")
+    handle:close()
+    local version = vim.split(result,'\n')[1]
+    health_ok('`node` found '..version..' (only needed for :TSInstallFromGrammar)')
+  end
+
   if fn.executable('git') == 0 then
     health_error('`git` executable not found.', {
       'Install it with your package manager.',

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -169,6 +169,9 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
     end
     return
   end
+  if generate_from_grammar and vim.fn.executable('node') ~= 1 then
+    api.nvim_err_writeln('node JS not found: `node` is not executable!')
+  end
   local cc = shell.select_executable(M.compilers)
   if not cc then
     api.nvim_err_writeln('No C compiler found! "'

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -170,7 +170,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
     return
   end
   if generate_from_grammar and vim.fn.executable('node') ~= 1 then
-    api.nvim_err_writeln('node JS not found: `node` is not executable!')
+    api.nvim_err_writeln('Node JS not found: `node` is not executable!')
   end
   local cc = shell.select_executable(M.compilers)
   if not cc then

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -544,11 +544,20 @@ function M.ft_to_lang(ft)
 end
 
 function M.available_parsers()
-  return vim.tbl_keys(M.list)
+  if vim.fn.executable('tree-sitter') == 1 then
+    return vim.tbl_keys(M.list)
+  else
+    return vim.tbl_filter(function(p) return not M.list[p].install_info.requires_generate_from_grammar end,
+                          vim.tbl_keys(M.list))
+  end
 end
 
 function M.maintained_parsers()
-  return vim.tbl_filter(function(lang) return M.list[lang].maintainers end, M.available_parsers())
+  local has_tree_sitter_cli = vim.fn.executable('tree-sitter') == 1
+  return vim.tbl_filter(function(lang)
+    return M.list[lang].maintainers
+           and (has_tree_sitter_cli or not M.list[lang].install_info.requires_generate_from_grammar) end,
+    M.available_parsers())
 end
 
 function M.get_parser_configs()

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -76,7 +76,6 @@ list.ledger = {
   install_info = {
     url = "https://github.com/cbarrete/tree-sitter-ledger",
     files = { "src/parser.c" },
-    requires_generate_from_grammar  = true,
   },
   maintainers = {"@cbarrete"},
 }


### PR DESCRIPTION
- Error when `node` is not available on `:TSInstallFromGrammar`
- exclude `requires_install_from_grammar` parsers from `all`/`maintained` when user has no tree-sitter CLI

Will the parsers be updated to 0.19.X at some point? @cbarrete @undu  @ostera @madskjeldgaard @leo60228