### PR TITLE
Add `del` keyword to python highlights

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -77,7 +77,7 @@
   function: (identifier) @function.builtin)
  (any-of? @function.builtin
           "abs" "all" "any" "ascii" "bin" "bool" "breakpoint" "bytearray" "bytes" "callable" "chr" "classmethod"
-          "compile" "complex" "delattr" "dict" "dir" "divmod" "enumerate" "eval" "exec" "filter" "float" "format"
+          "compile" "complex" "del" "delattr" "dict" "dir" "divmod" "enumerate" "eval" "exec" "filter" "float" "format"
           "frozenset" "getattr" "globals" "hasattr" "hash" "help" "hex" "id" "input" "int" "isinstance" "issubclass"
           "iter" "len" "list" "locals" "map" "max" "memoryview" "min" "next" "object" "oct" "open" "ord" "pow"
           "print" "property" "range" "repr" "reversed" "round" "set" "setattr" "slice" "sorted" "staticmethod" "str"
@@ -265,7 +265,7 @@
   body: (block
           (expression_statement
             (assignment
-              left: (_ 
+              left: (_
                      (identifier) @field)))))
  (#match? @field "^([A-Z])@!.*$"))
 


### PR DESCRIPTION
This PR adds the python keyword `del` for syntax highlighting.