### PR TITLE
Add Operators for Ruby

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -1,8 +1,5 @@
 ; Variables
 (identifier) @variable
-(interpolation
-  "#{" @punctuation.special
-  "}" @punctuation.special) @none
 
 ; Keywords
 
@@ -31,6 +28,7 @@
  "and"
  "or"
  "in"
+ "not"
 ] @keyword.operator
 
 [
@@ -166,13 +164,44 @@
 ; Operators
 
 [
+ "!"
  "="
+ "=="
+ "==="
+ "<=>"
  "=>"
  "->"
- "+"
- "-"
+ ">>"
+ "<<"
+ ">"
+ "<"
+ ">="
+ "<="
+ "**"
  "*"
  "/"
+ "%"
+ "+"
+ "-"
+ "&"
+ "|"
+ "^"
+ "&&"
+ "||"
+ "||="
+ "&&="
+ "!="
+ "%="
+ "+="
+ "-="
+ "*="
+ "/="
+ "=~"
+ "!~"
+ "?"
+ ":"
+ ".."
+ "..."
  ] @operator
 
 [
@@ -191,5 +220,9 @@
  "%w("
  "%i("
  ] @punctuation.bracket
+
+(interpolation
+  "#{" @punctuation.special
+  "}" @punctuation.special) @none
 
 (ERROR) @error


### PR DESCRIPTION
Many operators were missing from Ruby, so, I added them. There's a list on the ruby-docs site: https://ruby-doc.org/core-2.6.2/doc/syntax/precedence_rdoc.html

Additionally, with string interpolation (`"#{xxx}"`), the closing `}` was being matched to `punctuation.bracket` instead of `punctuation.special`, so I fixed that too.

I didn't see any further details about how to contribute, so if I've overlooked anything, I'll be happy to add it.