### PR TITLE
Highlight v-bind and v-on using javascript

### DIFF
--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -25,4 +25,8 @@
 ((interpolation
   (raw_text) @javascript))
 
+((directive_attribute 
+    (quoted_attribute_value 
+      (attribute_value) @javascript)))
+
 (comment) @comment


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5359825/115755401-96323d80-a39d-11eb-8d5c-c6a8e0f514c5.png)

After:
![image](https://user-images.githubusercontent.com/5359825/115755531-bc57dd80-a39d-11eb-987e-857da14ef627.png)

This also works for v-bind (but not for regular arguments). Is this PR too naive? Perhaps there's some cases that I missed