### PR TITLE
feat: get node at cursor of other win

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -124,7 +124,13 @@ end
 function M.get_node_at_cursor(winnr)
   local cursor = api.nvim_win_get_cursor(winnr or 0)
   local cursor_range = { cursor[1] - 1, cursor[2] }
-  local root = M.get_root_for_position(unpack(cursor_range))
+
+  local buf = vim.api.nvim_win_get_buf(winnr)
+  local root_lang_tree = parsers.get_parser(buf)
+  if not root_lang_tree then
+    return
+  end
+  local root = M.get_root_for_position(cursor_range[1], cursor_range[2], root_lang_tree)
 
   if not root then
     return


### PR DESCRIPTION
Currently, `ts_utils.get_node_at_cursor` does actually not work for any `winnr` other than `0`, even though the function signature suggests you can pass any valid `winnr`. This PR is a naive and minimum implementation to achieve that in a way that it should not interfere with any current other uses of `get_node_at_cursor` or `get_root_for_position`.


cc @danymat