### PR TITLE
Indent Ruby singleton classes

### DIFF
--- a/queries/ruby/indents.scm
+++ b/queries/ruby/indents.scm
@@ -1,5 +1,6 @@
 [
   (class)
+  (singleton_class)
   (method)
   (singleton_method)
   (module)


### PR DESCRIPTION
Hi all!

I have been using *nvim-treesitter*  for a few days (thanks!) and I found out that Ruby singleton classes are not indented. This is the result:

```ruby
class Sample
  class << self
  def say_hello
    "hello!"
  end
  end
end
```

Adding the `singleton_class` element to the `indents.scm` list makes indentation look good:

```ruby
class Sample
  class << self
    def say_hello
      "hello!"
    end
  end
end
```

Thanks!