### PR TITLE
ci: install tree-sitter CLI

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1.5.0
       - uses: actions/setup-node@v2
 
+      - name: Install tree-sitter CLI
+        run: npm i -g tree-sitter
+
       - name: Install and prepare Neovim
         run: |
           bash ./scripts/ci-install-${{ matrix.os }}.sh

--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -68,14 +68,10 @@ end
 local ok, err = pcall(do_check)
 local allowed_to_fail = vim.split(vim.env.ALLOWED_INSTALLATION_FAILURES or "", ",", true)
 
-for k, v in pairs(require("nvim-treesitter.parsers").get_parser_configs()) do
+for k, _ in pairs(require("nvim-treesitter.parsers").get_parser_configs()) do
   if not require("nvim-treesitter.parsers").has_parser(k) then
     -- On CI all parsers that can be installed from C files should be installed
-    if
-      vim.env.CI
-      and not v.install_info.requires_generate_from_grammar
-      and not vim.tbl_contains(allowed_to_fail, k)
-    then
+    if vim.env.CI and not vim.tbl_contains(allowed_to_fail, k) then
       print("Error: parser for " .. k .. " is not installed")
       vim.cmd "cq"
     else


### PR DESCRIPTION
Could it be that we forgot to install tree-sitter CLI? @stsewd I thought we have this already installed but I couldn't find where we installed it.

It add 23s to our CI... (and a lot more on Windows) ~but it seems to eliminate the warnings about some parsers not being installed.~ the parsers only get installed on Linux