### PR TITLE
[RFC] Make injections more configurable

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -92,9 +92,7 @@ end)
 -- Usage: (#inject-from! {value} [{default}])
 query.add_directive("inject-from!", function(match, pattern, bufnr, pred, metadata)
   local key = pred[2]
-  local default = pred[3] or ""
-
-  local injection = default
+  local injection = pred[3] or ""
   local language = parsers.get_buf_lang(bufnr)
   local config = configs.get_module("highlight").injections
   if config and config[language] and config[language][key] then

--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -1,4 +1,6 @@
 local query = require"vim.treesitter.query"
+local parsers = require"nvim-treesitter.parsers"
+local configs = require"nvim-treesitter.configs"
 
 local function error(str)
   vim.api.nvim_err_writeln(str)
@@ -84,6 +86,23 @@ query.add_predicate('has-type?', function(match, pattern, bufnr, pred)
 
   return vim.tbl_contains(types, node:type())
 end)
+
+
+-- Inject a language based on the value from `highlight.injections.{language}.{value}`.
+-- Usage: (#inject-from! {value} [{default}])
+query.add_directive("inject-from!", function(match, pattern, bufnr, pred, metadata)
+  local key = pred[2]
+  local default = pred[3] or ""
+
+  local injection = default
+  local language = parsers.get_buf_lang(bufnr)
+  local config = configs.get_module("highlight").injections
+  if config and config[language] and config[language][key] then
+    injection = config[key]
+  end
+  metadata.language = injection
+end)
+
 
 -- Just avoid some anoying warnings for this directive
 query.add_directive('make-range!', function() end)

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -6,21 +6,25 @@
  (#match? @regex "^r.*"))
 
 ; Module docstring
-((module . (expression_statement (string) @rst))
- (#offset! @rst 0 3 0 -3))
+((module . (expression_statement (string) @content))
+ (#offset! @content 0 3 0 -3)
+ (#inject-from! "docstrings" "rst"))
 
 ; Class docstring
 ((class_definition
-  body: (block . (expression_statement (string) @rst)))
- (#offset! @rst 0 3 0 -3))
+  body: (block . (expression_statement (string) @content)))
+ (#offset! @content 0 3 0 -3)
+ (#inject-from! "docstrings" "rst"))
 
 ; Function/method docstring
 ((function_definition
-  body: (block . (expression_statement (string) @rst)))
- (#offset! @rst 0 3 0 -3))
+  body: (block . (expression_statement (string) @content)))
+ (#offset! @content 0 3 0 -3)
+ (#inject-from! "docstrings" "rst"))
 
 ; Attribute docstring
-(((expression_statement (assignment)) . (expression_statement (string) @rst))
- (#offset! @rst 0 3 0 -3))
+(((expression_statement (assignment)) . (expression_statement (string) @content))
+ (#offset! @content 0 3 0 -3)
+ (#inject-from! "docstrings" "rst"))
 
 (comment) @comment


### PR DESCRIPTION
Mainly for the format used in python docstrings.

For example

```lua
require'nvim-treesitter.configs'.setup {
  highlight = {
    enable = true,
    disable = {},
    injections = {
      python = {
        docstrings: "markdown",
      },
    },
  },
}
```

If the implementation looks good I can document this

Close https://github.com/nvim-treesitter/nvim-treesitter/pull/1204