### PR TITLE
highlights(ecma): use KeywordFunction as a highlight group for function

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -210,7 +210,6 @@
 "debugger"
 "export"
 "extends"
-"function"
 "get"
 "in"
 "instanceof"
@@ -226,6 +225,10 @@
 "with"
 "yield"
 ] @keyword
+
+[
+ "function"
+] @keyword.function
 
 [
  "new"


### PR DESCRIPTION
Hi and thank you for your work!

This PR attempts to utilise more documented highlight treesitter groups. In the documentation it is mentioned that there is TSKeywordFunction which is not being used for ecma languages. This PR fixes it. Now theme developers should be able to distinguish function keyword from other language keywords.