### PR TITLE
Update CSharp highlights.

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -1,8 +1,8 @@
 (identifier) @variable
 
-((identifier) @keyword @_p
-  (#eq? @_p "value")
-  (#has-ancestor? @_p accessor_declaration))
+((identifier) @keyword
+  (#eq? @keyword "value")
+  (#has-ancestor? @keyword accessor_declaration))
 
 (method_declaration
   name: (identifier) @method)

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -1,5 +1,9 @@
 (identifier) @variable
 
+((identifier) @keyword @_p
+  (#eq? @_p "value")
+  (#has-ancestor? @_p accessor_declaration))
+
 (method_declaration
   name: (identifier) @method)
 
@@ -90,6 +94,8 @@
 (interface_declaration
   name: (identifier) @type)
 (class_declaration
+  name: (identifier) @type)
+(record_declaration
   name: (identifier) @type)
 (enum_declaration
   name: (identifier) @type)
@@ -299,16 +305,24 @@ type: (generic_name
  "using"
 ] @include
 
+(alias_qualified_name
+  (identifier "global") @include)
+
 [
  "with"
  "new"
  "typeof"
  "nameof"
  "sizeof"
- "ref"
  "is"
  "as"
+ "and"
+ "or"
+ "not"
+ "stackalloc"
+ "in"
  "out"
+ "ref"
 ] @keyword.operator
 
 [
@@ -319,11 +333,14 @@ type: (generic_name
  "abstract"
  "const"
  "extern"
+ "implicit"
+ "explicit"
  "internal"
  "override"
  "private"
  "protected"
  "public"
+ "internal"
  "partial"
  "readonly"
  "sealed"
@@ -340,8 +357,15 @@ type: (generic_name
  "struct"
  "get"
  "set"
+ "init"
  "where"
- "in"
+ "record"
+ "event"
+ "add"
+ "remove"
+ "checked"
+ "unchecked"
+ "fixed"
 ] @keyword
 
 (parameter_modifier "this" @keyword)
@@ -355,6 +379,8 @@ type: (generic_name
     "by"
     "ascending"
     "descending"
+    "equals"
+    "let"
   ] @keyword))
 
 [


### PR DESCRIPTION
Syntax highlighting update for C# language.

Changelist:
1. Added C#9 keywords:
   - `record`
   - `init`
   - `and`, `or`, `not` used in a pattern matching.
2. Added missing keywords from previous language versions:
    - `implicit`, `explicit`;
    - `internal`;
    - `event`, `add`, `remove`;
    - `checked`, `unchecked`, `fixed`.
3. Updated inline LINQ expressions with `let` and `equal`.
4. Highlighted `global` as a keyword when access to the global namespace.
5. Highlighted `value` as a keyword in filed accessors (`get`, `set`).

Used reference https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/

