### PR TITLE
Add filetype detection for go.mod files

### DIFF
--- a/ftdetect/gomod.vim
+++ b/ftdetect/gomod.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile go.mod set filetype=gomod


### PR DESCRIPTION
A parser for go.mod files was added in #1259, but neovim does not set the correct filetype for go.mod files by default. This adds a ftdetect rule to set `ft=gomod`. 