### PR TITLE
Yaml: update locals

### DIFF
--- a/queries/yaml/locals.scm
+++ b/queries/yaml/locals.scm
@@ -1,1 +1,4 @@
 (document) @scope
+
+(anchor) @definition
+(alias) @reference


### PR DESCRIPTION
The parser doesn't break the symbols in `*` `&` from the name of
anchors/aliases. So go to definition doesn't work, but highlight of
usage does :D

Test with

```yaml
Defaults: &defaults
  Company: foo
  Item: 123

Computer:
  <<: *defaults
  <<: *defaults
  Price: 3000
```

Ref https://github.com/nvim-treesitter/nvim-treesitter-refactor/issues/18