### PR TITLE
Add keyword.return & keyword.yield

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,6 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @keyword.function
 @keyword.operator (for operators that are English words, e.g. `and`, `or`)
 @keyword.return
-@keyword.yield
 @operator (for symbolic operators, e.g. `+`, `*`)
 @exception
 @include keywords for including modules (e.g. import/from in Python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,8 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @keyword
 @keyword.function
 @keyword.operator (for operators that are English words, e.g. `and`, `or`)
+@keyword.return
+@keyword.yield
 @operator (for symbolic operators, e.g. `+`, `*`)
 @exception
 @include keywords for including modules (e.g. import/from in Python)

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -530,11 +530,7 @@ for operators that are English words, e.g. `and`, `as`, `or`.
 
 							  *hl-TSKeywordReturn*
 `TSKeywordReturn`
-for the `return` keyword.
-
-							   *hl-TSKeywordYield*
-`TSKeywordYield`
-for the `yield` keyword.
+for the `return` and `yield` keywords.
 
 								  *hl-TSLabel*
 `TSLabel`

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -528,6 +528,14 @@ For keywords used to define a fuction.
 `TSKeywordOperator`
 for operators that are English words, e.g. `and`, `as`, `or`.
 
+							  *hl-TSKeywordReturn*
+`TSKeywordReturn`
+for the `return` keyword.
+
+							   *hl-TSKeywordYield*
+`TSKeywordYield`
+for the `yield` keyword.
+
 								  *hl-TSLabel*
 `TSLabel`
 For labels: `label:` in C and `:label:` in Lua.

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -47,7 +47,6 @@ hlmap["keyword"] = "TSKeyword"
 hlmap["keyword.function"] = "TSKeywordFunction"
 hlmap["keyword.operator"] = "TSKeywordOperator"
 hlmap["keyword.return"] = "TSKeywordReturn"
-hlmap["keyword.yield"] = "TSKeywordYield"
 
 hlmap["label"] = "TSLabel"
 

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -46,6 +46,8 @@ hlmap["include"] = "TSInclude"
 hlmap["keyword"] = "TSKeyword"
 hlmap["keyword.function"] = "TSKeywordFunction"
 hlmap["keyword.operator"] = "TSKeywordOperator"
+hlmap["keyword.return"] = "TSKeywordReturn"
+hlmap["keyword.yield"] = "TSKeywordYield"
 
 hlmap["label"] = "TSLabel"
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -63,6 +63,8 @@ highlight default link TSOperator Operator
 highlight default link TSKeyword Keyword
 highlight default link TSKeywordFunction Keyword
 highlight default link TSKeywordOperator TSOperator
+highlight default link TSKeywordReturn TSKeyword
+highlight default link TSKeywordYield TSKeyword
 highlight default link TSException Exception
 
 highlight default link TSType Type

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -64,7 +64,6 @@ highlight default link TSKeyword Keyword
 highlight default link TSKeywordFunction Keyword
 highlight default link TSKeywordOperator TSOperator
 highlight default link TSKeywordReturn TSKeyword
-highlight default link TSKeywordYield TSKeyword
 highlight default link TSException Exception
 
 highlight default link TSType Type

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -6,7 +6,6 @@
   "enum"
   "extern"
   "inline"
-  "return"
   "sizeof"
   "static"
   "struct"
@@ -16,6 +15,10 @@
   "goto"
   "register"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
 
 [
   "while"

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -16,9 +16,7 @@
   "register"
 ] @keyword
 
-[
-  "return"
-] @keyword.return
+"return" @keyword.return
 
 [
   "while"

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -260,8 +260,6 @@
  "params"
  "operator"
  "default"
- "yield"
- "return"
  "abstract"
  "const"
  "extern"
@@ -287,4 +285,12 @@
  "set"
  "where"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
+
+[
+  "yield"
+] @keyword.yield
 

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -288,9 +288,6 @@
 
 [
   "return"
-] @keyword.return
-
-[
   "yield"
-] @keyword.yield
+] @keyword.return
 

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -182,10 +182,13 @@
     "in"
     "is"
     "new"
-    "return"
     "super"
     "with"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
 
 
 ; Built in identifiers:
@@ -195,7 +198,6 @@
     "as"
     "async"
     "async*"
-    "yield"
     "sync*"
     "await"
     "covariant"
@@ -215,6 +217,10 @@
     "static"
     "typedef"
 ] @keyword
