### PR TITLE
Add Julia indent queries and update fold queries

### DIFF
--- a/queries/julia/folds.scm
+++ b/queries/julia/folds.scm
@@ -1,11 +1,17 @@
 [
- (module_definition)
- (struct_definition)
- (macro_definition)
- (function_definition)
- (compound_expression) ; begin blocks
- (let_statement)
- (if_statement)
- (for_statement)
- (while_statement)
+  (module_definition)
+  (struct_definition)
+  (macro_definition)
+  (function_definition)
+
+  (if_statement)
+  (try_statement)
+  (for_statement)
+  (while_statement)
+  (let_statement)
+  (quote_statement)
+
+  (do_clause)
+  (compound_expression)
 ] @fold
+

--- a/queries/julia/indents.scm
+++ b/queries/julia/indents.scm
@@ -1,0 +1,40 @@
+[
+  (struct_definition)
+  (macro_definition)
+  (function_definition)
+
+  (if_statement)
+  (try_statement)
+  (for_statement)
+  (while_statement)
+  (let_statement)
+  (quote_statement)
+
+  (do_clause)
+  (compound_expression)
+
+  (assignment_expression)
+  (binary_expression)
+  (call_expression)
+
+  (array_expression)
+  (tuple_expression)
+  (matrix_expression)
+] @indent
+
+[
+  "end"
+  "("
+  ")"
+  "["
+  "]"
+  (else_clause)
+  (elseif_clause)
+] @branch
+
+[
+  (comment)
+  (block_comment)
+  (triple_string)
+] @ignore
+

--- a/queries/julia/indents.scm
+++ b/queries/julia/indents.scm
@@ -30,6 +30,8 @@
   "]"
   (else_clause)
   (elseif_clause)
+  (catch_clause)
+  (finally_clause)
 ] @branch
 
 [


### PR DESCRIPTION
The julia.vim plugin has more indentation rules for collection literals, making matrices easier to read. I don't know how that would work with tree-sitter queries so I just ignored it. This only adds one indentation level, like the indent queries for other languages. I think it's fine for now, but I'd be interested in improving it in the future.