### PR TITLE
fix(ecma): add indent to switch and cases

### DIFF
--- a/queries/ecma/indents.scm
+++ b/queries/ecma/indents.scm
@@ -12,6 +12,8 @@
   (template_substitution)
   (expression_statement (call_expression))
   (export_clause)
+  (switch_statement)
+  (switch_case)
 ] @indent
 
 [


### PR DESCRIPTION
Fixes #1384

Before:
```js
var a = "b"
switch(a) {
case "a":
return "hmm";
case "b":
return "hmm2";
case "c":
return "hmm3";
case "d":
return "hmm4";
}
```

After:
```js
var a = "b"
switch(a) {
  case "a":
    return "hmm";
  case "b":
    return "hmm2";
  case "c":
    return "hmm3";
  case "d":
    return "hmm4";
}
```

---

This is my first functional PR here, please let me know if this isn't appropriate.