### PR TITLE
Fix bugs in TSRange

### DIFF
--- a/lua/nvim-treesitter/tsrange.lua
+++ b/lua/nvim-treesitter/tsrange.lua
@@ -4,9 +4,10 @@ TSRange.__index = TSRange
 
 local api = vim.api
 local ts_utils = require "nvim-treesitter.ts_utils"
+local parsers = require "nvim-treesitter.parsers"
 
 local function get_byte_offset(buf, row, col)
-  return api.nvim_buf_get_offset(buf, row) + vim.fn.byteidx(api.nvim_buf_get_lines(buf, row, row + 1, false), col)
+  return api.nvim_buf_get_offset(buf, row) + vim.fn.byteidx(api.nvim_buf_get_lines(buf, row, row + 1, false)[1], col)
 end
 
 function TSRange.new(buf, start_row, start_col, end_row, end_col)
@@ -49,7 +50,8 @@ function TSRange.from_table(buf, range)
 end
 
 function TSRange:parent()
-  local root = ts_utils.get_root_for_position(self[1], self[2])
+  local root_lang_tree = parsers.get_parser(self.buf)
+  local root = ts_utils.get_root_for_position(self[1], self[2], root_lang_tree)
 
   return root
       and root:named_descendant_for_range(self.start_pos[1], self.start_pos[2], self.end_pos[1], self.end_pos[2])


### PR DESCRIPTION
- TSRange:new() was missing to extract the line from nvim_buf_get_lines
- TSRange:parent() was only working when current buf == self.buf