### PR TITLE
Fix GDScript highlighting

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -464,7 +464,7 @@ list.gdscript = {
     requires_generate_from_grammar  = true,
   },
   readme_name = "Godot (gdscript)",
-  maintainers = {"not @tjdevries"},
+  maintainers = {"@Shatur95"},
 }
 
 list.turtle = {

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -30,7 +30,8 @@
   (#match? @type "^[A-Z]"))
 ((identifier) @constant
   (#match? @constant "^[A-Z][A-Z_0-9]*$"))
-((identifier) @type . ".")
+((identifier) @type
+  (#match? @type "^[A-Z][A-Z_0-9]*$") . (_))
 
 ((attribute
     (identifier) @field)

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -1,27 +1,127 @@
+;; Basic
 (identifier) @variable
-
 (name) @variable
 (type) @type
 (comment) @comment
+(get_node) @string
+(string) @string
+(float) @float
+(integer) @number
+(null) @constant
+(setter) @function
+(getter) @function
+(static_keyword) @keyword
+(tool_statement) @keyword
+(breakpoint_statement) @keyword
+(inferred_type) @operator
+[(true) (false)] @boolean
 
-(enum_definition
-  (name) @constant) @Statement
+(class_name_statement
+  (name) @type) @keyword
+
+(const_statement
+  (name) @constant) @keyword
+
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "self"))
+
+;; Identifier naming conventions
+((identifier) @type
+  (#match? @type "^[A-Z]"))
+((identifier) @constant
+  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+((identifier) @type . ".")
+
+((attribute
+    (identifier) @field)
+ (#vim-match? @field "^([A-Z])@!.*$"))
+
+;; Functions
+(constructor_definition) @constructor
 
 (function_definition
-  (name) @function
-  (parameters
-    (identifier)* @parameter) @punctuation.bracket) @Statement
+  (name) @function (parameters
+    (identifier) @parameter)*)
 
-(return_statement) @Statement
+(typed_parameter
+  (identifier) @parameter)
 
-(variable_statement
-  (inferred_type)? @operator) @Statement
+(default_parameter
+  (identifier) @parameter)
 
-(call (identifier) @function) @punctuation.bracket
-(attribute (attribute_call (identifier) @function) @punctuation.bracket)
+(call
+  (identifier) @function)
+(attribute_call
+  (identifier) @function)
 
-; simple items
-[ (binary_operator) (comparison_operator) ] @operator
-[ (false) (true) ] @boolean
-(string) @string
-(integer) @number
+;; Alternations
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
+
+["," "." ":"] @punctuation.delimiter
+
+["if" "elif" "else" "match"] @conditional
+
+["for" "while" "break" "continue"] @repeat
+
+[
+  "~"
+  "-"
+  "*"
+  "/"
+  "%"
+  "+"
+  "-"
+  "<<"
+  ">>"
+  "&"
+  "^"
+  "|"
+  "<"
+  ">"
+  "=="
+  "!="
+  ">="
+  "<="
+  "!"
+  "&&"
+  "||"
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
+  "%="
+  "&="
+  "|="
+  "->"
+] @operator
+
+[
+  "and"
+  "as"
+  "in"
+  "is"
+  "not"
+  "or"
+] @keyword.operator
+
+[
+  "pass"
+  "return"
+  "class"
+  "class_name"
+  "extends"
+  "signal"
+  "func"
+  "enum"
+  "var"
+  "onready"
+  "export"
+  "setget"
+  "remote"
+  "master"
+  "puppet"
+  "remotesync"
+  "mastersync"
+  "puppetsync"
+] @keyword


### PR DESCRIPTION
Everything is now highlighted correctly, similar to Python:
![изображение](https://user-images.githubusercontent.com/22453358/115152515-142ed580-a07a-11eb-93bf-42a7d395c666.png)

Also sent a PR to fix `:=` parsing in [grammar.js](https://github.com/PrestonKnopp/tree-sitter-gdscript/pull/5).

Many thanks to @theHamsta and @vigoux for guiding me!

Fixes #1181.