### PR TITLE
Improve :TSModuloInfo output

### DIFF
--- a/lua/nvim-treesitter/info.lua
+++ b/lua/nvim-treesitter/info.lua
@@ -37,15 +37,20 @@ local function print_info_module(sorted_languages, mod)
   end
 end
 
-local function print_info_modules(sorted_languages)
-  local max_str_len = #sorted_languages[1]
+local function print_info_modules(parserlist)
+  table.sort(parserlist, function(a, b) return #a > #b end)
+  local max_str_len = #parserlist[1]
+
   local header = string.rep(' ', max_str_len + 2)
-  for _, mod in pairs(configs.available_modules()) do
+  local mods = configs.available_modules()
+  table.sort(mods)
+  for _, mod in pairs(mods) do
     header = string.format('%s%s ', header, mod)
   end
   api.nvim_out_write(header..'\n')
 
-  for _, lang in pairs(sorted_languages) do
+  table.sort(parserlist)
+  for _, lang in pairs(parserlist) do
     local padding = string.rep(' ', max_str_len - #lang)
     api.nvim_out_write(lang..":"..padding)
 
@@ -68,7 +73,6 @@ local function module_info(mod)
   if mod and not configs.get_module(mod) then return end
 
   local parserlist = parsers.available_parsers()
-  table.sort(parserlist, function(a, b) return #a > #b end)
   if mod then
     print_info_module(parserlist, mod)
   else

--- a/lua/nvim-treesitter/info.lua
+++ b/lua/nvim-treesitter/info.lua
@@ -41,29 +41,26 @@ local function print_info_modules(parserlist)
   table.sort(parserlist, function(a, b) return #a > #b end)
   local max_str_len = #parserlist[1]
 
-  local header = string.rep(' ', max_str_len + 2)
+  local header = string.rep(' ', max_str_len + 1)
   local mods = configs.available_modules()
   table.sort(mods)
   for _, mod in pairs(mods) do
-    header = string.format('%s%s ', header, mod)
+    header = string.format('%s %s ', header, mod)
   end
-  api.nvim_out_write(header..'\n')
+  api.nvim_out_write(header .. '\n')
 
   table.sort(parserlist)
   for _, lang in pairs(parserlist) do
-    local padding = string.rep(' ', max_str_len - #lang)
-    api.nvim_out_write(lang..":"..padding)
+    local padding = string.rep(' ', max_str_len - #lang + 1)
+    api.nvim_out_write(lang .. ":" .. padding)
 
-    for _, mod in pairs(configs.available_modules()) do
-      local pad_len = #mod / 2 + 1
-      api.nvim_out_write(string.rep(' ', pad_len))
-
+    for _, mod in pairs(mods) do
       if configs.is_enabled(mod, lang) then
         api.nvim_out_write('✓')
       else
         api.nvim_out_write('✗')
       end
-      api.nvim_out_write(string.rep(' ', pad_len - 1))
+      api.nvim_out_write(string.rep(' ', #mod + 1))
     end
     api.nvim_out_write('\n')
   end


### PR DESCRIPTION
Just a few small changes to make it more pleasant to read (IMHO):

- 2 spaces between modules in the header
- always same module order in the header (random order is super confusing)
- marks are exactly below the start of the module name in the header
- most importantly.. sort the languges by name. :P

Before:

![](https://i.postimg.cc/1XF0JgMT/Screenshot-2021-04-05-at-13-39-09.png)

After:

![](https://i.postimg.cc/zXnShgyH/Screenshot-2021-04-05-at-13-39-31.png)