### PR TITLE
Add headers as an option to fold on

### DIFF
--- a/queries/beancount/folds.scm
+++ b/queries/beancount/folds.scm
@@ -1,4 +1,4 @@
 [
     (transaction)
-    (header)
+    (heading)
 ] @fold

--- a/queries/beancount/folds.scm
+++ b/queries/beancount/folds.scm
@@ -1,3 +1,4 @@
 [
     (transaction)
+    (header)
 ] @fold


### PR DESCRIPTION
treesitter-beancount added grammar rules around orgmode and markdown
headers so that they are recognized in beancount documents. This change
makes it so that they will be taken into consideration when folding
text.

Commit: https://github.com/polarmutex/tree-sitter-beancount/commit/79ae7c1f2654a2a6936b0f37bf754e5ff59c9186