### PR TITLE
highlight: add SCSS single_line_comment

### DIFF
--- a/queries/scss/highlights.scm
+++ b/queries/scss/highlights.scm
@@ -8,6 +8,7 @@
   "@include"
 ] @keyword
 
+(single_line_comment) @comment
 (function_name) @function
 
 


### PR DESCRIPTION
Single line comments, or doc comments, are defined in the [SCSS syntax](https://sass-lang.com/documentation/syntax/comments) and are also included in the [tree-sitter-scss/grammar.json](https://github.com/serenadeai/tree-sitter-scss/blob/9da7c979c010c350c28ad2235893103db4622c10/grammar.js#L366) file, but they are missing from the highlight files.

This PR adds the missing highlight group.

Before:
![screenshot_20210614_174406](https://user-images.githubusercontent.com/12140044/121959317-87905300-cd5c-11eb-9cc3-80a345b9007c.png)

After:
![screenshot_20210614_220515](https://user-images.githubusercontent.com/12140044/121959384-9e36aa00-cd5c-11eb-9b53-14494a9ed94a.png)
