### PR TITLE
fix: assignable selector was removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [beancount](https://github.com/polarmutex/tree-sitter-beancount) (maintained by @polarmutex)
 - [x] [bibtex](https://github.com/latex-lsp/tree-sitter-bibtex) (maintained by @theHamsta by asking @clason)
 - [x] [c](https://github.com/tree-sitter/tree-sitter-c) (maintained by @vigoux)
-- [x] [c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) (maintained by @svermeulen)
+- [x] [c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) (maintained by @Luxed)
 - [x] [clojure](https://github.com/sogaiu/tree-sitter-clojure) (maintained by @sogaiu)
 - [x] [comment](https://github.com/stsewd/tree-sitter-comment) (maintained by @stsewd)
 - [x] [commonlisp](https://github.com/theHamsta/tree-sitter-commonlisp) (maintained by @theHamsta)

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -112,8 +112,6 @@
 ; properties
 (unconditional_assignable_selector
   (identifier) @property)
-(assignable_selector
-  (identifier) @property)
 
 ; assignments
 (assignment_expression


### PR DESCRIPTION
This PR removes the usage of assignable selector, it turns out it was not necessary so it was hidden upstream to reduce noise in the tree. The same result is achievable for highlighting just using `unassignable_selector`

@theHamsta this should fix the issue caused by the most recent commits in the dart parser. I've done this as a PR into the `update-lockfile-pr` since the changes need to go together tbh. Can change it if you'd prefer staggering them or something in which case it's better that this goes in before the update one.

Full rationale for the change upstream is: https://github.com/UserNobody14/tree-sitter-dart/issues/19#issuecomment-854820659