### PR TITLE
[0.5-Compat] Back-port Elixir, Surface, HEEx improvements

### DIFF
--- a/after/ftplugin/elixir.vim
+++ b/after/ftplugin/elixir.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=#\ %s

--- a/after/ftplugin/heex.vim
+++ b/after/ftplugin/heex.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=<%#\ %s\ %>

--- a/after/ftplugin/surface.vim
+++ b/after/ftplugin/surface.vim
@@ -1,0 +1,1 @@
+setlocal commentstring={!--\ %s\ --}

--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,0 +1,2 @@
+au BufRead,BufNewFile *.ex,*.exs,mix.lock set filetype=elixir
+au BufRead,BufNewFile *.eex,*.leex,*.heex set filetype=eelixir

--- a/ftdetect/elixir.vim
+++ b/ftdetect/elixir.vim
@@ -1,2 +1,2 @@
 au BufRead,BufNewFile *.ex,*.exs,mix.lock set filetype=elixir
-au BufRead,BufNewFile *.eex,*.leex,*.heex set filetype=eelixir
+au BufRead,BufNewFile *.eex,*.leex set filetype=eelixir

--- a/ftdetect/heex.vim
+++ b/ftdetect/heex.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.heex set filetype=heex

--- a/ftdetect/surface.vim
+++ b/ftdetect/surface.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.sface set filetype=surface

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -261,6 +261,16 @@ list.elixir = {
   maintainers = { "@nifoc" },
 }
 
+list.surface = {
+  install_info = {
+    url = "https://github.com/connorlay/tree-sitter-surface",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  filetype = "sface",
+  maintainers = { "@connorlay" },
+}
+
 list.ocaml = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ocaml",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -271,6 +271,16 @@ list.surface = {
   maintainers = { "@connorlay" },
 }
 
+list.heex = {
+  install_info = {
+    url = "https://github.com/connorlay/tree-sitter-heex",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  filetype = "heex",
+  maintainers = { "@connorlay" },
+}
+
 list.ocaml = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ocaml",

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -78,6 +78,10 @@
  remote: [(atom) (module)] @type
  function: (function_identifier) @method)
 
+(dot_call
+ remote: (identifier) @variable
+ function: (function_identifier) @method)
+
 "fn" @keyword.function
 
 ; def, defp, defguard, ... everything that starts with def

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -1,180 +1,154 @@
-(identifier) @variable
-
-; _unused variables
-(unused_identifier) @comment
-
-; __MODULE__ and friends
-(special_identifier) @constant.builtin
-
-(module) @type
-
-[(atom) (keyword)] @symbol
-
-(integer) @number
-(float) @float
-
-[(true) (false)] @boolean
-
-(nil) @constant.builtin
-
-(comment) @comment
-
-[
-  ","
-  "."
-] @punctuation.delimiter
+(ERROR) @error
 
 [
   "("
   ")"
+  "<<"
+  ">>"
   "["
   "]"
   "{"
   "}"
-  "<<"
-  ">>"
 ] @punctuation.bracket
 
-(interpolation
- "#{" @punctuation.special
- "}" @punctuation.special) @none
+[
+  ","
+  "->"
+  "."
+] @punctuation.delimiter
+
+[
+  (sigil_start)
+  (sigil_end)
+  (heredoc_start)
+  (heredoc_end)
+] @punctuation.special
+
+(interpolation ["#{" "}"] @punctuation.special)
+
+[
+  "after"
+  "and" 
+  "catch"
+  "do"
+  "else"
+  "end"
+  "fn"
+  "in"
+  "not in"
+  "not"
+  "or"
+  "rescue"
+  "when" 
+] @keyword
+
+[
+  (comment) 
+  (unused_identifier)
+] @comment
 
 [
   (heredoc_content)
   (sigil_content)
-  (string_content)
-  (string_end)
-  (string_start)
+  (string)
 ] @string
 
+; __MODULE__ and friends
+(special_identifier) @constant.builtin
+
+(map ["%{" "}"] @constructor)
+
+(struct ["%" "{" "}"] @constructor)
+
+(binary_op operator: _ @operator)
+
+(unary_op operator: _ @operator)
+
+(atom) @symbol
+
+(keyword) @parameter
+
 [
-  (heredoc_end)
-  (heredoc_start)
+  (true) 
+  (false)
+] @boolean
+
+(nil) @constant.builtin
+
+(sigil) @string.special
+
+(identifier) @variable
+
+(module) @type
+
+(function_identifier) @function
+
+(integer) @number
+
+(float) @float
+
+[
+  (sigil_start) 
   (sigil_end)
-  (sigil_start)
 ] @string.special
 
