### PR TITLE
highlights(jsx): fix constant identifier

### DIFF
--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -32,7 +32,4 @@
 ; Handle the dot operator effectively - <My.Component />
 (jsx_self_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
 
-(variable_declarator ((identifier) @type
- (#match? @type "^[A-Z]")))
-
 (jsx_text) @none


### PR DESCRIPTION
**Before**:

![image](https://user-images.githubusercontent.com/8050659/123509011-e3c87080-d694-11eb-9ba8-85b34f5c0227.png)

**After**:

![image](https://user-images.githubusercontent.com/8050659/123509015-ec20ab80-d694-11eb-8a30-c3260cd904f8.png)
