### PR TITLE
rust: inject html to html! macro

### DIFF
--- a/queries/rust/injections.scm
+++ b/queries/rust/injections.scm
@@ -10,3 +10,12 @@
   (line_comment)
   (block_comment)
 ] @comment
+
+(
+  (macro_invocation
+    macro: ((identifier) @_html_def)
+    (token_tree) @html)
+
+    (#eq? @_html_def "html")
+)
+


### PR DESCRIPTION
> THANKSSSSSSSSSSSSSSSSSSSS @Conni2461 ❤️ ❤️ 

This PR adds html ot html! macro. Many packages define their own html! tag or use popular ones. Thus, it is an awesome addition for people expermenting with wasm and rust.
