### PR TITLE
[elixir] basic folds

### DIFF
--- a/queries/elixir/folds.scm
+++ b/queries/elixir/folds.scm
@@ -1,0 +1,9 @@
+[
+  (do_block)
+  (anonymous_function)
+  (map)
+  (struct)
+  (list)
+  (keyword_list)
+  (heredoc)
+] @fold


### PR DESCRIPTION
This adds support for folding in elixir files.

This adds basic folding to any do blocks and anonymous functions. I think we can probably add folding to lists and maps, but I couldn't get immediately work, so I figured I could add the bare basic support for and figure out the rest later.

cc @nifoc
