### PR TITLE
fix(d): don't use string_literals

### DIFF
--- a/queries/d/highlights.scm
+++ b/queries/d/highlights.scm
@@ -34,10 +34,14 @@
   "__PRETTY_FUNCTION__"
 ] @constant.macro
 
-(string_literals) @string
-
-; Don't highlight token strings as strings
-(token_string_tokens) @none
+[
+  (wysiwyg_string)
+  (alternate_wysiwyg_string)
+  (double_quoted_string)
+  (hex_string)
+  (delimited_string)
+  (token_string)
+] @string
 
 (character_literal) @character
 


### PR DESCRIPTION
string_literals is not used in single argument template instances, so for example the string in `TFoo!"bar".Ptr x;` wouldn't be highlighted. The string nodes are from [tree-sitter-d source code].

[tree-sitter-d source code]: https://github.com/CyberShadow/tree-sitter-d/blob/c2fbf21bd3aa45495fe13247e040ad5815250032/grammar.js#L536