### PR TITLE
Adds support for PHP's arrow funcion

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -76,9 +76,17 @@
 ; Keywords
 
 [
+ "as"
+] @keyword.operator
+
+[
+ "fn"
+ "function"
+] @keyword.function
+
+[
  "$"
  "abstract"
- "as"
  "break"
  "class"
  "const"
@@ -89,7 +97,6 @@
  "enddeclare"
  "extends"
  "final"
- "function"
  "global"
  "implements"
  "insteadof"


### PR DESCRIPTION
I added `fn` as a arrow funciton keyword for highlighting PHP code