### PR TITLE
docs: move description to the first line

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -1,6 +1,4 @@
-*nvim-treesitter*
-
-Treesitter configurations and abstraction layer for Neovim.
+*nvim-treesitter*  Treesitter configurations and abstraction layer for Neovim.
 
 Minimum version of neovim: nightly
 


### PR DESCRIPTION
This will make the description of nvim-treesitter show up in the LOCAL
ADDITIONS section of the help text. So this

|nvim-treesitter|

instead becomes

|nvim-treesitter|  Treesitter configurations and abstraction layer for Neovim.
