### PR TITLE
Allow failures for defined parsers

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Check query files (Unix)
         if: matrix.os != 'windows-latest'
+        env:
+          ALLOWED_INSTALLATION_FAILURES: haskell
         run: nvim --headless -c "luafile ./scripts/check-queries.lua" -c "q"
 
       - name: Compile parsers Windows
@@ -53,6 +55,8 @@ jobs:
 
       - name: Check query files (Windows)
         if: matrix.os == 'windows-latest'
+        env:
+          ALLOWED_INSTALLATION_FAILURES: haskell
         run: C:\\tools\\neovim\\Neovim\\bin\\nvim.exe --headless -c "luafile ./scripts/check-queries.lua" -c "q"
 
       - uses: actions/upload-artifact@v2

--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -58,11 +58,15 @@ end
 
 
 local ok, err = pcall(do_check)
+local allowed_to_fail = vim.split(vim.env.ALLOWED_INSTALLATION_FAILURES or '', ",", true)
 
 for k, v in pairs(require 'nvim-treesitter.parsers'.get_parser_configs()) do
   if not require 'nvim-treesitter.parsers'.has_parser(k) then
     -- On CI all parsers that can be installed from C files should be installed
-    if vim.env.CI and not v.install_info.requires_generate_from_grammar then
+    if vim.env.CI
+      and not v.install_info.requires_generate_from_grammar
+      and not vim.tbl_contains(allowed_to_fail, k) then
+
       print('Error: parser for '..k..' is not installed')
       vim.cmd('cq')
     else


### PR DESCRIPTION
@vigoux  I don't know how to handle this best. I guess @elianiva needs some more time with the Haskell parser and it was expected to fail for a long time. We could have this to actually check whether CI is not failing for parsers we would not expect that it would. We could also just wait until Haskell can be installed properly-

A PR adding queries for Haskell should find a proper solution. 