### PR TITLE
Update ocaml parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -102,10 +102,10 @@
     "revision": "50f38ceab667f9d482640edfee803d74f4edeba5"
   },
   "ocaml": {
-    "revision": "2f962cf4eb0bee87bba755347a79ee501cd58313"
+    "revision": "0348562f385bc2bd67ecf181425e1afd6d454192"
   },
   "ocaml_interface": {
-    "revision": "2f962cf4eb0bee87bba755347a79ee501cd58313"
+    "revision": "0348562f385bc2bd67ecf181425e1afd6d454192"
   },
   "ocamllex": {
     "revision": "ac1d5957e719d49bd6acd27439b79843e4daf8ed"

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -131,7 +131,9 @@
 
 [
   (prefix_operator)
+  (sign_operator)
   (infix_operator)
+  (hash_operator)
   (indexing_operator)
   (let_operator)
   (and_operator)


### PR DESCRIPTION
The updates removes a couple of aliases to avoid circular dependency. This causes a couple of more nodes to appear and needs a change in the highlights.

obsoletes #1282 