### PR TITLE
python(folds): fold whole functions not only body

### DIFF
--- a/queries/python/folds.scm
+++ b/queries/python/folds.scm
@@ -1,13 +1,14 @@
-(function_definition (block) @fold)
-(class_definition (block) @fold)
-
-(while_statement (block) @fold)
-(for_statement (block) @fold)
-(if_statement (block) @fold)
-(with_statement (block) @fold)
-(try_statement (block) @fold)
-
 [
+  (function_definition)
+  (class_definition)
+
+  (while_statement)
+  (for_statement)
+  (if_statement)
+  (with_statement)
+  (try_statement)
+  (match_statement)
+
   (import_from_statement)
   (parameters)
   (argument_list)


### PR DESCRIPTION
Fold queries of Python were an issue in this query https://github.com/nvim-treesitter/nvim-treesitter/issues/1441

I think we should streamline the Python fold queries with the other languages. I think this will be also beneficial for everyone liking the current behavior as then all languages could be folded with first-line visible. Right, know "omitting the first line from folding" would require a different logic for Python and for C++.