### PR TITLE
highlights(c): add __attribute__

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -170,4 +170,5 @@
 (preproc_params
   (identifier)) @parameter
 
+"__attribute__" @attribute
 (ERROR) @error


### PR DESCRIPTION
Highlight GCC's/Clang's __attribute__ specifier.