### PR TITLE
chore(vim): update to latest version

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -207,7 +207,7 @@
     "revision": "8f6b1f357d1231c420404b5f7a368a73c25adfa2"
   },
   "vim": {
-    "revision": "342cd0c05813024f98020bd499d87742dd400cbb"
+    "revision": "78721f95c8302eeb31c0f8a64006e0aeafb9779c"
   },
   "vue": {
     "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06"


### PR DESCRIPTION
Avoids using the lockfile update PR because it is broken.