### PR TITLE
locals(Go): add namespace definition for import_spec_list

### DIFF
--- a/queries/go/locals.scm
+++ b/queries/go/locals.scm
@@ -41,6 +41,10 @@
 (package_clause
    (package_identifier) @definition.namespace)
 
+(import_spec_list
+  (import_spec
+    name: (package_identifier) @definition.namespace))
+
 ;; Call references
 ((call_expression
    function: (identifier) @reference)


### PR DESCRIPTION
This would define `foo`
```go
import (
	foo "fmt"
)
```