### PR TITLE
feat: allow 'revision' override in parser config

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [scss](https://github.com/serenadeai/tree-sitter-scss) (maintained by @elianiva)
 - [x] [sparql](https://github.com/BonaBeavis/tree-sitter-sparql) (maintained by @bonabeavis)
 - [x] [supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) (maintained by @madskjeldgaard)
+- [x] [surface](https://github.com/connorlay/tree-sitter-surface) (maintained by @connorlay)
 - [x] [svelte](https://github.com/Himujjal/tree-sitter-svelte) (maintained by @elianiva)
 - [ ] [swift](https://github.com/tree-sitter/tree-sitter-swift)
 - [x] [teal](https://github.com/euclidianAce/tree-sitter-teal) (maintained by @euclidianAce)

--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ Note also that module functionality is only triggered if your language's filetyp
 If Neovim does not detect your language's filetype by default, you can add a short Vimscript file to nvim-treesitter's `ftdetect` runtime directory.
 See [Neovim's documentation](https://neovim.io/doc/user/filetype.html#new-filetype) on how to use Vimscript to detect a filetype.
 
+If you use a git repository for your parser and want to use a specific version, you can set the `revision` key
+in the `install_info` table for you parser config.
+
 ## Update parsers used_by
 
 Sometimes needs to use some parser for different filetype.

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -39,11 +39,36 @@ local function get_job_status()
     .. "]"
 end
 
+local function get_parser_install_info(lang, validate)
+  local parser_config = parsers.get_parser_configs()[lang]
+
+  if not parser_config then
+    return error("Parser not available for language " .. lang)
+  end
+
+  local install_info = parser_config.install_info
+
+  if validate then
+    vim.validate {
+      url = { install_info.url, "string" },
+      files = { install_info.files, "table" },
+    }
+  end
+
+  return install_info
+end
+
 local function get_revision(lang)
   if #lockfile == 0 then
     local filename = utils.join_path(utils.get_package_path(), "lockfile.json")
     lockfile = vim.fn.filereadable(filename) == 1 and vim.fn.json_decode(vim.fn.readfile(filename)) or {}
   end
+
+  local install_info = get_parser_install_info(lang)
+  if install_info.revision then
+    return install_info.revision
+  end
+
   return (lockfile[lang] and lockfile[lang].revision)
 end
 
@@ -59,7 +84,8 @@ local function is_installed(lang)
 end
 
 local function needs_update(lang)
-  return not get_revision(lang) or get_revision(lang) ~= get_installed_revision(lang)
+  local revision = get_revision(lang)
+  return not revision or revision ~= get_installed_revision(lang)
 end
 
 local function outdated_parsers()
@@ -315,16 +341,7 @@ local function install_lang(lang, ask_reinstall, cache_folder, install_folder, w
     end
   end
 
-  local parser_config = parsers.get_parser_configs()[lang]
-  if not parser_config then
-    return api.nvim_err_writeln("Parser not available for language " .. lang)
-  end
-
-  local install_info = parser_config.install_info
-  vim.validate {
-    url = { install_info.url, "string" },
-    files = { install_info.files, "table" },
-  }
+  local install_info = get_parser_install_info(lang, true)
 
   run_install(cache_folder, install_folder, lang, install_info, with_sync, generate_from_grammar)
 end


### PR DESCRIPTION
### UseCase

I want to write a plugin that provides tree-sitter queries for a custom `lua` parser.
And I want to leverages `nvim-treesitter`'s installation and update system for installing that custom parser.

Here's how the setup for that plugin would be:

```lua
local M = {
  _initialized = false,
}

function M.setup()
  if M._initialized then
    return
  end

  local parser_config = require("nvim-treesitter.parsers").get_parser_configs()

  parser_config.lua = {
    install_info = {
      url = "https://github.com/MunifTanjim/tree-sitter-lua",
      files = { "src/parser.c", "src/scanner.cc" },
      revision = "c910b4e77e9f4ff2408cec28f50eeeb572add33c",
    }
  }
end

return M
```

And after calling this function, user can simply do `:TSInstall lua` for installing the parser.

Without being able to set the `revision` key, that plugin won't be able to control the specific version of parser being installed, so the queries could become outdated.