### PR TITLE
chore(erlang): don't generate parser from grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [ ] [elm](https://github.com/elm-tooling/tree-sitter-elm)
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)
-- [ ] [fish](https://github.com/krnik/tree-sitter-fish)
+- [x] [fish](https://github.com/krnik/tree-sitter-fish) (maintained by @krnik, @ram02z)
 - [ ] [fortran](https://github.com/stadelmanma/tree-sitter-fortran)
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by @Shatur95)
 - [x] [Glimmer and Ember](https://github.com/alexlafroscia/tree-sitter-glimmer) (maintained by @alexlafroscia)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -216,7 +216,6 @@ list.erlang = {
     url = "https://github.com/AbstractMachinesLab/tree-sitter-erlang",
     files = { "src/parser.c" },
     branch = "main",
-    requires_generate_from_grammar  = true,
   },
   maintainers = { '@ostera' },
 }


### PR DESCRIPTION
Needed after #1280.
