### PR TITLE
highlights(rust): Fix punctuation.

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -255,4 +255,5 @@
 
 (attribute_item "#" @punctuation.special)
 (inner_attribute_item ["#" "!"] @punctuation.special)
+(macro_invocation "!" @function.macro) ; don't highlight `!` as an operator here
 

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -247,6 +247,7 @@
   ">" @punctuation.bracket)
 
 [
+":"
 "::"
 "."
 ";"
@@ -256,4 +257,3 @@
 (attribute_item "#" @punctuation.special)
 (inner_attribute_item ["#" "!"] @punctuation.special)
 (macro_invocation "!" @function.macro) ; don't highlight `!` as an operator here
-

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -112,32 +112,6 @@
 (block_comment)
  ] @comment
 
-[
- "("
- ")"
- "["
- "]"
- "{"
- "}"
-] @punctuation.bracket
-
-(type_arguments
-  "<" @punctuation.bracket
-  ">" @punctuation.bracket)
-(type_parameters
-  "<" @punctuation.bracket
-  ">" @punctuation.bracket)
-
-[
-"::"
-"."
-";"
-","
-] @punctuation.delimiter
-
-(attribute_item "#" @punctuation.special)
-(inner_attribute_item ["#" "!"] @punctuation.special)
-
 (parameter (identifier) @parameter)
 (closure_parameters (_) @parameter)
 
@@ -254,4 +228,31 @@
 "?"
 ] @operator
 
-(closure_parameters "|" @operator "|" @operator)
+[
+ "("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+] @punctuation.bracket
+
+(closure_parameters "|" @punctuation.bracket)
+
+(type_arguments
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+(type_parameters
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+
+[
+"::"
+"."
+";"
+","
+] @punctuation.delimiter
+
+(attribute_item "#" @punctuation.special)
+(inner_attribute_item ["#" "!"] @punctuation.special)
+


### PR DESCRIPTION
- Highlight angle brackets in type parameters and bars in closures as `@punctuation.bracket` not as `@operator`.
  The queries have to be added after the `@operator` queries because the are more specific.
- Don't highlight bang `!` in macro invocations as an operator.
- Highlight colon `:` as a punctuation delimiter.

