### PR TITLE
parsers: add glsl parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -85,6 +85,15 @@ list.cuda = {
   maintainers = { "@theHamsta" },
 }
 
+list.glsl = {
+  install_info = {
+    url = "https://github.com/theHamsta/tree-sitter-glsl",
+    files = { "src/parser.c" },
+    generate_requires_npm = true,
+  },
+  maintainers = { "@theHamsta" },
+}
+
 list.dockerfile = {
   install_info = {
     url = "https://github.com/camdencheek/tree-sitter-dockerfile",

--- a/queries/glsl/folds.scm
+++ b/queries/glsl/folds.scm
@@ -1,0 +1,1 @@
+; inherits: c

--- a/queries/glsl/highlights.scm
+++ b/queries/glsl/highlights.scm
@@ -1,0 +1,37 @@
+; inherits: c
+
+[
+  "in"
+  "out"
+  "inout"
+  "uniform"
+  "shared"
+  "layout"
+  "attribute"
+  "varying"
+  "buffer"
+  "coherent"
+  "readonly"
+  "writeonly"
+  "precision"
+  "highp"
+  "mediump"
+  "lowp"
+  "centroid"
+  "sample"
+  "patch"
+  "smooth"
+  "flat"
+  "noperspective"
+  "invariant"
+  "precise"
+] @keyword
+
+"subroutine" @keyword.function
+
+(extension_storage_class) @attribute
+
+(
+  (identifier) @variable.builtin
+  (#match? @variable.builtin "^gl_")
+)

--- a/queries/glsl/indents.scm
+++ b/queries/glsl/indents.scm
@@ -1,0 +1,1 @@
+; inherits: c

--- a/queries/glsl/injections.scm
+++ b/queries/glsl/injections.scm
@@ -1,0 +1,3 @@
+(preproc_arg) @glsl
+
+(comment) @comment

--- a/queries/glsl/locals.scm
+++ b/queries/glsl/locals.scm
@@ -1,0 +1,1 @@
+; inherits: c


### PR DESCRIPTION
In my config, I have 
```
    au! BufRead,BufNewFile *.glsl,*.vert,*.frag set filetype=glsl
```
I'm not sure if *.vert alone is sufficient to classify it as GL/Vulkan shader. Not sure if I should add ftdetect.