### PR TITLE
C++ highlights: Using namespace

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -50,6 +50,8 @@
 (namespace_definition
   name: (identifier) @namespace)
 
+(using_declaration . "using" . "namespace" . [(scoped_identifier) (identifier)] @namespace)
+
 (destructor_name
   (identifier) @method)
 


### PR DESCRIPTION
Highlight `using namespace foo; using namespace foo::bar;`