### PR TITLE
Feat: Added Pug parser with inital queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [php](https://github.com/tree-sitter/tree-sitter-php) (maintained by @tk-shirasaka)
 - [x] [pioasm](https://github.com/leo60228/tree-sitter-pioasm) (maintained by @leo60228)
 - [x] [prisma](https://github.com/victorhqc/tree-sitter-prisma) (maintained by @elianiva)
+- [x] [pug](https://github.com/zealot128/tree-sitter-pug) (maintained by @zealot128)
 - [x] [python](https://github.com/tree-sitter/tree-sitter-python) (maintained by @stsewd, @theHamsta)
 - [x] [ql](https://github.com/tree-sitter/tree-sitter-ql) (maintained by @pwntester)
 - [x] [Tree-sitter query language](https://github.com/nvim-treesitter/tree-sitter-query) (maintained by @steelsojka)

--- a/ftdetect/pug.vim
+++ b/ftdetect/pug.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.pug		setlocal filetype=pug

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -470,6 +470,15 @@ list.glimmer = {
   used_by = { "html.handlebars" },
 }
 
+list.pug = {
+  install_info = {
+    url = "https://github.com/zealot128/tree-sitter-pug",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  maintainers = { "@zealot128" },
+  filetype = "pug",
+}
+
 list.vue = {
   install_info = {
     url = "https://github.com/ikatyang/tree-sitter-vue",

--- a/queries/pug/highlights.scm
+++ b/queries/pug/highlights.scm
@@ -1,0 +1,27 @@
+(comment) @comment
+(tag_name) @tag
+(
+  (tag_name) @constant.builtin
+  ; https://www.script-example.com/html-tag-liste
+  (#any-of? @constant.builtin
+   "head" "title" "base" "link" "meta" "style"
+   "body" "article" "section" "nav" "aside" "h1" "h2" "h3" "h4" "h5" "h6" "hgroup" "header" "footer" "address"
+   "p" "hr" "pre" "blockquote" "ol" "ul" "menu" "li" "dl" "dt" "dd" "figure" "figcaption" "main" "div"
+   "a" "em" "strong" "small" "s" "cite" "q" "dfn" "abbr" "ruby" "rt" "rp" "data" "time" "code" "var" "samp" "kbd" "sub" "sup" "i" "b" "u" "mark" "bdi" "bdo" "span" "br" "wbr"
+   "ins" "del"
+   "picture" "source" "img" "iframe" "embed" "object" "param" "video" "audio" "track" "map" "area"
+   "table" "caption" "colgroup" "col" "tbody" "thead" "tfoot" "tr" "td" "th "
+   "form" "label" "input" "button" "select" "datalist" "optgroup" "option" "textarea" "output" "progress" "meter" "fieldset" "legend"
+   "details" "summary" "dialog"
+   "script" "noscript" "template" "slot" "canvas")
+)
+(content) @none
+(quoted_attribute_value) @string
+(id) @constant
+(class) @constant
+(attribute_name) @symbol
+(
+  (attribute_name )  @keyword
+  (#match? @keyword "^(:|v-bind|v-|\\@)")
+) @keyword
+

--- a/queries/pug/highlights.scm
+++ b/queries/pug/highlights.scm
@@ -25,3 +25,6 @@
   (#match? @keyword "^(:|v-bind|v-|\\@)")
 ) @keyword
 
+[
+  ":"
+] @punctuation.delimiter

--- a/queries/pug/injections.scm
+++ b/queries/pug/injections.scm
@@ -1,0 +1,7 @@
+(javascript) @javascript
+
+(
+   (attribute_name) @_attribute_name
+   (quoted_attribute_value (attribute_value )  @javascript)
+   (#match? @_attribute_name "^(:|v-bind|v-|\\@)")
+)

--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -25,4 +25,13 @@
     (quoted_attribute_value
       (attribute_value) @javascript)))
 
+(
+  (template_element
+    (start_tag
+      (attribute
+        (quoted_attribute_value (attribute_value) @_lang)))
+    (raw_text) @pug)
+  (#match? @_lang "pug")
+)
+
 (comment) @comment

--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -30,8 +30,8 @@
     (start_tag
       (attribute
         (quoted_attribute_value (attribute_value) @_lang)))
-    (raw_text) @pug)
-  (#match? @_lang "pug")
+    (text) @pug)
+  (#eq? @_lang "pug")
 )
 
 (comment) @comment


### PR DESCRIPTION
I discussed my progress in #1520 

This is a WIP with the Pug tree-parser. If worked OK for my type of files. I am sure it does not support all of the syntax, yet, but it would be much better than a white screen.

![Bildschirmfoto 2021-07-10 um 17 18 19](https://user-images.githubusercontent.com/147175/125168369-9294a280-e1a5-11eb-9c0b-f47de7975dca.png)

As you can see, the highlighting is quite ok for raw "example.pug" files.

Unfortunately, if does not work with Vue template files, yet. I've added the ``ftdetect`` rule, but it is unable to map the ``@pug`` with the pug file

```
<template lang="pug">
body: div 
  | this is unhighlighted
</template>
```

Is unhighlighted.... For test, I've changed the ``vue/injections.scm`` template rule from ``@pug`` to @typescript or @scss, and the highlighting works.... What am I missing? Where can I tell nvim how to handle the ``@pug`` marked parts as a pug file.

I've also tried using the @content + @language way described in the README without any success:

```
(template_element
 (start_tag
  (attribute
   ((attribute_name) @lang_key (#match? @lang_key "lang"))
   ((quoted_attribute_value) @language)
  )
 )
 ((text) @content)
 )
```

But it seems to be a problem with the vue-parer, which already processes the content of the script tag as html... If anybody has any ideas, I'll be glad!