### PR TITLE
Fix Elixir non-doc sigils

### DIFF
--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -209,7 +209,7 @@
 (unary_operator
   operator: "@"
   operand: (call
-    target: ((identifier) @_identifier (#match? @_identifier "doc$")) @comment
+    target: ((identifier) @_identifier (#any-of? @_identifier "moduledoc" "typedoc" "shortdoc" "doc")) @comment
     (arguments [
       (string)
       (boolean)

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -40,7 +40,7 @@
 ; Atoms & Keywords
 [
   (atom)
-  (quoted_atom) 
+  (quoted_atom)
   (keyword)
   (quoted_keyword)
 ] @symbol
@@ -84,11 +84,11 @@
 (stab_clause operator: _ @operator)
 
 ; Local Function Calls
-(call target: (identifier) @function) 
+(call target: (identifier) @function)
 
 ; Remote Function Calls
 (call target: (dot left: [
-  (atom) @type 
+  (atom) @type
   (_)
 ] right: (identifier) @function) (arguments))
 
@@ -154,7 +154,7 @@
   "do"
   "end"
   "fn"
-  "rescue" 
+  "rescue"
   "when"
   "else"
 ] @keyword
@@ -181,38 +181,34 @@
   ])
 
 ; Module attributes
-(unary_operator 
-  operator: "@" @constant 
+(unary_operator
+  operator: "@" @constant
   operand: [
     (identifier) @constant
     (call target: (identifier) @constant)])
 
 ; Sigils
-(sigil 
+(sigil
   "~" @string.special
   ((sigil_name) @string.special) @_sigil_name
-  quoted_start: _ @string.special 
+  quoted_start: _ @string.special
   quoted_end: _ @string.special
   ((sigil_modifiers) @string.special)?
   (#not-any-of? @_sigil_name "s" "S"))
 
-(sigil 
+(sigil
   "~" @string
   ((sigil_name) @string) @_sigil_name
-  quoted_start: _ @string 
+  quoted_start: _ @string
   (quoted_content) @string
   quoted_end: _ @string
   ((sigil_modifiers) @string)?
   (#any-of? @_sigil_name "s" "S"))
 
 ; Documentation
-(unary_operator 
-  operator: "@" @comment 
-  operand: (call 
-    target: (((identifier) @comment) @_identifier)
-    (arguments [
-      (string) @comment
-      (charlist) @comment
-      (boolean) @comment
-    ]))
+(unary_operator
+  operator: "@" @comment
+  operand: (call
+    target: ((identifier) @_identifier)
+    _) @comment
   (#any-of? @_identifier "moduledoc" "typedoc" "shortdoc" "doc"))

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -180,13 +180,6 @@
       ] operator: "/" right: (integer) @operator)
   ])
 
-; Module attributes
-(unary_operator
-  operator: "@" @constant
-  operand: [
-    (identifier) @constant
-    (call target: (identifier) @constant)])
-
 ; Sigils
 (sigil
   "~" @string.special
@@ -205,10 +198,20 @@
   ((sigil_modifiers) @string)?
   (#any-of? @_sigil_name "s" "S"))
 
+; Module attributes
+(unary_operator
+  operator: "@"
+  operand: [
+    (identifier)
+    (call target: (identifier) @constant)]) @constant
+
 ; Documentation
 (unary_operator
-  operator: "@" @comment
+  operator: "@"
   operand: (call
-    target: ((identifier) @_identifier)
-    _) @comment
-  (#any-of? @_identifier "moduledoc" "typedoc" "shortdoc" "doc"))
+    target: ((identifier) @_identifier (#match? @_identifier "doc$")) @comment
+    (arguments [
+      (string)
+      (boolean)
+      (charlist)
+    ] @comment))) @comment

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -1,21 +1,21 @@
-(sigil 
-  (sigil_name) @_sigil_name 
-  (quoted_content) @surface 
+(sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @surface
 (#eq? @_sigil_name "F"))
 
-(sigil 
-  (sigil_name) @_sigil_name 
-  (quoted_content) @heex 
+(sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @heex
 (#eq? @_sigil_name "H"))
 
-(sigil 
-  (sigil_name) @_sigil_name 
-  (quoted_content) @zig 
+(sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @zig
 (#eq? @_sigil_name "Z"))
 
-(sigil 
-  (sigil_name) @_sigil_name 
-  (quoted_content) @regex 
+(sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @regex
 (#any-of? @_sigil_name "r" "R"))
 
 (comment) @comment


### PR DESCRIPTION
It also adds support for colouring documentation metadata attributes (ex. `@doc foo: :bar`).
