### PR TITLE
Add basic vimscript injection in `vim.cmd`/`nvim_command`/`nvim_exec`

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -222,7 +222,7 @@
     "revision": "8f6b1f357d1231c420404b5f7a368a73c25adfa2"
   },
   "vim": {
-    "revision": "d141ba6da916ebaed0ceccafa069e0d24d8932b0"
+    "revision": "1d23679256edb241ebed8da1247e340bf9e0c0ad"
   },
   "vue": {
     "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06"

--- a/lockfile.json
+++ b/lockfile.json
@@ -222,7 +222,7 @@
     "revision": "8f6b1f357d1231c420404b5f7a368a73c25adfa2"
   },
   "vim": {
-    "revision": "fd7bc35927ab44670e02d5ad035e0363f4ffde2b"
+    "revision": "d141ba6da916ebaed0ceccafa069e0d24d8932b0"
   },
   "vue": {
     "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06"

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -1,3 +1,4 @@
+; C Injections
 (
   (function_call
     (field_expression
@@ -22,6 +23,31 @@
   (#eq? @_cdef_identifier "cdef")
   (#match? @c "^\\[\\[")
   (#offset! @c 0 2 0 -2)
+)
+
+; Vimscript Injections
+(
+  (function_call
+    (field_expression) @_vimcmd_identifier
+    (arguments
+      (string) @vim)
+  )
+
+  (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec")
+  (#match? @vim "^[\"']")
+  (#offset! @vim 0 1 0 -1)
+)
+
+(
+  (function_call
+    (field_expression) @_vimcmd_identifier
+    (arguments
+      (string) @vim)
+  )
+
+  (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec")
+  (#match? @vim "^\\[\\[")
+  (#offset! @vim 0 2 0 -2)
 )
 
 (comment) @comment


### PR DESCRIPTION
Hi!

This PR implements injection in `vim.cmd` codeblocks to improve the readability of Neovim+Lua codebases.
Currently it works for the following scenarios:
```lua
vim.cmd [[echo "Hello World!"]]
```
And:
```lua
vim.cmd "echo 'Hello World!'"
```

Obviously you can substitute `vim.cmd` for any of the other 3 functions that we have. There is one issue that I simply cannot resolve however, and that is this:
```lua
vim.cmd [[
    echo "Hello World!"
]]
```

Your `cdef` injection is plagued by the same problem, and that is that multiline strings that are `#match?`ed don't seem to have their respective parser injected. Any idea why this may even be? When I remove the `#match?` it works however then the `#offset!` of `2` messes with single-line strings that only use one char (`"`/`'`) instead of two (`[[`). Any idea why this could even be? lol