### PR TITLE
RST: add code-block to injections

### DIFF
--- a/queries/rst/injections.scm
+++ b/queries/rst/injections.scm
@@ -28,7 +28,7 @@
 ((directive
    name: (type) @_type
    body: (body (arguments) @language (content) @content))
- (#eq? @_type "code"))
+ (#any-of? @_type "code" "code-block"))
 
 ((directive
    name: (type) @_type


### PR DESCRIPTION
This isn't part of the rst spec,
but it's common enough on third party libs (sphinx specially).