### PR TITLE
c(folds): fold on enums

### DIFF
--- a/queries/c/folds.scm
+++ b/queries/c/folds.scm
@@ -7,6 +7,7 @@
  (case_statement)
  (function_definition)
  (struct_specifier)
+ (enum_specifier)
  (comment)
  (preproc_if)
  (preproc_elif)

--- a/queries/cpp/folds.scm
+++ b/queries/cpp/folds.scm
@@ -3,6 +3,9 @@
 [
  (for_range_loop)
  (class_specifier)
+ (field_declaration
+   type: (enum_specifier)
+   default_value: (initializer_list))
  (template_declaration)
  (namespace_definition)
  (try_statement)


### PR DESCRIPTION
In C++, enums insides classes are parsed as type and default_value.