### PR TITLE
Lua: highlight function definitions

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -123,6 +123,11 @@
 (local_function (identifier) @function)
 (local_function ["function" "end"] @keyword.function)
 
+(variable_declaration
+ (variable_declarator (identifier) @function) (function_definition))
+(local_variable_declaration
+ (variable_declarator (identifier) @function) (function_definition))
+
 (function_definition ["function" "end"] @keyword.function)
 
 (property_identifier) @property


### PR DESCRIPTION
In lua

```lua
function foo() end
```

is syntax sugar for

```lua
foo = function() end
```