### PR TITLE
fix: indents

### DIFF
--- a/queries/html/indents.scm
+++ b/queries/html/indents.scm
@@ -9,3 +9,5 @@
 ] @branch
 
 (comment) @ignore
+
+(text) @ignore_end

--- a/queries/jsx/indents.scm
+++ b/queries/jsx/indents.scm
@@ -10,3 +10,5 @@
   (jsx_closing_element)
   ">"
 ] @branch
+
+(jsx_text) @ignore_end

--- a/queries/rust/indents.scm
+++ b/queries/rust/indents.scm
@@ -3,6 +3,7 @@
   (struct_item)
   (enum_item)
   (impl_item)
+  (declaration_list)
   (for_expression)
   (struct_expression)
   (match_expression)


### PR DESCRIPTION
Well let me say one thing:
It is quite hard to make indent work for multiple languages. So many edge cases.

ok so what i've noted so far:
- by getting the last node on the last non empty line, it fixes rust else branch because the matched node was the `}` from the previous node
- but it doesn't fix the `else` branch for go
- python works on proper files, but opening a new one and entering `def main():<CR>` does not properly indent
- for this little hack to work, i had to make a special node table for xml like file (html, jsx) because last nodes are always `text` which wraps at the next line.
- also unrelated to this PR, but on typescript files, doing `o` after function calls like:
```typescript
func()
  .doSomething()
  .doOtherThing(' ');
```
will indent just like the previous line although we want to indent like the `func` line.
- oh and open a 3K lines file and typing `o` is terribly slow now. This whole algorithm takes too much time. Maybe it is too complex and we did not find the best alternative, although i'm not sure if there is one :(