### PR TITLE
Better differentiate 'keywords' for HCL

### DIFF
--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -68,7 +68,7 @@
   [
     (template_interpolation_start) ; ${
     (template_interpolation_end) ; }
-  ] @punctuation.bracket
+  ] @punctuation.special
 )
 
 (numeric_lit) @number
@@ -85,5 +85,13 @@
 ;
 ; highlight identifier keys as though they were block attributes
 (object_elem key: (expression (variable_expr (identifier) @field)))
+
+(variable_expr (identifier) @variable.builtin (#any-of? @variable.builtin "var" "local"))
+((identifier) @keyword (#any-of? @keyword "module" "resource" "variable" "data" "locals" "terraform" "provider" "output"))
+((identifier) @type.builtin (#any-of? @type.builtin "bool" "string" "number" "object" "tuple" "list" "map" "set" "any"))
+
+(object_elem val: (expression
+  (variable_expr
+    (identifier) @type.builtin (#any-of? @type.builtin "bool" "string" "number" "object" "tuple" "list" "map" "set" "any"))))
 
 (ERROR) @error

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -86,9 +86,10 @@
 ; highlight identifier keys as though they were block attributes
 (object_elem key: (expression (variable_expr (identifier) @field)))
 
-(variable_expr (identifier) @variable.builtin (#any-of? @variable.builtin "var" "local"))
-((identifier) @keyword (#any-of? @keyword "module" "resource" "variable" "data" "locals" "terraform" "provider" "output"))
+((identifier) @keyword (#any-of? @keyword "module" "root" "cwd" "resource" "variable" "data" "locals" "terraform" "provider" "output"))
 ((identifier) @type.builtin (#any-of? @type.builtin "bool" "string" "number" "object" "tuple" "list" "map" "set" "any"))
+(variable_expr (identifier) @variable.builtin (#any-of? @variable.builtin "var" "local" "path"))
+(get_attr (identifier) @variable.builtin (#any-of? @variable.builtin  "root" "cwd" "module"))
 
 (object_elem val: (expression
   (variable_expr


### PR DESCRIPTION
# Description
I noticed the queries could be improved for better terraform highlighting.
Maybe this should be an inherited query for terraform instead?

# Before
<img width="600" alt="Screen Shot 2021-07-04 at 4 03 28 PM" src="https://user-images.githubusercontent.com/2881382/124400656-62e72580-dce1-11eb-9e47-68e26781601e.png">


# After
<img width="600" alt="Screen Shot 2021-07-04 at 4 05 50 PM" src="https://user-images.githubusercontent.com/2881382/124400702-c07b7200-dce1-11eb-9322-e566f78066c3.png">

