### PR TITLE
highlights(latex): fix regexes with backslashes

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -10,7 +10,7 @@
    name: (word) @_env)) @text.math
    (#match? @_env "^(displaymath|equation|multline|eqnarray|align|array|split)[*]?$"))
 
-;; This at the begining of the file would be the alternative to highlight
+;; This at the beginning of the file would be the alternative to highlight
 ;; only the interior of the environment
 ;((environment
   ;(begin
@@ -149,18 +149,18 @@
 ((generic_command
   name:(generic_command_name) @_name
   arg: (_) @text.emphasis)
- (#match? @_name "^(\\textit|\\mathit)$"))
+ (#match? @_name "^(\\\\textit|\\\\mathit)$"))
 
 ((generic_command
   name:(generic_command_name) @_name
   arg: (_) @text.strong)
- (#match? @_name "^(\\textbf|\\mathbf)$"))
+ (#match? @_name "^(\\\\textbf|\\\\mathbf)$"))
 
 ((generic_command
   name:(generic_command_name) @_name
   .
   arg: (_) @text.uri)
- (#match? @_name "^(\\url|\\href)$"))
+ (#match? @_name "^(\\\\url|\\\\href)$"))
 
 (ERROR) @error
 


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/14382 requires to escape `\` in regexes if they are verbatim `\` (behavior of tree-sitter web or tree-sitter rust lib)

The change in Neovim was incompatible so people that are still behind that revision will have this regex not matching (but it should at least not error)