### PR TITLE
feat: add HCL file type detection

### DIFF
--- a/ftdetect/hcl.vim
+++ b/ftdetect/hcl.vim
@@ -1,0 +1,1 @@
+autocmd BufRead,BufNewFile *.hcl,*.tf,*.tfvars set filetype=hcl

--- a/ftdetect/hcl.vim
+++ b/ftdetect/hcl.vim
@@ -1,1 +1,2 @@
-autocmd BufRead,BufNewFile *.hcl,*.tf,*.tfvars set filetype=hcl
+autocmd BufRead,BufNewFile *.hcl set filetype=hcl
+autocmd BufRead,BufNewFile *.tf,*.tfvars set filetype=terraform


### PR DESCRIPTION
HCL parser was added in https://github.com/nvim-treesitter/nvim-treesitter/pull/1445, but neovim does not set the correct filetype for `*.hcl`, `*.tf` and `*.tfvars` by default:

<img width="281" alt="image" src="https://user-images.githubusercontent.com/27996771/125388194-445fe900-e3c9-11eb-9655-c2fd798d66e1.png">

This PR adds a `ftdetect` rule for those files:

<img width="306" alt="image" src="https://user-images.githubusercontent.com/27996771/125388214-4cb82400-e3c9-11eb-839e-e100c3be2031.png">