### PR TITLE
vim.cmd vimscript syntax highlighting

### DIFF
--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -9,4 +9,16 @@
   (#eq? @_cdef_identifier "cdef")
 )
 
+(
+  (function_call
+    (field_expression
+      (property_identifier) @_cmd_identifier)
+    (arguments
+      (string) @vim)
+  )
+
+  (#eq? @_cmd_identifier "cmd")
+)
+
+
 (comment) @comment


### PR DESCRIPTION
This pull request adds a query that performs whenever there is a function called "cmd" that accepts one string. It will change the syntax highlighting of that string into vimscript to make writing vimscript in lua easier.