### PR TITLE
Fix instance and singleton method locals for Ruby

### DIFF
--- a/queries/ruby/locals.scm
+++ b/queries/ruby/locals.scm
@@ -36,7 +36,8 @@
 
 (module name: (constant) @definition.namespace)
 (class name: (constant) @definition.type)
-(method name: (identifier) @definition.function)
+(method name: [(identifier) (constant)] @definition.function)
+(singleton_method name: [(identifier) (constant)] @definition.function)
 
 (method_parameters (identifier) @definition.var)
 (lambda_parameters (identifier) @definition.var)


### PR DESCRIPTION
Ruby singleton methods (`def x.y ... end`) weren't covered in the list
of locals. In addition, instance methods didn't support names that are
capitalised (`def Integer ... end`).

This commit ensures that both instance and singleton methods are
supported, and that both support identifiers and constants as their
names. This ensures that all following examples are covered:

    def foo; end
    def FOO; end
    def self.bar; end
    def self.BAR; end