### PR TITLE
Improve clojure highlighting

### DIFF
--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -111,7 +111,7 @@
 
 ; Comment
 ((sym_lit) @comment
- (#any-of? @comment "comment" "quote"))
+ (#any-of? @comment "comment"))
 
 ; Conditionals
 ((sym_lit) @conditional

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -329,7 +329,7 @@
 ;; namespaces
 (list_lit
  .
- (sym_lit) @a
- (#eq? @a "ns")
+ (sym_lit) @_include
+ (#eq? @_include "ns")
  .
  (sym_lit) @namespace)

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -53,6 +53,9 @@
 ((sym_lit) @parameter
  (#match? @parameter "^[&]"))
 
+((sym_lit) @variable.builtin
+ (#match? @variable.builtin "^[%]"))
+
 ;; TODO: General symbol highlighting
 ;((sym_lit) @symbol
 ; (#eq? @symbol @variable))

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -284,7 +284,8 @@
  .
  (sym_lit)
  .
- (str_lit)? @text
+ ;; TODO: Add @comment highlight
+ (str_lit)?
  .
  (_))
 
@@ -296,7 +297,8 @@
  .
  (sym_lit)? @function
  .
- (str_lit)? @text)
+ ;; TODO: Add @comment highlight
+ (str_lit)?)
 ;; TODO: Fix parameter highlighting
 ;;       I think there's a bug here in nvim-treesitter
 ;; TODO: Reproduce bug and file ticket

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -12,7 +12,7 @@
 
 ["'" "`"] @string.escape
 
-["~" "~@" "#" "^"] @punctuation.special
+["~" "~@" "#"] @punctuation.special
 
 ["{" "}" "[" "]" "(" ")"] @punctuation.bracket
 
@@ -236,3 +236,10 @@
   "vector" "vector-of" "vector?" "volatile!" "volatile?"
   "vreset!" "with-bindings*" "with-meta" "with-redefs-fn" "xml-seq"
   "zero?" "zipmap"))
+
+; Meta punctuation
+;; NOTE: When the above `Function definitions` query captures the
+;;       the @function it also captures the child meta_lit
+;;       We capture the meta_lit symbol (^) after so that the later
+;;       highlighting overrides the former
+"^" @punctuation.special

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -1,39 +1,18 @@
 ;; >> Litterals
 
 (dis_expr) @comment
-
 (kwd_lit) @symbol
-
 (str_lit) @string
-
 (num_lit) @number
-
 (char_lit) @character
-
 (bool_lit) @boolean
-
 (nil_lit) @constant.builtin
-
 (comment) @comment
-
 (regex_lit) @string.regex
 
-;; TODO: Quote whole quoted symbol?
-(quoting_lit
- marker: "'" @string.escape)
+["'" "`"] @string.escape
 
-(syn_quoting_lit
- marker: "`" @string.escape)
-(unquoting_lit
- marker: "~" @punctuation.special)
-(unquote_splicing_lit
- marker: "~@" @punctuation.special)
-
-(set_lit
- marker: "#" @punctuation.special)
-
-(anon_fn_lit
- marker: "#" @punctuation.special)
+["~" "~@" "#" "^"] @punctuation.special
 
 ["{" "}" "[" "]" "(" ")"] @punctuation.bracket
 
@@ -41,13 +20,7 @@
 
 ;; >> Symbols
 
-;; metadata
-;; TODO: Mark whole meta tag?
-;; TODO: If not, handle java classes?
-(meta_lit
- marker: "^" @punctuation.special)
-
-;; parameter-related
+; parameter-related
 ((sym_lit) @parameter
  (#match? @parameter "^[&]"))
 
@@ -57,7 +30,7 @@
 ;; TODO: General symbol highlighting
 ;; use @variable?
 ;((sym_lit) @symbol
-; (#eq? @symbol @variable))
+; (#not-eq? @symbol @variable))
 
 ;; dynamic variables
 ((sym_lit) @variable.builtin
@@ -82,11 +55,15 @@
  .
  (sym_lit)? @function
  .
+ ;; This marks strings twice, should probably fix 🤔
  (str_lit)? @text
  .
- ; TODO: Get this working?
- (vec_lit
-  (sym_lit) @parameter)?)
+ ;; TODO: Get working
+ [(vec_lit
+   (sym_lit) @parameter)
+  (list_lit
+   (vec_lit
+    (sym_lit) @parameter))+]?)
  
 
 ;; namespaces
@@ -109,13 +86,13 @@
 ;; Ordinary calls
 ;; TODO
 ;; Do this by having a big scope with all symbols in it and
-;; use `#not-eq? @myvar @parameter`
+;; use `#not-eq? @myvar @parameter etc`
 ;; NOTE: That's a big hack
 
 ;; Ordinary calls
 ;; TODO
 ;; Do this by having a big scope with all symbols in it and
-;; use `#not-eq? @myvar @parameter`
+;; use `#not-eq? @myvar @parameter etc`
 
 ;; Interop
 (list_lit

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -40,9 +40,15 @@
 (meta_lit
  marker: "^" @punctuation.special)
 
-;;; parameter-related
+;; TODO: Highlight code in comments?
+
+;; parameter-related
 ((sym_lit) @parameter
-(#match? @parameter "^[&]"))
+ (#match? @parameter "^[&]"))
+
+;; TODO: General symbol highlighting
+;((sym_lit) @symbol
+; (#eq? @symbol @variable))
 
 ;; dynamic variables
 ((sym_lit) @variable.builtin
@@ -52,45 +58,184 @@
 ((sym_lit) @variable
  (#match? @variable "^.*#$"))
 
+
+
+;; >> Functions
+
 ;; def-like things
-(list_lit
- .
- (sym_lit) @function.macro
- .
- (sym_lit) @function
- (#any-of? @function.macro
-    "declare" "def" "definline" "definterface"
-    "defmacro" "defmethod" "defmulti" "defn"
-    "defn-" "defonce" "defprotocol" "defstruct"
-    "deftype" "ns"))
+;; TODO
+;(list_lit
+; .
+; (sym_lit) @keyword.function
+; (#match? @keyword.function "^(declare|def.*|ns)$")
+; .
+; (sym_lit) @function)
 
-;; other macros
-(list_lit
- .
- (sym_lit) @function.macro
- (#match? @function.macro "^(\\.|\\.\\.|\\->|\\->>|amap|and|areduce|as\\->|assert|binding|bound\\-fn|case|catch|comment|cond|cond\\->|cond\\->>|condp|delay|do|doseq|dosync|dotimes|doto|extend-protocol|extend-type|finally|fn|fn\\*|for|future|gen-class|gen-interface|if|if\\-let|if\\-not|if\\-some|import|io!|lazy\\-cat|lazy\\-seq|let|letfn|locking|loop|memfn|monitor\\-enter|monitor\\-exit|or|proxy|proxy-super|pvalues|quote|recur|refer\\-clojure|reify|set!|some\\->|some\\->>|sync|throw|time|try|unquote|unquote\\-splicing|var|vswap!|when|when\\-first|when\\-let|when\\-not|when\\-some|while|with\\-bindings|with\\-in\\-str|with\\-loading\\-context|with\\-local\\-vars|with\\-open|with\\-out\\-str|with\\-precision|with\\-redefs)$"))
+;; def-like things
+;; TODO
+;(list_lit
+; .
+; (sym_lit) @keyword.function
+; (#match? @keyword.function "^(declare|def.*|ns)$")
+; .
+; (sym_lit) @function)
 
-;; clojure.core=> (cp/pprint (sort (keep (fn [[s v]] (when-not (:macro (meta v)) s)) (ns-publics *ns*))))
-;; ...and then some manual filtering...
-(list_lit
- .
- (sym_lit) @function.builtin
- (#match? @function.builtin "^(\\*|\\*'|\\+|\\+'|\\-|\\-'|\\->ArrayChunk|\\->Eduction|\\->Vec|\\->VecNode|\\->VecSeq|\\-cache\\-protocol\\-fn|\\-reset\\-methods|/|<|<\\=|>|>\\=|\\=|\\=\\=|PrintWriter\\-on|StackTraceElement\\->vec|Throwable\\->map|accessor|aclone|add\\-classpath|add\\-tap|add\\-watch|agent|agent\\-error|agent\\-errors|aget|alength|alias|all\\-ns|alter|alter\\-meta!|alter\\-var\\-root|ancestors|any\\?|apply|array\\-map|aset|aset\\-boolean|aset\\-byte|aset\\-char|aset\\-double|aset\\-float|aset\\-int|aset\\-long|aset\\-short|assoc|assoc!|assoc\\-in|associative\\?|atom|await|await\\-for|await1|bases|bean|bigdec|bigint|biginteger|bit\\-and|bit\\-and\\-not|bit\\-clear|bit\\-flip|bit\\-not|bit\\-or|bit\\-set|bit\\-shift\\-left|bit\\-shift\\-right|bit\\-test|bit\\-xor|boolean|boolean\\-array|boolean\\?|booleans|bound\\-fn\\*|bound\\?|bounded\\-count|butlast|byte|byte\\-array|bytes|bytes\\?|cast|cat|char|char\\-array|char\\-escape\\-string|char\\-name\\-string|char\\?|chars|chunk|chunk\\-append|chunk\\-buffer|chunk\\-cons|chunk\\-first|chunk\\-next|chunk\\-rest|chunked\\-seq\\?|class|class\\?|clear\\-agent\\-errors|clojure\\-version|coll\\?|commute|comp|comparator|compare|compare\\-and\\-set!|compile|complement|completing|concat|conj|conj!|cons|constantly|construct\\-proxy|contains\\?|count|counted\\?|create\\-ns|create\\-struct|cycle|dec|dec'|decimal\\?|dedupe|default\\-data\\-readers|delay\\?|deliver|denominator|deref|derive|descendants|destructure|disj|disj!|dissoc|dissoc!|distinct|distinct\\?|doall|dorun|double|double\\-array|double\\?|doubles|drop|drop\\-last|drop\\-while|eduction|empty|empty\\?|ensure|ensure\\-reduced|enumeration\\-seq|error\\-handler|error\\-mode|eval|even\\?|every\\-pred|every\\?|ex\\-cause|ex\\-data|ex\\-info|ex\\-message|extend|extenders|extends\\?|false\\?|ffirst|file\\-seq|filter|filterv|find|find\\-keyword|find\\-ns|find\\-protocol\\-impl|find\\-protocol\\-method|find\\-var|first|flatten|float|float\\-array|float\\?|floats|flush|fn\\?|fnext|fnil|force|format|frequencies|future\\-call|future\\-cancel|future\\-cancelled\\?|future\\-done\\?|future\\?|gensym|get|get\\-in|get\\-method|get\\-proxy\\-class|get\\-thread\\-bindings|get\\-validator|group\\-by|halt\\-when|hash|hash\\-combine|hash\\-map|hash\\-ordered\\-coll|hash\\-set|hash\\-unordered\\-coll|ident\\?|identical\\?|identity|ifn\\?|in\\-ns|inc|inc'|indexed\\?|init\\-proxy|inst\\-ms|inst\\-ms\\*|inst\\?|instance\\?|int|int\\-array|int\\?|integer\\?|interleave|intern|interpose|into|into\\-array|ints|isa\\?|iterate|iterator\\-seq|juxt|keep|keep\\-indexed|key|keys|keyword|keyword\\?|last|line\\-seq|list|list\\*|list\\?|load|load\\-file|load\\-reader|load\\-string|loaded\\-libs|long|long\\-array|longs|macroexpand|macroexpand\\-1|make\\-array|make\\-hierarchy|map|map\\-entry\\?|map\\-indexed|map\\?|mapcat|mapv|max|max\\-key|memoize|merge|merge\\-with|meta|method\\-sig|methods|min|min\\-key|mix\\-collection\\-hash|mod|munge|name|namespace|namespace\\-munge|nat\\-int\\?|neg\\-int\\?|neg\\?|newline|next|nfirst|nil\\?|nnext|not|not\\-any\\?|not\\-empty|not\\-every\\?|not=|ns\\-aliases|ns\\-imports|ns\\-interns|ns\\-map|ns\\-name|ns\\-publics|ns\\-refers|ns\\-resolve|ns\\-unalias|ns\\-unmap|nth|nthnext|nthrest|num|number\\?|numerator|object\\-array|odd\\?|parents|partial|partition|partition\\-all|partition\\-by|pcalls|peek|persistent!|pmap|pop|pop!|pop\\-thread\\-bindings|pos\\-int\\?|pos\\?|pr|pr\\-str|prefer\\-method|prefers|primitives\\-classnames|print|print\\-ctor|print\\-dup|print\\-method|print\\-simple|print\\-str|printf|println|println\\-str|prn|prn\\-str|promise|proxy\\-call\\-with\\-super|proxy\\-mappings|proxy\\-name|push\\-thread\\-bindings|qualified\\-ident\\?|qualified\\-keyword\\?|qualified\\-symbol\\?|quot|rand|rand\\-int|rand\\-nth|random\\-sample|range|ratio\\?|rational\\?|rationalize|re\\-find|re\\-groups|re\\-matcher|re\\-matches|re\\-pattern|re\\-seq|read|read+string|read\\-line|read\\-string|reader\\-conditional|reader\\-conditional\\?|realized\\?|record\\?|reduce|reduce\\-kv|reduced|reduced\\?|reductions|ref|ref\\-history\\-count|ref\\-max\\-history|ref\\-min\\-history|ref\\-set|refer|release\\-pending\\-sends|rem|remove|remove\\-all\\-methods|remove\\-method|remove\\-ns|remove\\-tap|remove\\-watch|repeat|repeatedly|replace|replicate|require|requiring\\-resolve|reset!|reset\\-meta!|reset\\-vals!|resolve|rest|restart\\-agent|resultset\\-seq|reverse|reversible\\?|rseq|rsubseq|run!|satisfies\\?|second|select\\-keys|send|send\\-off|send\\-via|seq|seq\\?|seqable\\?|seque|sequence|sequential\\?|set|set\\-agent\\-send\\-executor!|set\\-agent\\-send\\-off\\-executor!|set\\-error\\-handler!|set\\-error\\-mode!|set\\-validator!|set\\?|short|short\\-array|shorts|shuffle|shutdown\\-agents|simple\\-ident\\?|simple\\-keyword\\?|simple\\-symbol\\?|slurp|some|some\\-fn|some\\?|sort|sort\\-by|sorted\\-map|sorted\\-map\\-by|sorted\\-set|sorted\\-set\\-by|sorted\\?|special\\-symbol\\?|spit|split\\-at|split\\-with|str|string\\?|struct|struct\\-map|subs|subseq|subvec|supers|swap!|swap\\-vals!|symbol|symbol\\?|tagged\\-literal|tagged\\-literal\\?|take|take\\-last|take\\-nth|take\\-while|tap>|test|the\\-ns|thread\\-bound\\?|to\\-array|to\\-array\\-2d|trampoline|transduce|transient|tree\\-seq|true\\?|type|unchecked\\-add|unchecked\\-add\\-int|unchecked\\-byte|unchecked\\-char|unchecked\\-dec|unchecked\\-dec\\-int|unchecked\\-divide\\-int|unchecked\\-double|unchecked\\-float|unchecked\\-inc|unchecked\\-inc\\-int|unchecked\\-int|unchecked\\-long|unchecked\\-multiply|unchecked\\-multiply\\-int|unchecked\\-negate|unchecked\\-negate\\-int|unchecked\\-remainder\\-int|unchecked\\-short|unchecked\\-subtract|unchecked\\-subtract\\-int|underive|unquote|unquote\\-splicing|unreduced|unsigned\\-bit\\-shift\\-right|update|update\\-in|update\\-proxy|uri\\?|use|uuid\\?|val|vals|var\\-get|var\\-set|var\\?|vary\\-meta|vec|vector|vector\\-of|vector\\?|volatile!|volatile\\?|vreset!|with\\-bindings\\*|with\\-meta|with\\-redefs\\-fn|xml\\-seq|zero\\?|zipmap)$"))
+;; operators
+((sym_lit) @operator
+ (#any-of? @operator
+  "*" "*'" "+" "+'" "-" "-'" "/"
+  "<" "<=" ">" ">=" "=" "=="))
 
-;; other calls
-(list_lit
- .
- (sym_lit) @function)
+;; Ordinary calls
+;; TODO
+;; Do this by having a big scope with all symbols in it and
+;; use `#not-eq? @myvar @parameter`
 
-;; interop-ish
+;; Interop
 (list_lit
  .
  (sym_lit) @method
  (#match? @method "^\\."))
 
+;; other macros
+((sym_lit) @function.macro
+ (#any-of? @function.macro
+  "." ".." "->" "->>" "amap" "and" "areduce" "as->" "assert"
+  "binding" "bound-fn" "case" "catch" "comment" "cond" "cond->"
+  "cond->>" "condp" "delay" "do" "doseq" "dosync" "dotimes"
+  "doto" "extend-protocol" "extend-type" "finally" "fn" "fn*"
+  "for" "future" "gen-class" "gen-interface" "if" "if-let"
+  "if-not" "if-some" "import" "io!" "lazy-cat" "lazy-seq" "let"
+  "letfn" "locking" "loop" "memfn" "monitor-enter" "monitor-exit"
+  "or" "proxy" "proxy-super" "pvalues" "quote" "recur"
+  "refer-clojure" "reify" "set!" "some->" "some->>" "sync"
+  "throw" "time" "try" "unquote" "unquote-splicing" "var"
+  "vswap!" "while"))
+
+((sym_lit) @function.macro
+ (#match? @function.macro "^when(\\-.+)$"))
+
+((sym_lit) @function.macro
+ (#match? @function.macro "^with\\-.*$"))
+
+
+;; clojure.core=> (cp/pprint (sort (keep (fn [[s v]] (when-not (:macro (meta v)) s)) (ns-publics *ns*))))
+;; ...and then some manual filtering...
+((sym_lit) @function.builtin
+ (#any-of? @function.builtin
+  "->ArrayChunk" "->Eduction" "->Vec" "->VecNode" "->VecSeq"
+  "-cache-protocol-fn" "-reset-methods" "PrintWriter-on"
+  "StackTraceElement->vec" "Throwable->map" "accessor"
+  "aclone" "add-classpath" "add-tap" "add-watch" "agent"
+  "agent-error" "agent-errors" "aget" "alength" "alias"
+  "all-ns" "alter" "alter-meta!" "alter-var-root" "ancestors"
+  "any?" "apply" "array-map" "aset" "aset-boolean" "aset-byte"
+  "aset-char" "aset-double" "aset-float" "aset-int"
+  "aset-long" "aset-short" "assoc" "assoc!" "assoc-in"
+  "associative?" "atom" "await" "await-for" "await1"
+  "bases" "bean" "bigdec" "bigint" "biginteger" "bit-and"
+  "bit-and-not" "bit-clear" "bit-flip" "bit-not" "bit-or"
+  "bit-set" "bit-shift-left" "bit-shift-right" "bit-test"
+  "bit-xor" "boolean" "boolean-array" "boolean?"
+  "booleans" "bound-fn*" "bound?" "bounded-count"
+  "butlast" "byte" "byte-array" "bytes" "bytes?"
+  "cast" "cat" "char" "char-array" "char-escape-string"
+  "char-name-string" "char?" "chars" "chunk" "chunk-append"
+  "chunk-buffer" "chunk-cons" "chunk-first" "chunk-next"
+  "chunk-rest" "chunked-seq?" "class" "class?"
+  "clear-agent-errors" "clojure-version" "coll?"
+  "commute" "comp" "comparator" "compare" "compare-and-set!"
+  "compile" "complement" "completing" "concat" "conj"
+  "conj!" "cons" "constantly" "construct-proxy" "contains?"
+  "count" "counted?" "create-ns" "create-struct" "cycle"
+  "dec" "dec'" "decimal?" "dedupe" "default-data-readers"
+  "delay?" "deliver" "denominator" "deref" "derive"
+  "descendants" "destructure" "disj" "disj!" "dissoc"
+  "dissoc!" "distinct" "distinct?" "doall" "dorun" "double"
+  "double-array" "eduction" "empty" "empty?" "ensure" "ensure-reduced"
+  "enumeration-seq" "error-handler" "error-mode" "eval"
+  "even?" "every-pred" "every?" "ex-cause" "ex-data"
+  "ex-info" "ex-message" "extend" "extenders" "extends?"
+  "false?" "ffirst" "file-seq" "filter" "filterv" "find"
+  "find-keyword" "find-ns" "find-protocol-impl"
+  "find-protocol-method" "find-var" "first" "flatten"
+  "float" "float-array" "float?" "floats" "flush" "fn?"
+  "fnext" "fnil" "force" "format" "frequencies"
+  "future-call" "future-cancel" "future-cancelled?"
+  "future-done?" "future?" "gensym" "get" "get-in"
+  "get-method" "get-proxy-class" "get-thread-bindings"
+  "get-validator" "group-by" "halt-when" "hash"
+  "hash-combine" "hash-map" "hash-ordered-coll" "hash-set"
+  "hash-unordered-coll" "ident?" "identical?" "identity"
+  "ifn?" "in-ns" "inc" "inc'" "indexed?" "init-proxy"
+  "inst-ms" "inst-ms*" "inst?" "instance?" "int" "int-array"
+  "int?" "integer?" "interleave" "intern" "interpose" "into"
+  "into-array" "ints" "isa?" "iterate" "iterator-seq" "juxt"
+  "keep" "keep-indexed" "key" "keys" "keyword" "keyword?"
+  "last" "line-seq" "list" "list*" "list?" "load" "load-file"
+  "load-reader" "load-string" "loaded-libs" "long" "long-array"
+  "longs" "macroexpand" "macroexpand-1" "make-array" "make-hierarchy"
+  "map" "map-entry?" "map-indexed" "map?" "mapcat" "mapv"
+  "max" "max-key" "memoize" "merge" "merge-with" "meta"
+  "method-sig" "methods" "min" "min-key" "mix-collection-hash"
+  "mod" "munge" "name" "namespace" "namespace-munge" "nat-int?"
+  "neg-int?" "neg?" "newline" "next" "nfirst" "nil?" "nnext"
+  "not" "not-any?" "not-empty" "not-every?" "not=" "ns-aliases"
+  "ns-imports" "ns-interns" "ns-map" "ns-name" "ns-publics"
+  "ns-refers" "ns-resolve" "ns-unalias" "ns-unmap" "nth"
+  "nthnext" "nthrest" "num" "number?" "numerator" "object-array"
+  "odd?" "parents" "partial" "partition" "partition-all"
+  "partition-by" "pcalls" "peek" "persistent!" "pmap" "pop"
+  "pop!" "pop-thread-bindings" "pos-int?" "pos?" "pr"
+  "pr-str" "prefer-method" "prefers" "primitives-classnames"
+  "print" "print-ctor" "print-dup" "print-method" "print-simple"
+  "print-str" "printf" "println" "println-str" "prn" "prn-str"
+  "promise" "proxy-call-with-super" "proxy-mappings" "proxy-name"
+  "push-thread-bindings" "qualified-ident?" "qualified-keyword?"
+  "qualified-symbol?" "quot" "rand" "rand-int" "rand-nth" "random-sample"
+  "range" "ratio?" "rational?" "rationalize" "re-find" "re-groups"
+  "re-matcher" "re-matches" "re-pattern" "re-seq" "read"
+  "read+string" "read-line" "read-string" "reader-conditional"
+  "reader-conditional?" "realized?" "record?" "reduce"
+  "reduce-kv" "reduced" "reduced?" "reductions" "ref" "ref-history-count"
+  "ref-max-history" "ref-min-history" "ref-set" "refer"
+  "release-pending-sends" "rem" "remove" "remove-all-methods"
+  "remove-method" "remove-ns" "remove-tap" "remove-watch"
+  "repeat" "repeatedly" "replace" "replicate" "require"
+  "requiring-resolve" "reset!" "reset-meta!" "reset-vals!"
+  "resolve" "rest" "restart-agent" "resultset-seq" "reverse"
+  "reversible?" "rseq" "rsubseq" "run!" "satisfies?"
+  "second" "select-keys" "send" "send-off" "send-via"
+  "seq" "seq?" "seqable?" "seque" "sequence" "sequential?"
+  "set" "set-agent-send-executor!" "set-agent-send-off-executor!"
+  "set-error-handler!" "set-error-mode!" "set-validator!"
+  "set?" "short" "short-array" "shorts" "shuffle"
+  "shutdown-agents" "simple-ident?" "simple-keyword?"
+  "simple-symbol?" "slurp" "some" "some-fn" "some?"
+  "sort" "sort-by" "sorted-map" "sorted-map-by"
+  "sorted-set" "sorted-set-by" "sorted?" "special-symbol?"
+  "spit" "split-at" "split-with" "str" "string?"
+  "struct" "struct-map" "subs" "subseq" "subvec" "supers"
+  "swap!" "swap-vals!" "symbol" "symbol?" "tagged-literal"
+  "tagged-literal?" "take" "take-last" "take-nth" "take-while"
+  "tap>" "test" "the-ns" "thread-bound?" "to-array"
+  "to-array-2d" "trampoline" "transduce" "transient"
+  "tree-seq" "true?" "type" "unchecked-add" "unchecked-add-int"
+  "unchecked-byte" "unchecked-char" "unchecked-dec"
+  "unchecked-dec-int" "unchecked-divide-int" "unchecked-double"
+  "unchecked-float" "unchecked-inc" "unchecked-inc-int"
+  "unchecked-int" "unchecked-long" "unchecked-multiply"
+  "unchecked-multiply-int" "unchecked-negate" "unchecked-negate-int"
+  "unchecked-remainder-int" "unchecked-short" "unchecked-subtract"
+  "unchecked-subtract-int" "underive" "unquote"
+  "unquote-splicing" "unreduced" "unsigned-bit-shift-right"
+  "update" "update-in" "update-proxy" "uri?" "use" "uuid?"
+  "val" "vals" "var-get" "var-set" "var?" "vary-meta" "vec"
+  "vector" "vector-of" "vector?" "volatile!" "volatile?"
+  "vreset!" "with-bindings*" "with-meta" "with-redefs-fn" "xml-seq"
+  "zero?" "zipmap"))
+
+
 ;; other symbols with dots
-((sym_lit) @variable
- (#match? @variable "\\."))
-
-
-
+;((sym_lit) @variable
+; (#match? @variable "\\."))

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -20,109 +20,133 @@
 
 ;; >> Symbols
 
-; parameter-related
+; General symbol highlighting
+(sym_lit) @variable
+
+; General function calls
+(list_lit
+ .
+ (sym_lit) @function)
+
+; Quoted symbols
+(quoting_lit
+ (sym_lit) @symbol)
+(syn_quoting_lit
+ (sym_lit) @symbol)
+
+; Used in destructure pattern
 ((sym_lit) @parameter
  (#match? @parameter "^[&]"))
 
+; Inline function variables
 ((sym_lit) @variable.builtin
  (#match? @variable.builtin "^[%]"))
 
-;; TODO: General symbol highlighting
-;; use @variable?
-;((sym_lit) @symbol
-; (#not-eq? @symbol @variable))
+; Constants
+;; TODO: Improve?
+;; - Mark all symbols as constants?
+;; - Remove, just use @variable?
+((sym_lit) @constant
+ (#match? @constant "^[A-Z_-]+$"))
 
-;; dynamic variables
+; Constructor
+((sym_lit) @constructor
+ (#match? @constructor "^-\\>[^\\>].*"))
+
+; Dynamic variables
 ((sym_lit) @variable.builtin
  (#match? @variable.builtin "^[*].+[*]$"))
 
-;; gensym
+; Gensym
+;; TODO: is this needed?
 ((sym_lit) @variable
  (#match? @variable "^.*#$"))
 
+; Types
+;; TODO: improve?
+;; - symbols with `.` but not `/`?
+((sym_lit) @type
+ (#match? @type "^[A-Z][^/]*$"))
 
-
-;; >> Functions
-;; TODO: Enforce function-like things are the first thing in a list?
-
-;; def & fn
-; TODO: fix it so that meta isn't marked as @function
-; e.g (fn ^:meta name [a] a) marks `^:meta` as @function
-(list_lit
- .
- (sym_lit) @keyword.function
- (#match? @keyword.function "^(fn|fn[*]|def.*)$")
- .
- (sym_lit)? @function
- .
- ;; This marks strings twice, should probably fix 🤔
- (str_lit)? @text
- .
- ;; TODO: Get working
- [(vec_lit
-   (sym_lit) @parameter)
-  (list_lit
-   (vec_lit
-    (sym_lit) @parameter))+]?)
- 
-
-;; namespaces
-;; TODO
-;(list_lit
-; .
-; (sym_lit) @keyword.function
-; (#match? @keyword.function "^(declare|def.*|ns)$")
-; .
-; (sym_lit) @function)
-
-;; TODO: symbols with `.`, mark them as namespaces?
-
-;; operators
-((sym_lit) @operator
- (#any-of? @operator
-  "*" "*'" "+" "+'" "-" "-'" "/"
-  "<" "<=" ">" ">=" "=" "==" "not" "not="))
-
-;; Ordinary calls
-;; TODO
-;; Do this by having a big scope with all symbols in it and
-;; use `#not-eq? @myvar @parameter etc`
-;; NOTE: That's a big hack
-
-;; Ordinary calls
-;; TODO
-;; Do this by having a big scope with all symbols in it and
-;; use `#not-eq? @myvar @parameter etc`
-
-;; Interop
+; Interop
+((sym_lit) @method
+ (#match? @method "^\\.[^-]"))
+((sym_lit) @field
+ (#match? @field "^\\.-"))
+((sym_lit) @field
+ (#match? @field "^[A-Z].*/.+"))
 (list_lit
  .
  (sym_lit) @method
- (#match? @method "^\\."))
+ (#match? @method "^[A-Z].*/.+"))
+;; TODO: Special casing for the `.` macro
 
-;; other macros
+; Operators
+((sym_lit) @operator
+ (#any-of? @operator
+  "*" "*'" "+" "+'" "-" "-'" "/"
+  "<" "<=" ">" ">=" "=" "=="))
+((sym_lit) @keyword.operator
+ (#any-of? @keyword.operator
+  "not" "not=" "and" "or"))
+
+; Definition functions
+((sym_lit) @keyword
+ (#match? @keyword "^def.*$"))
+((sym_lit) @keyword
+ (#eq? @keyword "declare"))
+((sym_lit) @keyword.function
+ (#match? @keyword.function "^(defn|defn-|fn|fn[*])$"))
+
+; Comment
+((sym_lit) @comment
+ (#any-of? @comment "comment" "quote"))
+
+; Conditionals
+((sym_lit) @conditional
+ (#any-of? @conditional
+  "case" "cond" "cond->" "cond->>" "condp"))
+((sym_lit) @conditional
+ (#match? @conditional "^if(\\-.*)?$"))
+((sym_lit) @conditional
+ (#match? @conditional "^when(\\-.*)?$"))
+
+; Repeats
+((sym_lit) @repeat
+ (#any-of? @repeat
+  "doseq" "dotimes" "for" "loop" "recur" "while"))
+
+; Exception
+((sym_lit) @exception
+ (#any-of? @exception
+  "throw" "try" "catch" "finally" "ex-info"))
+
+; Includes
+((sym_lit) @include
+ (#any-of? @include "ns" "import" "require" "use"))
+
+; Builtin macros
+;; TODO: Do all these items belong here?
 ((sym_lit) @function.macro
  (#any-of? @function.macro
-  "." ".." "->" "->>" "amap" "and" "areduce" "as->" "assert"
-  "binding" "bound-fn" "case" "catch" "comment" "cond" "cond->"
-  "cond->>" "condp" "delay" "do" "doseq" "dosync" "dotimes"
-  "doto" "extend-protocol" "extend-type" "finally"
-  "for" "future" "gen-class" "gen-interface" "if" "if-let"
-  "if-not" "if-some" "import" "io!" "lazy-cat" "lazy-seq" "let"
-  "letfn" "locking" "loop" "memfn" "monitor-enter" "monitor-exit"
-  "or" "proxy" "proxy-super" "pvalues" "quote" "recur"
+  "." ".." "->" "->>" "amap" "areduce" "as->" "assert"
+  "binding" "bound-fn" "delay" "do" "dosync"
+  "doto" "extend-protocol" "extend-type" "future"
+  "gen-class" "gen-interface" "io!" "lazy-cat"
+  "lazy-seq" "let" "letfn" "locking" "memfn" "monitor-enter"
+  "monitor-exit" "proxy" "proxy-super" "pvalues"
   "refer-clojure" "reify" "set!" "some->" "some->>" "sync"
-  "throw" "time" "try" "unquote" "unquote-splicing" "var"
-  "vswap!" "while"))
-
-((sym_lit) @function.macro
- (#match? @function.macro "^when(\\-.+)$"))
-
+  "time" "unquote" "unquote-splicing" "var" "vswap!"
+  "ex-cause" "ex-data" "ex-message")) 
 ((sym_lit) @function.macro
  (#match? @function.macro "^with\\-.*$"))
 
-;; clojure.core=> (cp/pprint (sort (keep (fn [[s v]] (when-not (:macro (meta v)) s)) (ns-publics *ns*))))
-;; ...and then some manual filtering...
+; All builtin functions
+; (->> (ns-publics *ns*)
+;      (keep (fn [[s v]] (when-not (:macro (meta v)) s)))
+;      sort
+;      cp/print))
+;; ...and then lots of manual filtering...
 ((sym_lit) @function.builtin
  (#any-of? @function.builtin
   "->ArrayChunk" "->Eduction" "->Vec" "->VecNode" "->VecSeq"
@@ -156,8 +180,7 @@
   "dissoc!" "distinct" "distinct?" "doall" "dorun" "double"
   "double-array" "eduction" "empty" "empty?" "ensure" "ensure-reduced"
   "enumeration-seq" "error-handler" "error-mode" "eval"
-  "even?" "every-pred" "every?" "ex-cause" "ex-data"
-  "ex-info" "ex-message" "extend" "extenders" "extends?"
+  "even?" "every-pred" "every?" "extend" "extenders" "extends?"
   "false?" "ffirst" "file-seq" "filter" "filterv" "find"
   "find-keyword" "find-ns" "find-protocol-impl"
   "find-protocol-method" "find-var" "first" "flatten"
@@ -203,7 +226,7 @@
   "ref-max-history" "ref-min-history" "ref-set" "refer"
   "release-pending-sends" "rem" "remove" "remove-all-methods"
   "remove-method" "remove-ns" "remove-tap" "remove-watch"
-  "repeat" "repeatedly" "replace" "replicate" "require"
+  "repeat" "repeatedly" "replace" "replicate"
   "requiring-resolve" "reset!" "reset-meta!" "reset-vals!"
   "resolve" "rest" "restart-agent" "resultset-seq" "reverse"
   "reversible?" "rseq" "rsubseq" "run!" "satisfies?"
@@ -231,7 +254,7 @@
   "unchecked-remainder-int" "unchecked-short" "unchecked-subtract"
   "unchecked-subtract-int" "underive" "unquote"
   "unquote-splicing" "unreduced" "unsigned-bit-shift-right"
-  "update" "update-in" "update-proxy" "uri?" "use" "uuid?"
+  "update" "update-in" "update-proxy" "uri?" "uuid?"
   "val" "vals" "var-get" "var-set" "var?" "vary-meta" "vec"
   "vector" "vector-of" "vector?" "volatile!" "volatile?"
   "vreset!" "with-bindings*" "with-meta" "with-redefs-fn" "xml-seq"

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -1,3 +1,5 @@
+;; >> Litterals
+
 (dis_expr) @comment
 
 (kwd_lit) @symbol
@@ -15,6 +17,24 @@
 (comment) @comment
 
 (regex_lit) @string.regex
+
+(quoting_lit
+ marker: "'" @string.escape)
+
+(syn_quoting_lit
+ marker: "`" @string.escape)
+
+(set_lit
+ marker: "#" @punctuation.special)
+
+(anon_fn_lit
+ marker: "#" @punctuation.special)
+
+["{" "}" "[" "]" "(" ")"] @punctuation.bracket
+
+
+
+;; >> Symbols
 
 ;; metadata experiment
 (meta_lit
@@ -72,10 +92,5 @@
 ((sym_lit) @variable
  (#match? @variable "\\."))
 
-;; quote
-(quoting_lit) @string.escape
 
-;; syntax quote
-(syn_quoting_lit) @string.escape
 
-["{" "}" "[" "]" "(" ")"] @punctuation.bracket

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -47,8 +47,6 @@
 (meta_lit
  marker: "^" @punctuation.special)
 
-;; TODO: Highlight code in comments?
-
 ;; parameter-related
 ((sym_lit) @parameter
  (#match? @parameter "^[&]"))
@@ -57,6 +55,7 @@
  (#match? @variable.builtin "^[%]"))
 
 ;; TODO: General symbol highlighting
+;; use @variable?
 ;((sym_lit) @symbol
 ; (#eq? @symbol @variable))
 
@@ -90,7 +89,7 @@
   (sym_lit) @parameter)?)
  
 
-;; def-like things
+;; namespaces
 ;; TODO
 ;(list_lit
 ; .
@@ -99,11 +98,19 @@
 ; .
 ; (sym_lit) @function)
 
+;; TODO: symbols with `.`, mark them as namespaces?
+
 ;; operators
 ((sym_lit) @operator
  (#any-of? @operator
   "*" "*'" "+" "+'" "-" "-'" "/"
   "<" "<=" ">" ">=" "=" "==" "not" "not="))
+
+;; Ordinary calls
+;; TODO
+;; Do this by having a big scope with all symbols in it and
+;; use `#not-eq? @myvar @parameter`
+;; NOTE: That's a big hack
 
 ;; Ordinary calls
 ;; TODO
@@ -252,8 +259,3 @@
   "vector" "vector-of" "vector?" "volatile!" "volatile?"
   "vreset!" "with-bindings*" "with-meta" "with-redefs-fn" "xml-seq"
   "zero?" "zipmap"))
-
-
-;; other symbols with dots
-;((sym_lit) @variable
-; (#match? @variable "\\."))

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -260,9 +260,63 @@
   "vreset!" "with-bindings*" "with-meta" "with-redefs-fn" "xml-seq"
   "zero?" "zipmap"))
 
+
+
+;; >> Context based highlighting
+
+; def-likes
+; Correctly highlight docstrings
+(list_lit
+ .
+ (sym_lit) @a
+ (#match? @a "^def.*")
+ .
+ (sym_lit)
+ .
+ (str_lit)? @text
+ .
+ (_))
+
+; Funciton definitions
+(list_lit
+ .
+ (sym_lit) @a
+ (#any-of? @a "fn" "fn*" "defn" "defn-")
+ .
+ (sym_lit)? @function
+ .
+ (str_lit)? @text)
+;; TODO: Fix parameter highlighting
+;;       I think there's a bug here in nvim-treesitter
+;; TODO: Reproduce bug and file ticket
+ ;.
+ ;[(vec_lit
+ ;  (sym_lit)* @parameter)
+ ; (list_lit
+ ;  (vec_lit
+ ;   (sym_lit)* @parameter))])
+  
+;[((list_lit
+;   (vec_lit
+;    (sym_lit) @parameter)
+;   (_)
+;  +
+; ((vec_lit
+;   (sym_lit) @parameter)
+;  (_)))
+   
+
 ; Meta punctuation
 ;; NOTE: When the above `Function definitions` query captures the
 ;;       the @function it also captures the child meta_lit
 ;;       We capture the meta_lit symbol (^) after so that the later
 ;;       highlighting overrides the former
 "^" @punctuation.special
+
+;; namespaces
+(list_lit
+ .
+ (sym_lit) @a
+ (#eq? @a "ns")
+ .
+ (sym_lit) @namespace)

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -40,6 +40,9 @@
 (list_lit
  .
  (sym_lit) @function)
+(anon_fn_lit
+ .
+ (sym_lit) @function)
 
 ; Quoted symbols
 (quoting_lit

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -92,7 +92,7 @@
 ((sym_lit) @operator
  (#any-of? @operator
   "*" "*'" "+" "+'" "-" "-'" "/"
-  "<" "<=" ">" ">=" "=" "=="))
+  "<" "<=" ">" ">=" "=" "==" "not" "not="))
 
 ;; Ordinary calls
 ;; TODO
@@ -187,7 +187,7 @@
   "method-sig" "methods" "min" "min-key" "mix-collection-hash"
   "mod" "munge" "name" "namespace" "namespace-munge" "nat-int?"
   "neg-int?" "neg?" "newline" "next" "nfirst" "nil?" "nnext"
-  "not" "not-any?" "not-empty" "not-every?" "not=" "ns-aliases"
+  "not-any?" "not-empty" "not-every?" "ns-aliases"
   "ns-imports" "ns-interns" "ns-map" "ns-name" "ns-publics"
   "ns-refers" "ns-resolve" "ns-unalias" "ns-unmap" "nth"
   "nthnext" "nthrest" "num" "number?" "numerator" "object-array"

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -58,13 +58,6 @@
 ((sym_lit) @variable.builtin
  (#match? @variable.builtin "^[%]"))
 
-; Constants
-;; TODO: Improve?
-;; - Mark all symbols as constants?
-;; - Remove, just use @variable?
-((sym_lit) @constant
- (#match? @constant "^[A-Z_-]+$"))
-
 ; Constructor
 ((sym_lit) @constructor
  (#match? @constructor "^-\\>[^\\>].*"))

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -73,14 +73,22 @@
 ;; >> Functions
 ;; TODO: Enforce function-like things are the first thing in a list?
 
-;; def-like things
-;; TODO
-;(list_lit
-; .
-; (sym_lit) @keyword.function
-; (#match? @keyword.function "^(declare|def.*|ns)$")
-; .
-; (sym_lit) @function)
+;; def & fn
+; TODO: fix it so that meta isn't marked as @function
+; e.g (fn ^:meta name [a] a) marks `^:meta` as @function
+(list_lit
+ .
+ (sym_lit) @keyword.function
+ (#match? @keyword.function "^(fn|fn[*]|def.*)$")
+ .
+ (sym_lit)? @function
+ .
+ (str_lit)? @text
+ .
+ ; TODO: Get this working?
+ (vec_lit
+  (sym_lit) @parameter)?)
+ 
 
 ;; def-like things
 ;; TODO
@@ -114,7 +122,7 @@
   "." ".." "->" "->>" "amap" "and" "areduce" "as->" "assert"
   "binding" "bound-fn" "case" "catch" "comment" "cond" "cond->"
   "cond->>" "condp" "delay" "do" "doseq" "dosync" "dotimes"
-  "doto" "extend-protocol" "extend-type" "finally" "fn" "fn*"
+  "doto" "extend-protocol" "extend-type" "finally"
   "for" "future" "gen-class" "gen-interface" "if" "if-let"
   "if-not" "if-some" "import" "io!" "lazy-cat" "lazy-seq" "let"
   "letfn" "locking" "loop" "memfn" "monitor-enter" "monitor-exit"

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -18,6 +18,7 @@
 
 (regex_lit) @string.regex
 
+;; TODO: Quote whole quoted symbol?
 (quoting_lit
  marker: "'" @string.escape)
 
@@ -40,7 +41,9 @@
 
 ;; >> Symbols
 
-;; metadata experiment
+;; metadata
+;; TODO: Mark whole meta tag?
+;; TODO: If not, handle java classes?
 (meta_lit
  marker: "^" @punctuation.special)
 
@@ -65,6 +68,7 @@
 
 
 ;; >> Functions
+;; TODO: Enforce function-like things are the first thing in a list?
 
 ;; def-like things
 ;; TODO
@@ -121,7 +125,6 @@
 
 ((sym_lit) @function.macro
  (#match? @function.macro "^with\\-.*$"))
-
 
 ;; clojure.core=> (cp/pprint (sort (keep (fn [[s v]] (when-not (:macro (meta v)) s)) (ns-publics *ns*))))
 ;; ...and then some manual filtering...

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -73,9 +73,11 @@
 
 ; Types
 ;; TODO: improve?
-;; - symbols with `.` but not `/`?
 ((sym_lit) @type
  (#match? @type "^[A-Z][^/]*$"))
+;; Symbols with `.` but not `/`
+((sym_lit) @type
+ (#match? @type "^[^/]+[.][^/]*$"))
 
 ; Interop
 ((sym_lit) @method

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -23,6 +23,10 @@
 
 (syn_quoting_lit
  marker: "`" @string.escape)
+(unquoting_lit
+ marker: "~" @punctuation.special)
+(unquote_splicing_lit
+ marker: "~@" @punctuation.special)
 
 (set_lit
  marker: "#" @punctuation.special)

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -1,3 +1,6 @@
+;; TODO: Make comparison screenshot
+;; TODO: Try out for a while
+;; TODO: Tweak
 ;; >> Litterals
 
 (dis_expr) @comment

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -1,6 +1,16 @@
-;; TODO: Make comparison screenshot
-;; TODO: Try out for a while
-;; TODO: Tweak
+;; >> Explanation
+;; Parsers for lisps are a bit weird in that they just return the raw forms.
+;; This means we have to do a bit of extra work in the queries to get things
+;; highlighted as they should be.
+;;
+;; For the most part this means that some things have to be assigned multiple
+;; groups.
+;; By doing this we can add a basic capture and then later refine it with more
+;; specialied captures.
+;; This can mean that sometimes things are highlighted weirdly because they
+;; have multiple highlight groups applied to them.
+
+
 ;; >> Litterals
 
 (dis_expr) @comment

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -279,8 +279,8 @@
 ; Correctly highlight docstrings
 (list_lit
  .
- (sym_lit) @a ; Don't really want to highlight twice
- (#match? @a "^def.*")
+ (sym_lit) @_keyword ; Don't really want to highlight twice
+ (#match? @_keyword "^def.*")
  .
  (sym_lit)
  .
@@ -291,8 +291,8 @@
 ; Funciton definitions
 (list_lit
  .
- (sym_lit) @a
- (#any-of? @a "fn" "fn*" "defn" "defn-")
+ (sym_lit) @_keyword.function
+ (#any-of? @_keyword.function "fn" "fn*" "defn" "defn-")
  .
  (sym_lit)? @function
  .

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -67,7 +67,7 @@
  (#match? @variable.builtin "^[*].+[*]$"))
 
 ; Gensym
-;; TODO: is this needed?
+;; Might not be needed
 ((sym_lit) @variable
  (#match? @variable "^.*#$"))
 
@@ -279,7 +279,7 @@
 ; Correctly highlight docstrings
 (list_lit
  .
- (sym_lit) @a
+ (sym_lit) @a ; Don't really want to highlight twice
  (#match? @a "^def.*")
  .
  (sym_lit)


### PR DESCRIPTION
I've been using these for the last week or so and they seem pretty good.
Some tweaks may be needed but they're definitely a better start (imo).

## Screenshots:
(using [moonlight.nvim](https://github.com/shaunsingh/moonlight.nvim))

### `Neovim default` vs `Original tree-sittter` vs `Updated tree-sitter`
<div float="left">
    <img width="250" alt="Screenshot 2021-06-13 at 23 14 52" src="https://user-images.githubusercontent.com/8889986/121823715-fd35e980-cc9e-11eb-81ce-c02877e46518.png">
    <img width="250" alt="Screenshot 2021-06-13 at 23 14 34" src="https://user-images.githubusercontent.com/8889986/121823730-0e7ef600-cc9f-11eb-86da-caa4bfabd9da.png">
    <img width="250" alt="Screenshot 2021-06-13 at 23 14 34" src="https://user-images.githubusercontent.com/8889986/121823736-176fc780-cc9f-11eb-869e-4f0681e987ea.png">
</div>

I think the Neovim default might be coming from conjure, but I still think the tree-sitter one is cool.