### PR TITLE
Fish queries remove `@combined` from injections

### DIFF
--- a/queries/fish/injections.scm
+++ b/queries/fish/injections.scm
@@ -1,1 +1,1 @@
-(comment) @comment @combined
+(comment) @comment


### PR DESCRIPTION
I used the bash injections.scm file as reference before #1266 was merged, so I am removing `@combined` since its clearly problematic.