### PR TITLE
Add condition function to module config

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -335,8 +335,9 @@ M.commands = {
 }
 
 -- @param mod: module (string)
--- @param ft: filetype (string)
-function M.is_enabled(mod, lang)
+-- @param lang: the language of the buffer (string)
+-- @param bufnr: the bufnr (number)
+function M.is_enabled(mod, lang, bufnr)
   if not parsers.list[lang] or not parsers.has_parser(lang) then
     return false
   end
@@ -347,6 +348,10 @@ function M.is_enabled(mod, lang)
   end
 
   if not module_config.enable or not module_config.is_supported(lang) then
+    return false
+  end
+
+  if module_config.cond and not module_config.cond(lang, bufnr) then
     return false
   end
 
@@ -445,7 +450,7 @@ function M.attach_module(mod_name, bufnr, lang)
   local lang = lang or parsers.get_buf_lang(bufnr)
   local resolved_mod = resolve_module(mod_name)
 
-  if resolved_mod and not attached_buffers_by_module.has(mod_name, bufnr) and M.is_enabled(mod_name, lang) then
+  if resolved_mod and not attached_buffers_by_module.has(mod_name, bufnr) and M.is_enabled(mod_name, lang, bufnr) then
     attached_buffers_by_module.set(mod_name, bufnr, true)
     resolved_mod.attach(bufnr, lang)
   end

--- a/lua/nvim-treesitter/info.lua
+++ b/lua/nvim-treesitter/info.lua
@@ -58,7 +58,7 @@ local function longest_string_length(list)
   return length
 end
 
-local function append_module_table(curbuf, parserlist, namespace, modulelist)
+local function append_module_table(curbuf, origbuf, parserlist, namespace, modulelist)
   local maxlen_parser = longest_string_length(parserlist)
   table.sort(modulelist)
 
@@ -77,7 +77,7 @@ local function append_module_table(curbuf, parserlist, namespace, modulelist)
     for _, module in pairs(modulelist) do
       local modlen = #module
       module = namespace_prefix .. module
-      if configs.is_enabled(module, parser) then
+      if configs.is_enabled(module, parser, origbuf) then
         line = line .. "✓"
       else
         line = line .. "✗"
@@ -91,6 +91,7 @@ local function append_module_table(curbuf, parserlist, namespace, modulelist)
 end
 
 local function print_info_modules(parserlist, module)
+  local origbuf = api.nvim_get_current_buf()
   api.nvim_command "enew"
   local curbuf = api.nvim_get_current_buf()
 
@@ -109,7 +110,7 @@ local function print_info_modules(parserlist, module)
 
   table.sort(parserlist)
   for _, namespace in ipairs(namespaces) do
-    append_module_table(curbuf, parserlist, namespace, modules[namespace])
+    append_module_table(curbuf, origbuf, parserlist, namespace, modules[namespace])
   end
 
   api.nvim_buf_set_option(curbuf, "modified", false)


### PR DESCRIPTION
The function is called with the language and bufnr, if it returns false,
the module is disabled for that buffer.

This gives the user more fine-grained control over whether a module is
started.

This is an initial implementation to gather feedback. I chose to add an additional `cond` setting, but I could just as well change it to support function values for the `disabled` config. Let me know what you prefer or if you'd rather have a completely different approach.

My problem was that some modules (mainly `highlight` and [`rainbow`](https://github.com/p00f/nvim-ts-rainbow)) massively slowed down opening of large files and I wanted a way to disable some or all modules for large files. I first tried using autocmds to just disable them with `TSBufDisable` but the autocmd events fired either before the buffer was filled or after the TS modules already ran.

TODOs:

* [ ] Add to documentation