### PR TITLE
Comment: highlight text nodes

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -18,7 +18,7 @@
     "revision": "95c7959c461406381b42113dcf4591008c663d21"
   },
   "comment": {
-    "revision": "4a47080791683ce1bdfba85255df4d512edbb5d5"
+    "revision": "814bf323edb504caee2331872b854c9f19eb5d2b"
   },
   "cpp": {
     "revision": "c61212414a3e95b5f7507f98e83de1d638044adc"

--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -10,7 +10,13 @@
 ((tag ((name) @text.warning))
  (#match? @text.warning "^(TODO|HACK|WARNING)$"))
 
+("text" @text.warning
+ (#match? @text.warning "^(TODO|HACK|WARNING)$"))
+
 ((tag ((name) @text.danger))
+ (#match? @text.danger "^(FIXME|XXX|BUG)$"))
+
+("text" @text.danger
  (#match? @text.danger "^(FIXME|XXX|BUG)$"))
 
 ; Issue number (#123)


### PR DESCRIPTION
As requested in https://github.com/nvim-treesitter/nvim-treesitter/issues/236#issuecomment-797878646. No colons needed.

![Screenshot from 2021-04-02 12-00-09](https://user-images.githubusercontent.com/4975310/113436817-048d6c80-93ab-11eb-8116-6504e1d33f86.png)
