### PR TITLE
CI: remove LLVM compilation from Mac CI

### DIFF
--- a/scripts/ci-install-macos-latest.sh
+++ b/scripts/ci-install-macos-latest.sh
@@ -1,5 +1,4 @@
 brew update
-brew install llvm --HEAD
 brew install neovim --HEAD
 mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
 ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter/start


### PR DESCRIPTION
Out CI compiles the LLVM project at the moment. No wonder that Mac CI takes a long time.