### PR TITLE
:TSModuleInfo rewrite

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -269,8 +269,17 @@ A list of languages can be found at |:TSInstallInfo|
                                                                *:TSModuleInfo*
 :TSModuleInfo [{module}]~
 
-List modules state for the current session.
+List the state for the given module or all modules for the current session in
+a new buffer.
 
+These highlight groups are used by default:
+>
+    highlight default TSModuleInfoGood guifg=LightGreen gui=bold
+    highlight default TSModuleInfoBad  guifg=Crimson
+    highlight default link TSModuleInfoHeader    Type
+    highlight default link TSModuleInfoNamespace Statement
+    highlight default link TSModuleInfoParser    Identifier
+<
 ==============================================================================
 UTILS                                                  *nvim-treesitter-utils*
 

--- a/lua/nvim-treesitter/info.lua
+++ b/lua/nvim-treesitter/info.lua
@@ -37,33 +37,97 @@ local function print_info_module(sorted_languages, mod)
   end
 end
 
-local function print_info_modules(parserlist)
-  table.sort(parserlist, function(a, b) return #a > #b end)
-  local max_str_len = #parserlist[1]
-
-  local header = string.rep(' ', max_str_len + 1)
-  local mods = configs.available_modules()
-  table.sort(mods)
-  for _, mod in pairs(mods) do
-    header = string.format('%s %s ', header, mod)
-  end
-  api.nvim_out_write(header .. '\n')
-
-  table.sort(parserlist)
-  for _, lang in pairs(parserlist) do
-    local padding = string.rep(' ', max_str_len - #lang + 1)
-    api.nvim_out_write(lang .. ":" .. padding)
-
-    for _, mod in pairs(mods) do
-      if configs.is_enabled(mod, lang) then
-        api.nvim_out_write('✓')
-      else
-        api.nvim_out_write('✗')
+-- Sort a list of modules into namespaces.
+-- {'mod1', 'mod2.sub1', 'mod2.sub2', 'mod3'}
+-- ->
+-- { default = {'mod1', 'mod3'}, mod2 = {'sub1', 'sub2'}}
+local function namespace_modules(modulelist)
+  local modules = { default = {} }
+  for _, module in ipairs(modulelist) do
+    if module:find('%.') then
+      local namespace, submodule = module:match('^(.*)%.(.*)$')
+      if not modules[namespace] then
+        modules[namespace] = {}
       end
-      api.nvim_out_write(string.rep(' ', #mod + 1))
+      table.insert(modules[namespace], submodule)
+    else
+      table.insert(modules.default, module)
     end
-    api.nvim_out_write('\n')
   end
+  return modules
+end
+
+local function longest_string_length(list)
+  local length = 0
+  for _, value in ipairs(list) do
+    if #value > length then
+      length = #value
+    end
+  end
+  return length
+end
+
+local function append_module_table(curbuf, parserlist, namespace, modulelist)
+  local maxlen_parser = longest_string_length(parserlist)
+  table.sort(modulelist)
+
+  -- header
+  local header = '>> ' .. namespace .. string.rep(' ', maxlen_parser - #namespace - 1)
+  for _, module in pairs(modulelist) do
+    header = header .. module .. '  '
+  end
+  api.nvim_buf_set_lines(curbuf, -1, -1, true, {header})
+
+  -- actual table
+  for _, parser in ipairs(parserlist) do
+    local padding = string.rep(' ', maxlen_parser - #parser + 2)
+    local line = parser ..  padding
+    local namespace_prefix = (namespace == 'default') and '' or namespace .. '.'
+    for _, module in pairs(modulelist) do
+      local modlen = #module
+      module = namespace_prefix .. module
+      if configs.is_enabled(module, parser) then
+        line = line .. '✓'
+      else
+        line = line .. '✗'
+      end
+      line = line .. string.rep(' ', modlen + 1)
+    end
+    api.nvim_buf_set_lines(curbuf, -1, -1, true, {line})
+  end
+
+  api.nvim_buf_set_lines(curbuf, -1, -1, true, {''})
+end
+
+local function print_info_modules(parserlist)
+  api.nvim_command('enew')
+  local curbuf = api.nvim_get_current_buf()
+
+  local modules = namespace_modules(configs.available_modules())
+  table.sort(parserlist)
+
+  local namespaces = {}
+  for k, _ in pairs(modules) do table.insert(namespaces, k) end
+  table.sort(namespaces)
+
+  for _, namespace in ipairs(namespaces) do
+    append_module_table(curbuf, parserlist, namespace, modules[namespace])
+  end
+
+  api.nvim_buf_set_option(curbuf, 'modified', false)
+  api.nvim_buf_set_option(curbuf, 'buftype', 'nofile')
+  api.nvim_exec([[
+    syntax match TSModuleInfoGood      /✓/
+    syntax match TSModuleInfoBad       /✗/
+    syntax match TSModuleInfoHeader    /^>>.*$/ contains=TSModuleInfoNamespace
+    syntax match TSModuleInfoNamespace /^>> \w*/ contained
+    syntax match TSModuleInfoParser    /^[^> ]*\ze /
+    highlight default TSModuleInfoGood guifg=LightGreen gui=bold
+    highlight default TSModuleInfoBad  guifg=Crimson
+    highlight default link TSModuleInfoHeader    Type
+    highlight default link TSModuleInfoNamespace Statement
+    highlight default link TSModuleInfoParser    Identifier
+  ]], false)
 end
 
 local function module_info(mod)


### PR DESCRIPTION
The new version uses its own buffer for listing the modules state for the current session.

Since there can be many modules and many using submodules, the code sorts them into namespaces. A list with the following modules..

    {'indent', 'highlight', 'refactor.smart_rename', 'refactor.navigation'}

..will be changed to..

    { default = {'indent', 'highlight'}, refactor = {'smart_rename', 'navigation'} }

There is one table per namespace.

The colors are up for debate, but I added the highlight groups to the doc, in case people don't like the defaults.

![](https://i.postimg.cc/wxnsrWss/Screenshot-2021-04-05-at-23-46-22.png)

![](https://i.postimg.cc/3xT08d18/Screenshot-2021-04-05-at-23-46-40.png)