### PR TITLE
Fix #1207: update Haskell

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -54,7 +54,7 @@
     "revision": "ed8723cd660451c0b192af79183e29b5ce9916d2"
   },
   "haskell": {
-    "revision": "381dca04f20381ecb3f4306d727474755ad19cc4"
+    "revision": "2e33ffa3313830faa325fe25ebc3769896b3a68b"
   },
   "html": {
     "revision": "d93af487cc75120c89257195e6be46c999c6ba18"


### PR DESCRIPTION
Otherwise the Haskell parser would eat up all your RAM within seconds.