### PR TITLE
rebased AdnoC/windows-tar-workaround on master

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -187,7 +187,6 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
         opts = {
           args = {
             'clone',
-            '-c', 'core.symlinks=true',
             '--single-branch',
             '--branch', repo.branch or 'master',
             repo.url,
@@ -202,7 +201,6 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
         err = 'Error while checking out revision',
         opts = {
           args = {
-            '-c', 'core.symlinks=true',
             'checkout', revision
           },
           cwd = git_folder

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -121,15 +121,13 @@ end
 
 function M.select_download_commands(repo, project_name, cache_folder, revision)
 
-  local has_tar = vim.fn.executable('tar') == 1
-  local has_curl = vim.fn.executable('curl') == 1
-  local is_github = repo.url:find("github.com", 1, true)
-  local is_gitlab = repo.url:find("gitlab.com", 1, true)
+  local can_use_tar = vim.fn.executable('tar') == 1 and vim.fn.executable('curl') == 1
+  local is_github_or_gitlab = repo.url:find("github.com", 1, true) or repo.url:find("gitlab.com", 1, true)
   local is_windows = fn.has('win32') == 1
 
   revision = revision or repo.branch or "master"
 
-  if has_tar and has_curl and (is_github or is_gitlab) and not is_windows then
+  if can_use_tar and is_github_or_gitlab and not is_windows then
 
     local path_sep = utils.get_path_sep()
     local url = repo.url:gsub('.git$', '')

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -185,8 +185,6 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
         opts = {
           args = {
             'clone',
-            '--single-branch',
-            '--branch', repo.branch or 'master',
             repo.url,
             project_name
           },
@@ -199,7 +197,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
         err = 'Error while checking out revision',
         opts = {
           args = {
-            'checkout', revision
+            'checkout', revision,
           },
           cwd = git_folder
         }

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -175,9 +175,6 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
   else
     local git_folder = utils.join_path(cache_folder, project_name)
     local clone_error = 'Error during download, please verify your internet connection'
-    if is_windows then
-      clone_error = clone_error .. ". If on Windows you may need to enable Developer mode"
-    end
 
     return {
       {

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -141,7 +141,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
         opts = {
           args = {
             '-L', -- follow redirects
-            is_github and url.."/archive/"..revision..".tar.gz"
+            is_github_or_gitlab and url.."/archive/"..revision..".tar.gz"
                       or url.."/-/archive/"..revision.."/"..project_name.."-"..revision..".tar.gz",
             '--output',
             project_name..".tar.gz"

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -122,12 +122,14 @@ end
 function M.select_download_commands(repo, project_name, cache_folder, revision)
 
   local can_use_tar = vim.fn.executable('tar') == 1 and vim.fn.executable('curl') == 1
-  local is_github_or_gitlab = repo.url:find("github.com", 1, true) or repo.url:find("gitlab.com", 1, true)
+  local is_github = repo.url:find("github.com", 1, true)
+  local is_gitlab = repo.url:find("gitlab.com", 1, true)
+
   local is_windows = fn.has('win32') == 1
 
   revision = revision or repo.branch or "master"
 
-  if can_use_tar and is_github_or_gitlab and not is_windows then
+  if can_use_tar and (is_github or is_gitlab) and not is_windows then
 
     local path_sep = utils.get_path_sep()
     local url = repo.url:gsub('.git$', '')
@@ -141,7 +143,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
         opts = {
           args = {
             '-L', -- follow redirects
-            is_github_or_gitlab and url.."/archive/"..revision..".tar.gz"
+            is_github and url.."/archive/"..revision..".tar.gz"
                       or url.."/-/archive/"..revision.."/"..project_name.."-"..revision..".tar.gz",
             '--output',
             project_name..".tar.gz"


### PR DESCRIPTION
This PR is a rebase of https://github.com/AdnoC/nvim-treesitter/tree/windows-tar-workaround as requested in #813.
This is a quick rebase, I've tried to keep the intended logic in place but I'm not exactly a git guru. 😃

There was one change introduced in 60e67de18c69d57691b09738585d58515458a281 which introduces the use of  `'-c', 'core.symlinks=true'` which caused the clone to fail again so I deleted that line.

I hope, that's okay. 😃 
At least I could now run `:TSUpdate`  and successfully update tree-sitter-typescript.
