### PR TITLE
fix(lua): correctly highlight field names

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -138,7 +138,8 @@
 (string) @string
 (number) @number
 (label_statement) @label
-(field (identifier) @field)
+; A bit of a tricky one, this will only match field names
+(field . (identifier) @field (_))
 (shebang) @comment
 
 ;; Error


### PR DESCRIPTION
This correctly handles field names in lua.
The query is a bit bizarre then, but that's because the parser does
not handle fields so well...

Fixes #1180
