### PR TITLE
add @tag.attribute for html like attributes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,7 @@ Used for xml-like tags
 
 ```
 @tag
+@tag.attribute
 @tag.delimiter
 ```
 

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -616,6 +616,10 @@ For identifiers referring to symbols or atoms.
 `TSTag`
 Tags like html tag names.
 
+							   *hl-TSTagAttribute*
+`TSTagAttribute`
+For html tag attributes.
+
 							   *hl-TSTagDelimiter*
 `TSTagDelimiter`
 Tag delimiter like `<` `>` `/`

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -77,6 +77,7 @@ hlmap["string.special"] = "TSStringSpecial"
 hlmap["symbol"] = "TSSymbol"
 
 hlmap["tag"] = "TSTag"
+hlmap["tag.attribute"] = "TSTagAttribute"
 hlmap["tag.delimiter"] = "TSTagDelimiter"
 
 hlmap["text"] = "TSText"

--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -1,7 +1,7 @@
 (tag_name) @tag
 (erroneous_end_tag_name) @error
 (comment) @comment
-(attribute_name) @property
+(attribute_name) @tag.attribute
 (attribute_value) @string
 (quoted_attribute_value) @string
 (text) @none

--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -4,6 +4,7 @@
   close_tag: (jsx_closing_element ["<" "/" ">"] @tag.delimiter))
 (jsx_self_closing_element ["/" ">" "<"] @tag.delimiter)
 (jsx_fragment [">" "<" "/"] @tag.delimiter)
+(jsx_attribute (property_identifier) @tag.attribute)
 
 (jsx_opening_element
   name: (identifier) @tag)


### PR DESCRIPTION
This PR adds distinct `@tag.attribute` for things like html/jsx, and to avoid mixing up the markup stuff with attributes/annotations from programming languages.

Sorry @theHamsta, I did a mess with the rebase in the other PR so I re-did it from current master. I hope it all looks ok now!