### PR TITLE
c++ highlights: don't capture all identifiers with uppercase initials as types

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -32,10 +32,6 @@
     name: (identifier) @function))
 
 
-((identifier) @type
- (#match? @type "^[A-Z].*[a-z]")
- (#not-has-parent? @type function_declarator))
-
 (namespace_identifier) @namespace
 ((namespace_identifier) @type
                         (#match? @type "^[A-Z]"))


### PR DESCRIPTION
Current highlighting queries capture all identifiers with uppercase initials as types, which may work very poorly on some codebases, e.g. LLVM. This PR removes these heuristics and let (I guess) the inherited c highlighting queries do their work. Below are a comparison before and after the changes:

<img width="629" alt="CleanShot 2021-06-04 at 20 01 05@2x" src="https://user-images.githubusercontent.com/3103188/120798488-0244bb80-c570-11eb-8d18-d8ee3e83ed24.png">
<img width="629" alt="CleanShot 2021-06-04 at 20 01 15@2x" src="https://user-images.githubusercontent.com/3103188/120798495-04a71580-c570-11eb-8f9c-d91ecdc38992.png">
