### PR TITLE
c: don't treat uppercase functions as constants

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -110,15 +110,6 @@
 (number_literal) @number
 (char_literal) @character
 
-(call_expression
-  function: (identifier) @function)
-(call_expression
-  function: (field_expression
-    field: (field_identifier) @function))
-(function_declarator
-  declarator: (identifier) @function)
-(preproc_function_def
-  name: (identifier) @function.macro)
 [
  (preproc_arg)
  (preproc_defined)
@@ -156,6 +147,15 @@
   argument: (_) @constant
   (#eq? @_u "#undef"))
 
+(call_expression
+  function: (identifier) @function)
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @function))
+(function_declarator
+  declarator: (identifier) @function)
+(preproc_function_def
+  name: (identifier) @function.macro)
 
 (comment) @comment
 


### PR DESCRIPTION
A macro function such as

    #define FOO(x) ...

should be highlighted with `@function.macro`, even though the name is in
all-caps (which would otherwise be treated as a constant). Similarly,
call sites of such functions, e.g.

    int y = FOO(x);

should be highlighted with `@function` instead of `@constant`.

This is as simple as moving the query definition for functions
after the query definition for constants.
