### PR TITLE
Update new parse and query for zig

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -216,6 +216,6 @@
     "revision": "8e9d175982afcefa3dac8ca20d40d1643accd2bd"
   },
   "zig": {
-    "revision": "33764aedfbd11294450e31f11e1a8416cde96317"
+    "revision": "f062c24b22fe0e744194f14748c25aa39a7ff012"
   }
 }

--- a/queries/zig/folds.scm
+++ b/queries/zig/folds.scm
@@ -2,5 +2,8 @@
   (Block)
   (ContainerDecl)
   (SwitchExpr)
+  (InitList)
   (AsmExpr)
+  (ErrorSetDecl)
+  (LINESTRING)
 ] @fold

--- a/queries/zig/indents.scm
+++ b/queries/zig/indents.scm
@@ -1,9 +1,9 @@
 [
-  ; BUG: why function block not indent
   (Block)
   (ContainerDecl)
   (SwitchExpr)
   (InitList)
+  (ContainerDecl)
 ] @indent
 
 [
@@ -19,5 +19,5 @@
   (line_comment)
   (container_doc_comment)
   (doc_comment)
-  (STRINGLITERAL)
+  (LINESTRING)
 ] @ignore


### PR DESCRIPTION
In this release:
 - All parsing error were fixed https://github.com/maxxnino/tree-sitter-zig/commit/4f4f96b9dc53fee7cc6287712714a2a5c6f93c2a. 
 - Performance improve from 120ms -> 6ms
> ![performance](https://user-images.githubusercontent.com/34153891/130397661-784249b5-86cd-4889-b5c6-1ba7701e1ee7.png)
 - Add fold for InitList, ErrorSetDecl and multiline string
 - More highlight for function, type
 - Add highlight for escape and format sequence in string and character
> Check my [Gallery](https://github.com/maxxnino/tree-sitter-zig/wiki/Gallery) for more images
