### PR TITLE
query: Only highlight predicate name

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -2,7 +2,7 @@
 (escape_sequence) @string.escape
 (capture) @type
 (anonymous_node) @string
-(predicate) @function
+(predicate name: (identifier) @function)
 (named_node
   name: (identifier) @variable
   (field_definition


### PR DESCRIPTION
Only highlight the name of the predicate using TSFunction rather than
the entire predicate block.
