### PR TITLE
feat(tests): test highlights

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,8 +11,10 @@ run() {
 if [[ $1 = '--summary' ]]; then
     # really simple results summary by filtering plenary busted output
     run tests/indent/ 2> /dev/null | grep -E '^\S*(Success|Fail(ed)?|Errors?)'
+    run tests/highlight/ 2> /dev/null | grep -E '^\S*(Success|Fail(ed)?|Errors?)'
 elif [[ $1 = '--unit' ]]; then
     run tests/unit
 else
     run tests/indent/
+    run tests/highlight/
 fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 HERE="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
-cd $HERE/..
+cd "$HERE/.." || exit 1
 
 run() {
     nvim --headless --noplugin -u scripts/minimal_init.lua \

--- a/tests/highlight/common.lua
+++ b/tests/highlight/common.lua
@@ -2,19 +2,35 @@ local M = {}
 
 local assert = require "luassert"
 local Path = require "plenary.path"
+local ft_to_lang = require("nvim-treesitter.parsers").ft_to_lang
 
--- Get table of nodes from file
--- @param file  a tested file
-local function get_nodes(file)
+-- Get table with highlight query captures
+-- @param file A path to file to parse
+local function get_highlight_captures(file)
   assert(vim.fn.filereadable(file) == 1, string.format('File "%s" not readable', file))
 
   -- load reference file
   vim.cmd(string.format("edit %s", file))
 
-  local parser = vim.treesitter.get_parser(0)
-  local tstree = parser:parse()
+  local ft = vim.bo.filetype
+  local lang = ft_to_lang(ft)
 
-  return tstree:root()
+  local parser = vim.treesitter.get_parser(0, lang)
+  local tree = parser:parse()[1]
+
+  local query = vim.treesitter.query.get_query(lang, "highlights")
+  local captures = {}
+
+  for id, node, _ in query:iter_captures(tree:root(), 0, 0, -1) do
+    local capture = {}
+
+    capture.name = query.captures[id]
+    capture.begin_row, capture.begin_column, capture.end_row, capture.end_column = node:range()
+
+    table.insert(captures, capture)
+  end
+
+  return captures
 end
 
 local Runner = {}
@@ -30,12 +46,10 @@ function Runner:new(it, base_dir)
   return setmetatable(runner, self)
 end
 
-function Runner:expect_nodes(file, spec, title)
-  title = title and title or tostring(spec.on_line)
-
-  self.it(string.format("%s[%s]", file, title), function()
+function Runner:expect_nodes(file, spec)
+  self.it(string.format("%s", file), function()
     local path = self.base_dir / file
-    local nodes = get_nodes(path.filename)
+    local nodes = get_highlight_captures(path.filename)
     assert.are.same(nodes, spec)
   end)
 end

--- a/tests/highlight/common.lua
+++ b/tests/highlight/common.lua
@@ -1,0 +1,45 @@
+local M = {}
+
+local assert = require "luassert"
+local Path = require "plenary.path"
+
+-- Get table of nodes from file
+-- @param file  a tested file
+local function get_nodes(file)
+  assert(vim.fn.filereadable(file) == 1, string.format('File "%s" not readable', file))
+
+  -- load reference file
+  vim.cmd(string.format("edit %s", file))
+
+  local parser = vim.treesitter.get_parser(0)
+  local tstree = parser:parse()
+
+  return tstree:root()
+end
+
+local Runner = {}
+Runner.__index = Runner
+
+-- Helper to avoid boilerplate when defining tests
+-- @param it  the "it" function that busted defines globally in spec files
+-- @param base_dir  all other paths will be resolved relative to this directory
+function Runner:new(it, base_dir)
+  local runner = {}
+  runner.it = it
+  runner.base_dir = Path:new(base_dir)
+  return setmetatable(runner, self)
+end
+
+function Runner:expect_nodes(file, spec, title)
+  title = title and title or tostring(spec.on_line)
+
+  self.it(string.format("%s[%s]", file, title), function()
+    local path = self.base_dir / file
+    local nodes = get_nodes(path.filename)
+    assert.are.same(nodes, spec)
+  end)
+end
+
+M.Runner = Runner
+
+return M

--- a/tests/highlight/d/import.d
+++ b/tests/highlight/d/import.d
@@ -1,0 +1,1 @@
+import std.stdio: writeln;

--- a/tests/highlight/d_spec.lua
+++ b/tests/highlight/d_spec.lua
@@ -1,0 +1,15 @@
+local Runner = require("tests.highlight.common").Runner
+
+local runner = Runner:new(it, "tests/highlight/d")
+
+describe("D highlights", function()
+  runner:expect_nodes("import.d", {
+    {
+      begin_line = 1,
+      begin_column = 1,
+      end_line = 1,
+      end_column = 8,
+      name = "@include",
+    },
+  })
+end)

--- a/tests/highlight/d_spec.lua
+++ b/tests/highlight/d_spec.lua
@@ -2,12 +2,12 @@ local Runner = require("tests.highlight.common").Runner
 
 local runner = Runner:new(it, "tests/highlight/d")
 
-describe("D highlights", function()
+describe("D highlights:", function()
   runner:expect_nodes("import.d", {
     {
-      begin_line = 1,
+      begin_row = 1,
       begin_column = 1,
-      end_line = 1,
+      end_row = 1,
       end_column = 8,
       name = "@include",
     },


### PR DESCRIPTION
Every time I change something in D highlights I am afraid that I will break highlight in some other place. D is a quite complex language, so testing manually can be cumbersome.

This PR is in no way complete, so I am creating a draft. I would also like to know what other think about such tests.

~For now I am stuck with getting a syntax tree from an opened file in a buffer. `vim.treesitter.get_parser(0):parse():root()` crashes with `attempt to call method 'root' (a nil value)`. Maybe someone knows a better way?~

### TODO
- [x] Find a way to get parser tree
- [ ] Fix duplicated results from `get_highlight_captures`
- [ ] Reduce duplicated code between `tests/indent` and `tests/highlight`
- [ ] Write actual tests