### PR TITLE
D: fix duplicate `@namespace` capture

### DIFF
--- a/queries/d/highlights.scm
+++ b/queries/d/highlights.scm
@@ -250,10 +250,8 @@
 
 (fundamental_type) @type.builtin
 
-[
-  (module_name)
-  (module_fully_qualified_name)
-] @namespace
+(module_fully_qualified_name (packages (package_name) @namespace))
+(module_name) @namespace
 
 (at_attribute) @attribute
 


### PR DESCRIPTION
The previous query was highlighting everything inside that node,
but we only want to highlight the identifiers.

Ref https://github.com/nvim-treesitter/nvim-treesitter/pull/1930/files#r735105675