### PR TITLE
feat(dart): add function call expression highlight

### DIFF
--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -3,10 +3,16 @@
 ; Methods
 ; --------------------
 (super) @function
+
 ; TODO: add method/call_expression to grammar and
 ; distinguish method call from variable access
 (function_expression_body (identifier) @function)
 ; ((identifier)(selector (argument_part)) @function)
+
+; NOTE: This query is a bit of a work around for the fact that the dart grammar doesn't
+; specifically identify a node as a function call
+(((identifier) @function (#match? @function "^_?[a-z]"))
+  . (selector . (argument_part))) @function
 
 ; Annotations
 ; --------------------


### PR DESCRIPTION
This is a work around since currently the upstream grammar does not support a `call_expression`. I hope to add this at some point in the future, but I'm not sure exactly when I'll have time to do it. In the short term, this allows function calls to be highlighted by using the fact that function calls are structured in a certain way, i.e. an identifier with a sibling node that has an argument part.