### PR TITLE
Update used_by for parent parsers

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -37,7 +37,7 @@ list.javascript = {
     url = "https://github.com/tree-sitter/tree-sitter-javascript",
     files = { "src/parser.c", "src/scanner.c" },
   },
-  used_by = { "javascriptreact" },
+  used_by = { "javascriptreact", "ecma" },
   maintainers = { "@steelsojka" },
 }
 
@@ -207,6 +207,7 @@ list.html = {
     url = "https://github.com/tree-sitter/tree-sitter-html",
     files = { "src/parser.c", "src/scanner.cc" },
   },
+  used_by = { "html_tags" },
   maintainers = { "@TravonteD" },
 }
 


### PR DESCRIPTION
html_tags and ecma don't have a parser of they own,
but that's actually just to get around to inherit
common queries.

When editing these "base" queries,
the playground breaks. Having them in used_by would fix this https://github.com/nvim-treesitter/playground/pull/43