### PR TITLE
highlights(rust): Reorder macro queries

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -79,24 +79,28 @@
     name: (identifier) @constant)
   (#match? @constant "^[A-Z]"))
 
-;; Assume that all `#[derive]` arguments are types
+;; Macro definitions
+"$" @function.macro
+(metavariable) @function.macro
+
+;; Attribute macros
+(meta_item (identifier) @function.macro)
+(meta_item (scoped_identifier (identifier) @function.macro .))
+
+;; Derive macros (assume all arguments are types)
 (meta_item
   (identifier) @_name
   arguments: (meta_arguments (meta_item (identifier) @type))
   (#eq? @_name "derive"))
 
+;; Function-like macros
 (macro_invocation
   macro: (identifier) @function.macro)
 (macro_invocation
   macro: (scoped_identifier
            (identifier) @function.macro .))
 
-(metavariable) @function.macro
-(meta_item (identifier) @function.macro)
-(meta_item (scoped_identifier (identifier) @function.macro .)) 
 
-
-"$" @function.macro
 
 ; Function definitions
 


### PR DESCRIPTION
derive macros have to be defined after attribute macros for types to be highlighted properly.

EDIT: I wrote it the other way around in the commit :s

See #570