### PR TITLE
Fix ecma template string braces highlight group

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -108,10 +108,6 @@
 ; Punctuation
 ;------------
 
-(template_substitution
-  "${" @punctuation.special
-  "}" @punctuation.special) @none
-
 "..." @punctuation.special
 
 ";" @punctuation.delimiter
@@ -175,6 +171,10 @@
 "]" @punctuation.bracket
 "{" @punctuation.bracket
 "}" @punctuation.bracket
+
+(template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @none
 
 ; Keywords
 ;----------


### PR DESCRIPTION
I believe I have discovered a bug and a potential fix for it. I noticed that the braces for template string quasis are coloured inconsistently, I have set vivid colours for these 2 highlight groups

```vim
hi TSPunctBracket guifg=Yellow
hi TSPunctSpecial guifg=Red
```

<img width="734" alt="Screen Shot 2021-07-06 at 23 55 41" src="https://user-images.githubusercontent.com/5817809/124666197-5b2caa00-deb6-11eb-8ba2-ddf99e8d9415.png">

`:TSHighlightCapturesUnderCursor` output for the closing brace

```
* @string -> javascriptTSString -> TSString
* @none -> javascriptTSNone -> TSNone
* @punctuation.special -> javascriptTSPunctSpecial -> TSPunctSpecial
* @punctuation.bracket -> javascriptTSPunctBracket -> TSPunctBracket
```

It seems that `TSPunctBracket` is overlaying(not sure if the word suits here) `TSPunctSpecial` which should be preferred here.

By placing the template string section after the section with braces  in `queries/ecma/highlights.scm` the problem goes away and the appropriate highlight group gets applied to the closing brace within a template string. In my tests this change did not affect the highlighting of other braces such as objects, code blocks, classes, functions and methods.

Hope this helps 🙂
