### PR TITLE
indents(c/cpp): let C++ use the C indents and add class_specifier

### DIFF
--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -4,6 +4,9 @@
   (preproc_arg)
   (field_declaration_list)
   (case_statement)
+  (conditional_expression)
+  (enumerator_list)
+  (struct_specifier)
 ] @indent
 
 

--- a/queries/cpp/indents.scm
+++ b/queries/cpp/indents.scm
@@ -1,18 +1,7 @@
+; inherits: c
+
 [
-  (enumerator_list)
-  (struct_specifier)
-  (compound_statement)
-  (case_statement)
+  (field_declaration_list)
+  (class_specifier)
   (condition_clause)
-  (conditional_expression)
 ] @indent
-
-[
-  (statement_identifier)
-  "#ifdef"
-  "#endif"
-  "{"
-  "}"
-] @branch
-
-(comment) @ignore


### PR DESCRIPTION
Fixes #1320

I don't know very well how indents works so better rely on C indents. Also add class_specifier.