### PR TITLE
c: highlight struct and enum keywords with @type

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -3,13 +3,11 @@
 [
   "const"
   "default"
-  "enum"
   "extern"
   "inline"
   "return"
   "sizeof"
   "static"
-  "struct"
   "typedef"
   "union"
   "volatile"
@@ -139,7 +137,12 @@
 (primitive_type)
 (sized_type_specifier)
 (type_descriptor)
- ] @type
+] @type
+
+[
+  "struct"
+  "enum"
+] @type
 
 (declaration (type_qualifier) @type)
 (cast_expression type: (type_descriptor) @type)


### PR DESCRIPTION
In C, `struct foo` is a type. That is, given:

```c
struct foo x;
```

the variable `x` has type `struct foo`, not `foo` (and likewise for
`enum bar`). Therefore the `struct` and `enum` keywords should be
highlighted as types, not keywords.
