### PR TITLE
fix(ts_utils): get_root_for_position now includes end column

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -185,6 +185,11 @@ function M.get_node_at_cursor(winnr, ignore_injected_langs)
   return root:named_descendant_for_range(cursor_range[1], cursor_range[2], cursor_range[1], cursor_range[2])
 end
 
+--- Retrieves root for position
+-- @param line number
+-- @param col number
+-- @param root_lang_tree LanguageTree
+-- @returns {TSNode?, TSTree?, LanguageTree}
 function M.get_root_for_position(line, col, root_lang_tree)
   if not root_lang_tree then
     if not parsers.has_parser() then
@@ -199,7 +204,7 @@ function M.get_root_for_position(line, col, root_lang_tree)
   for _, tree in ipairs(lang_tree:trees()) do
     local root = tree:root()
 
-    if root and M.is_in_node_range(root, line, col) then
+    if M.is_in_node_range(root, line, col) then
       return root, tree, lang_tree
     end
   end
@@ -281,24 +286,16 @@ function M.node_length(node)
 end
 
 --- Determines whether (line, col) position is in node range
--- @param node Node defining the range
+-- @param node TSNode defining the range
 -- @param line A line (0-based)
 -- @param col A column (0-based)
 function M.is_in_node_range(node, line, col)
-  local start_line, start_col, end_line, end_col = node:range()
-  if line >= start_line and line <= end_line then
-    if line == start_line and line == end_line then
-      return col >= start_col and col < end_col
-    elseif line == start_line then
-      return col >= start_col
-    elseif line == end_line then
-      return col < end_col
-    else
-      return true
-    end
-  else
-    return false
-  end
+  local range = { line, col, line, col }
+  local start_row, start_col, end_row, end_col = node:range()
+  local start_fits = start_row < range[1] or (start_row == range[1] and start_col <= range[2])
+  local end_fits = end_row > range[3] or (end_row == range[3] and end_col >= range[4])
+
+  return start_fits and end_fits
 end
 
 function M.get_node_range(node_or_range)

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -185,6 +185,16 @@ function M.get_node_at_cursor(winnr, ignore_injected_langs)
   return root:named_descendant_for_range(cursor_range[1], cursor_range[2], cursor_range[1], cursor_range[2])
 end
 
+--- Determines whether (line, col) position is root node end
+-- @param node TSNode defining the range
+-- @param row A row (0-based)
+-- @param col A column (0-based)
+local function is_root_node_end(node, row, col)
+  local _, _, end_row, end_col = node:range()
+  local is_last_row = end_row == row
+  return is_last_row and end_col == 0 and col == 0
+end
+
 --- Retrieves root for position
 -- @param line number
 -- @param col number
@@ -204,7 +214,7 @@ function M.get_root_for_position(line, col, root_lang_tree)
   for _, tree in ipairs(lang_tree:trees()) do
     local root = tree:root()
 
-    if M.is_in_node_range(root, line, col) then
+    if M.is_in_node_range(root, line, col) or is_root_node_end(root, line, col) then
       return root, tree, lang_tree
     end
   end

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -287,13 +287,16 @@ end
 
 --- Determines whether (line, col) position is in node range
 -- @param node TSNode defining the range
--- @param line A line (0-based)
+-- @param row A row (0-based)
 -- @param col A column (0-based)
-function M.is_in_node_range(node, line, col)
-  local range = { line, col, line, col }
+function M.is_in_node_range(node, row, col)
   local start_row, start_col, end_row, end_col = node:range()
-  local start_fits = start_row < range[1] or (start_row == range[1] and start_col <= range[2])
-  local end_fits = end_row > range[3] or (end_row == range[3] and end_col >= range[4])
+  local is_first_row = start_row == row
+  local is_last_row = end_row == row
+  local is_root_node_end = is_last_row and end_col == 0 and col == 0
+
+  local start_fits = start_row < row or (is_first_row and start_col <= col)
+  local end_fits = end_row > row or (is_last_row and end_col > col) or is_root_node_end
 
   return start_fits and end_fits
 end

--- a/tests/unit/ts_utils_spec.lua
+++ b/tests/unit/ts_utils_spec.lua
@@ -1,4 +1,5 @@
 local tsutils = require "nvim-treesitter.ts_utils"
