### PR TITLE
Allow to select from the start of the line on some nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ lua <<EOF
 require'nvim-treesitter.configs'.setup {
   incremental_selection = {
     enable = true,
+    -- Automatically decide if the selection should start from
+    -- the start of the line instead of the start of the node.
+    auto_expand = false,
     keymaps = {
       init_selection = "gnn",
       node_incremental = "grn",

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -175,6 +175,9 @@ Query files: `locals.scm`.
 Supported options:
 - enable: `true` or `false`.
 - disable: list of languages.
+- auto_expand: Automatically decide if the selection should start from
+  the start of the line instead of the start of the node.
+  Defaults to `false`.
 - keymaps:
   - init_selection: in normal mode, start incremental selection.
     Defaults to `gnn`.

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -32,6 +32,7 @@ local builtin_modules = {
   incremental_selection = {
     module_path = "nvim-treesitter.incremental_selection",
     enable = false,
+    auto_expand = false,
     keymaps = {
       init_selection = "gnn",
       node_incremental = "grn",


### PR DESCRIPTION
This is mainly for textobjects and incremental selection,
when you copy/cut something like `dif`,
it won't include the start of the line.

```python
def foo(bar):
  print("hello")
  if bar:
    print("bar")
```

Which is a problem when pasting the result

```python
print("hello")
  if bar:
    print("bar")
```

This can be done with `dVif`, but I think it will be better if the plugin can automatically decide when to include the start of the line in the selection. 
I'm adding a new option to smartly decide when to include the selection
from the start of the line or from the start of the node.

I'm not sure how to name that option, `expand_selection`? When the name is decided, I'll send to PR on the textobjects repo to expose that option.