### PR TITLE
feat: added `self` as builtin keyword for Lua

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -1,6 +1,8 @@
 ;;; Highlighting for lua
 
 ;;; Builtins
+(self) @variable.builtin
+
 ;; Keywords
 
 (if_statement


### PR DESCRIPTION
I added `self` as a builtin keyword for highlighting Lua code