### PR TITLE
Add go-mod tree-sitter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by not @tjdevries)
 - [x] [Glimmer and Ember](https://github.com/alexlafroscia/tree-sitter-glimmer) (maintained by @alexlafroscia)
 - [x] [go](https://github.com/tree-sitter/tree-sitter-go) (maintained by @theHamsta, @WinWisely268)
+- [x] [gomod](https://github.com/camdencheek/tree-sitter-go-mod) (maintained by @camdencheek)
 - [x] [graphql](https://github.com/bkegley/tree-sitter-graphql) (maintained by @bkegley)
 - [ ] [haskell](https://github.com/tree-sitter/tree-sitter-haskell)
 - [x] [html](https://github.com/tree-sitter/tree-sitter-html) (maintained by @TravonteD)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -104,6 +104,16 @@ list.go = {
   maintainers = {"@theHamsta", "@WinWisely268"},
 }
 
+list.gomod = {
+  install_info = {
+    url = "https://github.com/camdencheek/tree-sitter-go-mod",
+	branch = "main",
+    files = { "src/parser.c" },
+  },
+  maintainers = {"@camdencheek"},
+  filetype = "gomod",
+}
+
 list.graphql = {
   install_info = {
     url = "https://github.com/bkegley/tree-sitter-graphql",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -107,7 +107,7 @@ list.go = {
 list.gomod = {
   install_info = {
     url = "https://github.com/camdencheek/tree-sitter-go-mod",
-	branch = "main",
+    branch = "main",
     files = { "src/parser.c" },
   },
   maintainers = {"@camdencheek"},

--- a/queries/gomod/highlights.scm
+++ b/queries/gomod/highlights.scm
@@ -1,0 +1,17 @@
+[
+  "require"
+  "replace"
+  "go"
+  "exclude"
+  "retract"
+  "module"
+] @keyword
+
+"=>" @operator
+
+(comment) @comment
+
+[
+(version)
+(go_version)
+] @string


### PR DESCRIPTION
Adds a tree-sitter config for go.mod files as well as highlighting
queries.

A couple of notes:
- This only adds highlighting queries (not indentation, folds, etc.). I couldn't find any documentation on how those are interpreted. Happy to add those as well with some help. 
- This requires a `ftdetect` rule for go.mod files that sets `filetype=gomod`. It seems that graphql also doesn't set its filetype, so I wasn't sure if this is something that should be handled in this plugin. 

Example of it in action:
![image](https://user-images.githubusercontent.com/12631702/116315020-280ac380-a76d-11eb-9ddb-ebca2940dcf4.png)
