### PR TITLE
Elixir heredocs as comments

### DIFF
--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -133,7 +133,7 @@
        (heredoc
         [(heredoc_start)
          (heredoc_content)
-         (heredoc_end)] @string))
+         (heredoc_end)] @comment))
  (#any-of? @attribute "doc" "moduledoc"))
 
 (unary_op


### PR DESCRIPTION
Treat strings tagged as Elixir @doc or @moduledoc as comments, rather than strings, in order to get a more consistent syntax highlighting.

<img width="311" alt="124633937-138e2a00-de86-11eb-89a7-873801191e2c" src="https://user-images.githubusercontent.com/12581/124732192-48948e00-df13-11eb-914f-745b9b7735ad.png">
