### PR TITLE
Rust: fix macros highlights

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -81,9 +81,9 @@
 
 ;; Assume that all `#[derive]` arguments are types
 (meta_item
-  (identifier) @type
+  (identifier) @_name
   arguments: (meta_arguments (meta_item (identifier) @type))
-  (#eq? @type "derive"))
+  (#eq? @_name "derive"))
 
 (macro_invocation
   macro: (identifier) @function.macro)
@@ -92,6 +92,9 @@
            (identifier) @function.macro .))
 
 (metavariable) @function.macro
+(meta_item (identifier) @function.macro)
+(meta_item (scoped_identifier (identifier) @function.macro .)) 
+
 
 "$" @function.macro
 
@@ -126,7 +129,10 @@
 "."
 ";"
 ","
- ] @punctuation.delimiter
+] @punctuation.delimiter
+
+(attribute_item "#" @punctuation.special)
+(inner_attribute_item ["#" "!"] @punctuation.special)
 
 (parameter (identifier) @parameter)
 (closure_parameters (_) @parameter)
@@ -166,10 +172,7 @@
 "where"
 (mutable_specifier)
 (super)
-; TODO(vigoux): attribute items should have some kind of injections
-(attribute_item)
-(inner_attribute_item)
- ] @keyword
+] @keyword
 
 "fn" @keyword.function
 


### PR DESCRIPTION
- The derive query was incorrect, it was only matching `#[derive(derive)]`
- Macros were being highlighted as keywords
- Procedural macros symbols weren't highlighted (`#`, `#!`)