### PR TITLE
queries(hcl): improve highlighting

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -78,7 +78,7 @@
     "revision": "a0c1adb59e390f7d839a146c57fdb33d36ed97e6"
   },
   "hcl": {
-    "revision": "30e9f3eae8ec798f6540b05e3b4bb6c6e1313156"
+    "revision": "88c7c031d1b1d9c5a6fa0ef1739f3bc17ffceafe"
   },
   "html": {
     "revision": "d93af487cc75120c89257195e6be46c999c6ba18"

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -64,10 +64,12 @@
   (heredoc_start) ; END
 ] @punctuation.delimiter
 
-[
-  (template_interpolation_start) ; ${
-  (template_interpolation_end) ; }
-] @string.escape
+( template_interpolation
+  [
+    (template_interpolation_start) ; ${
+    (template_interpolation_end) ; }
+  ] @punctuation.bracket
+)
 
 (numeric_lit) @number
 (bool_lit) @boolean

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -54,18 +54,20 @@
 ] @conditional
 
 [
-  (string_lit)
-  (quoted_template)
-  (heredoc_template)
+  (quoted_template_start) ; "
+  (quoted_template_end); "
+  (template_literal) ; non-interpolation/directive content
 ] @string
 
-
 [
-  (heredoc_identifier)
-  (heredoc_start)
+  (heredoc_identifier) ; <<END
+  (heredoc_start) ; END
 ] @punctuation.delimiter
 
-(template_interpolation) @string.escape
+[
+  (template_interpolation_start) ; ${
+  (template_interpolation_end) ; }
+] @string.escape
 
 (numeric_lit) @number
 (bool_lit) @boolean
@@ -76,5 +78,10 @@
 (block (identifier) @type)
 (function_call (identifier) @function)
 (attribute (identifier) @field)
+
+; { key: val }
+;
+; highlight identifier keys as though they were block attributes
+(object_elem key: (expression (variable_expr (identifier) @field)))
 
 (ERROR) @error


### PR DESCRIPTION
* bumped the dependency of the hcl parser to make some tokens visible
* added a query for object element keys that are identifiers to highlight them as though they were block attributes
* dont highlight the whole `quoted_template` and `heredoc_template` as strings, but only the "stringy" parts

# Before
![Auswahl_026](https://user-images.githubusercontent.com/17451647/124232200-a5f29e80-db11-11eb-9fc3-9f4e8f729674.png)

# After
![Auswahl_027](https://user-images.githubusercontent.com/17451647/124232215-abe87f80-db11-11eb-9e0c-2bfe376c410a.png)
