### PR TITLE
CI: don't require to have parsers installed to check for injections

### DIFF
--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -18,7 +18,7 @@ local function extract_captures()
   end
 
   -- Complete captures for injections.
-  local parsers = require("nvim-treesitter.info").installed_parsers()
+  local parsers = vim.tbl_keys(require("nvim-treesitter.parsers").list)
   for _, lang in pairs(parsers) do
     table.insert(captures["injections"], lang)
   end


### PR DESCRIPTION
A faster fix for https://github.com/nvim-treesitter/nvim-treesitter/pull/1651