### PR TITLE
Fixed typo in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more detailed information on setting these up, see ["Advanced setup"](#advan
 ## Requirements
 
 - Neovim [nightly](https://github.com/neovim/neovim#install-from-source)
-- `tar` and `curl` in your path (or alternativly `git`)
+- `tar` and `curl` in your path (or alternatively `git`)
 - A C compiler in your path and libstdc++ installed ([Windows users please read this!](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Windows-support)).
 
 ## Installation


### PR DESCRIPTION
Fixed typo for "alternatively".