### PR TITLE
parsers: add HCL

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [gomod](https://github.com/camdencheek/tree-sitter-go-mod) (maintained by @camdencheek)
 - [x] [graphql](https://github.com/bkegley/tree-sitter-graphql) (maintained by @bkegley)
 - [ ] [haskell](https://github.com/tree-sitter/tree-sitter-haskell)
+- [x] [hcl](https://github.com/MichaHoffmann/tree-sitter-hcl) (maintained by @MichaHoffmann)
 - [x] [html](https://github.com/tree-sitter/tree-sitter-html) (maintained by @TravonteD)
 - [x] [java](https://github.com/tree-sitter/tree-sitter-java) (maintained by @p00f)
 - [x] [javascript](https://github.com/tree-sitter/tree-sitter-javascript) (maintained by @steelsojka)

--- a/lockfile.json
+++ b/lockfile.json
@@ -77,6 +77,9 @@
   "haskell": {
     "revision": "a0c1adb59e390f7d839a146c57fdb33d36ed97e6"
   },
+  "hcl": {
+    "revision": "7d8ecd053a11274a15b0aa1d1e82f37e64edeb42"
+  },
   "html": {
     "revision": "d93af487cc75120c89257195e6be46c999c6ba18"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -78,7 +78,7 @@
     "revision": "a0c1adb59e390f7d839a146c57fdb33d36ed97e6"
   },
   "hcl": {
-    "revision": "7d8ecd053a11274a15b0aa1d1e82f37e64edeb42"
+    "revision": "0e7d8ddb4b1e64984234f1079156bceaec9f99cf"
   },
   "html": {
     "revision": "d93af487cc75120c89257195e6be46c999c6ba18"

--- a/lockfile.json
+++ b/lockfile.json
@@ -78,7 +78,7 @@
     "revision": "a0c1adb59e390f7d839a146c57fdb33d36ed97e6"
   },
   "hcl": {
-    "revision": "0e7d8ddb4b1e64984234f1079156bceaec9f99cf"
+    "revision": "30e9f3eae8ec798f6540b05e3b4bb6c6e1313156"
   },
   "html": {
     "revision": "d93af487cc75120c89257195e6be46c999c6ba18"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -355,6 +355,7 @@ list.hcl = {
     branch = "main"
   },
   filetype = "hcl",
+  used_by = { "terraform", "packer", "nomad" },
 }
 
 -- FIXME(vigoux): markdown is broken for now

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -355,7 +355,6 @@ list.hcl = {
     branch = "main"
   },
   filetype = "hcl",
-  used_by = {"tf", "tfvars"}
 }
 
 -- FIXME(vigoux): markdown is broken for now

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -348,6 +348,16 @@ list.haskell = {
   }
 }
 
+list.hcl = {
+  install_info = {
+    url = "https://github.com/MichaHoffmann/tree-sitter-hcl",
+    files = {"src/parser.c", "src/scanner.cc"},
+    branch = "main"
+  },
+  filetype = "hcl",
+  used_by = {"tf", "tfvars"}
+}
+
 -- FIXME(vigoux): markdown is broken for now
 -- list.markdown = {
 --   install_info = {

--- a/queries/hcl/folds.scm
+++ b/queries/hcl/folds.scm
@@ -1,0 +1,5 @@
+[
+ (comment)
+ (block)
+ (heredoc_template)
+] @fold

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -24,21 +24,21 @@
   "]"
   "("
   ")"
-  "[*]"
-  ".*"
-] @specialChar
+] @punctuation.bracket
 
 [
   "."
+  ".*"
   ","
-] @specialChar
+  "[*]"
+] @punctuation.delimiter
 
 [
   (ellipsis)
   "\?"
   ":"
   "=>"
-] @special
+] @punctuation.special
 
 [
   "for"
@@ -55,18 +55,19 @@
   (heredoc_template)
 ] @string
 
+(template_interpolation) @string.escape
+
 (heredoc_identifier) @namespace
 (heredoc_start) @namespace
-(template_interpolation) @statement
 (numeric_lit) @number
 (bool_lit) @boolean
 (null_lit) @constant
 (comment) @comment
-(identifier) @identifier
+(identifier) @variable
 
 (block (identifier) @namespace)
 (function_call (identifier) @function)
 (function_call (function_arguments) @parameter)
-(attribute (identifier) @symbol)
+(attribute (identifier) @definition.var)
 
 (ERROR) @error

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -61,9 +61,9 @@
 
 
 [
-  (heredoc_identifier) @punctuation.delimiter
-  (heredoc_start) @punctuation.delimiter
-]
+  (heredoc_identifier)
+  (heredoc_start)
+] @punctuation.delimiter
 
 (template_interpolation) @string.escape
 

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -36,9 +36,13 @@
 [
   (ellipsis)
   "\?"
-  ":"
   "=>"
 ] @punctuation.special
+
+[
+  ":"
+  "="
+] @none
 
 [
   "for"
@@ -55,19 +59,22 @@
   (heredoc_template)
 ] @string
 
+
+[
+  (heredoc_identifier) @punctuation.delimiter
+  (heredoc_start) @punctuation.delimiter
+]
+
 (template_interpolation) @string.escape
 
-(heredoc_identifier) @namespace
-(heredoc_start) @namespace
 (numeric_lit) @number
 (bool_lit) @boolean
 (null_lit) @constant
 (comment) @comment
 (identifier) @symbol
 
-(block (identifier) @namespace)
+(block (identifier) @type)
 (function_call (identifier) @function)
-(function_call (function_arguments) @parameter)
-(attribute (identifier) @symbol)
+(attribute (identifier) @keyword)
 
 (ERROR) @error

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -68,6 +68,6 @@
 (block (identifier) @namespace)
 (function_call (identifier) @function)
 (function_call (function_arguments) @parameter)
-(attribute (identifier) @definition.var)
+(attribute (identifier) @symbol)
 
 (ERROR) @error

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -71,10 +71,10 @@
 (bool_lit) @boolean
 (null_lit) @constant
 (comment) @comment
-(identifier) @symbol
+(identifier) @variable
 
 (block (identifier) @type)
 (function_call (identifier) @function)
-(attribute (identifier) @keyword)
+(attribute (identifier) @field)
 
 (ERROR) @error

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -63,7 +63,7 @@
 (bool_lit) @boolean
 (null_lit) @constant
 (comment) @comment
-(identifier) @variable
+(identifier) @symbol
 
 (block (identifier) @namespace)
 (function_call (identifier) @function)

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -1,0 +1,72 @@
+; highlights.scm
+
+[
+  "!"
+  "\*"
+  "/"
+  "%"
+  "\+"
+  "-"
+  ">"
+  ">="
+  "<"
+  "<="
+  "=="
+  "!="
+  "&&"
+  "||"
+] @operator
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+  "("
+  ")"
+  "[*]"
+  ".*"
+] @specialChar
+
+[
+  "."
+  ","
+] @specialChar
+
+[
+  (ellipsis)
+  "\?"
+  ":"
+  "=>"
+] @special
+
+[
+  "for"
+  "in"
+] @repeat
+
+[ 
+  "if"
+] @conditional
+
+[
+  (string_lit)
+  (quoted_template)
+  (heredoc_template)
+] @string
+
+(heredoc_identifier) @namespace
+(heredoc_start) @namespace
+(template_interpolation) @statement
+(numeric_lit) @number
+(bool_lit) @boolean
+(null_lit) @constant
+(comment) @comment
+(identifier) @identifier
+
+(block (identifier) @namespace)
+(function_call (identifier) @function)
+(function_call (function_arguments) @parameter)
+(attribute (identifier) @symbol)
+
+(ERROR) @error

--- a/queries/hcl/injections.scm
+++ b/queries/hcl/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment


### PR DESCRIPTION
# What

A parser for HCL (https://github.com/hashicorp/hcl). It could be useful for terraform, nomad, waypoint etc. It works fairly well for me right now.  

https://github.com/MichaHoffmann/tree-sitter-hcl

I'm using the highlight queries with the `onedark` colorscheme right now and they look ok, but are probably not canonical: 

![Auswahl_024](https://user-images.githubusercontent.com/17451647/123677840-e28a7580-d845-11eb-8512-26472d204daf.png)
