### PR TITLE
jsx query - Components as constructor instead of type

### DIFF
--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -14,23 +14,23 @@
 (jsx_self_closing_element
   name: (identifier) @tag)
 
-(jsx_opening_element ((identifier) @type
- (#match? @type "^[A-Z]")))
+(jsx_opening_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
 
 ; Handle the dot operator effectively - <My.Component>
-(jsx_opening_element ((nested_identifier (identifier) @tag (identifier) @type)))
+(jsx_opening_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
 
-(jsx_closing_element ((identifier) @type
- (#match? @type "^[A-Z]")))
+(jsx_closing_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
 
 ; Handle the dot operator effectively - </My.Component>
-(jsx_closing_element ((nested_identifier (identifier) @tag (identifier) @type)))
+(jsx_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
 
-(jsx_self_closing_element ((identifier) @type
- (#match? @type "^[A-Z]")))
+(jsx_self_closing_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
 
 ; Handle the dot operator effectively - <My.Component />
-(jsx_self_closing_element ((nested_identifier (identifier) @tag (identifier) @type)))
+(jsx_self_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
 
 (variable_declarator ((identifier) @type
  (#match? @type "^[A-Z]")))


### PR DESCRIPTION
PR links to [this issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/1028).
JSX queries for highlighting are updated so that components with capital first letter are highlighted as constructor instead of type which should be the correct behavior.

### Before
![Screenshot 2021-06-03 at 09 57 04](https://user-images.githubusercontent.com/22654504/120611767-ccf77b00-c454-11eb-8c20-6f81e03ab44f.png)

### After
![Screenshot 2021-06-03 at 09 58 47](https://user-images.githubusercontent.com/22654504/120612326-5e66ed00-c455-11eb-86f3-5b48704cea2a.png)
