### PR TITLE
Indent c compound literal expression

### DIFF
--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -7,6 +7,7 @@
   (conditional_expression)
   (enumerator_list)
   (struct_specifier)
+  (compound_literal_expression)
 ] @indent
 
 

--- a/tests/indent/c/compound_lit.c
+++ b/tests/indent/c/compound_lit.c
@@ -1,0 +1,10 @@
+struct foo {
+    int x, y;
+};
+
+struct foo bar(int x, int y) {
+    return (struct foo) {
+        .x = x,
+        .y = y
+    };
+}

--- a/tests/indent/c_spec.lua
+++ b/tests/indent/c_spec.lua
@@ -14,6 +14,7 @@ describe("indent C:", function()
 
   describe("new line:", function()
     runner:new_line("array.c", { on_line = 2, text = "0,", indent = 4 })
+    runner:new_line("compound_lit.c", { on_line = 7, text = ".z = 5,", indent = 8 })
     runner:new_line("cond.c", { on_line = 3, text = "x++;", indent = 8 })
     runner:new_line("cond.c", { on_line = 8, text = "x++;", indent = 8 })
     runner:new_line("expr.c", { on_line = 10, text = "2 *", indent = 8 })


### PR DESCRIPTION
Before:
```c
    return (struct foo) {
    .x = x,
    .y = y
    };
```
After:
```c
    return (struct foo) {
        .x = x,
        .y = y
    };
```