### PR TITLE
fix(ecma): remove `@none` from interpolation

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -172,16 +172,16 @@
 (ternary_expression ["?" ":"] @conditional)
 (unary_expression ["!" "~" "-" "+" "delete" "void" "typeof"]  @operator)
 
-"(" @punctuation.bracket
-")" @punctuation.bracket
-"[" @punctuation.bracket
-"]" @punctuation.bracket
-"{" @punctuation.bracket
-"}" @punctuation.bracket
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
 
-((template_substitution ["${" "}"] @punctuation.special) @none
- ; Substitutions should have a higher priority than injections.
- (#set! "priority" 105))
+((template_substitution ["${" "}"] @punctuation.special) @none)
 
 ; Keywords
 ;----------


### PR DESCRIPTION
This PR removes the `@none` override for the interpolation because it overrides every ecma based template literal, setting none with a higher priority than ecma groups which made every template string look `un`highlighted.

should fix https://github.com/nvim-treesitter/nvim-treesitter/issues/1848