### PR TITLE
fix: check if invalidate_query_cache[lang] is set before invalidating

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -101,7 +101,9 @@ do
   function M.invalidate_query_cache(lang, query_name)
     if lang and query_name then
       cache[lang][query_name] = nil
-      query_files_cache[lang][query_name] = nil
+      if query_files_cache[lang] then
+        query_files_cache[lang][query_name] = nil
+      end
     elseif lang and not query_name then
       query_files_cache[lang] = nil
       for query_name, _ in pairs(cache[lang]) do


### PR DESCRIPTION
Check for `nil` is needed

Fixes #1444