### PR TITLE
Use `#any-of?` instead of `#match?` where posible

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -90,7 +90,9 @@
 (command_name (word) @function)
 
 ((command_name (word) @function.builtin)
- (#match? @function.builtin "^(cd|echo|eval|exit|getopts|pushd|popd|return|set|shift)$"))
+ (#any-of? @function.builtin
+    "cd" "echo" "eval" "exit" "getopts"
+    "pushd" "popd" "return" "set" "shift"))
 
 (command
   argument: [

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -38,7 +38,11 @@
  (sym_lit) @function.macro
  .
  (sym_lit) @function
- (#match? @function.macro "^(declare|def|definline|definterface|defmacro|defmethod|defmulti|defn|defn-|defonce|defprotocol|defstruct|deftype|ns)$"))
+ (#any-of? @function.macro
+    "declare" "def" "definline" "definterface"
+    "defmacro" "defmethod" "defmulti" "defn"
+    "defn-" "defonce" "defprotocol" "defstruct"
+    "deftype" "ns"))
 
 ;; other macros
 (list_lit

--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -8,16 +8,16 @@
 (tag (name) @text.note (user)? @constant)
 
 ((tag ((name) @text.warning))
- (#match? @text.warning "^(TODO|HACK|WARNING)$"))
+ (#any-of? @text.warning "TODO" "HACK" "WARNING)$"))
 
 ("text" @text.warning
- (#match? @text.warning "^(TODO|HACK|WARNING)$"))
+ (#any-of? @text.warning "TODO" "HACK" "WARNING"))
 
 ((tag ((name) @text.danger))
- (#match? @text.danger "^(FIXME|XXX|BUG)$"))
+ (#any-of? @text.danger "FIXME" "XXX" "BUG"))
 
 ("text" @text.danger
- (#match? @text.danger "^(FIXME|XXX|BUG)$"))
+ (#any-of? @text.danger "FIXME" "XXX" "BUG"))
 
 ; Issue number (#123)
 ("text" @number (#match? @number "^#[0-9]+$"))

--- a/queries/glimmer/highlights.scm
+++ b/queries/glimmer/highlights.scm
@@ -58,7 +58,7 @@
 
 ; If the identifier is just "yield" or "outlet", it's a keyword
 ((mustache_statement (identifier) @keyword)
-  (#match? @keyword "yield|outlet"))
+  (#any-of? @keyword "yield" "outlet"))
 
 ; Helpers are functions
 ((helper_invocation helper: [

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -109,13 +109,20 @@
 ;; Builtin types
 
 ((type_identifier) @type.builtin
- (#match? @type.builtin "^(bool|byte|complex128|complex64|error|float32|float64|int|int16|int32|int64|int8|rune|string|uint|uint16|uint32|uint64|uint8|uintptr)$"))
+ (#any-of? @type.builtin
+    "bool" "byte" "complex128" "complex64" "error"
+    "float32" "float64" "int" "int16" "int32" "int64"
+    "int8" "rune" "string" "uint" "uint16" "uint32"
+    "uint64" "uint8" "uintptr"))
 
 
 ;; Builtin functions
 
 ((identifier) @function.builtin
- (#match? @function.builtin "^(append|cap|close|complex|copy|delete|imag|len|make|new|panic|print|println|real|recover)$"))
+ (#any-of? @function.builtin
+    "append" "cap" "close" "complex" "copy"
+    "delete" "imag" "len" "make" "new" "panic"
+    "print" "println" "real" "recover"))
 
 
 ; Delimiters

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -134,7 +134,7 @@
   "type"
 ] @keyword
 
-((identifier) @keyword (#match? @keyword "^(global|local)$"))
+((identifier) @keyword (#any-of? @keyword "global" "local"))
 
 (compound_expression
   ["begin" "end"] @keyword)

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -8,7 +8,10 @@
 
 (
   (type_constructor) @type.builtin
-  (#match? @type.builtin "^(int|char|bytes|string|float|bool|unit|exn|array|list|option|int32|int64|nativeint|format6|lazy_t)$")
+  (#any-of? @type.builtin
+    "int" "char" "bytes" "string" "float"
+    "bool" "unit" "exn" "array" "list" "option"
+    "int32" "int64" "nativeint" "format6" "lazy_t")
 )
 
 [(class_name) (class_type_name) (type_constructor)] @type

--- a/queries/svelte/injections.scm
+++ b/queries/svelte/injections.scm
@@ -6,7 +6,7 @@
       (attribute
         (quoted_attribute_value (attribute_value) @_lang)))
     (raw_text) @scss)
-  (#match? @_lang "(scss|postcss|less)")
+  (#any-of? @_lang "scss" "postcss" "less")
 )
 
 ((attribute
@@ -22,7 +22,7 @@
       (attribute
         (quoted_attribute_value (attribute_value) @_lang)))
     (raw_text) @typescript)
-  (#match? @_lang "(ts|typescript)")
+  (#any-of? @_lang "ts" "typescript")
 )
 
 (comment) @comment

--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -6,7 +6,7 @@
       (attribute
         (quoted_attribute_value (attribute_value) @_lang)))
     (raw_text) @scss)
-  (#match? @_lang "(scss|postcss|less)")
+  (#any-of? @_lang "scss" "postcss" "less")
 )
 
 (
@@ -15,7 +15,7 @@
       (attribute
         (quoted_attribute_value (attribute_value) @_lang)))
     (raw_text) @typescript)
-  (#match? @_lang "(ts|typescript)")
+  (#any-of? @_lang "ts" "typescript")
 )
 
 ((interpolation


### PR DESCRIPTION
With this pr, uses of `#match?` of the form
```lisp
(#match? "^(opt1|opt2)$")
```
are translated to
```lisp
(#any-of? "opt1" "opt2")
```
to increase readability, except where the pattern includes a prefix before the choices