### PR TITLE
graphql: highlight `description` as a comment

### DIFF
--- a/queries/graphql/highlights.scm
+++ b/queries/graphql/highlights.scm
@@ -109,7 +109,8 @@
 ; Literals
 ;---------
 
-(description) @comment
+(description
+  (string_value) @comment)
 
 (comment) @comment
 


### PR DESCRIPTION
Fixes #1843

![image](https://user-images.githubusercontent.com/24727447/135575121-5807d925-a2da-4742-af50-4908449c381a.png)
