### PR TITLE
highlights(csharp): add "with" as `@keyword.operator`

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -179,18 +179,22 @@
 ] @include
 
 [
- "lock"
- "params"
- "ref"
+ "with"
+ "new"
+ "typeof"
  "sizeof"
- "operator"
+ "ref"
  "is"
  "as"
- "new"
+] @keyword.operator
+
+[
+ "lock"
+ "params"
+ "operator"
  "default"
  "yield"
  "return"
- "typeof"
  "abstract"
  "const"
  "extern"


### PR DESCRIPTION
Last update mentioned operator "with". We didn't have it in the queries.