### PR TITLE
Python: highlight nested types definitions

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -89,6 +89,8 @@
   name: (identifier) @function)
 
 (type (identifier) @type)
+((subscript (identifier) @type) @_child
+ (#has-ancestor? @_child type))
 (type
   (subscript
     (identifier) @type)) ; type subscript: Tuple[int]


### PR DESCRIPTION
Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1899

Think this was considered slow? I'll test this change for a while and
check the performance (but probably I won't notice any change on my
computer)