### PR TITLE
More C# improvements

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -291,7 +291,7 @@ list.c_sharp = {
     files = { "src/parser.c", "src/scanner.c" },
   },
   filetype = 'cs',
-  maintainers = {'@svermeulen'},
+  maintainers = {'@Luxed'},
 }
 
 list.typescript = {

--- a/queries/c_sharp/folds.scm
+++ b/queries/c_sharp/folds.scm
@@ -1,0 +1,18 @@
+[
+ (class_declaration)
+ (constructor_declaration)
+ (enum_declaration)
+ (interface_declaration)
+ (method_declaration)
+ (namespace_declaration)
+ (struct_declaration)
+
+ (do_statement)
+ (for_each_statement)
+ (for_statement)
+ (if_statement)
+ (switch_statement)
+ (try_statement)
+ (using_statement)
+ (while_statement)
+] @fold

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -9,16 +9,16 @@
 (interpolation) @none
 
 (invocation_expression
-     (member_access_expression
-            name: (identifier) @method))
+  (member_access_expression
+    name: (identifier) @method))
+
+(invocation_expression
+  function: (conditional_access_expression
+    (member_binding_expression
+      name: (identifier) @method)))
 
 (namespace_declaration
   name: [(qualified_name) (identifier)] @namespace)
-
-((member_access_expression
-  (identifier) @type
-  (_) .)
-  (#match? @type "^[A-Z].*[a-z]"))
 
 (qualified_name
   (identifier) @type)
@@ -26,11 +26,14 @@
 (invocation_expression
       (identifier) @method)
 
-((identifier) @field
- (#match? @field "^_"))
+(field_declaration
+  (variable_declaration
+    (variable_declarator
+      (identifier) @field)))
 
-((identifier) @field
- (#match? @field "^m_"))
+(initializer_expression
+  (assignment_expression
+    left: (identifier) @field))
 
 (parameter_list
   (parameter
@@ -56,9 +59,10 @@
 
 [
  (predefined_type)
- (implicit_type)
  (void_keyword)
 ] @type.builtin
+
+(implicit_type) @keyword
 
 (comment) @comment
 
@@ -67,6 +71,12 @@
 
 (property_declaration
   name: (identifier) @property)
+
+(property_declaration
+  type: (identifier) @type)
+
+(nullable_type
+  (identifier) @type)
 
 (catch_declaration
   type: (identifier) @type)
@@ -88,14 +98,28 @@
 (generic_name
   (identifier) @type)
 
+(invocation_expression
+  (member_access_expression
+    (generic_name
+      (identifier) @method)))
+
 (base_list
   (identifier) @type)
 
 (type_argument_list
  (identifier) @type)
 
+(type_parameter_list
+  (type_parameter) @type)
+
+(type_parameter_constraints_clause
+  target: (identifier) @type)
+
 (attribute
  name: (identifier) @attribute)
+
+(for_each_statement
+  type: (identifier) @type)
 
 [
  "if"
@@ -228,5 +252,6 @@
  "struct"
  "get"
  "set"
+ "where"
 ] @keyword
 

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -121,13 +121,46 @@
 (for_each_statement
   type: (identifier) @type)
 
+(warning_directive) @text.warning
+(error_directive) @exception
+
+(define_directive
+  (identifier) @constant) @constant.macro
+(undef_directive
+  (identifier) @constant) @constant.macro
+
+(line_directive) @constant.macro
+(line_directive
+  (preproc_integer_literal) @constant
+  (preproc_string_literal)? @string)
+
+(pragma_directive
+  (identifier) @constant) @constant.macro
+(pragma_directive
+  (preproc_string_literal) @string) @constant.macro
+
+[
+ (nullable_directive)
+ (region_directive)
+ (endregion_directive)
+] @constant.macro
+
 [
  "if"
  "else"
  "switch"
  "break"
  "case"
+ (if_directive)
+ (elif_directive)
+ (else_directive)
+ (endif_directive)
 ] @conditional
+
+(if_directive
+  (identifier) @constant)
+(elif_directive
+  (identifier) @constant)
 
 [
  "while"


### PR DESCRIPTION
Improved highlights and folds. Addresses #1349.
Here's a before and after for the highlights:

<details>
<summary>before:</summary>

![image](https://user-images.githubusercontent.com/10234894/120567287-608e6480-c3df-11eb-9135-5c036079e5b0.png)

</details>

<details>
<summary>after:</summary>

![image](https://user-images.githubusercontent.com/10234894/120567172-186f4200-c3df-11eb-99bb-18d5b6323772.png)

</details>

<details>
<summary>folds in action:</summary>

![image](https://user-images.githubusercontent.com/10234894/120567431-c4b12880-c3df-11eb-98a3-b5bc197ec75b.png)

</details>

Some notable changes:

- `var` is now highlighted as a keyword. This felt like a more logical highlight than type.
- The first identifier in a series of identifiers (like `Console.WriteLine()`) is no longer highlighted as a type. This change was reverted (from #1351). The reasoning behind this is that this identifier isn't necessarily a type, it could also be a namespace. Since we don't really have any idea of which it could be, I think it's better to leave it blank for now.
- Field declarations are no longer restricted to starting with `_` or `m_`.

Suggestions are welcome!