### PR TITLE
Add support for parsers to support multipart filetypes, and add `html.handlebars` as a valid type for the glimmer parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -457,6 +457,7 @@ list.glimmer = {
   readme_name = "Glimmer and Ember",
   maintainers = { "@alexlafroscia" },
   filetype = "handlebars",
+  used_by = { "html.handlebars" },
 }
 
 list.vue = {

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -767,8 +767,13 @@ local M = {
 }
 
 function M.ft_to_lang(ft)
-  ft = vim.split(ft, ".", true)[1]
-  return ft_to_parsername[ft] or ft
+  local result = ft_to_parsername[ft]
+  if result then
+    return result
+  else
+    ft = vim.split(ft, ".", true)[1]
+    return ft_to_parsername[ft] or ft
+  end
 end
 
 function M.available_parsers()


### PR DESCRIPTION
This PR does two things:

* Add support for a parser to have multipart filetype support (e.g. `glimmer` parser actually does support `html.handlebars` just fine) by changing the implementation from #1771 slightly, to allow an exact match to exist before falling back to the first segment of the multipart filetype.
* Add `html.handlebars` as `used_by` for the `glimmer` parser. This filetype is in common use due to https://github.com/mustache/vim-mustache-handlebars/blob/master/ftdetect/handlebars.vim#L2.