### PR TITLE
fish: make use of any_of predicate for builtin functions

### DIFF
--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -148,7 +148,8 @@
 (comment) @comment
 (test_option) @string
 
-[(true) (false)] @boolean
+((word) @boolean
+(#any-of? @boolean "true" "false"))
 
 ;; Error
 

--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -109,7 +109,7 @@
 (command
   name: [
         (word) @function.builtin
-        (#match? @function.builtin "^(.|:|_|alias|argparse|bg|bind|block|breakpoint|builtin|cd|command|commandline|complete|contains|count|disown|echo|emit|eval|exec|exit|fg|functions|history|isatty|jobs|math|printf|pwd|random|read|realpath|set|set_color|source|status|string|time|type|ulimit|wait)$")
+        (#any-of? @function.builtin "." ":" "_" "alias" "argparse" "bg" "bind" "block" "breakpoint" "builtin" "cd" "command" "commandline" "complete" "contains" "count" "disown" "echo" "emit" "eval" "exec" "exit" "fg" "functions" "history" "isatty" "jobs" "math" "printf" "pwd" "random" "read" "realpath" "set" "set_color" "source" "status" "string" "test" "time" "type" "ulimit" "wait")
         ]
 )
 
@@ -148,8 +148,7 @@
 (comment) @comment
 (test_option) @string
 
-((word) @boolean
-(#match? @boolean "^(true|false)$"))
+[(true) (false)] @boolean
 
 ;; Error
 


### PR DESCRIPTION
- Changes `match?` to `any-of?` for builtin functions
- Simplifies boolean highlight