### PR TITLE
Feature: Add Surface language and integrate with Elixir

### DIFF
--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,1 +1,2 @@
 au BufRead,BufNewFile *.ex,*.exs,mix.lock set filetype=elixir
+au BufRead,BufNewFile *.eex,*.leex,*.heex set filetype=eelixir

--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.ex,*.exs,mix.lock set filetype=elixir

--- a/ftdetect/surface.vim
+++ b/ftdetect/surface.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.sface set filetype=surface

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -261,6 +261,16 @@ list.elixir = {
   maintainers = { "@nifoc" },
 }
 
+list.surface = {
+  install_info = {
+    url = "https://github.com/connorlay/tree-sitter-surface",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  filetype = "sface",
+  maintainers = { "@connorlay" },
+}
+
 list.ocaml = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ocaml",

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -78,6 +78,10 @@
  remote: [(atom) (module)] @type
  function: (function_identifier) @method)
 
+(dot_call
+ remote: (identifier) @variable
+ function: (function_identifier) @method)
+
 "fn" @keyword.function
 
 ; def, defp, defguard, ... everything that starts with def

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -8,3 +8,8 @@
    (sigil_start) @_start
    (sigil_content) @regex)
  (#match? @_start "~(r|R)[/</\\\"[({|]"))
+
+((sigil
+   (sigil_start) @_start
+   (sigil_content) @surface)
+ (#match? @_start "~F"))

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -1,9 +1,3 @@
-(comment) @comment
-
-; TODO: re-add when markdown is added
-; (heredoc
-;   (heredoc_content) @markdown)
-
 ((sigil
    (sigil_start) @_start
    (sigil_content) @regex)
@@ -11,4 +5,5 @@
 
 ((sigil
    (sigil_start) @_start
-   (sigil_content) @surface))
+   (sigil_content) @surface)
+ (#eq? @_start "~F\"\"\""))

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -11,5 +11,4 @@
 
 ((sigil
    (sigil_start) @_start
-   (sigil_content) @surface)
- (#match? @_start "~F"))
+   (sigil_content) @surface))

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -1,3 +1,9 @@
+(comment) @comment
+
+; TODO: re-add when markdown is added
+; (heredoc
+;   (heredoc_content) @markdown)
+
 ((sigil
    (sigil_start) @_start
    (sigil_content) @regex)

--- a/queries/surface/folds.scm
+++ b/queries/surface/folds.scm
@@ -1,0 +1,5 @@
+; Surface folds similar to HTML and includes blocks
+[
+  (tag)
+  (block)
+] @fold

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -1,18 +1,14 @@
-; Surface has two types of comments, both are highlighted as such
-[
-  (comment) 
-] @comment
+; Surface text is highlighted as such
+(text) @text
 
-; Disable highlighting for injection sites and plain text
-[
-  (text) 
-  (expression)
-] @none
+; Surface has two types of comments, both are highlighted as such
+(comment) @comment
+
+; Surface attributes are highlighted as HTML attributes
+(attribute_name) @tag.attribute
 
 ; Attributes are highlighted as strings
-[
-  (attribute_value)
-] @string
+(attribute_value) @string
 
 ; Surface blocks are highlighted as keywords
 [
@@ -26,18 +22,25 @@
   (start_tag)
   (end_tag)
   (self_closing_tag)
+  (start_component)
+  (end_component)
+  (self_closing_component)
 ] @tag.delimiter
 
+; Expressions are similar to string interpolation, and are highloghted as such
+(expression) @punctuation.special
 
-; Surface components are highlighted as Elixir modules
-((tag_name) @tag)
-((tag_name) @type (#match? @type "^[A-Z#]+.*"))
+; Expressions should be highlighted as Elixir, fallback to special strings
+(expression_value) @string.special
 
-; Surface directives are highligted as keywords
-((attribute_name) @tag.attribute)
-((attribute_name) @keyword (#match? @keyword "^[:]+.*"))
+; Surface tags are highlighted as HTML
+(tag_name) @tag
+
+; Surface components are highlighted as types (Elixir modules)
+(component_name) @type
+
+; Surface directives are highlighted as keywords
+(directive_name) @keyword
 
 ; Surface operators
-[
-  "="
-] @operator
+["="] @operator

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -1,7 +1,6 @@
 ; Surface has two types of comments, both are highlighted as such
 [
-  (private_comment) 
-  (public_comment)
+  (comment) 
 ] @comment
 
 ; Disable highlighting for injection sites and plain text

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -1,16 +1,43 @@
-(tag_name) @type
-(public_comment) @comment
-(private_comment) @comment
-
-(attribute_name) @symbol
-(attribute_value) @string
-
+; Surface has two types of comments, both are highlighted as such
 [
-  "{"
-  "}"
-  "<"
-  ">"
-  "/>"
-] @punctuation.bracket
+  (private_comment) 
+  (public_comment)
+] @comment
 
-"=" @operator
+; Disable highlighting for injection sites and plain text
+[
+  (text) 
+  (expression)
+] @none
+
+; Attributes are highlighted as strings
+[
+  (attribute_value)
+] @string
+
+; Surface blocks are highlighted as keywords
+[
+  (start_block) 
+  (end_block)
+] @keyword
+
+; Surface supports HTML tags and are highlighted as such
+[
+  (start_tag)
+  (end_tag)
+  (self_closing_tag)
+] @tag.delimiter
+
+
+; Surface components are highlighted as Elixir modules
+((tag_name) @tag)
+((tag_name) @type (#match? @type "^[A-Z#]+.*"))
+
+; Surface directives are highligted as keywords
+((attribute_name) @tag.attribute)
+((attribute_name) @keyword (#match? @keyword "^[:]+.*"))
+
+; Surface operators
+[
+  "="
+] @operator

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -1,0 +1,16 @@
+(tag_name) @type
+(public_comment) @comment
+(private_comment) @comment
+
+(attribute_name) @symbol
+(attribute_value) @string
+
+[
+  "{"
+  "}"
+  "<"
+  ">"
+  "/>"
+] @punctuation.bracket
+
+"=" @operator

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -18,6 +18,7 @@
 [
   (start_block) 
   (end_block)
+  (subblock)
 ] @keyword
 
 ; Surface supports HTML tags and are highlighted as such

--- a/queries/surface/indents.scm
+++ b/queries/surface/indents.scm
@@ -1,0 +1,12 @@
+; Surface indents like HTML, with the addition of blocks 
+[
+  (tag)
+  (block)
+] @indent
+
+; Dedent at the end of each tag, as well as a subblock
+[
+  (end_tag)
+  (end_block)
+  (subblock)
+] @branch

--- a/queries/surface/injections.scm
+++ b/queries/surface/injections.scm
@@ -1,1 +1,2 @@
+; Surface expressions are always Elixir code
 (expression_value) @elixir

--- a/queries/surface/injections.scm
+++ b/queries/surface/injections.scm
@@ -1,0 +1,1 @@
+(expression_value) @elixir

--- a/queries/surface/injections.scm
+++ b/queries/surface/injections.scm
@@ -1,2 +1,8 @@
-; Surface expressions are always Elixir code
-(expression_value) @elixir
+; Surface expressions and components are Elixir code
+[
+  (expression_value)
+  (component_name)
+] @elixir
+
+; Surface comments are nvim-treesitter comments
+(comment) @comment


### PR DESCRIPTION
[Surface](https://surface-ui.org/) is a template language and component library for Elixir and Phoenix LiveView. The syntax is like JSX, but for Elixir!

I created a new Surface [grammar](https://github.com/connorlay/tree-sitter-surface) and and I am happy with the results so far. This PR adds the necessary integration and queries to support using the grammar with NeoVim.

The grammar does not call any external scanners and it should be fairly stable at this point, save for any upstream changes to the language itself. I based the highlights and other queries on the existing work for Elixir, HTML, and JSX.

Additionally, I added ftdetect files for Elixir and Surface, and fixed a small bug with how Elixir highlights function call identifiers when the remote is a variable.

This is my first time authoring a Tree-sitter grammar, any feedback is greatly appreciated 😄 