### PR TITLE
feat(dart): add multiplicative_operator

### DIFF
--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -45,6 +45,7 @@
  ">="
  "<="
  "||"
+ (multiplicative_operator)
  (increment_operator)
  (is_operator)
  (prefix_operator)
@@ -111,6 +112,9 @@
 
 ; properties
 (unconditional_assignable_selector
+  (identifier) @property)
+
+(conditional_assignable_selector
   (identifier) @property)
 
 ; assignments

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -6,6 +6,7 @@
 ; TODO: add method/call_expression to grammar and
 ; distinguish method call from variable access
 (function_expression_body (identifier) @function)
+; ((identifier)(selector (argument_part)) @function)
 
 ; Annotations
 ; --------------------


### PR DESCRIPTION
This PR adds in some more missing highlights for dart namely
* conditional_assignable_selector `field?.property`
* multiplicative operator e.g. `/,*`

I'm also trying to gerryrig a function call highlight, since there isn't really a node that identifies a function call.

From the grammar I see that the structure of a function call is
```dart
function_call(args)
// Identifier - selectors (argument_part)
```
So I tried using
```scheme
(((identifier) (selector . (argument_part)) @function)
```
However, using that query matches too many incorrect things, any advice would be much appreciated.