### PR TITLE
Feature: Add HEEx language and integrate with Elixir

### DIFF
--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=#\ %s

--- a/after/ftplugin/heex.vim
+++ b/after/ftplugin/heex.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=<%#\ %s\ %>

--- a/after/ftplugin/surface.vim
+++ b/after/ftplugin/surface.vim
@@ -1,0 +1,1 @@
+setlocal commentstring={!--\ %s\ --}

--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,2 +1,2 @@
 au BufRead,BufNewFile *.ex,*.exs,mix.lock set filetype=elixir
-au BufRead,BufNewFile *.eex,*.leex,*.heex set filetype=eelixir
+au BufRead,BufNewFile *.eex,*.leex set filetype=eelixir

--- a/ftdetect/heex.vim
+++ b/ftdetect/heex.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.heex set filetype=heex

--- a/lockfile.json
+++ b/lockfile.json
@@ -171,7 +171,7 @@
     "revision": "67ecede8fc5f2e342a7f0516b87d0476b36035ac"
   },
   "surface": {
-    "revision": "54082c44547e63e8a7e0f8b90ac855a6c3c4c1e3"
+    "revision": "21b7676859c1187645a27ff301f76738af5dfd44"
   },
   "svelte": {
     "revision": "349a5984513b4a4a9e143a6e746120c6ff6cf6ed"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -271,6 +271,16 @@ list.surface = {
   maintainers = { "@connorlay" },
 }
 
+list.heex = {
+  install_info = {
+    url = "https://github.com/connorlay/tree-sitter-heex",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  filetype = "heex",
+  maintainers = { "@connorlay" },
+}
+
 list.ocaml = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ocaml",

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -13,3 +13,8 @@
    (sigil_start) @_start
    (sigil_content) @surface)
  (#eq? @_start "~F\"\"\""))
+
+((sigil
+   (sigil_start) @_start
+   (sigil_content) @heex)
+ (#eq? @_start "~H\"\"\""))

--- a/queries/heex/folds.scm
+++ b/queries/heex/folds.scm
@@ -1,0 +1,5 @@
+; HEEx folds similar to HTML
+[
+  (tag)
+  (component)
+] @fold

--- a/queries/heex/highlights.scm
+++ b/queries/heex/highlights.scm
@@ -1,29 +1,29 @@
-; HEEx text is highlighted as such
 (text) @text
-
-; HEEx has two types of comments, both are highlighted as such
 (comment) @comment
+(doctype) @constant
 
 ; HEEx attributes are highlighted as HTML attributes
 (attribute_name) @tag.attribute
-
-; Attributes are highlighted as strings
 (quoted_attribute_value) @string
 
-; HEEx supports HTML tags and are highlighted as such
 [
-  "<"
-  ">"
-  "</"
-  "/>"
-  "<%"
-  "<%="
-  "<%%="
-  "<%#"
   "%>"
+  "/>"
+  "<!"
+  "<"
+  "<%"
+  "<%#"
+  "<%%="
+  "<%="
+  "</"
+  ">"
   "{"
   "}"
 ] @tag.delimiter
+
+[
+  "="
+] @operator
 
 ; HEEx tags are highlighted as HTML
 (tag_name) @tag
@@ -31,5 +31,3 @@
 ; HEEx components are highlighted as types (Elixir modules)
 (component_name) @type
 
-; HEEx operators
-["="] @operator

--- a/queries/heex/highlights.scm
+++ b/queries/heex/highlights.scm
@@ -1,0 +1,35 @@
+; HEEx text is highlighted as such
+(text) @text
+
+; HEEx has two types of comments, both are highlighted as such
+(comment) @comment
+
+; HEEx attributes are highlighted as HTML attributes
+(attribute_name) @tag.attribute
+
+; Attributes are highlighted as strings
+(quoted_attribute_value) @string
+
+; HEEx supports HTML tags and are highlighted as such
+[
+  "<"
+  ">"
+  "</"
+  "/>"
+  "<%"
+  "<%="
+  "<%%="
+  "<%#"
+  "%>"
+  "{"
+  "}"
+] @tag.delimiter
+
+; HEEx tags are highlighted as HTML
+(tag_name) @tag
+
+; HEEx components are highlighted as types (Elixir modules)
+(component_name) @type
+
+; HEEx operators
+["="] @operator

--- a/queries/heex/indents.scm
+++ b/queries/heex/indents.scm
@@ -1,0 +1,11 @@
+; HEEx  indents like HTML
+[
+  (component)
+  (tag)
+] @indent
+
+; Dedent at the end of each tag
+[
+  (end_tag)
+  (end_component)
+] @branch

--- a/queries/heex/injections.scm
+++ b/queries/heex/injections.scm
@@ -1,0 +1,7 @@
+; Directives are combined to support do blocks
+(directive (expression_value) @elixir @combined)
+
+; Expressions are not combined, as they exist separately from do blocks
+(expression (expression_value) @elixir)
+
+(comment) @comment

--- a/queries/heex/injections.scm
+++ b/queries/heex/injections.scm
@@ -1,7 +1,10 @@
+; TODO: once @combined is fixed for all modules, replace this with the two queries below
+(expression_value) @elixir
+
 ; Directives are combined to support do blocks
-(directive (expression_value) @elixir @combined)
+; (directive (expression_value) @elixir @combined)
 
 ; Expressions are not combined, as they exist separately from do blocks
-(expression (expression_value) @elixir)
+; (expression (expression_value) @elixir)
 
 (comment) @comment

--- a/queries/surface/folds.scm
+++ b/queries/surface/folds.scm
@@ -1,5 +1,6 @@
 ; Surface folds similar to HTML and includes blocks
 [
   (tag)
+  (component)
   (block)
 ] @fold

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -19,12 +19,12 @@
 
 ; Surface supports HTML tags and are highlighted as such
 [
-  (start_tag)
-  (end_tag)
-  (self_closing_tag)
-  (start_component)
-  (end_component)
-  (self_closing_component)
+  "<"
+  ">"
+  "</"
+  "/>"
+  "{"
+  "}"
 ] @tag.delimiter
 
 ; Expressions are similar to string interpolation, and are highloghted as such

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -8,7 +8,7 @@
 (attribute_name) @tag.attribute
 
 ; Attributes are highlighted as strings
-(attribute_value) @string
+(quoted_attribute_value) @string
 
 ; Surface blocks are highlighted as keywords
 [
@@ -25,13 +25,11 @@
   "/>"
   "{"
   "}"
+  "<!--"
+  "-->"
+  "{!--"
+  "--}"
 ] @tag.delimiter
-
-; Expressions are similar to string interpolation, and are highloghted as such
-(expression) @punctuation.special
-
-; Expressions should be highlighted as Elixir, fallback to special strings
-(expression_value) @string.special
 
 ; Surface tags are highlighted as HTML
 (tag_name) @tag

--- a/queries/surface/indents.scm
+++ b/queries/surface/indents.scm
@@ -1,5 +1,6 @@
 ; Surface indents like HTML, with the addition of blocks 
 [
+  (component)
   (tag)
   (block)
 ] @indent
@@ -7,6 +8,7 @@
 ; Dedent at the end of each tag, as well as a subblock
 [
   (end_tag)
+  (end_component)
   (end_block)
   (subblock)
 ] @branch


### PR DESCRIPTION
[HEEx](https://github.com/phoenixframework/phoenix_live_view/blob/master/CHANGELOG.md#new-html-engine) is a new template language for Elixir and Phoenix LiveView that extends EEx with HTML-aware validations.

I created a new HEEx [grammar](https://github.com/connorlay/tree-sitter-heex), based on my existing grammar for Surface. Similar to the Surface grammar, the new HEEx grammar does not use any external scanners. See my previous PR for more information on the Surface grammar: https://github.com/nvim-treesitter/nvim-treesitter/pull/1645

In addition to adding HEEx, this PR updates the version of the Surface grammar to support the addition of a new node type, bringing the HEEx and Surface grammars closer together.

Finally, this PR adds the missing `commentstring` definitions for Elixir, HEEx, and Surface. This improves support for the [nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring) plugin.