### PR TITLE
fix missing maintainer in hcl parser config

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -354,6 +354,7 @@ list.hcl = {
     files = {"src/parser.c", "src/scanner.cc"},
     branch = "main"
   },
+  maintainers = {"@MichaHoffmann"},
   filetype = "hcl",
   used_by = { "terraform", "packer", "nomad" },
 }


### PR DESCRIPTION
Fixes the missing `maintainer` field in the hcl parser config.