### PR TITLE
Add tree-sitter-pioasm with highlights and injections

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [ocaml_interface](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
 - [x] [ocamllex](https://github.com/atom-ocaml/tree-sitter-ocamllex) (maintained by @undu)
 - [x] [php](https://github.com/tree-sitter/tree-sitter-php) (maintained by @tk-shirasaka)
+- [x] [pioasm](https://github.com/leo60228/tree-sitter-pioasm) (maintained by @leo60228)
 - [x] [python](https://github.com/tree-sitter/tree-sitter-python) (maintained by @stsewd, @theHamsta)
 - [x] [ql](https://github.com/tree-sitter/tree-sitter-ql) (maintained by @pwntester)
 - [x] [Tree-sitter query language](https://github.com/nvim-treesitter/tree-sitter-query) (maintained by @steelsojka)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -693,6 +693,15 @@ list.json5 = {
   maintainers = { "@Joakker" },
 }
 
+list.pioasm = {
+  install_info = {
+    url = "https://github.com/leo60228/tree-sitter-pioasm",
+    branch = "main",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@leo60228" },
+}
+
 local M = {
   list = list,
 }

--- a/queries/pioasm/highlights.scm
+++ b/queries/pioasm/highlights.scm
@@ -1,0 +1,30 @@
+[ (line_comment) (block_comment) ] @comment
+
+(label_decl) @label
+
+(string) @string
+
+(instruction
+  opcode: _ @keyword)
+
+[ "pins" "x" "y" "null" "isr" "osr" "status" "pc" "exec" ] @variable.builtin
+
+(out_target "pindirs" @variable.builtin)
+(directive "pindirs" @keyword)
+
+(condition [ "--" "!=" ] @operator)
+(expression [ "+" "-" "*" "/" "|" "&" "^" "::" ] @operator)
+(not) @operator
+
+[ "optional" "opt" "side" "sideset" "side_set" "pin" "gpio" "osre" ] @keyword
+[ "block" "noblock" "iffull" "ifempty" "rel" ] @keyword
+(irq_modifiers) @keyword
+
+(integer) @number
+
+(directive (identifier) @variable)
+(directive (symbol_def (identifier) @variable))
+(value (identifier) @variable)
+
+(directive
+  directive: _ @keyword)

--- a/queries/pioasm/injections.scm
+++ b/queries/pioasm/injections.scm
@@ -5,10 +5,5 @@
 
 ((code_block
   (code_block_language) @_language
-  (code_block_body) @ada)
- (#eq? @_language "ada"))
-
-((code_block
-  (code_block_language) @_language
   (code_block_body) @python)
  (#eq? @_language "python"))

--- a/queries/pioasm/injections.scm
+++ b/queries/pioasm/injections.scm
@@ -1,9 +1,11 @@
+ [ (line_comment) (block_comment) ] @comment
+
 ((code_block
   (code_block_language) @_language
   (code_block_body) @c)
  (#eq? @_language "c-sdk"))
 
 ((code_block
-  (code_block_language) @_language
-  (code_block_body) @python)
- (#eq? @_language "python"))
+  (code_block_language) @language
+  (code_block_body) @content)
+ (#eq? @language "python"))

--- a/queries/pioasm/injections.scm
+++ b/queries/pioasm/injections.scm
@@ -1,0 +1,14 @@
+((code_block
+  (code_block_language) @_language
+  (code_block_body) @c)
+ (#eq? @_language "c-sdk"))
+
+((code_block
+  (code_block_language) @_language
+  (code_block_body) @ada)
+ (#eq? @_language "ada"))
+
+((code_block
+  (code_block_language) @_language
+  (code_block_body) @python)
+ (#eq? @_language "python"))

--- a/queries/pioasm/injections.scm
+++ b/queries/pioasm/injections.scm
@@ -5,7 +5,6 @@
   (code_block_body) @c)
  (#eq? @_language "c-sdk"))
 
-((code_block
+(code_block
   (code_block_language) @language
   (code_block_body) @content)
- (#eq? @language "python"))


### PR DESCRIPTION
This adds syntax highlighting for the RP2040 PIO assembler, [pioasm](https://github.com/raspberrypi/pico-sdk/tree/master/tools/pioasm) (documented in section 3.3 of the [RP2040 datasheet](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf)). Some sample files are available in [pico-examples](https://github.com/raspberrypi/pico-examples/tree/master/pio).