### PR TITLE
update hcl parser, update queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -90,7 +90,7 @@
     "revision": "bf7d643b494b7c7eed909ed7fbd8447231152cb0"
   },
   "hcl": {
-    "revision": "b048a42c6d907ff04e1a82e8dadcd9e8957024a1"
+    "revision": "3cb7fc28247efbcb2973b97e71c78838ad98a583"
   },
   "heex": {
     "revision": "1dfda4f3c86ea39bcd9e89b5ed21a44d0c94a5a5"

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -46,11 +46,14 @@
 
 [
   "for"
+  "endfor"
   "in"
 ] @repeat
 
 [ 
   "if"
+  "else"
+  "endif"
 ] @conditional
 
 [
@@ -64,12 +67,13 @@
   (heredoc_start) ; END
 ] @punctuation.delimiter
 
-( template_interpolation
-  [
-    (template_interpolation_start) ; ${
-    (template_interpolation_end) ; }
-  ] @punctuation.special
-)
+[
+  (template_interpolation_start) ; ${
+  (template_interpolation_end) ; }
+  (template_directive_start) ; %{
+  (template_directive_end) ; }
+  (strip_marker) ; ~
+] @punctuation.special
 
 (numeric_lit) @number
 (bool_lit) @boolean


### PR DESCRIPTION
This PR updates the tree-sitter-hcl parser to v0.6.0, supporting template-if and template-for directives.

Before: 
![image](https://user-images.githubusercontent.com/17451647/134067442-5720fab6-7d62-4fbb-8d68-2a8b24c31531.png)
After:
![image](https://user-images.githubusercontent.com/17451647/134067470-1ed78c0a-e07e-4562-a397-e298145bd21b.png)
