### PR TITLE
feat: use serenadeai scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [ruby](https://github.com/tree-sitter/tree-sitter-ruby) (maintained by @TravonteD)
 - [x] [rust](https://github.com/tree-sitter/tree-sitter-rust) (maintained by @vigoux)
 - [ ] [scala](https://github.com/tree-sitter/tree-sitter-scala)
-- [ ] [scss](https://github.com/elianiva/tree-sitter-scss)
+- [x] [scss](https://github.com/serenadeai/tree-sitter-scss) (maintained by @elianiva)
 - [x] [sparql](https://github.com/BonaBeavis/tree-sitter-sparql) (maintained by @bonabeavis)
 - [x] [supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) (maintained by @madskjeldgaard)
 - [x] [svelte](https://github.com/Himujjal/tree-sitter-svelte) (maintained by @elianiva)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -225,9 +225,10 @@ list.css = {
 
 list.scss = {
   install_info = {
-    url = "https://github.com/elianiva/tree-sitter-scss",
+    url = "https://github.com/serenadeai/tree-sitter-scss",
     files = { "src/parser.c", "src/scanner.c" }
   },
+  maintainers = {"@elianiva"},
 }
 
 list.erlang = {


### PR DESCRIPTION
The original repo has been updated [4 days ago](https://github.com/serenadeai/tree-sitter-scss/commit/9da7c979c010c350c28ad2235893103db4622c10), better to use that instead.