### PR TITLE
python(highlights): don't use type for APP

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -9,7 +9,7 @@
 
 ;; Identifier naming conventions
 ((identifier) @type
- (#match? @type "^[A-Z]"))
+ (#match? @type "^[A-Z].*[a-z]"))
 ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
 


### PR DESCRIPTION
Apply fix suggested in https://github.com/nvim-treesitter/nvim-treesitter/issues/1441#issuecomment-870342791