### PR TITLE
highlights(typescript): fix indentifier for type imports

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -20,6 +20,12 @@
 (type_identifier) @type
 (predefined_type) @type.builtin
 
+(import_statement "type"
+  (import_clause
+    (named_imports
+      ((import_specifier
+          name: (identifier) @type)))))
+
 ; punctuation
 
 (type_arguments


### PR DESCRIPTION
**Before**:

![image](https://user-images.githubusercontent.com/8050659/123508760-27ba7600-d693-11eb-9bdf-7a48ea28e7f0.png)

**After**:

![image](https://user-images.githubusercontent.com/8050659/123508762-3b65dc80-d693-11eb-9ce2-14a980738e9a.png)
