### PR TITLE
supercollider: Rename methods

### DIFF
--- a/queries/supercollider/highlights.scm
+++ b/queries/supercollider/highlights.scm
@@ -24,10 +24,7 @@
   name: (identifier) @property) 
 
 ; Methods
-(instance_method_call 
-        name: (method_name) @function)
-(class_method_call 
-        name: (class_method_name) @method)
+(method_call name: (method_name) @method)
 
 ; Classes
 (class) @type


### PR DESCRIPTION
This seems to fix https://github.com/nvim-treesitter/nvim-treesitter/issues/1347

