### PR TITLE
doc: be more explicit about additional_vim_regex_highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ require'nvim-treesitter.configs'.setup {
   highlight = {
     enable = true,              -- false will disable the whole extension
     disable = { "c", "rust" },  -- list of language that will be disabled
+    -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+    -- Instead of true it can also be a list of languages
+    additional_vim_regex_highlighting = false,
   },
 }
 EOF
@@ -225,6 +228,9 @@ require'nvim-treesitter.configs'.setup {
       -- Highlight the @foo.bar capture group with the "Identifier" highlight group.
       ["foo.bar"] = "Identifier",
     },
+    -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+    -- Instead of true it can also be a list of languages
+    additional_vim_regex_highlighting = false,
   },
 }
 EOF

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ require'nvim-treesitter.configs'.setup {
     enable = true,              -- false will disable the whole extension
     disable = { "c", "rust" },  -- list of language that will be disabled
     -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+    -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
+    -- Using this option may slow down your editor, and you may see some duplicate highlights.
     -- Instead of true it can also be a list of languages
     additional_vim_regex_highlighting = false,
   },
@@ -229,6 +231,8 @@ require'nvim-treesitter.configs'.setup {
       ["foo.bar"] = "Identifier",
     },
     -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+    -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
+    -- Using this option may slow down your editor, and you may see some duplicate highlights.
     -- Instead of true it can also be a list of languages
     additional_vim_regex_highlighting = false,
   },

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -126,8 +126,7 @@ Supported options:
         -- Highlight the @foo.bar capture group with the "Identifier" highlight group.
         ["foo.bar"] = "Identifier",
       },
-      -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
-      -- Instead of true it can also be a list of languages
+      -- Setting this to true or a list of languages will run `:h syntax` and tree-sitter at the same time.
       additional_vim_regex_highlighting = false,
     },
   }

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -111,7 +111,7 @@ Supported options:
 - disable: list of languages.
 - custom_captures: A map of user defined capture groups to highlight groups.
   See |nvim-treesitter-query-extensions|.
-- additional_vim_regex_highlighting: `true` or `false`, or a dictionary of languages.
+- additional_vim_regex_highlighting: `true` or `false`, or a list of languages.
   Set this to `true` if you depend on 'syntax' being enabled
   (like for indentation). Using this option may slow down your editor,
   and you may see some duplicate highlights.
@@ -126,6 +126,9 @@ Supported options:
         -- Highlight the @foo.bar capture group with the "Identifier" highlight group.
         ["foo.bar"] = "Identifier",
       },
+      -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+      -- Instead of true it can also be a list of languages
+      additional_vim_regex_highlighting = false,
     },
   }
   EOF


### PR DESCRIPTION
It's a bit a of a duplication but at least the option is present where ever the other options of the module are documented.

Should the disclaimer of `docs/nvim-treesitter` also be added to the short-info in README?

