### PR TITLE
highlights(php): fix method access using nullsafe operator

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -34,6 +34,9 @@
 (function_definition
   name: (name) @function)
 
+(nullsafe_member_call_expression
+    name: (name) @method)
+
 ; Member
 
 (property_element


### PR DESCRIPTION
With this change, methods that are accessed using `nullsafe` operator will be highlighted correctly.

before:
![image](https://user-images.githubusercontent.com/20175215/131417710-6c4b24d4-2d50-42cb-8892-4120dc24c606.png)

after:
![image](https://user-images.githubusercontent.com/20175215/131417741-1ae8d2c4-2773-4afb-b874-8842c860dbee.png)