-(escape_sequence) @string.escape
+; Module attributes as "attributes"
+(unary_op operator: "@" @attribute [
+  (call function: (function_identifier) @attribute) 
+  (identifier) @attribute
+])
 
-[
-  "after"
-  "do"
-  "end"
-] @keyword
+; Erlang modules (when they are the remote of a function call) are highlighted as Elixir modules
+(dot_call remote: (atom) @type)
 
-[
-  "and"
-  "in"
-  "not"
-  "not in"
-  "or"
-] @keyword.operator
+(call (function_identifier) @keyword.function (#any-of? @keyword.function 
+  "def"
+  "defdelegate"
+  "defexception"
+  "defguard"
+  "defguardp"
+  "defimpl"
+  "defmacro"
+  "defmacrop"
+  "defmodule"
+  "defoverridable"
+  "defp"
+  "defprotocol"
+  "defstruct"
+) [(identifier) @function (_)]) ; 0-arity function def without parens
 
-; Call to a local function
-(call (function_identifier) @method)
+(call (function_identifier) @include (#any-of? @include 
+  "alias" 
+  "import" 
+  "require" 
+  "use"
+))
 
-; Call to a remote (or external) function
-(dot_call
- remote: [(atom) (module)] @type
- function: (function_identifier) @method)
+(call (function_identifier) @conditional (#any-of? @conditional 
+  "case"
+  "cond"
+  "else"
+  "if"
+  "unless"
+  "with"
+  "receive"
+))
 
-(dot_call
- remote: (identifier) @variable
- function: (function_identifier) @method)
+(call (function_identifier) @exception (#any-of? @exception 
+  "raise"
+  "reraise"
+  "throw"
+  "try"
+))
 
-"fn" @keyword.function
+(call (function_identifier) @repeat (#any-of? @repeat 
+  "for"
+))
 
