### PR TITLE
highlights(lua): Fix method calls

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -132,9 +132,12 @@
 
 (property_identifier) @property
 
-(function_call (identifier) @function . (arguments))
-(function_call [(identifier) @variable (_)] (method) @method . (arguments))
-(function_call (field_expression (property_identifier) @function) . (arguments))
+(function_call
+  [((identifier) @variable (method) @method)
+   ((_) (method) @method)
+   (identifier) @function
+   (field_expression (property_identifier) @function)]
+  . (arguments))
 
 ;; Parameters
 (parameters

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -131,9 +131,9 @@
 (function_definition ["function" "end"] @keyword.function)
 
 (property_identifier) @property
-(method) @method
 
 (function_call (identifier) @function . (arguments))
+(function_call [(identifier) @variable (_)] (method) @method . (arguments))
 (function_call (field_expression (property_identifier) @function) . (arguments))
 
 ;; Parameters


### PR DESCRIPTION
The usual `function_call` query would highlight the objects at the
beginning of a method call. The `method` query has to account for this,
and highlight the identifier as a variable again.