### PR TITLE
Add common quasiquote highlights/injections for Haskell

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -127,5 +127,5 @@
 ;; ----------------------------------------------------------------------------
 ;; Quasi-quotes
 
-(quoter) @function.special
+(quoter) @function
 ; Highlighting of quasiquote_body is handled by injections.scm

--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -122,3 +122,10 @@
 
 ; True or False
 ((constructor) @_bool (#match? @_bool "(True|False)")) @boolean
+
+
+;; ----------------------------------------------------------------------------
+;; Quasi-quotes
+
+(quoter) @function.special
+; Highlighting of quasiquote_body is handled by injections.scm

--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -9,7 +9,14 @@
 
 ;; -----------------------------------------------------------------------------
 ;; shakespeare library
-;; NOTE: excludes CoffeeScript (Text.Coffee) and doesn't support templating
+;; NOTE: doesn't support templating
+
+; TODO: add once CoffeeScript parser is added
+; ; CoffeeScript: Text.Coffee
+; (quasiquote
+;  (quoter) @_name
+;  (#eq? @_name "coffee")
+;  ((quasiquote_body) @coffeescript)
 
 ; CSS: Text.Cassius, Text.Lucius
 (quasiquote

--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -9,14 +9,7 @@
 
 ;; -----------------------------------------------------------------------------
 ;; shakespeare library
-;; NOTE: doesn't support templating
-
-; CoffeeScript: Text.Coffee
-(quasiquote
- (quoter) @_name
- (#eq? @_name "coffee")
- ((quasiquote_body) @coffeescript)
-)
+;; NOTE: excludes CoffeeScript (Text.Coffee) and doesn't support templating
 
 ; CSS: Text.Cassius, Text.Lucius
 (quasiquote

--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -30,7 +30,7 @@
 ; HTML: Text.Hamlet
 (quasiquote 
  (quoter) @_name
- (#any-of? @_name "shamlet" "xshamlet")
+ (#any-of? @_name "shamlet" "xshamlet" "hamlet" "xhamlet" "ihamlet")
  ((quasiquote_body) @content)
  (#set! language "html")
 )
@@ -38,7 +38,7 @@
 ; JS: Text.Julius
 (quasiquote 
  (quoter) @_name
- (#eq? @_name "julius")
+ (#any-of? @_name "js" "julius")
  ((quasiquote_body) @content)
  (#set! language "javascript")
 )
@@ -46,7 +46,7 @@
 ; TS: Text.TypeScript
 (quasiquote 
  (quoter) @_name
- (#eq? @_name "tsc" "tscJSX")
+ (#any-of? @_name "tsc" "tscJSX")
  ((quasiquote_body) @content)
  (#set! language "typescript")
 )

--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -1,0 +1,63 @@
+;; ----------------------------------------------------------------------------- 
+;; General language injection
+
+(quasiquote 
+ ((quoter) @language)
+ ((quasiquote_body) @content)
+)
+
+
+;; ----------------------------------------------------------------------------- 
+;; shakespeare library
+;; NOTE: doesn't support templating
+
+; CoffeeScript: Text.Coffee
+(quasiquote 
+ (quoter) @_name
+ (#eq? @_name "coffee")
+ ((quasiquote_body) @content)
+ (#set! language "coffeescript")
+)
+
+; CSS: Text.Cassius, Text.Lucius
+(quasiquote 
+ (quoter) @_name
+ (#any-of? @_name "cassius" "lucius")
+ ((quasiquote_body) @content)
+ (#set! language "css")
+)
+
+; HTML: Text.Hamlet
+(quasiquote 
+ (quoter) @_name
+ (#any-of? @_name "shamlet" "xshamlet")
+ ((quasiquote_body) @content)
+ (#set! language "html")
+)
+
+; JS: Text.Julius
+(quasiquote 
+ (quoter) @_name
+ (#eq? @_name "julius")
+ ((quasiquote_body) @content)
+ (#set! language "javascript")
+)
+
+; TS: Text.TypeScript
+(quasiquote 
+ (quoter) @_name
+ (#eq? @_name "tsc" "tscJSX")
+ ((quasiquote_body) @content)
+ (#set! language "typescript")
+)
+
+
+;; ----------------------------------------------------------------------------- 
+;; HSX
+
+(quasiquote 
+ (quoter) @_name
+ (#eq? @_name "hsx")
+ ((quasiquote_body) @content)
+ (#set! language "html")
+)

--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -15,40 +15,35 @@
 (quasiquote
  (quoter) @_name
  (#eq? @_name "coffee")
- ((quasiquote_body) @content)
- (#set! language "coffeescript")
+ ((quasiquote_body) @coffeescript)
 )
 
 ; CSS: Text.Cassius, Text.Lucius
 (quasiquote
  (quoter) @_name
  (#any-of? @_name "cassius" "lucius")
- ((quasiquote_body) @content)
- (#set! language "css")
+ ((quasiquote_body) @css)
 )
 
 ; HTML: Text.Hamlet
 (quasiquote
  (quoter) @_name
  (#any-of? @_name "shamlet" "xshamlet" "hamlet" "xhamlet" "ihamlet")
- ((quasiquote_body) @content)
- (#set! language "html")
+ ((quasiquote_body) @html)
 )
 
 ; JS: Text.Julius
 (quasiquote
  (quoter) @_name
  (#any-of? @_name "js" "julius")
- ((quasiquote_body) @content)
- (#set! language "javascript")
+ ((quasiquote_body) @javascript)
 )
 
 ; TS: Text.TypeScript
 (quasiquote
  (quoter) @_name
  (#any-of? @_name "tsc" "tscJSX")
- ((quasiquote_body) @content)
- (#set! language "typescript")
+ ((quasiquote_body) @typescript)
 )
 
 
@@ -58,6 +53,5 @@
 (quasiquote
  (quoter) @_name
  (#eq? @_name "hsx")
- ((quasiquote_body) @content)
- (#set! language "html")
+ ((quasiquote_body) @html)
 )

--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -1,18 +1,18 @@
-;; ----------------------------------------------------------------------------- 
+;; -----------------------------------------------------------------------------
 ;; General language injection
 
-(quasiquote 
+(quasiquote
  ((quoter) @language)
  ((quasiquote_body) @content)
 )
 
 
-;; ----------------------------------------------------------------------------- 
+;; -----------------------------------------------------------------------------
 ;; shakespeare library
 ;; NOTE: doesn't support templating
 
 ; CoffeeScript: Text.Coffee
-(quasiquote 
+(quasiquote
  (quoter) @_name
  (#eq? @_name "coffee")
  ((quasiquote_body) @content)
@@ -20,7 +20,7 @@
 )
 
 ; CSS: Text.Cassius, Text.Lucius
-(quasiquote 
+(quasiquote
  (quoter) @_name
  (#any-of? @_name "cassius" "lucius")
  ((quasiquote_body) @content)
@@ -28,7 +28,7 @@
 )
 
 ; HTML: Text.Hamlet
-(quasiquote 
+(quasiquote
  (quoter) @_name
  (#any-of? @_name "shamlet" "xshamlet" "hamlet" "xhamlet" "ihamlet")
  ((quasiquote_body) @content)
@@ -36,7 +36,7 @@
 )
 
 ; JS: Text.Julius
-(quasiquote 
+(quasiquote
  (quoter) @_name
  (#any-of? @_name "js" "julius")
  ((quasiquote_body) @content)
@@ -44,7 +44,7 @@
 )
 
 ; TS: Text.TypeScript
-(quasiquote 
+(quasiquote
  (quoter) @_name
  (#any-of? @_name "tsc" "tscJSX")
  ((quasiquote_body) @content)
@@ -52,10 +52,10 @@
 )
 
 
-;; ----------------------------------------------------------------------------- 
+;; -----------------------------------------------------------------------------
 ;; HSX
 
-(quasiquote 
+(quasiquote
  (quoter) @_name
  (#eq? @_name "hsx")
  ((quasiquote_body) @content)


### PR DESCRIPTION
This PR adds highlights and injections for some common quasiquotes in Haskell.

I've been recently playing around with [IHP](https://github.com/digitallyinduced/ihp) which uses HSX quasiquotes. The screenshots below show the difference:

**Before:**

![screenshot_20210627_143410](https://user-images.githubusercontent.com/12140044/123546585-205ba100-d755-11eb-82cd-619980dc5cf2.png)

**After:**

![screenshot_20210627_143730](https://user-images.githubusercontent.com/12140044/123546610-379a8e80-d755-11eb-8a12-110e67694b62.png)

As well as HSX, the PR also adds injections for the [shakespeare library](https://hackage.haskell.org/package/shakespeare), though at the moment it doesn't have special highlighting for templates. 