### PR TITLE
downcase predicate: nil protection

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -119,7 +119,7 @@ query.add_directive("downcase!", function(match, _, bufnr, pred, metadata)
     text = value
   else
     local node = match[value]
-    text = query.get_node_text(node, bufnr)
+    text = query.get_node_text(node, bufnr) or ""
   end
 
   if #pred == 3 then


### PR DESCRIPTION
get_node_text could be nil if the range is invalid.

Together with https://github.com/neovim/neovim/pull/15030/
this fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1531