### PR TITLE
graphql: add `commentstring`

### DIFF
--- a/after/ftplugin/graphql.vim
+++ b/after/ftplugin/graphql.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=#\ %s


### PR DESCRIPTION
By default, `graphql` filetype have `/* %s */` as the commentstring instead of `# %s`. This PR attempts to fix that. As the filetype detection is already in the treesitter, I thought adding `commenstring` here would be appropriate.

Please feel free to close it, if this doesn't belong here :)