### PR TITLE
indents(hcl): add more indentation rules for HCL

### DIFF
--- a/queries/hcl/indents.scm
+++ b/queries/hcl/indents.scm
@@ -1,4 +1,13 @@
 [
-  "}"
-  "]"
+  (object)
+  (block)
+  (tuple)
+  (for_tuple_expr)
+  (for_object_expr)
+] @indent
+
+[
+  (object_end)
+  (block_end)
+  (tuple_end)
 ] @branch


### PR DESCRIPTION
I ran a few comparisons to `terraform fmt` on some random local files and did not see any differences.  This should be an improvement over the previous indents definition.