### PR TITLE
Add YANG parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [verilog](https://github.com/tree-sitter/tree-sitter-verilog) (maintained by @zegervdv)
 - [x] [vue](https://github.com/ikatyang/tree-sitter-vue) (maintained by @WhyNotHugo)
 - [x] [yaml](https://github.com/ikatyang/tree-sitter-yaml) (maintained by @stsewd)
+- [x] [yang](https://github.com/Hubro/tree-sitter-yang) (maintained by @Hubro)
 - [x] [zig](https://github.com/Himujjal/tree-sitter-zig) (maintained by @Himujjal)
 <!--parserinfo-->
 

--- a/ftdetect/yang.vim
+++ b/ftdetect/yang.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.yang set filetype=yang

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -424,6 +424,15 @@ list.yaml = {
   maintainers = { "@stsewd" },
 }
 
+list.yang = {
+  install_info = {
+    url = "https://github.com/Hubro/tree-sitter-yang",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@Hubro" },
+  filetype = "yang",
+}
+
 list.nix = {
   install_info = {
     url = "https://github.com/cstrahan/tree-sitter-nix",

--- a/queries/yang/highlights.scm
+++ b/queries/yang/highlights.scm
@@ -1,0 +1,29 @@
+
+(comment) @comment
+
+; Module / submodule
+["module" "submodule"] @keyword
+
+; Keywords
+(statement_keyword) @keyword
+(extension_keyword) @string.escape
+
+; Arguments
+(built_in_type) @type.builtin
+(integer) @number
+(boolean) @boolean
+(date) @number
+(range) @string.escape
+(unquoted_range) @string.escape
+(yang_version) @string.escape
+(identifier) @variable
+(node_identifier) @variable
+(glob) @string
+(string) @string
+(unquoted_string) @string
+(keypath) @string.escape
+
+; Punctuation
+(plus_symbol) @punctuation.delimiter
+["{" "}"] @punctuation.bracket
+[";"] @punctuation.delimiter


### PR DESCRIPTION
I spent the last couple of weeks learning about Tree-sitter and implemented a parser for YANG, which I use extensively at work. It would be cool to add it to nvim-treesitter. I made a highlights query as well, it works really well:

![image](https://user-images.githubusercontent.com/597206/126110239-834c9e18-7826-4205-ac20-b3721018bbb5.png)
