### PR TITLE
C#: Improve highlights + Improve folds + Add locals

### DIFF
--- a/queries/c_sharp/folds.scm
+++ b/queries/c_sharp/folds.scm
@@ -1,18 +1,15 @@
-[
- (class_declaration)
- (constructor_declaration)
- (enum_declaration)
- (interface_declaration)
- (method_declaration)
- (namespace_declaration)
- (struct_declaration)
-
- (do_statement)
- (for_each_statement)
- (for_statement)
- (if_statement)
- (switch_statement)
- (try_statement)
- (using_statement)
- (while_statement)
+body: [
+  (declaration_list)
+  (switch_body)
+  (enum_member_declaration_list)
 ] @fold
+
+accessors: [
+  (accessor_list)
+] @fold
+
+initializer: [
+  (initializer_expression)
+] @fold
+
+(block) @fold

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -3,7 +3,13 @@
 (method_declaration
   name: (identifier) @method)
 
+(local_function_statement
+  name: (identifier) @method)
+
 (method_declaration
+  type: (identifier) @type)
+
+(local_function_statement
   type: (identifier) @type)
 
 (interpolation) @none
@@ -89,14 +95,46 @@
   name: (identifier) @type)
 (constructor_declaration
   name: (identifier) @constructor)
+(constructor_initializer [
+  "base" @constructor
+])
 
 (variable_declaration
   (identifier) @type)
 (object_creation_expression
   (identifier) @type)
 
-(generic_name
+; Generic Types.
+(type_of_expression
+  (generic_name
+    (identifier) @type))
+
+(type_argument_list
+  (generic_name
+    (identifier) @type))
+
+(base_list
+  (generic_name
+    (identifier) @type))
+
+(type_constraint
+  (generic_name
+    (identifier) @type))
+
+(object_creation_expression
+  (generic_name
+   (identifier) @type))
+
+(property_declaration
+  (generic_name
+    (identifier) @type))
+
+type: (generic_name
   (identifier) @type)
+
+; Generic Method invocation with generic type
+(invocation_expression
+  function: (generic_name) @method)
 
 (invocation_expression
   (member_access_expression
@@ -120,6 +158,23 @@
 
 (for_each_statement
   type: (identifier) @type)
+
+(tuple_element
+  type: (identifier) @type)
+
+(tuple_expression
+  (argument
+    (declaration_expression
+      type: (identifier) @type)))
+
+(as_expression
+  right: (identifier) @type)
+
+(type_of_expression
+  (identifier) @type)
+
+(name_colon
+  (identifier) @parameter)
 
 (warning_directive) @text.warning
 (error_directive) @exception
@@ -167,7 +222,6 @@
  "for"
  "do"
  "continue"
- "in"
  "goto"
  "foreach"
 ] @repeat
@@ -249,10 +303,12 @@
  "with"
  "new"
  "typeof"
+ "nameof"
  "sizeof"
  "ref"
  "is"
  "as"
+ "out"
 ] @keyword.operator
 
 [
@@ -268,6 +324,7 @@
  "private"
  "protected"
  "public"
+ "partial"
  "readonly"
  "sealed"
  "static"
@@ -284,10 +341,23 @@
  "get"
  "set"
  "where"
+ "in"
 ] @keyword
+
+(parameter_modifier "this" @keyword)
+
+(query_expression
+  (_ [
+    "from"
+    "orderby"
+    "select"
+    "group"
+    "by"
+    "ascending"
+    "descending"
+  ] @keyword))
 
 [
   "return"
   "yield"
 ] @keyword.return
-

--- a/queries/c_sharp/locals.scm
+++ b/queries/c_sharp/locals.scm
@@ -1,0 +1,41 @@
+;; Definitions
+(variable_declarator
+  . (identifier) @definition.var)
+
+(variable_declarator
+  (tuple_pattern
+    (identifier) @definition.var))
+
+(declaration_expression
+  name: (identifier) @definition.var)
+
+(for_each_statement
+  left: (identifier) @definition.var)
+
+(for_each_statement
+  left: (tuple_pattern
+    (identifier) @definition.var))
+
+(parameter
+  (identifier) @definition.parameter)
+
+(method_declaration
+  name: (identifier) @definition.method)
+
+(local_function_statement
+  name: (identifier) @definition.method)
+
+(property_declaration
+  name: (identifier) @definition)
+
+(type_parameter
+  (identifier) @definition.type)
+
+(class_declaration
+  name: (identifier) @definition)
+
+;; References
+(identifier) @reference
+
+;; Scope
+(block) @scope


### PR DESCRIPTION
3 main improvements in this one to further improve C# highlighting (as discussed in #1349):

1. Improved highlights:
    Most notable improvements include missing keywords, support for [LINQ query syntax](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/linq/query-syntax-and-method-syntax-in-linq), better local function support and better generics support.
 2. Improved folds:
     This was actually simplified. Instead of folding entire methods _including_ their attributes, this new way of folding will only fold their _blocks_. This makes it easier to look through code when you have methods with a lot of Attributes or a lot of arguments split into multiple lines.
3. Added locals:
    This is a very simple implementation and is most likely not very good. It works, but not perfectly, to highlight the definitions using the refactor module but hasn't been extensively tested.

I don't have any screenshots for this unfortunately but I should be able to make some if needed (although they won't show all of the changes)