### PR TITLE
Add tree-sitter-dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @Akin909)
 - [x] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree) (maintained by @jedrzejboczar)
 - [x] [dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) (maintained by @camdencheek)
+- [x] [DOT](https://github.com/rydesun/tree-sitter-dot) (maintained by @rydesun)
 - [x] [elixir](https://github.com/ananthakumaran/tree-sitter-elixir) (maintained by @nifoc)
 - [ ] [elm](https://github.com/elm-tooling/tree-sitter-elm)
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)

--- a/ftdetect/dot.vim
+++ b/ftdetect/dot.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.dot,*.gv set filetype=dot

--- a/ftdetect/dot.vim
+++ b/ftdetect/dot.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile *.dot,*.gv set filetype=dot

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -94,6 +94,15 @@ list.dockerfile = {
   maintainers = { "@camdencheek" },
 }
 
+list.dot = {
+  install_info = {
+    url = "https://github.com/rydesun/tree-sitter-dot",
+    branch = "main",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@rydesun" },
+}
+
 list.rust = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-rust",

--- a/queries/dot/highlights.scm
+++ b/queries/dot/highlights.scm
@@ -1,0 +1,39 @@
+(identifier) @identifier
+(keyword) @keyword
+(string_literal) @string
+(number_literal) @number
+(html_string) @tag
+
+[
+  (edgeop)
+  (operator)
+] @operator
+
+[
+  ","
+  ";"
+] @punctuation.delimiter
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+(attribute
+  name: (id
+    (identifier) @type)
+)
+
+(attribute
+  value: (id
+    (identifier) @constant)
+)
+
+[
+(comment)
+(preproc)
+] @comment
+
+(ERROR) @error

--- a/queries/dot/highlights.scm
+++ b/queries/dot/highlights.scm
@@ -1,4 +1,4 @@
-(identifier) @variable
+(identifier) @type
 (keyword) @keyword
 (string_literal) @string
 (number_literal) @number
@@ -18,11 +18,18 @@
   "}"
   "["
   "]"
+  "<"
+  ">"
 ] @punctuation.bracket
+
+(subgraph
+  id: (id
+    (identifier) @namespace)
+)
 
 (attribute
   name: (id
-    (identifier) @type)
+    (identifier) @field)
 )
 
 (attribute

--- a/queries/dot/highlights.scm
+++ b/queries/dot/highlights.scm
@@ -2,7 +2,6 @@
 (keyword) @keyword
 (string_literal) @string
 (number_literal) @number
-(html_string) @tag
 
 [
   (edgeop)

--- a/queries/dot/highlights.scm
+++ b/queries/dot/highlights.scm
@@ -1,4 +1,4 @@
-(identifier) @identifier
+(identifier) @variable
 (keyword) @keyword
 (string_literal) @string
 (number_literal) @number

--- a/queries/dot/injections.scm
+++ b/queries/dot/injections.scm
@@ -1,0 +1,1 @@
+(html_internal) @html


### PR DESCRIPTION
DOT is a graph description language used in software Graphviz. I have written [tree-sitter-dot](https://github.com/rydesun/tree-sitter-dot), and this PR adds support for DOT.