+
+[
+  "yield"
+] @keyword.yield
 
 ; when used as an identifier:
 ((identifier) @variable.builtin

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -188,6 +188,7 @@
 
 [
   "return"
+  "yield"
 ] @keyword.return
 
 
@@ -217,10 +218,6 @@
     "static"
     "typedef"
 ] @keyword
-
-[
-  "yield"
-] @keyword.yield
 
 ; when used as an identifier:
 ((identifier) @variable.builtin

--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -226,11 +226,8 @@
 
 [
 "return"
-] @keyword.return
-
-[
 "yield"
-] @keyword.yield
+] @keyword.return
 
 [
  "function"

--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -214,7 +214,6 @@
 "in"
 "instanceof"
 "let"
-"return"
 "set"
 "static"
 "switch"
@@ -223,8 +222,15 @@
 "var"
 "void"
 "with"
-"yield"
 ] @keyword
+
+[
+"return"
+] @keyword.return
+
+[
+"yield"
+] @keyword.yield
 
 [
  "function"

--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -76,10 +76,13 @@
 
 [
  "in"
- "return"
  (break)
  (continue)
 ] @keyword
+
+[
+ "return"
+] @keyword.return
 
 ;; Punctuation
 

--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -80,9 +80,7 @@
  (continue)
 ] @keyword
 
-[
- "return"
-] @keyword.return
+"return" @keyword.return
 
 ;; Punctuation
 

--- a/queries/fortran/highlights.scm
+++ b/queries/fortran/highlights.scm
@@ -70,13 +70,16 @@
   "print"
   "program"
   "read"
-  "return"
   "stop"
   "use"
   "write"
   (default)
   (procedure_qualifier)
 ] @keyword
+
+[
+  "return"
+] @keyword.return
 
 [
   "else"

--- a/queries/fortran/highlights.scm
+++ b/queries/fortran/highlights.scm
@@ -77,9 +77,7 @@
   (procedure_qualifier)
 ] @keyword
 
-[
-  "return"
-] @keyword.return
+"return" @keyword.return
 
 [
   "else"

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -108,7 +108,6 @@
 
 [
   "pass"
-  "return"
   "class"
   "class_name"
   "extends"
@@ -126,3 +125,7 @@
   "mastersync"
   "puppetsync"
 ] @keyword
+
+[
+  "return"
+] @keyword.return

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -126,6 +126,4 @@
   "puppetsync"
 ] @keyword
 
-[
-  "return"
-] @keyword.return
+"return" @keyword.return

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -94,13 +94,16 @@
   "interface"
   "map"
   "range"
-  "return"
   "select"
   "struct"
   "type"
   "var"
   "fallthrough"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
 
 "for" @repeat
 

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -101,9 +101,7 @@
   "fallthrough"
 ] @keyword
 
-[
-  "return"
-] @keyword.return
+"return" @keyword.return
 
 "for" @repeat
 

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -187,11 +187,8 @@
 
 [
 "return"
-] @keyword.return
-
-[
 "yield"
-] @keyword.yield
+] @keyword.return
 
 [
  "new"

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -174,8 +174,6 @@
 "provides"
 "public"
 "requires"
-"return"
-"yield"
 "static"
 "strictfp"
 "synchronized"
@@ -186,6 +184,14 @@
 "volatile"
 "with"
 ] @keyword
