### PR TITLE
CI: install node on all OSes

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ilammy/msvc-dev-cmd@v1.5.0
+      - uses: actions/setup-node@v2
 
       - name: Install and prepare Neovim
         run: |


### PR DESCRIPTION
Try to install a recent npm version on Ubuntu. This will enable CI testing for Elixir and other `requires_generate_from_grammar` languages on Linux.