### PR TITLE
parsers: generate_requires_npm for commonlisp

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -58,6 +58,7 @@ list.commonlisp = {
   install_info = {
     url = "https://github.com/theHamsta/tree-sitter-commonlisp",
     files = { "src/parser.c" },
+    generate_requires_npm = true,
   },
   filetype = 'lisp',
   maintainers = {"@theHamsta"},


### PR DESCRIPTION
The Common Lisp parsers depends on the Clojure parser when installed from grammar.js