### PR TITLE
Highlight: prevent re-activating syntax when the files type is changed

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -114,6 +114,9 @@ function M.attach(bufnr, lang)
   local is_table = type(config.additional_vim_regex_highlighting) == "table"
   if config.additional_vim_regex_highlighting and (not is_table or config.additional_vim_regex_highlighting[lang]) then
     api.nvim_buf_set_option(bufnr, "syntax", "ON")
+  else
+    -- Prevent re-activating syntax when the file type is set/changed.
+    api.nvim_command(string.format("autocmd NvimTreesitter Syntax <buffer=%d> set syntax=", bufnr))
   end
 end
 
@@ -121,6 +124,7 @@ function M.detach(bufnr)
   if ts.highlighter.active[bufnr] then
     ts.highlighter.active[bufnr]:destroy()
   end
+  api.nvim_command(string.format("autocmd! NvimTreesitter Syntax <buffer=%d>", bufnr))
   api.nvim_buf_set_option(bufnr, "syntax", "ON")
 end
 


### PR DESCRIPTION
Basically when you have `syntax on` (default),
anytime you execute `set ft=foo` it will change the value from syntax to
`foo`.

Setting the file type after the buffer is loaded is done by
https://github.com/neovim/neovim/blob/master/runtime/scripts.vim
or any other plugin could be changing the file type, or modelines.

This will prevent a lot of issues where a plugin re-activates syntax.

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1544