### PR TITLE
[fix] wrong highlight on preproc function definition

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -168,7 +168,7 @@
   declarator: (pointer_declarator) @parameter)
 
 (preproc_params
-  (identifier)) @parameter
+  (identifier)) @c
 
 [
   "__attribute__"


### PR DESCRIPTION
There was an wrong highlight issue on definitions of preproc function. The last bracket in the function definition is only getting highlighted as a bracket.

![image](https://user-images.githubusercontent.com/45588457/141665075-7cdb36b5-32dd-46a5-910d-541c25468660.png)

Actually the picture above is cpp code, but i thought the problem was based on c query, and now it works like below.

![image](https://user-images.githubusercontent.com/45588457/141665281-db9b9289-0525-42af-9353-e039471104a8.png)