+
+[
+"return"
+] @keyword.return
+
+[
+"yield"
+] @keyword.yield
 
 [
  "new"

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -127,12 +127,15 @@
 
 [
   "const"
-  "return"
   "macro"
   "struct"
   "primitive"
   "type"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
 
 ((identifier) @keyword (#any-of? @keyword "global" "local"))
 

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -133,9 +133,7 @@
   "type"
 ] @keyword
 
-[
-  "return"
-] @keyword.return
+"return" @keyword.return
 
 ((identifier) @keyword (#any-of? @keyword "global" "local"))
 

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -121,9 +121,7 @@
  "throw"
 ] @keyword
 
-[
-  "return"
-] @keyword.return
+"return" @keyword.return
 
 (null_literal) @keyword
 

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -117,10 +117,13 @@
  "by"
  "fun"
  "companion"
- "return"
  "constructor"
  "throw"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
 
 (null_literal) @keyword
 

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -58,9 +58,7 @@
  "goto"
 ] @keyword
 
-[
- "return"
-] @keyword.return
+"return" @keyword.return
 
 ;; Operators
 

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -54,10 +54,13 @@
 [
  "in"
  "local"
- "return"
  (break_statement)
  "goto"
 ] @keyword
+
+[
+ "return"
+] @keyword.return
 
 ;; Operators
 

--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -106,10 +106,13 @@
  "private"
  "protected"
  "public"
- "return"
  "static"
  "trait"
  ] @keyword
+
+[
+ "return"
+] @keyword.return
 
 [
  "case"

--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -110,9 +110,7 @@
  "trait"
  ] @keyword
 
-[
- "return"
-] @keyword.return
+"return" @keyword.return
 
 [
  "case"

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -217,11 +217,8 @@
 
 [
   "return"
-] @keyword.return
-
-[
   "yield"
-] @keyword.yield
+] @keyword.return
 
 ["from" "import"] @include
 (aliased_import "as" @include)

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -210,12 +210,18 @@
   "pass"
   "print"
   "raise"
-  "return"
   "try"
   "with"
-  "yield"
   "as"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
+
+[
+  "yield"
+] @keyword.yield
 
 ["from" "import"] @include
 (aliased_import "as" @include)

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -19,10 +19,16 @@
  "next"
  "rescue"
  "retry"
- "return"
  "then"
- "yield"
  ] @keyword
+
+[
+ "return"
+] @keyword.return
+
+[
+ "yield"
+] @keyword.yield
 
 [
  "and"

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -24,11 +24,8 @@
 
 [
  "return"
-] @keyword.return
-
-[
  "yield"
-] @keyword.yield
+] @keyword.return
 
 [
  "and"

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -173,9 +173,7 @@
 (super)
 ] @keyword
 
-[
-"return"
-] @keyword.return
+"return" @keyword.return
 
 "fn" @keyword.function
 

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -160,7 +160,6 @@
 "move"
 "pub"
 "ref"
-"return"
 "static"
 "struct"
 "trait"
@@ -173,6 +172,10 @@
 (mutable_specifier)
 (super)
 ] @keyword
+
+[
+"return"
+] @keyword.return
 
 "fn" @keyword.function
 

--- a/queries/teal/highlights.scm
+++ b/queries/teal/highlights.scm
@@ -20,7 +20,7 @@
 [ "if" "then" "elseif" "else" ] @conditional
 [ "for" "while" "repeat" "until" ] @repeat
 [ "in" "local" (break) (goto) "do" "end" ] @keyword
-[ "return" ] @keyword.return
+"return" @keyword.return
 (label) @label
 
 ;; Global isn't a real keyword, but it gets special treatment in these places

--- a/queries/teal/highlights.scm
+++ b/queries/teal/highlights.scm
@@ -19,7 +19,8 @@
 ;; Basic statements/Keywords
 [ "if" "then" "elseif" "else" ] @conditional
 [ "for" "while" "repeat" "until" ] @repeat
-[ "in" "local" "return" (break) (goto) "do" "end" ] @keyword
+[ "in" "local" (break) (goto) "do" "end" ] @keyword
+[ "return" ] @keyword.return
 (label) @label
 
 ;; Global isn't a real keyword, but it gets special treatment in these places

--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -13,7 +13,6 @@
   "typedef"
   "class"
   "endclass"
-  "return"
   "default"
   "break"
   "interface"
@@ -27,6 +26,10 @@
   "join_any"
   "assert"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
 
 [
   "begin"

--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -27,9 +27,7 @@
   "assert"
 ] @keyword
 
-[
-  "return"
-] @keyword.return
+"return" @keyword.return
 
 [
   "begin"

--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -112,9 +112,7 @@
   "while"
 ] @keyword
 
-[
-  "return"
-] @keyword.return
+"return" @keyword.return
 
 "fn" @keyword.function
 

--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -95,7 +95,6 @@
   ; "packed"
   "pub"
   "resume"
-  "return"
   ; "linksection"
   "struct"
   "suspend"
@@ -112,6 +111,10 @@
   "volatile"
   "while"
 ] @keyword
+
+[
+  "return"
+] @keyword.return
 
 "fn" @keyword.function
 


### PR DESCRIPTION
Not too sure about [`teal`](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/teal/highlights.scm#L22) and [`fish`](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/fish/highlights.scm#L79-L81) since I wasn't able to find the meaning of `(WORD)` within a group of word.

I have tested this locally and it seems to work as expected.

closes #1485

@theHamsta 