### PR TITLE
HTML: highlight text nodes as text

### DIFF
--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -4,7 +4,7 @@
 (attribute_name) @tag.attribute
 (attribute_value) @string
 (quoted_attribute_value) @string
-(text) @none
+(text) @text
 
 ((element (start_tag (tag_name) @_tag) (text) @text.title)
  (#match? @_tag "^(h[0-9]|title)$"))


### PR DESCRIPTION
Guss this was a mistake trying to highlight those nodes as white