### PR TITLE
fix erratic highlighting of python function arguments

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -93,13 +93,6 @@
   (subscript
     (identifier) @type)) ; type subscript: Tuple[int]
 
-((call
-  function: (identifier) @_isinstance
-  arguments: (argument_list
-    (_)
-    (identifier) @type))
- (#eq? @_isinstance "isinstance"))
-
 ;; Normal parameters
 (parameters
   (identifier) @parameter)


### PR DESCRIPTION
This PR fixed my https://github.com/nvim-treesitter/nvim-treesitter/issues/871#issuecomment-920319185 without other complications so far.
