### PR TITLE
refactor: make html-like languages inherit from single query

### DIFF
--- a/queries/html/highlights.scm
+++ b/queries/html/highlights.scm
@@ -1,43 +1,5 @@
-(tag_name) @tag
-(erroneous_end_tag_name) @error
+; inherits: html_tags
+
 (doctype) @constant
-(attribute_name) @property
-(attribute_value) @string
-(quoted_attribute_value) @string
-(comment) @comment
 
-((element (start_tag (tag_name) @_tag) (text) @text.title)
- (#match? @_tag "^(h[0-9]|title)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.strong)
- (#match? @_tag "^(strong|b)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.emphasis)
- (#match? @_tag "^(em|i)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.strike)
- (#match? @_tag "^(s|del)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.underline)
- (#eq? @_tag "u"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.literal)
- (#match? @_tag "^(code|kbd)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.uri)
- (#eq? @_tag "a"))
-
-((attribute
-   (attribute_name) @_attr
-   (quoted_attribute_value (attribute_value) @text.uri))
- (#match? @_attr "^(href|src)$"))
-
-"=" @operator
-
-[
- "<"
- "<!"
- ">"
- "</"
- "/>"
-] @tag.delimiter
+"<!" @tag.delimiter

--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -1,0 +1,42 @@
+(tag_name) @tag
+(erroneous_end_tag_name) @error
+(comment) @comment
+(attribute_name) @property
+(attribute_value) @string
+(quoted_attribute_value) @string
+(text) @none
+
+((element (start_tag (tag_name) @_tag) (text) @text.title)
+ (#match? @_tag "^(h[0-9]|title)$"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.strong)
+ (#match? @_tag "^(strong|b)$"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.emphasis)
+ (#match? @_tag "^(em|i)$"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.strike)
+ (#match? @_tag "^(s|del)$"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.underline)
+ (#eq? @_tag "u"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.literal)
+ (#match? @_tag "^(code|kbd)$"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.uri)
+ (#eq? @_tag "a"))
+
+((attribute
+   (attribute_name) @_attr
+   (quoted_attribute_value (attribute_value) @text.uri))
+ (#match? @_attr "^(href|src)$"))
+
+[
+ "<"
+ ">"
+ "</"
+ "/>"
+] @tag.delimiter
+
+"=" @operator

--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -1,0 +1,7 @@
+((style_element
+  (raw_text) @css))
+
+((script_element
+  (raw_text) @javascript))
+
+(comment) @comment @combined

--- a/queries/svelte/highlights.scm
+++ b/queries/svelte/highlights.scm
@@ -1,43 +1,6 @@
-((element (start_tag (tag_name) @_tag) (text) @text.title)
- (#match? @_tag "^(h[0-9]|title)$"))
+; inherits: html_tags
 
-((element (start_tag (tag_name) @_tag) (text) @text.strong)
- (#match? @_tag "^(strong|b)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.emphasis)
- (#match? @_tag "^(em|i)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.strike)
- (#match? @_tag "^(s|del)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.underline)
- (#eq? @_tag "u"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.literal)
- (#match? @_tag "^(code|kbd)$"))
-
-((element (start_tag (tag_name) @_tag) (text) @text.uri)
- (#eq? @_tag "a"))
-
-((attribute
-   (attribute_name) @_attr
-   (quoted_attribute_value (attribute_value) @text.uri))
- (#match? @_attr "^(href|src)$"))
-
-(tag_name) @tag
-(attribute_name) @property
-(erroneous_end_tag_name) @error
-(comment) @comment
-
-[
-  (attribute_value)
-  (quoted_attribute_value)
-] @string
-
-[
-  (text)
-  (raw_text_expr)
-] @none
+(raw_text_expr) @none
 
 [
   (special_block_keyword)
@@ -50,13 +13,7 @@
   "}"
 ] @punctuation.bracket
 
-"=" @operator
-
 [
-  "<"
-  ">"
-  "</"
-  "/>"
   "#"
   ":"
   "/"

--- a/queries/svelte/injections.scm
+++ b/queries/svelte/injections.scm
@@ -1,5 +1,4 @@
-((style_element
-  (raw_text) @css))
+; inherits: html_tags
 
 (
   (style_element
@@ -15,10 +14,7 @@
    (quoted_attribute_value (attribute_value) @css))
  (#eq? @_attr "style"))
 
-((script_element
-  (raw_text) @javascript))
-
-((raw_text_expr) @javascript)
+(raw_text_expr) @javascript
 
 (
   (script_element

--- a/queries/vue/highlights.scm
+++ b/queries/vue/highlights.scm
@@ -1,22 +1,13 @@
+; inherits: html_tags
+
 [
-  (component)
   (template_element)
-  (start_tag)
-  (tag_name)
   (directive_attribute)
   (directive_dynamic_argument)
   (directive_dynamic_argument_value)
   (component)
-  (end_tag)
 ] @tag
 
-(erroneous_end_tag_name) @error
-(attribute_name) @property
-(attribute_value) @string
-(quoted_attribute_value) @string
-(comment) @comment
-
-(text) @none
 (element) @string
 (interpolation) @punctuation.special
 (interpolation
@@ -27,12 +18,3 @@
   (directive_name)
   (directive_argument)
 ] @method
-
-"=" @operator
-
-[
- "<"
- ">"
- "</"
- "/>"
- ] @tag.delimiter

--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -1,5 +1,4 @@
-((style_element
-  (raw_text) @css))
+; inherits: html_tags
 
 (
   (style_element
@@ -9,9 +8,6 @@
     (raw_text) @scss)
   (#match? @_lang "(scss|postcss|less)")
 )
-
-((script_element
-  (raw_text) @javascript))
 
 (
   (script_element
@@ -25,8 +21,8 @@
 ((interpolation
   (raw_text) @javascript))
 
-((directive_attribute 
-    (quoted_attribute_value 
+((directive_attribute
+    (quoted_attribute_value
       (attribute_value) @javascript)))
 
 (comment) @comment


### PR DESCRIPTION
This should avoid duplication and easier maintenance for html, vue, and svelte. 
While doing this, I noticed `<script>` tag injection with `lang="ts"` injects both Javascript and Typescript -- which causes the type for a line like `export let asdf: string` gets highlighted as Javascript indetifier instead of Typescript type.
This is similar to #1209 which hopefully will be fixed by #1238.