### PR TITLE
feature: add godotResource queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by @Shatur95)
 - [x] [Glimmer and Ember](https://github.com/alexlafroscia/tree-sitter-glimmer) (maintained by @alexlafroscia)
 - [x] [go](https://github.com/tree-sitter/tree-sitter-go) (maintained by @theHamsta, @WinWisely268)
+- [x] [Godot Resources (godotResource)](https://github.com/PrestonKnopp/tree-sitter-godot-resource) (maintained by @pierpo)
 - [x] [gomod](https://github.com/camdencheek/tree-sitter-go-mod) (maintained by @camdencheek)
 - [x] [graphql](https://github.com/bkegley/tree-sitter-graphql) (maintained by @bkegley)
 - [ ] [haskell](https://github.com/tree-sitter/tree-sitter-haskell)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -545,6 +545,16 @@ list.gdscript = {
   maintainers = { "@Shatur95" },
 }
 
+list.godotResource = {
+  install_info = {
+    url = "https://github.com/PrestonKnopp/tree-sitter-godot-resource",
+    files = { "src/parser.c", "src/scanner.c" },
+    requires_generate_from_grammar = true,
+  },
+  readme_name = "Godot Resources (godotResource)",
+  maintainers = { "@pierpo" },
+}
+
 list.turtle = {
   install_info = {
     url = "https://github.com/BonaBeavis/tree-sitter-turtle",

--- a/queries/godotResource/folds.scm
+++ b/queries/godotResource/folds.scm
@@ -1,0 +1,3 @@
+[
+  (section)
+] @fold

--- a/queries/godotResource/highlights.scm
+++ b/queries/godotResource/highlights.scm
@@ -1,0 +1,28 @@
+(identifier) @type.builtin
+
+(attribute (identifier) @property)
+(property (path) @property)
+(constructor (identifier) @constructor)
+
+(string) @string
+(integer) @number
+(float) @float
+
+(true) @constant.builtin
+(false) @constant.builtin
+
+[
+  "["
+  "]"
+] @tag.delimiter
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket
+
+"=" @operator
+
+(ERROR) @error

--- a/queries/godotResource/locals.scm
+++ b/queries/godotResource/locals.scm
@@ -1,0 +1,3 @@
+[
+  (section)
+] @scope


### PR DESCRIPTION
This aims at giving support to `*.tscn` and `*.tres` files for Godot Engine.

I am not sure about the filetype... I took the name given by the author of the parser, but `godotResource` as a filetype does not feel very conventional with vim. (I'd expect `gdresource`, similarly to `gdscript`)

Here's a preview:

![Screenshot from 2021-07-28 19-56-25](https://user-images.githubusercontent.com/6313316/127372885-514beea9-e681-4f90-a2d4-5ee22a7eeb39.png)

![Screenshot from 2021-07-28 19-59-12](https://user-images.githubusercontent.com/6313316/127372888-2a088107-310a-4962-9063-79dfc3d74ff9.png)
