### PR TITLE
Remove regex for field in GDScript

### DIFF
--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -33,10 +33,6 @@
 ((identifier) @type
   (#match? @type "^[A-Z][A-Z_0-9]*$") . (_))
 
-((attribute
-    (identifier) @field)
- (#vim-match? @field "^([A-Z])@!.*$"))
-
 ;; Functions
 (constructor_definition) @constructor
 


### PR DESCRIPTION
The regex is broken and decided to remove it, it's better to parse it at the grammar side.

Before:

![изображение](https://user-images.githubusercontent.com/22453358/126554418-f6abdd54-a279-4fd1-9912-216ea098f491.png)

After:

![изображение](https://user-images.githubusercontent.com/22453358/126554478-3df77f22-fa29-4bc3-8183-ad21ca26b2d5.png)
