### PR TITLE
Folds: remove ending marks for folds

### DIFF
--- a/lua/nvim-treesitter/fold.lua
+++ b/lua/nvim-treesitter/fold.lua
@@ -84,7 +84,11 @@ local folds_levels = tsutils.memoize_by_buf_tick(function(bufnr)
     if trimmed_level - last_trimmed_level > 0 then
       prefix = ">"
     elseif trimmed_level - next_trimmed_level > 0 then
-      prefix = "<"
+      -- Ending marks tend to confuse vim more than it helps, particularly when
+      -- the fold level changes by at least 2; we can uncomment this if
+      -- vim's behavior gets fixed.
+      -- prefix = "<"
+      prefix = ""
     end
 
     levels[lnum + 1] = prefix .. tostring(trimmed_level)


### PR DESCRIPTION
These cause vim to become more confused when there are multiple folds ending on the same line. For instance, consider:
```
int main() {         // >2
    if (1) {         // >3
        if (0) {     // >4
    }}               // <4
}                    // <2
```
For some reason, including the ending mark on line 5 causes the level-3 fold to end on line 5 instead of line 4 (???). This should probably get fixed upstream, but this is a fine workaround for now.