### PR TITLE
highlights(jsx): remove TSConstant from ecma and jsx

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -15,9 +15,6 @@
 ; Special identifiers
 ;--------------------
 
-((identifier) @constructor
- (#match? @constructor "^[A-Z]"))
-
 ((identifier) @constant
  (#vim-match? @constant "^[A-Z_][A-Z\\d_]+$"))
 

--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -6,30 +6,27 @@
 (jsx_fragment [">" "<" "/"] @tag.delimiter)
 
 (jsx_opening_element
-  name: (identifier) @tag)
+ name: [
+  ; <Component>
+  (identifier) @tag
+  ; <Component.Foo>
+  (nested_identifier (identifier) @tag (identifier) @tag)
+])
 
 (jsx_closing_element
-  name: (identifier) @tag)
+ name: [
+  ; </Component>
+  (identifier) @tag
+  ; </Component.Foo>
+  (nested_identifier (identifier) @tag (identifier) @tag)
+])
 
 (jsx_self_closing_element
-  name: (identifier) @tag)
-
-(jsx_opening_element ((identifier) @constructor
- (#match? @constructor "^[A-Z]")))
-
-; Handle the dot operator effectively - <My.Component>
-(jsx_opening_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
-
-(jsx_closing_element ((identifier) @constructor
- (#match? @constructor "^[A-Z]")))
-
-; Handle the dot operator effectively - </My.Component>
-(jsx_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
-
-(jsx_self_closing_element ((identifier) @constructor
- (#match? @constructor "^[A-Z]")))
-
-; Handle the dot operator effectively - <My.Component />
-(jsx_self_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
+ name: [
+  ; <Component />
+  (identifier) @tag
+  ; <Component.Foo />
+  (nested_identifier (identifier) @tag (identifier) @tag)
+])
 
 (jsx_text) @none


### PR DESCRIPTION
closes #1547 

This PR removes `TSConstant` from `ecma` and `jsx` since it was based on casing and in the ecma family languages the casing does not affect the runtime. I have also grouped the queries using [alternations](https://tree-sitter.github.io/tree-sitter/using-parsers#alternations). This change does not affect the documentation.

The result can be seen below

![Screen Shot 2021-07-11 at 23 47 23](https://user-images.githubusercontent.com/5817809/125209601-9fe38700-e2a2-11eb-959e-d7dfae9c0276.png)

The one thing I could not figure out is the recursive queries. For example when the jsx element name can contain the nested identifier which incase can be another nested identifier like in the example  above called `member_expr_3`