### PR TITLE
Highlights: define string.special

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -602,6 +602,10 @@ For regexes.
 `TSStringEscape`
 For escape characters within a string.
 
+							  *hl-TSStringSpecial*
+`TSStringSpecial`
+For strings with special meaning that don't fit into the above categories.
+
 								 *hl-TSSymbol*
 `TSSymbol`
 For identifiers referring to symbols or atoms.

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -72,6 +72,7 @@ hlmap["repeat"] = "TSRepeat"
 hlmap["string"] = "TSString"
 hlmap["string.regex"] = "TSStringRegex"
 hlmap["string.escape"] = "TSStringEscape"
+hlmap["string.special"] = "TSStringSpecial"
 
 hlmap["symbol"] = "TSSymbol"
 

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -37,6 +37,7 @@ highlight default link TSConstMacro Define
 highlight default link TSString String
 highlight default link TSStringRegex String
 highlight default link TSStringEscape SpecialChar
+highlight default link TSStringSpecial SpecialChar
 highlight default link TSCharacter Character
 highlight default link TSNumber Number
 highlight default link TSBoolean Boolean

--- a/queries/supercollider/highlights.scm
+++ b/queries/supercollider/highlights.scm
@@ -93,7 +93,7 @@
 ; control structure
 (control_structure) @conditional
 
-(escape_sequence) @string.special
+(escape_sequence) @string.escape
 
 ; SinOsc.ar()!2
 (duplicated_statement) @repeat


### PR DESCRIPTION
This was in our CONTRIBUTING.md file,
but wasn't defined.

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1405