### PR TITLE
feat(vue): add indents.scm file

### DIFF
--- a/queries/html/indents.scm
+++ b/queries/html/indents.scm
@@ -1,11 +1,1 @@
-[
-  (element)
-] @indent
-
-[
-  (end_tag)
-  ">"
-  "/>"
-] @branch
-
-(comment) @ignore
+; inherits: html_tags

--- a/queries/html_tags/indents.scm
+++ b/queries/html_tags/indents.scm
@@ -1,0 +1,11 @@
+[
+  (element)
+] @indent
+
+[
+  (end_tag)
+  ">"
+  "/>"
+] @branch
+
+(comment) @ignore

--- a/queries/vue/indents.scm
+++ b/queries/vue/indents.scm
@@ -1,0 +1,12 @@
+[
+  (element)
+  (template_element)
+] @indent
+
+[
+  (end_tag)
+  ">"
+  "/>"
+] @branch
+
+(comment) @ignore

--- a/queries/vue/indents.scm
+++ b/queries/vue/indents.scm
@@ -1,12 +1,1 @@
-[
-  (element)
-  (template_element)
-] @indent
-
-[
-  (end_tag)
-  ">"
-  "/>"
-] @branch
-
-(comment) @ignore
+; inherits: html_tags

--- a/queries/vue/indents.scm
+++ b/queries/vue/indents.scm
@@ -1,1 +1,5 @@
 ; inherits: html_tags
+
+[
+  (template_element)
+] @indent


### PR DESCRIPTION
There's no indentation file for Vue. This implementation is based on the HTML indentation file with a minor support for the `template_element` tag. As JS is bind with the JS Tree-sitter, the indentation is already fine.