### PR TITLE
highlights(c): not highlight anything in sizeof(.) as type

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -143,7 +143,6 @@
 
 (declaration (type_qualifier) @type)
 (cast_expression type: (type_descriptor) @type)
-(sizeof_expression value: (parenthesized_expression (identifier) @type))
 
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z0-9_]+$"))


### PR DESCRIPTION
We assumed that an identifier inside `sizeof` is a type. But you can also use sizeof like `int foo = 1; printf("%zu", sizeof(foo));`