### PR TITLE
Add comment highlighting in LaTeX for `TODO`, `FIXME`, etc.

### DIFF
--- a/queries/latex/injections.scm
+++ b/queries/latex/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment


### PR DESCRIPTION
Fixes #1457.