### PR TITLE
Fix TSEditQuery with several files

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -207,9 +207,18 @@ function M.edit_query_file(query_group, lang)
     vim.cmd(':edit '..files[1])
   else
     local counter = 0
-    local choice = vim.fn.inputlist(vim.tbl_map(function(f) counter = counter + 1;return counter..'. '..f end, files))
-    if choice > 0 then
-      vim.cmd(':edit '..files[choice + 1])
+    local choices = {
+      'Select a file:',
+      table.unpack(vim.tbl_map(function(f)
+          counter = counter + 1
+          return counter..'. '..f
+        end,
+        files
+      ))
+    }
+    local choice = vim.fn.inputlist(choices)
+    if choice > 0 and choice <= #files then
+      vim.cmd(':edit '..files[choice])
     end
   end
 end


### PR DESCRIPTION
- Choice already starts with 1, there isn't need to increment 1
- The first item is the prompt as recommended in `:h inputlist()`
  (this way the choice matches when using the mouse)