### PR TITLE
Add fish queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [ ] [elm](https://github.com/elm-tooling/tree-sitter-elm)
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)
+- [ ] [fish](https://github.com/krnik/tree-sitter-fish)
 - [ ] [fortran](https://github.com/stadelmanma/tree-sitter-fortran)
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by @Shatur95)
 - [x] [Glimmer and Ember](https://github.com/alexlafroscia/tree-sitter-glimmer) (maintained by @alexlafroscia)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -145,6 +145,7 @@ list.fish = {
     url = "https://github.com/krnik/tree-sitter-fish",
     files = { "src/parser.c", "src/scanner.c" },
   },
+  maintainers = {"@krnik", "@ram02z"},
 }
 
 list.php = {

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -140,6 +140,13 @@ list.bash = {
   maintainers = {"@TravonteD"},
 }
 
+list.fish = {
+  install_info = {
+    url = "https://github.com/krnik/tree-sitter-fish",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+}
+
 list.php = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-php",

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -102,6 +102,7 @@
 
 (string_literal) @string
 (system_lib_string) @string
+(escape_sequence) @string.escape
 
 (null) @constant.builtin
 (number_literal) @number

--- a/queries/fish/folds.scm
+++ b/queries/fish/folds.scm
@@ -1,0 +1,8 @@
+[
+ (function_definition)
+ (if_statement)
+ (switch_statement)
+ (for_statement)
+ (while_statement)
+ (begin_statement)
+] @fold

--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -1,0 +1,155 @@
+;; Fish highlighting
+
+;; Operators
+
+[
+ "&&"
+ "||"
+ "|"
+ "&"
+ "="
+ "!="
+ ".."
+ "!"
+ (direction)
+ (stream_redirect)
+] @operator
+
+[
+ "not"
+ "and"
+ "or"
+] @keyword.operator
+
+;; Conditionals
+
+(if_statement
+[
+ "if"
+ "end"
+] @conditional)
+
+(switch_statement
+[
+ "switch"
+ "end"
+] @conditional)
+
+(case_clause
+[
+ "case"
+] @conditional)
+
+(else_clause 
+[
+ "else"
+] @conditional)
+
+(else_if_clause 
+[
+ "else"
+ "if"
+] @conditional)
+
+;; Loops/Blocks
+
+(while_statement
+[
+ "while"
+ "end"
+] @repeat)
+
+(for_statement
+[
+ "for"
+ "end"
+] @repeat)
+
+(begin_statement
+[
+ "begin"
+ "end"
+] @repeat)
+
+;; Keywords
+
+[
+ "in"
+ "return"
+ (break)
+ (continue)
+] @keyword
+
+;; Punctuation
+
+[
+ "["
+ "]"
+ "{"
+ "}"
+ "("
+ ")"
+] @punctuation.bracket
+
+"," @punctuation.delimiter
+
+;; Commands
+
+(command
+  argument: [
+             (word) @parameter (#match? @parameter "^-")
+            ]
+)
+
+; non-bultin command names
+(command name: (word) @function)
+
+; derived from builtin -n (fish 3.2.2)
+(command
+  name: [
+        (word) @function.builtin
+        (#match? @function.builtin "^(.|:|_|alias|argparse|bg|bind|block|breakpoint|builtin|cd|command|commandline|complete|contains|count|disown|echo|emit|eval|exec|exit|fg|functions|history|isatty|jobs|math|printf|pwd|random|read|realpath|set|set_color|source|status|string|test|time|type|ulimit|wait)$")
+        ]
+)
+
+
+;; Functions
+
+(function_definition ["function" "end"] @keyword.function)
+
+(function_definition
+  name: [
+        (word) (concatenation)
+        ] 
+@function)
+
+(function_definition
+  option: [
+          (word)
+          (concatenation (word))
+          ] @parameter (#match? @parameter "^-")
+)
+
+;; Strings
+
+[(double_quote_string) (single_quote_string)] @string
+(escape_sequence) @string.escape
+
+;; Variables
+
+(variable_name) @variable
+(variable_expansion) @constant
+
+;; Nodes
+
+[(integer) (float)] @number
+(comment) @comment
+(test_option) @string
+
+((word) @boolean
+(#match? @boolean "^(true|false)$"))
+
+;; Error
+
+(ERROR) @error
+

--- a/queries/fish/indents.scm
+++ b/queries/fish/indents.scm
@@ -1,0 +1,16 @@
+[
+ (function_definition)
+ (while_statement)
+ (for_statement)
+ (if_statement)
+ (begin_statement)
+ (switch_statement)
+] @indent
+
+[
+ (else_if_clause)
+ (else_clause)
+ "end"
+] @branch
+
+(comment) @ignore

--- a/queries/fish/injections.scm
+++ b/queries/fish/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment @combined

--- a/queries/fish/locals.scm
+++ b/queries/fish/locals.scm
@@ -1,0 +1,10 @@
+;; Scopes
+(function_definition) @scope
+
+;; Definitions
+(function_definition
+  name: (word) @definition.function)
+
+;; References
+(variable_name) @reference
+(word) @reference


### PR DESCRIPTION
Closes #1268.
One small issue I have which I have not been able to figure out is how to highlight all command options like `--description`. As you can see from the highlight snippet below, only the first command option is highlighted (`--argument-names`) and following option on the same line (`--description`) is ignored. The following syntax highlight rule is from line 93:

```
(command
  argument: [
             (word) @parameter (#vim-match? @parameter "^-")
            ]
)
```

> Highlight

![image](https://user-images.githubusercontent.com/59267627/116797063-73103800-aad9-11eb-8e14-3045701d9c17.png)

> Indent

Works well for every statement listed in `indents.scm` apart from `if_statement`. When adding `else` or `else if` clauses the indenation doesn't work and the `end` keyword indents on enter. See gif below.
![if_indent_bug](https://user-images.githubusercontent.com/59267627/116796621-cd0efe80-aad5-11eb-8a2e-a158c3fee2c8.gif)

> Folds

![fish_foldr](https://user-images.githubusercontent.com/59267627/116796753-fed49500-aad6-11eb-84c3-ddc2c3887f66.gif)
