### PR TITLE
C: fix macro param hl

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [heex](https://github.com/connorlay/tree-sitter-heex) (maintained by @connorlay)
 - [x] [hjson](https://github.com/winston0410/tree-sitter-hjson) (maintained by @winston0410)
 - [x] [html](https://github.com/tree-sitter/tree-sitter-html) (maintained by @TravonteD)
+- [x] [http](https://github.com/NTBBloodbath/tree-sitter-http) (maintained by @NTBBloodbath)
 - [x] [java](https://github.com/tree-sitter/tree-sitter-java) (maintained by @p00f)
 - [x] [javascript](https://github.com/tree-sitter/tree-sitter-javascript) (maintained by @steelsojka)
 - [x] [jsdoc](https://github.com/tree-sitter/tree-sitter-jsdoc) (maintained by @steelsojka)

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -167,8 +167,7 @@
 (parameter_declaration
   declarator: (pointer_declarator) @parameter)
 
-(preproc_params
-  (identifier)) @parameter
+(preproc_params (identifier) @parameter)
 
 [
   "__attribute__"


### PR DESCRIPTION
We are matching too much, we only want to match the identifier

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1999