### PR TITLE
Add `-z` switch to tar.

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -158,7 +158,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
         err = "Error during tarball extraction.",
         opts = {
           args = {
-            "-xvfz",
+            "-xvzf",
             project_name .. ".tar.gz",
             "-C",
             project_name .. "-tmp",

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -158,7 +158,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision)
         err = "Error during tarball extraction.",
         opts = {
           args = {
-            "-xvf",
+            "-xvfz",
             project_name .. ".tar.gz",
             "-C",
             project_name .. "-tmp",


### PR DESCRIPTION
Some versions of tar automatically infer `-z` if a `.gz` (or other compressed extension) file is passed -- but some, including OpenBSD's, don't do this and require an explicit `-z`. As far as I know, any version of tar which automatically unzips files supports `-z` so this should be a backwards compatible change for most versions of tar.