### PR TITLE
Add GDScript filetype and use BufNewFile,BufRead

### DIFF
--- a/ftdetect/gdscript.vim
+++ b/ftdetect/gdscript.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.gd set ft=gdscript

--- a/ftdetect/query.vim
+++ b/ftdetect/query.vim
@@ -8,4 +8,4 @@ function! s:shouldFt(path)
   endif
 endfunction
 
-autocmd BufEnter,BufNewFile *.scm call s:shouldFt(expand("%"))
+autocmd BufNewFile,BufRead *.scm call s:shouldFt(expand("%"))


### PR DESCRIPTION
I used `BufNewFile,BufRead` as suggested in `:h ftdetect`. I also noticed that we have `query.vim` that use `BufEnter,BufNewFile`. Probably we should change it to `BufNewFile,BufRead` too.