### PR TITLE
Add config for Dockerfile parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [css](https://github.com/tree-sitter/tree-sitter-css) (maintained by @TravonteD)
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @Akin909)
 - [x] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree) (maintained by @jedrzejboczar)
+- [x] [dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) (maintained by @camdencheek)
 - [ ] [elm](https://github.com/elm-tooling/tree-sitter-elm)
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -64,6 +64,15 @@ list.cpp = {
   maintainers = {"@theHamsta"},
 }
 
+list.dockerfile = {
+  install_info = {
+    url = "https://github.com/camdencheek/tree-sitter-dockerfile",
+	branch = "main",
+    files = { "src/parser.c" },
+  },
+  maintainers = {"@camdencheek"},
+}
+
 list.rust = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-rust",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -67,7 +67,7 @@ list.cpp = {
 list.dockerfile = {
   install_info = {
     url = "https://github.com/camdencheek/tree-sitter-dockerfile",
-	branch = "main",
+    branch = "main",
     files = { "src/parser.c" },
   },
   maintainers = {"@camdencheek"},

--- a/queries/dockerfile/highlights.scm
+++ b/queries/dockerfile/highlights.scm
@@ -1,0 +1,51 @@
+[
+	"FROM"
+	"AS"
+	"RUN"
+	"CMD"
+	"LABEL"
+	"EXPOSE"
+	"ENV"
+	"ADD"
+	"COPY"
+	"ENTRYPOINT"
+	"VOLUME"
+	"USER"
+	"WORKDIR"
+	"ARG"
+	"ONBUILD"
+	"STOPSIGNAL"
+	"HEALTHCHECK"
+	"SHELL"
+	"MAINTAINER"
+	"CROSS_BUILD"
+] @keyword
+
+[
+	":"
+	"@"
+] @operator
+
+(comment) @comment
+
+
+(image_spec
+	(image_tag
+		":" @punctuation.special)
+	(image_digest
+		"@" @punctuation.special))
+
+(double_quoted_string) @string
+
+(expansion
+  [
+	"$"
+	"{"
+	"}"
+  ] @punctuation.special
+) @none
+
+((variable) @constant
+ (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+
+

--- a/queries/dockerfile/highlights.scm
+++ b/queries/dockerfile/highlights.scm
@@ -1,51 +1,50 @@
 [
-	"FROM"
-	"AS"
-	"RUN"
-	"CMD"
-	"LABEL"
-	"EXPOSE"
-	"ENV"
-	"ADD"
-	"COPY"
-	"ENTRYPOINT"
-	"VOLUME"
-	"USER"
-	"WORKDIR"
-	"ARG"
-	"ONBUILD"
-	"STOPSIGNAL"
-	"HEALTHCHECK"
-	"SHELL"
-	"MAINTAINER"
-	"CROSS_BUILD"
+  "FROM"
+  "AS"
+  "RUN"
+  "CMD"
+  "LABEL"
+  "EXPOSE"
+  "ENV"
+  "ADD"
+  "COPY"
+  "ENTRYPOINT"
+  "VOLUME"
+  "USER"
+  "WORKDIR"
+  "ARG"
+  "ONBUILD"
+  "STOPSIGNAL"
+  "HEALTHCHECK"
+  "SHELL"
+  "MAINTAINER"
+  "CROSS_BUILD"
 ] @keyword
 
 [
-	":"
-	"@"
+  ":"
+  "@"
 ] @operator
 
 (comment) @comment
 
-
 (image_spec
-	(image_tag
-		":" @punctuation.special)
-	(image_digest
-		"@" @punctuation.special))
+  (image_tag
+    ":" @punctuation.special)
+  (image_digest
+    "@" @punctuation.special))
 
 (double_quoted_string) @string
 
 (expansion
   [
-	"$"
-	"{"
-	"}"
+    "$"
+    "{"
+    "}"
   ] @punctuation.special
-) @none
+)
 
 ((variable) @constant
- (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 

--- a/queries/dockerfile/injections.scm
+++ b/queries/dockerfile/injections.scm
@@ -1,0 +1,3 @@
+(comment) @comment
+
+(shell_command) @bash


### PR DESCRIPTION
This adds a config, highlights, and injections for Dockerfile parsing. 

Example:
<img width="1326" alt="Screen Shot 2021-05-11 at 09 21 45" src="https://user-images.githubusercontent.com/12631702/117841460-5216b800-b23a-11eb-9a69-c9b29254f26b.png">