+local is_in_node_range = tsutils.is_in_node_range
 
 describe("is_in_node_range", function()
   local node = {
@@ -6,36 +7,43 @@ describe("is_in_node_range", function()
       return unpack { 0, 3, 2, 5 }
     end,
   }
-  local function test_is_in_node_range(line, col)
-    return tsutils.is_in_node_range(node, line, col)
-  end
+  local root_node = {
+    range = function()
+      return unpack { 0, 0, 2, 0 }
+    end,
+  }
 
   it("returns false before node start", function()
-    assert.is_false(test_is_in_node_range(0, 0))
-    assert.is_false(test_is_in_node_range(0, 1))
-    assert.is_false(test_is_in_node_range(0, 2))
+    assert.is_false(is_in_node_range(node, 0, 0))
+    assert.is_false(is_in_node_range(node, 0, 1))
+    assert.is_false(is_in_node_range(node, 0, 2))
   end)
 
   it("returns true at node start", function()
-    assert.is_true(test_is_in_node_range(0, 3))
+    assert.is_true(is_in_node_range(node, 0, 3))
   end)
 
   it("returns true on first line of the node", function()
-    assert.is_true(test_is_in_node_range(0, 4))
+    assert.is_true(is_in_node_range(node, 0, 4))
   end)
 
   it("returns true between node lines", function()
-    assert.is_true(test_is_in_node_range(1, 2))
-    assert.is_true(test_is_in_node_range(1, 20))
+    assert.is_true(is_in_node_range(node, 1, 2))
+    assert.is_true(is_in_node_range(node, 1, 20))
   end)
 
-  it("returns true at node end", function()
-    assert.is_true(test_is_in_node_range(2, 5))
+  it("returns false at node end for normal nodes", function()
+    assert.is_false(is_in_node_range(node, 2, 5))
+  end)
+
+  it("returns true at node end for root node", function()
+    assert.is_true(is_in_node_range(root_node, 2, 0))
   end)
 
   it("returns false after node end", function()
-    assert.is_false(test_is_in_node_range(2, 6))
-    assert.is_false(test_is_in_node_range(3, 0))
+    assert.is_false(is_in_node_range(node, 2, 6))
+    assert.is_false(is_in_node_range(node, 3, 0))
+    assert.is_false(is_in_node_range(root_node, 3, 0))
   end)
 end)
 

--- a/tests/unit/ts_utils_spec.lua
+++ b/tests/unit/ts_utils_spec.lua
@@ -36,7 +36,7 @@ describe("is_in_node_range", function()
     assert.is_false(is_in_node_range(node, 2, 5))
   end)
 
-  it("returns true at node end for root node", function()
+  it("returns false at node end for root node", function()
     assert.is_true(is_in_node_range(root_node, 2, 0))
   end)
 

--- a/tests/unit/ts_utils_spec.lua
+++ b/tests/unit/ts_utils_spec.lua
@@ -1,12 +1,12 @@
 local tsutils = require "nvim-treesitter.ts_utils"
 
 describe("is_in_node_range", function()
+  local node = {
+    range = function()
+      return unpack { 0, 3, 2, 5 }
+    end,
+  }
   local function test_is_in_node_range(line, col)
-    local node = {
-      range = function()
-        return unpack { 0, 3, 2, 5 }
-      end,
-    }
     return tsutils.is_in_node_range(node, line, col)
   end
 
@@ -29,9 +29,8 @@ describe("is_in_node_range", function()
     assert.is_true(test_is_in_node_range(1, 20))
   end)
 
-  it("returns false on node end", function()
-    -- Ranges are end-exclusive
-    assert.is_false(test_is_in_node_range(2, 5))
+  it("returns true at node end", function()
+    assert.is_true(test_is_in_node_range(2, 5))
   end)
 
   it("returns false after node end", function()


### PR DESCRIPTION
is_in_node_range is now almost exact copy of private function [tree_contains](https://github.com/neovim/neovim/blob/284199bc4bf36bb74c481da9c8b2a43c1bbbeb51/runtime/lua/vim/treesitter/languagetree.lua#L484) from neovim.

And their version is end-inclusive, so there's no reason to be different.

This change fixes nonexistent indents at the end of file in python.

---

@theHamsta i'm tagging you for this, in previous my PR you said that this function should be end-exclusive, but after digging neovim code, i found exact copy of what we doing here, and that function is end-inclusive.

Looking at git blame, it was @steelsojka written tree_contains, so we can also ask him if that function should be end-inclusive?

And, if this change could break something, we should add test for that. But i believe it does not break anything, i've used it for a few days without issues.