### PR TITLE
fix: query_predicate - nth

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [scss](https://github.com/serenadeai/tree-sitter-scss) (maintained by @elianiva)
 - [x] [sparql](https://github.com/BonaBeavis/tree-sitter-sparql) (maintained by @bonabeavis)
 - [x] [supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) (maintained by @madskjeldgaard)
+- [x] [surface](https://github.com/connorlay/tree-sitter-surface) (maintained by @connorlay)
 - [x] [svelte](https://github.com/Himujjal/tree-sitter-svelte) (maintained by @elianiva)
 - [ ] [swift](https://github.com/tree-sitter/tree-sitter-swift)
 - [x] [teal](https://github.com/euclidianAce/tree-sitter-teal) (maintained by @euclidianAce)

--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -26,7 +26,7 @@ query.add_predicate("nth?", function(match, pattern, bufnr, pred)
   end
 
   local node = match[pred[2]]
-  local n = pred[3]
+  local n = tonumber(pred[3])
   if node and node:parent() and node:parent():named_child_count() > n then
     return node:parent():named_child(n) == node
   end


### PR DESCRIPTION
`pred[3]` is string. So, `node:parent():named_child_count() > n` throws error.