-; def, defp, defguard, ... everything that starts with def
-(call (function_identifier) @keyword.function
- (#lua-match? @keyword.function "^def%a*$"))
-
-(call (function_identifier) @keyword.function
- (#any-of? @keyword.function "describe" "doctest" "on_exit" "setup" "setup_all" "test"))
-
-"else" @conditional
-
-(call (function_identifier) @conditional
- (#any-of? @conditional "case" "cond" "if" "unless" "with"))
-
-(call (function_identifier) @repeat
- (#eq? @repeat "for"))
-
-(call (function_identifier) @include
- (#any-of? @include "alias" "import" "require" "use"))
-
-[
-  "catch"
-  "rescue"
-] @exception
-
-(call (function_identifier) @exception
- (#any-of? @exception "raise" "try"))
-
-; Regex sigil
-(sigil
- (sigil_start) @_sigil-type
- [(sigil_content) (escape_sequence)] @string.regex
- (sigil_end)
- (#lua-match? @_sigil-type "^~r"))
-
-"->" @operator
-
-(unary_op
- operator: _ @operator)
-
-(binary_op
- operator: _ @operator)
-
-(unary_op
- operator: "@" @attribute
- [(call
-   function: (function_identifier) @attribute)
-  (identifier) @attribute])
-
-(unary_op
- operator: "@"
- (call (function_identifier) @attribute
-       (heredoc
-        [(heredoc_start)
-         (heredoc_content)
-         (heredoc_end)] @string))
- (#any-of? @attribute "doc" "moduledoc"))
-
-(unary_op
- operator: "@"
- (call (function_identifier) @attribute
-       (binary_op
-        left: (identifier) @method))
- (#eq? @attribute "spec"))
-
-; Definition without arguments
-(call (function_identifier) @keyword.function
- (identifier) @function 
- (#lua-match? @keyword.function "^def%a*$"))
-
-; Definition with (some) arguments and (optional) defaults
-(call (function_identifier) @keyword.function
- (call
-  function: (function_identifier) @function
-    (arguments))
- (#lua-match? @keyword.function "^def%a*$"))
-
-; Definition with (some) arguments and guard(s)
-(call (function_identifier) @keyword.function
- (binary_op
-  left:
-   (call
-    function: (function_identifier) @function
-    (arguments))
-  operator: "when")
- (#lua-match? @keyword.function "^def%a*$"))
-
-; Definition of custom binary operator(s)
-(call (function_identifier) @keyword.function
- (binary_op
-  left: (identifier) @parameter
-  operator: _ @function
-  right: (identifier) @parameter)
- (#any-of? @keyword.function "def" "defp"))
-
-(ERROR) @error
+(call (function_identifier) @keyword.function (#any-of? @keyword.function 
+  "describe"
+  "setup"
+  "setup_all"
+  "test"
+  "using"
+))

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -8,3 +8,8 @@
    (sigil_start) @_start
    (sigil_content) @regex)
  (#match? @_start "~(r|R)[/</\\\"[({|]"))
+
+((sigil
+   (sigil_start) @_start
+   (sigil_content) @surface)
+ (#eq? @_start "~F\"\"\""))

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -13,3 +13,8 @@
    (sigil_start) @_start
    (sigil_content) @surface)
  (#eq? @_start "~F\"\"\""))
+
+((sigil
+   (sigil_start) @_start
+   (sigil_content) @heex)
+ (#eq? @_start "~H\"\"\""))

--- a/queries/heex/folds.scm
+++ b/queries/heex/folds.scm
@@ -1,0 +1,5 @@
+; HEEx folds similar to HTML
+[
+  (tag)
+  (component)
+] @fold

--- a/queries/heex/highlights.scm
+++ b/queries/heex/highlights.scm
@@ -1,29 +1,29 @@
-; HEEx text is highlighted as such
 (text) @text
-
-; HEEx has two types of comments, both are highlighted as such
 (comment) @comment
+(doctype) @constant
 
 ; HEEx attributes are highlighted as HTML attributes
 (attribute_name) @tag.attribute
-
-; Attributes are highlighted as strings
 (quoted_attribute_value) @string
 
-; HEEx supports HTML tags and are highlighted as such
 [
-  "<"
-  ">"
-  "</"
-  "/>"
-  "<%"
-  "<%="
-  "<%%="
-  "<%#"
   "%>"
+  "/>"
+  "<!"
+  "<"
+  "<%"
+  "<%#"
+  "<%%="
+  "<%="
+  "</"
+  ">"
   "{"
   "}"
 ] @tag.delimiter
+
+[
+  "="
+] @operator
 
 ; HEEx tags are highlighted as HTML
 (tag_name) @tag
@@ -31,5 +31,3 @@
 ; HEEx components are highlighted as types (Elixir modules)
 (component_name) @type
 
-; HEEx operators
-["="] @operator

--- a/queries/heex/highlights.scm
+++ b/queries/heex/highlights.scm
@@ -1,0 +1,35 @@
+; HEEx text is highlighted as such
+(text) @text
+
+; HEEx has two types of comments, both are highlighted as such
+(comment) @comment
+
+; HEEx attributes are highlighted as HTML attributes
+(attribute_name) @tag.attribute
+
+; Attributes are highlighted as strings
+(quoted_attribute_value) @string
+
+; HEEx supports HTML tags and are highlighted as such
+[
+  "<"
+  ">"
+  "</"
+  "/>"
+  "<%"
+  "<%="
+  "<%%="
+  "<%#"
+  "%>"
+  "{"
+  "}"
+] @tag.delimiter
+
+; HEEx tags are highlighted as HTML
+(tag_name) @tag
+
+; HEEx components are highlighted as types (Elixir modules)
+(component_name) @type
+
+; HEEx operators
+["="] @operator

--- a/queries/heex/indents.scm
+++ b/queries/heex/indents.scm
@@ -1,0 +1,11 @@
+; HEEx  indents like HTML
+[
+  (component)
+  (tag)
+] @indent
+
+; Dedent at the end of each tag
+[
+  (end_tag)
+  (end_component)
+] @branch

--- a/queries/heex/injections.scm
+++ b/queries/heex/injections.scm
@@ -1,0 +1,7 @@
+; Directives are combined to support do blocks
+(directive (expression_value) @elixir @combined)
+
+; Expressions are not combined, as they exist separately from do blocks
+(expression (expression_value) @elixir)
+
+(comment) @comment

--- a/queries/heex/injections.scm
+++ b/queries/heex/injections.scm
@@ -1,7 +1,10 @@
+; TODO: once @combined is fixed for all modules, replace this with the two queries below
+(expression_value) @elixir
+
 ; Directives are combined to support do blocks
-(directive (expression_value) @elixir @combined)
+; (directive (expression_value) @elixir @combined)
 
 ; Expressions are not combined, as they exist separately from do blocks
-(expression (expression_value) @elixir)
+; (expression (expression_value) @elixir)
 
 (comment) @comment

--- a/queries/surface/folds.scm
+++ b/queries/surface/folds.scm
@@ -1,0 +1,5 @@
+; Surface folds similar to HTML and includes blocks
+[
+  (tag)
+  (block)
+] @fold

--- a/queries/surface/folds.scm
+++ b/queries/surface/folds.scm
@@ -1,5 +1,6 @@
 ; Surface folds similar to HTML and includes blocks
 [
   (tag)
+  (component)
   (block)
 ] @fold

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -1,0 +1,46 @@
+; Surface text is highlighted as such
+(text) @text
+
+; Surface has two types of comments, both are highlighted as such
+(comment) @comment
+
+; Surface attributes are highlighted as HTML attributes
+(attribute_name) @tag.attribute
+
+; Attributes are highlighted as strings
+(attribute_value) @string
+
+; Surface blocks are highlighted as keywords
+[
+  (start_block) 
+  (end_block)
+  (subblock)
+] @keyword
+
+; Surface supports HTML tags and are highlighted as such
+[
+  (start_tag)
+  (end_tag)
+  (self_closing_tag)
+  (start_component)
+  (end_component)
+  (self_closing_component)
+] @tag.delimiter
+
+; Expressions are similar to string interpolation, and are highloghted as such
+(expression) @punctuation.special
+
+; Expressions should be highlighted as Elixir, fallback to special strings
+(expression_value) @string.special
+
+; Surface tags are highlighted as HTML
+(tag_name) @tag
+
+; Surface components are highlighted as types (Elixir modules)
+(component_name) @type
+
+; Surface directives are highlighted as keywords
+(directive_name) @keyword
+
+; Surface operators
+["="] @operator

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -19,12 +19,12 @@
 
 ; Surface supports HTML tags and are highlighted as such
 [
-  (start_tag)
-  (end_tag)
-  (self_closing_tag)
-  (start_component)
-  (end_component)
-  (self_closing_component)
+  "<"
+  ">"
+  "</"
+  "/>"
+  "{"
+  "}"
 ] @tag.delimiter
 
 ; Expressions are similar to string interpolation, and are highloghted as such

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -8,7 +8,7 @@
 (attribute_name) @tag.attribute
 
 ; Attributes are highlighted as strings
-(attribute_value) @string
+(quoted_attribute_value) @string
 
 ; Surface blocks are highlighted as keywords
 [
@@ -25,13 +25,11 @@
   "/>"
   "{"
   "}"
+  "<!--"
+  "-->"
+  "{!--"
+  "--}"
 ] @tag.delimiter
-
-; Expressions are similar to string interpolation, and are highloghted as such
-(expression) @punctuation.special
-
-; Expressions should be highlighted as Elixir, fallback to special strings
-(expression_value) @string.special
 
 ; Surface tags are highlighted as HTML
 (tag_name) @tag

--- a/queries/surface/indents.scm
+++ b/queries/surface/indents.scm
@@ -1,0 +1,12 @@
+; Surface indents like HTML, with the addition of blocks 
+[
+  (tag)
+  (block)
+] @indent
+
+; Dedent at the end of each tag, as well as a subblock
+[
+  (end_tag)
+  (end_block)
+  (subblock)
+] @branch

--- a/queries/surface/indents.scm
+++ b/queries/surface/indents.scm
@@ -1,5 +1,6 @@
 ; Surface indents like HTML, with the addition of blocks 
 [
+  (component)
   (tag)
   (block)
 ] @indent
@@ -7,6 +8,7 @@
 ; Dedent at the end of each tag, as well as a subblock
 [
   (end_tag)
+  (end_component)
   (end_block)
   (subblock)
 ] @branch

--- a/queries/surface/injections.scm
+++ b/queries/surface/injections.scm
@@ -1,0 +1,8 @@
+; Surface expressions and components are Elixir code
+[
+  (expression_value)
+  (component_name)
+] @elixir
+
+; Surface comments are nvim-treesitter comments
+(comment) @comment


### PR DESCRIPTION
This PR back-ports my recent work with Elixir, Surface, and HEEx to the `0.5-compat` branch so non-nightly users (such as LunarVim) can access those features.

I cherry-picked the relevant commits from `master` and there were no conflicts to resolve.

See related ticket: https://github.com/connorlay/tree-sitter-heex/issues/2#issuecomment-917700175