### PR TITLE
Comment: use `@combined` to create just one tree per buffer

### DIFF
--- a/queries/bash/injections.scm
+++ b/queries/bash/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -1,3 +1,3 @@
 (preproc_arg) @c
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/c_sharp/injections.scm
+++ b/queries/c_sharp/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/clojure/injections.scm
+++ b/queries/clojure/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/cpp/injections.scm
+++ b/queries/cpp/injections.scm
@@ -1,3 +1,3 @@
 (preproc_arg) @cpp
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/css/injections.scm
+++ b/queries/css/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/dart/injections.scm
+++ b/queries/dart/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/devicetree/injections.scm
+++ b/queries/devicetree/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -1,4 +1,4 @@
-(comment) @jsdoc
+(comment) @jsdoc @combined
 (comment) @comment @combined
 
 ((regex_pattern) @regex)

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -1,5 +1,5 @@
 (comment) @jsdoc
-(comment) @comment
+(comment) @comment @combined
 
 ((regex_pattern) @regex)
 

--- a/queries/fennel/injections.scm
+++ b/queries/fennel/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/gdscript/injections.scm
+++ b/queries/gdscript/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/go/injections.scm
+++ b/queries/go/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/graphql/injections.scm
+++ b/queries/graphql/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -9,4 +9,4 @@
 ((script_element
   (raw_text) @javascript))
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/java/injections.scm
+++ b/queries/java/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/jsonc/highlights.scm
+++ b/queries/jsonc/highlights.scm
@@ -1,3 +1,3 @@
 ; inherits: json
 
-(comment) @comment @combined
+(comment) @comment

--- a/queries/jsonc/highlights.scm
+++ b/queries/jsonc/highlights.scm
@@ -1,3 +1,3 @@
 ; inherits: json
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/jsonc/injections.scm
+++ b/queries/jsonc/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -1,4 +1,4 @@
 ((triple_string) @markdown
   (#offset! @markdown 0 3 0 -3))
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/kotlin/injections.scm
+++ b/queries/kotlin/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/ledger/injections.scm
+++ b/queries/ledger/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -9,4 +9,4 @@
   (#eq? @_cdef_identifier "cdef")
 )
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/ocaml/injections.scm
+++ b/queries/ocaml/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/ocamllex/injections.scm
+++ b/queries/ocamllex/injections.scm
@@ -1,3 +1,3 @@
 (ocaml) @ocaml
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/php/injections.scm
+++ b/queries/php/injections.scm
@@ -1,3 +1,3 @@
 (text) @html
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -23,4 +23,4 @@
 (((expression_statement (assignment)) . (expression_statement (string) @rst))
  (#offset! @rst 0 3 0 -3))
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/ql/injections.scm
+++ b/queries/ql/injections.scm
@@ -2,4 +2,4 @@
   (line_comment)
   (block_comment)
   (qldoc)
-] @comment
+] @comment @combined

--- a/queries/query/injections.scm
+++ b/queries/query/injections.scm
@@ -3,4 +3,4 @@
   parameters: (parameters (string) @regex))
  (#match? @_name "^#?(not-)?(match|vim-match|lua-match)$"))
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/rst/injections.scm
+++ b/queries/rst/injections.scm
@@ -59,4 +59,4 @@
   (role) @_role)
  (#eq? @_role ":math:"))
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/ruby/injections.scm
+++ b/queries/ruby/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/rust/injections.scm
+++ b/queries/rust/injections.scm
@@ -9,4 +9,4 @@
 [
   (line_comment)
   (block_comment)
-] @comment
+] @comment @combined

--- a/queries/scss/highlights.scm
+++ b/queries/scss/highlights.scm
@@ -37,3 +37,5 @@
 ] @punctuation.bracket
 
 (include_statement (identifier) @function)
+
+(single_line_comment) @comment

--- a/queries/scss/injections.scm
+++ b/queries/scss/injections.scm
@@ -1,0 +1,3 @@
+; inherits: css
+
+(single_line_comment) @comment @combined

--- a/queries/sparql/injections.scm
+++ b/queries/sparql/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/supercollider/injections.scm
+++ b/queries/supercollider/injections.scm
@@ -1,4 +1,4 @@
 [
   (line_comment)
   (block_comment)
-] @comment
+] @comment @combined

--- a/queries/svelte/injections.scm
+++ b/queries/svelte/injections.scm
@@ -29,4 +29,4 @@
   (#match? @_lang "(ts|typescript)")
 )
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/teal/injections.scm
+++ b/queries/teal/injections.scm
@@ -9,4 +9,4 @@
   (#eq? @_cdef_identifier "cdef")
 )
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/toml/injections.scm
+++ b/queries/toml/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/turtle/injections.scm
+++ b/queries/turtle/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/verilog/injections.scm
+++ b/queries/verilog/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -29,4 +29,4 @@
     (quoted_attribute_value 
       (attribute_value) @javascript)))
 
-(comment) @comment
+(comment) @comment @combined

--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment
+(comment) @comment @combined

--- a/queries/zig/injections.scm
+++ b/queries/zig/injections.scm
@@ -1,1 +1,1 @@
-(line_comment) @comment
+(line_comment) @comment @combined


### PR DESCRIPTION
There is no need to create a tree per line/block for comments.
Should fix https://github.com/nvim-treesitter/nvim-treesitter/issues/1251