### PR TITLE
Add `ftdetect` setup for `glimmer` parser.

### DIFF
--- a/ftdetect/glimmer.vim
+++ b/ftdetect/glimmer.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.hbs set ft=handlebars


### PR DESCRIPTION
Without this, `*.hbs` files are not highlighted (unless you have some other plugin that adds it for you).

Fixes https://github.com/alexlafroscia/tree-sitter-glimmer/issues/44
