### PR TITLE
Python: highlight interpolation escaped chars

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -140,7 +140,11 @@
 
 (comment) @comment
 (string) @string
-(escape_sequence) @string.escape
+[
+  (escape_sequence)
+  "{{"
+  "}}"
+] @string.escape
 
 ; Tokens
 


### PR DESCRIPTION
Support for these was just added in the grammar.