### PR TITLE
#downcase! directive to use with ruby injections

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -87,3 +87,30 @@ end)
 
 -- Just avoid some anoying warnings for this directive
 query.add_directive('make-range!', function() end)
+
+query.add_directive('downcase!', function(match, _, bufnr, pred, metadata)
+  local text, key, value
+
+  if #pred == 3 then
+    -- (#downcase! @capture "key")
+    key = pred[3]
+    value = metadata[pred[2]][key]
+  else
+    -- (#downcase! "key")
+    key = pred[2]
+    value = metadata[key]
+  end
+
+  if type(value) == "string" then
+    text = value
+  else
+    local node = match[value]
+    text = query.get_node_text(node, bufnr)
+  end
+
+  if #pred == 3 then
+    metadata[pred[2]][key] = string.lower(text)
+  else
+    metadata[key] = string.lower(text)
+  end
+end)

--- a/queries/ruby/injections.scm
+++ b/queries/ruby/injections.scm
@@ -1,1 +1,7 @@
 (comment) @comment
+
+(heredoc_body
+ (heredoc_content) @content
+ (heredoc_end) @language
+ (#set! "language" @language)
+ (#downcase! "language"))


### PR DESCRIPTION
## What

This is a follow-up to https://github.com/neovim/neovim/pull/14152 which was superseded by https://github.com/neovim/neovim/pull/14046 which allows setting the injected parser language on the metadata field of directives.

### Add a `downcase!` directive

I moved the implementation of the `#downcase!` directive I proposed in https://github.com/neovim/neovim/pull/14152 to this plugin as it seems to be a better home for it.

Often times the text matched by an `@language` node may not exactly resemble the name of the parser for that language. More often than not the parser name will be lowercase, i.e. `html` instead of `HTML`. In the below example ruby code a string constant is defined using ruby's heredoc syntax. The coding conventions for heredocs are to surround the string content with the name of the language in all uppercase letters ie. `HTML`, `SQL`, `JAVASCRIPT`, etc.

```ruby
class A
  MY_HTML = <<~HTML
    <title>This is a title</title>
    <div class="example-class">
      <span>This is a span</span>
    </div>
  HTML
end
```

The `downcase!` directive is used in an `queries/ruby/injections.scm` file like so to convert the `HTML` value in the `@language` node to a valid lowercase `html` name of the parser.

```scm
(heredoc_body
 (heredoc_content) @content
 (heredoc_end) @language
 (#set! "language" @language)
 (#downcase! "language"))
```

### Screenshot

<img width="1283" alt="Screen Shot 2021-04-15 at 15 48 00" src="https://user-images.githubusercontent.com/6456191/114919545-f277e900-9e02-11eb-813e-b11ad53df99a.png">
