### PR TITLE
Update highlights (C, Lua)

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -6,7 +6,6 @@
   "enum"
   "extern"
   "inline"
-  "sizeof"
   "static"
   "struct"
   "typedef"
@@ -16,6 +15,7 @@
   "register"
 ] @keyword
 
+"sizeof" @keyword.operator
 "return" @keyword.return
 
 [

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -141,6 +141,15 @@
    (field_expression (property_identifier) @function)]
   . (arguments))
 
+(function_call
+  (identifier) @function.builtin
+  (#any-of? @function.builtin
+    ;; built-in functions in Lua 5.1
+    "assert" "collectgarbage" "dofile" "error" "getfenv" "getmetatable" "ipairs"
+    "load" "loadfile" "loadstring" "module" "next" "pairs" "pcall" "print"
+    "rawequal" "rawget" "rawset" "require" "select" "setfenv" "setmetatable"
+    "tonumber" "tostring" "type" "unpack" "xpcall"))
+
 ;; Parameters
 (parameters
   (identifier) @parameter)


### PR DESCRIPTION
- Add Lua 5.1 built-in functions
- Make `sizeof` a `keyword.operator`