### PR TITLE
highlights(rust): highlight fields with shorthand_field_initializer

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -16,6 +16,8 @@
 (type_identifier) @type
 (primitive_type) @type.builtin
 (field_identifier) @field
+(shorthand_field_initializer
+  (identifier) @field)
 (mod_item
  name: (identifier) @namespace)
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7189118/119385736-de0ef200-bcc6-11eb-94ce-6f5945739269.png)


After:

![image](https://user-images.githubusercontent.com/7189118/119385686-c9caf500-bcc6-11eb-8293-f429bf2f7de4.png)
