### PR TITLE
Luacheck: use config file to exclude files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           sudo luarocks install luacheck
 
       - name: Run Luacheck
-        run: sudo ./scripts/style-check.sh
+        run: luacheck .
 
   stylua:
     name: StyLua

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,10 @@
 -- Rerun tests only if their modification time changed.
 cache = true
+codes = true
+
+exclude_files = {
+  "tests/indent/lua/"
+}
 
 -- Glorious list of warnings: https://luacheck.readthedocs.io/en/stable/warnings.html
 ignore = {

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -3,5 +3,8 @@
 # Can be used as a pre-push hook
 # Just symlink this file to .git/hooks/pre-push
 
-echo "Running style check..."
-./scripts/style-check.sh
+echo "Running linter..."
+luacheck .
+
+echo "Checking formatting..."
+stylua --check .

--- a/scripts/style-check.sh
+++ b/scripts/style-check.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# ignore indent test files
-luacheck `find -name  "*.lua" -not -path "./tests/indent/lua/*"` --codes


### PR DESCRIPTION
The `--codes` flag can also be set from the config file