### PR TITLE
parsers: add tree-sitter-cuda

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [commonlisp](https://github.com/theHamsta/tree-sitter-commonlisp) (maintained by @theHamsta)
 - [x] [cpp](https://github.com/tree-sitter/tree-sitter-cpp) (maintained by @theHamsta)
 - [x] [css](https://github.com/tree-sitter/tree-sitter-css) (maintained by @TravonteD)
+- [x] [cuda](https://github.com/theHamsta/tree-sitter-cuda) (maintained by @theHamsta)
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @Akin909)
 - [x] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree) (maintained by @jedrzejboczar)
 - [x] [dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) (maintained by @camdencheek)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -70,7 +70,14 @@ list.cpp = {
     files = { "src/parser.c", "src/scanner.cc" },
     generate_requires_npm = true,
   },
-  used_by = { "cuda" },
+  maintainers = {"@theHamsta"},
+}
+
+list.cuda = {
+  install_info = {
+    url = "https://github.com/theHamsta/tree-sitter-cuda",
+    files = {"src/parser.c", "src/scanner.cc"},
+  },
   maintainers = {"@theHamsta"},
 }
 

--- a/queries/cuda/folds.scm
+++ b/queries/cuda/folds.scm
@@ -1,0 +1,1 @@
+; inherits: cpp

--- a/queries/cuda/highlights.scm
+++ b/queries/cuda/highlights.scm
@@ -1,0 +1,12 @@
+; inherits: cpp
+
+[ "<<<" ">>>" ] @punctuation.bracket
+
+[
+  "__local__"
+  "__shared__"
+  "__global__"
+  "__host__"
+  "__device__"
+  "__forceinline__"
+] @keyword

--- a/queries/cuda/indents.scm
+++ b/queries/cuda/indents.scm
@@ -1,0 +1,1 @@
+; inherits: cpp

--- a/queries/cuda/locals.scm
+++ b/queries/cuda/locals.scm
@@ -1,0 +1,1 @@
+; inherits: cpp


### PR DESCRIPTION
I working on a CUDA parser that is basically just an extension of the C++ parser with support for CUDA's kernel call syntax.