### PR TITLE
Fix incremental selection for nodes that include EOL

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -208,7 +208,8 @@ function M.update_selection(buf, node, selection_mode)
 
   -- Convert exclusive end position to inclusive
   if end_col == 1 then
-    vim.fn.setpos(".", { buf, end_row - 1, -1, 0 })
+    local previous_col = vim.fn.col { end_row - 1, "$" } - 1
+    vim.fn.setpos(".", { buf, end_row - 1, previous_col, 0 })
   else
     vim.fn.setpos(".", { buf, end_row, end_col - 1, 0 })
   end


### PR DESCRIPTION
From `:h setpos()`

> If "col" is smaller than 1 then 1 is used.

This can be tested with incremental selection on a vim file.

```vim
set title
```

Probably the vim parser shouldn't include `\n` in the nodes, but that's an improvement for the parser.