### PR TITLE
Rust: highlight uppercase identifiers in match arms as constant

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -5,6 +5,8 @@
 ; Identifier conventions
 
 (identifier) @variable
+((identifier) @type
+ (#match? @type "^[A-Z]"))
 (const_item
   name: (identifier) @constant)
 ; Assume all-caps names are constants
@@ -81,6 +83,16 @@
     "::"
     name: (identifier) @constant)
   (#match? @constant "^[A-Z]"))
+
+; Assume uppercase names in a match arm are constants.
+((match_arm
+   pattern: (match_pattern (identifier) @constant))
+ (#match? @constant "^[A-Z]"))
+((match_arm
+   pattern: (match_pattern
+     (scoped_identifier
+       name: (identifier) @constant)))
+ (#match? @constant "^[A-Z]"))
 
 ;; Macro definitions
 "$" @function.macro

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -94,6 +94,9 @@
        name: (identifier) @constant)))
  (#match? @constant "^[A-Z]"))
 
+((identifier) @constant.builtin
+ (#any-of? @constant.builtin "Some" "None" "Ok" "Err"))
+
 ;; Macro definitions
 "$" @function.macro
 (metavariable) @function.macro


### PR DESCRIPTION
Closes https://github.com/nvim-treesitter/nvim-treesitter/issues/1928