### PR TITLE
fish: only highlight 'test' keyword instead of entire condition

### DIFF
--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -113,7 +113,7 @@
         ]
 )
 
-(test_command) @function.builtin
+(test_command "test" @function.builtin)
 
 ;; Functions
 


### PR DESCRIPTION
With this change, only the `test` keyword in test commands is highlighted as a function rather than the entire condition.

Before:

![Screen Shot 2021-07-01 at 3 00 21 PM](https://user-images.githubusercontent.com/8965202/124189068-624e5500-da7d-11eb-81cc-2d3c2c9e580a.png)

After:

![Screen Shot 2021-07-01 at 2 59 58 PM](https://user-images.githubusercontent.com/8965202/124189078-667a7280-da7d-11eb-9cd4-3fd579f05d9d.png)

Notice in the before picture that the parens and operator in the condition are highlighted.