### PR TITLE
Reorder json5 queries

### DIFF
--- a/queries/json5/highlights.scm
+++ b/queries/json5/highlights.scm
@@ -5,13 +5,13 @@
 
 "null" @constant
 
-(member
-    name: (_) @keyword)
-
 (string) @string
 
 (number) @number
 
 (comment) @comment
+
+(member
+    name: (_) @keyword)
 
 (ERROR) @error


### PR DESCRIPTION
I realized that the old order for the queries makes key strings be highlighted as `@string` instead of `@keyword`. This should fix that 😄 