### PR TITLE
fix(highlights): always highlight ternary operator as operator

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -205,7 +205,7 @@
 ] @operator
 
 (binary_expression "/" @operator)
-(ternary_expression ["?" ":"] @operator)
+(ternary_expression ["?" ":"] @conditional)
 (unary_expression ["!" "~" "-" "+" "delete" "void" "typeof"]  @operator)
 
 "(" @punctuation.bracket

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -119,7 +119,7 @@
 (else_clause
   ["else"] @conditional)
 (ternary_expression
-  ["?" ":"] @operator)
+  ["?" ":"] @conditional)
 
 (function_definition ["function" "end"] @keyword.function)
 


### PR DESCRIPTION
Closes #470.

As a note:
  - Rust can't be done because the ternary is actually and `if {} else {}` statement
  - I can't find anything in Dart
