### PR TITLE
fix: make additional_vim_regex_highlighting actually accept a list

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -114,7 +114,10 @@ function M.attach(bufnr, lang)
   ts.highlighter.new(parser, {})
 
   local is_table = type(config.additional_vim_regex_highlighting) == "table"
-  if config.additional_vim_regex_highlighting and (not is_table or config.additional_vim_regex_highlighting[lang]) then
+  if
+    config.additional_vim_regex_highlighting
+    and (not is_table or vim.tbl_contains(config.additional_vim_regex_highlighting, lang))
+  then
     api.nvim_buf_set_option(bufnr, "syntax", "ON")
   end
 end


### PR DESCRIPTION
I was debugging a telescope buffer previewer yesterday and stumped upon this "inconsistency".
The docs are talking that this could be a list of languages. https://github.com/nvim-treesitter/nvim-treesitter#modules
But you were treating it like a set.

One of both needs to be adjusted in my opinion, its your call which one :)