### PR TITLE
parsers: Fortran/Supercollider no longer requires_generate_from_grammar

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -48,7 +48,7 @@
     "revision": "3e31952b0ef7454b2c52af8e60e4db9b6f43c82f"
   },
   "fortran": {
-    "revision": "81a8ad412f3c468223bce97a2bae11ffa4ff2f68"
+    "revision": "fee62c037f15d01ba51f35de899682b4cc7e0a43"
   },
   "gdscript": {
     "revision": "59e7e41e186d3759592e9938291f69055200783f"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -571,7 +571,6 @@ list.fortran = {
   install_info = {
     url = "https://github.com/stadelmanma/tree-sitter-fortran",
     files = { "src/parser.c", "src/scanner.cc", },
-    requires_generate_from_grammar = true,
   },
 }
 

--- a/queries/fortran/highlights.scm
+++ b/queries/fortran/highlights.scm
@@ -34,7 +34,7 @@
 [
 "implicit"
 (none)
-] @annotation
+] @attribute
 
 [
   "function"


### PR DESCRIPTION
Supercollider no longer requires generate from source