### PR TITLE
Add comment highlighting for keywords in Haskell

### DIFF
--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -6,6 +6,7 @@
  ((quasiquote_body) @content)
 )
 
+(comment) @comment)
 
 ;; -----------------------------------------------------------------------------
 ;; shakespeare library

--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -6,7 +6,7 @@
  ((quasiquote_body) @content)
 )
 
-(comment) @comment)
+(comment) @comment
 
 ;; -----------------------------------------------------------------------------
 ;; shakespeare library


### PR DESCRIPTION
Keywords like "TODO" or "FIXME" that are in single line or multi-line comments are not currently highlighted like they are in other languages. 

Before:

![ts-nohighlight-comment](https://user-images.githubusercontent.com/9307830/129437791-874dbb59-a2db-4166-98ae-9d3ccf68e2dd.png)

After:

![ts-highlight-comment](https://user-images.githubusercontent.com/9307830/129437794-c85160e9-d17e-471f-8c40-90c725aecc28.png)


