### PR TITLE
One-Line Fix For Broken Spellchecking With Highlight Enabled

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -110,6 +110,7 @@ function M.attach(bufnr, lang)
   end
 
   ts.highlighter.new(parser, {})
+  api.nvim_buf_set_option(bufnr, 'syntax', lang)
 
   local is_table = type(config.additional_vim_regex_highlighting) == 'table'
   if config.additional_vim_regex_highlighting and (not is_table or config.additional_vim_regex_highlighting[lang]) then


### PR DESCRIPTION
Thanks for the super helpful plugin!

While setting up my new `init.lua` recently, I encountered a mysterious issue with Neovim's built-in spellchecking. It seemed to be spell checking bits of syntax that it wasn't supposed to (like function and variable names, as opposed to just strings and comments). I eventually tracked down the issue to the `highlight` feature of `nvim-treesitter` which seems to replace vim's normal `:syntax enable` to some extent.

As I now understand, Neovim's spellcheck relies on the `syntax` option to know what should be spell-checked and what shouldn't be. Unfortunately, it seems that something in `highlight.lua` prevents this from being set correctly! I've added a line to manually set this option and fix my spell checking (without breaking anything I could find?).

More visually, here is a screenshot from `master`:
![image](https://user-images.githubusercontent.com/6251883/122400655-cf3cf780-cf73-11eb-892b-ccf0bf182758.png)
Note that the `syntax` option is unset and the spellchecker is highlighting things like `opt.expandtab`.

Here is what it looks like with my patch:
![image](https://user-images.githubusercontent.com/6251883/122401055-28a52680-cf74-11eb-98e4-075c3c5e0ad7.png)
The `syntax` option is now correctly set to `lua` and things like `opt.expandtab` no longer upset the spell-checker. The strings and comments in the above section, however, are still being checked as expected!

Let me know what you think! I only picked up (Neo)vim a couple of days ago, so it's possible I'm overlooking something here, but I'm happy to make any changes you think this might need!