### PR TITLE
Add python to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,10 @@ charset = utf-8
 [*.lua]
 tab_width = 2
 
+[*.py]
+indent_size = 4
+tab_width = 4
+
 [{Makefile,**/Makefile,runtime/doc/*.txt}]
 indent_style = tab
 indent_size = 8


### PR DESCRIPTION
This adds python to editorconfig, becouse current config incorrectly uses indent 2 and tab_size 8 for python files.