### PR TITLE
Prefer lua-match over match

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -102,7 +102,7 @@
              ])
 
 ((word) @number
-  (#match? @number "^[0-9]+$"))
+  (#lua-match? @number "^[0-9]+$"))
 
 (file_redirect
   descriptor: (file_descriptor) @operator
@@ -114,7 +114,7 @@
 (variable_name) @variable
 
 ((variable_name) @constant
- (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+ (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 (case_item
   value: (word) @parameter)

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -138,7 +138,7 @@
 (sizeof_expression value: (parenthesized_expression (identifier) @type))
 
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z0-9_]+$"))
+ (#lua-match? @constant "^[A-Z][A-Z0-9_]+$"))
 
 ;; Preproc def / undef
 (preproc_def

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -55,7 +55,7 @@
 
 ; Used in destructure pattern
 ((sym_lit) @parameter
- (#match? @parameter "^[&]"))
+ (#lua-match? @parameter "^[&]"))
 
 ; Inline function variables
 ((sym_lit) @variable.builtin
@@ -106,7 +106,7 @@
 
 ; Definition functions
 ((sym_lit) @keyword
- (#match? @keyword "^def.*$"))
+ (#lua-match? @keyword "^def.*$"))
 ((sym_lit) @keyword
  (#eq? @keyword "declare"))
 ((sym_lit) @keyword.function
@@ -283,7 +283,7 @@
 (list_lit
  .
  (sym_lit) @_keyword ; Don't really want to highlight twice
- (#match? @_keyword "^def.*")
+ (#lua-match? @_keyword "^def.*")
  .
  (sym_lit)
  .

--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -20,6 +20,6 @@
  (#any-of? @text.danger "FIXME" "XXX" "BUG"))
 
 ; Issue number (#123)
-("text" @number (#match? @number "^#[0-9]+$"))
+("text" @number (#lua-match? @number "^#[0-9]+$"))
 ; User mention (@user)
-("text" @constant (#match? @constant "^[@][a-zA-Z0-9_-]+$"))
+("text" @constant (#lua-match? @constant "^[@][a-zA-Z0-9_-]+$"))

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -33,9 +33,9 @@
 
 (namespace_identifier) @namespace
 ((namespace_identifier) @type
-                        (#match? @type "^[A-Z]"))
+                        (#lua-match? @type "^[A-Z]"))
 ((namespace_identifier) @constant
-                        (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+                        (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 (namespace_definition
   name: (identifier) @namespace)
 
@@ -50,7 +50,7 @@
 ((function_declarator
       declarator: (qualified_identifier
         name: (identifier) @constructor))
- (#match? @constructor "^[A-Z]"))
+ (#lua-match? @constructor "^[A-Z]"))
 
 (operator_name) @function
 "static_assert" @function.builtin
@@ -65,22 +65,22 @@
 
 ((call_expression
   function: (identifier) @constructor)
-(#match? @constructor "^[A-Z]"))
+(#lua-match? @constructor "^[A-Z]"))
 ((call_expression
   function: (qualified_identifier
               name: (identifier) @constructor))
-(#match? @constructor "^[A-Z]"))
+(#lua-match? @constructor "^[A-Z]"))
 
 ((call_expression
   function: (field_expression
               field: (field_identifier) @constructor))
-(#match? @constructor "^[A-Z]"))
+(#lua-match? @constructor "^[A-Z]"))
 
 ;; constructing a type in an initializer list: Constructor ():  **SuperType (1)**
 ((field_initializer
   (field_identifier) @constructor
   (argument_list))
- (#match? @constructor "^[A-Z]"))
+ (#lua-match? @constructor "^[A-Z]"))
 
 
 ; Constants

--- a/queries/dockerfile/highlights.scm
+++ b/queries/dockerfile/highlights.scm
@@ -45,6 +45,6 @@
 )
 
 ((variable) @constant
-  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+  (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 

--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -20,13 +20,13 @@
 ;--------------------
 
 ((identifier) @constructor
- (#match? @constructor "^[A-Z]"))
+ (#lua-match? @constructor "^[A-Z]"))
 
 ((identifier) @constant
- (#vim-match? @constant "^[A-Z_][A-Z\\d_]+$"))
+ (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
 
 ((shorthand_property_identifier) @constant
- (#vim-match? @constant "^[A-Z_][A-Z\\d_]+$"))
+ (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
 
 ((identifier) @variable.builtin
  (#vim-match? @variable.builtin "^(arguments|module|console|window|document)$"))

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -27,11 +27,11 @@
 
 ;; Identifier naming conventions
 ((identifier) @type
-  (#match? @type "^[A-Z]"))
+  (#lua-match? @type "^[A-Z]"))
 ((identifier) @constant
-  (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+  (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 ((identifier) @type
-  (#match? @type "^[A-Z][A-Z_0-9]*$") . (_))
+  (#lua-match? @type "^[A-Z][A-Z_0-9]*$") . (_))
 
 ;; Functions
 (constructor_definition) @constructor

--- a/queries/glimmer/highlights.scm
+++ b/queries/glimmer/highlights.scm
@@ -6,7 +6,7 @@
   (#match? @tag "^(:)?[a-z]"))
 ; Tags that start with a capital letter are Glimmer components
 ((tag_name) @constructor
-  (#match? @constructor "^[A-Z]"))
+  (#lua-match? @constructor "^[A-Z]"))
 
 (attribute_name) @property
 
@@ -26,7 +26,7 @@
 (block_statement_start path: (identifier) @conditional)
 (block_statement_end path: (identifier) @conditional)
 ((mustache_statement (identifier) @conditional)
- (#match? @conditional "else"))
+ (#lua-match? @conditional "else"))
 
 ; == Mustache Statements ===
 
@@ -54,7 +54,7 @@
   (#not-match? @variable "this"))
 ; `this` should be highlighted as a built-in variable
 ((identifier) @variable.builtin
-  (#match? @variable.builtin "this"))
+  (#lua-match? @variable.builtin "this"))
 
 ; If the identifier is just "yield" or "outlet", it's a keyword
 ((mustache_statement (identifier) @keyword)
@@ -67,9 +67,9 @@
   ])
   (#not-match? @function "if|yield"))
 ((helper_invocation helper: (identifier) @conditional)
-  (#match? @conditional "if"))
+  (#lua-match? @conditional "if"))
 ((helper_invocation helper: (identifier) @keyword)
-  (#match? @keyword "yield"))
+  (#lua-match? @keyword "yield"))
 
 (hash_pair key: (identifier) @property)
 

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -95,10 +95,10 @@
 
 ((field_access
   object: (identifier) @type)
-  (#match? @type "^[A-Z]"))
+  (#lua-match? @type "^[A-Z]"))
 ((scoped_identifier
   scope: (identifier) @type)
-  (#match? @type "^[A-Z]"))
+  (#lua-match? @type "^[A-Z]"))
 
 ; Fields
 
@@ -118,7 +118,7 @@
 ; Variables
 
 ((identifier) @constant
-  (#match? @constant "^[A-Z_][A-Z\d_]+$"))
+  (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
 
 (this) @variable.builtin
 

--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -16,19 +16,19 @@
   name: (identifier) @tag)
 
 (jsx_opening_element ((identifier) @constructor
- (#match? @constructor "^[A-Z]")))
+ (#lua-match? @constructor "^[A-Z]")))
 
 ; Handle the dot operator effectively - <My.Component>
 (jsx_opening_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
 
 (jsx_closing_element ((identifier) @constructor
- (#match? @constructor "^[A-Z]")))
+ (#lua-match? @constructor "^[A-Z]")))
 
 ; Handle the dot operator effectively - </My.Component>
 (jsx_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))
 
 (jsx_self_closing_element ((identifier) @constructor
- (#match? @constructor "^[A-Z]")))
+ (#lua-match? @constructor "^[A-Z]")))
 
 ; Handle the dot operator effectively - <My.Component />
 (jsx_self_closing_element ((nested_identifier (identifier) @tag (identifier) @constructor)))

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -116,7 +116,7 @@
 (nil) @constant.builtin
 (spread) @constant ;; "..."
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+ (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 ;; Functions
 (function [(function_name) (identifier)] @function)

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -8,7 +8,7 @@
   )
 
   (#eq? @_cdef_identifier "cdef")
-  (#match? @c "^[\"']")
+  (#lua-match? @c "^[\"']")
   (#offset! @c 0 1 0 -1)
 )
 
@@ -21,7 +21,7 @@
   )
 
   (#eq? @_cdef_identifier "cdef")
-  (#match? @c "^\\[\\[")
+  (#lua-match? @c "^%[%[")
   (#offset! @c 0 2 0 -2)
 )
 
@@ -34,7 +34,7 @@
   )
 
   (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec")
-  (#match? @vim "^[\"']")
+  (#lua-match? @vim "^[\"']")
   (#offset! @vim 0 1 0 -1)
 )
 
@@ -46,7 +46,7 @@
   )
 
   (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec")
-  (#match? @vim "^\\[\\[")
+  (#lua-match? @vim "^%[%[")
   (#offset! @vim 0 2 0 -2)
 )
 

--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -56,7 +56,7 @@
  (#vim-match? @constant "^_?[A-Z][A-Z\d_]+$"))
 
 ((name) @constructor
- (#match? @constructor "^[A-Z]"))
+ (#lua-match? @constructor "^[A-Z]"))
 
 ((name) @variable.builtin
  (#eq? @variable.builtin "this"))

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -9,12 +9,12 @@
 
 ;; Identifier naming conventions
 ((identifier) @type
- (#match? @type "^[A-Z].*[a-z]"))
+ (#lua-match? @type "^[A-Z].*[a-z]"))
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+ (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 ((identifier) @constant.builtin
- (#match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
+ (#lua-match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
 
 ((identifier) @constant.builtin
  (#any-of? @constant.builtin
@@ -64,12 +64,12 @@
 
 ((call
    function: (identifier) @constructor)
- (#match? @constructor "^[A-Z]"))
+ (#lua-match? @constructor "^[A-Z]"))
 
 ((call
   function: (attribute
               attribute: (identifier) @constructor))
- (#match? @constructor "^[A-Z]"))
+ (#lua-match? @constructor "^[A-Z]"))
 
 ;; Builtin functions
 
@@ -133,7 +133,7 @@
 (none) @constant.builtin
 [(true) (false)] @boolean
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^self$"))
+ (#lua-match? @variable.builtin "^self$"))
 
 (integer) @number
 (float) @float

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -3,7 +3,7 @@
 	  object: (identifier) @_re)
   arguments: (argument_list (string) @regex))
  (#eq? @_re "re")
- (#match? @regex "^r.*"))
+ (#lua-match? @regex "^r.*"))
 
 ; Module docstring
 ((module . (expression_statement (string) @rst))

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -6,12 +6,12 @@
 
 (identifier) @variable
 ((identifier) @type
- (#match? @type "^[A-Z]"))
+ (#lua-match? @type "^[A-Z]"))
 (const_item
   name: (identifier) @constant)
 ; Assume all-caps names are constants
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z\\d_]*$"))
+ (#lua-match? @constant "^[A-Z][A-Z%d_]*$"))
 
 ; Other identifiers
 
@@ -44,7 +44,7 @@
 
 ; Assume other uppercase names are enum constructors
 ((field_identifier) @constant
- (#match? @constant "^[A-Z]"))
+ (#lua-match? @constant "^[A-Z]"))
 
 (enum_variant
   name: (identifier) @constant)
@@ -62,10 +62,10 @@
   name: (identifier) @namespace))
 ((scoped_identifier
   path: (identifier) @type)
- (#match? @type "^[A-Z]"))
+ (#lua-match? @type "^[A-Z]"))
 ((scoped_identifier
     name: (identifier) @type)
- (#match? @type "^[A-Z]"))
+ (#lua-match? @type "^[A-Z]"))
 
 (crate) @namespace
 (scoped_use_list
@@ -74,25 +74,25 @@
   path: (scoped_identifier
             (identifier) @namespace))
 (use_list (scoped_identifier (identifier) @namespace . (_)))
-(use_list (identifier) @type (#match? @type "^[A-Z]"))
-(use_as_clause alias: (identifier) @type (#match? @type "^[A-Z]"))
+(use_list (identifier) @type (#lua-match? @type "^[A-Z]"))
+(use_as_clause alias: (identifier) @type (#lua-match? @type "^[A-Z]"))
 
 ;; Correct enum constructors
 (call_expression
   function: (scoped_identifier
     "::"
     name: (identifier) @constant)
-  (#match? @constant "^[A-Z]"))
+  (#lua-match? @constant "^[A-Z]"))
 
 ; Assume uppercase names in a match arm are constants.
 ((match_arm
    pattern: (match_pattern (identifier) @constant))
- (#match? @constant "^[A-Z]"))
+ (#lua-match? @constant "^[A-Z]"))
 ((match_arm
    pattern: (match_pattern
      (scoped_identifier
        name: (identifier) @constant)))
- (#match? @constant "^[A-Z]"))
+ (#lua-match? @constant "^[A-Z]"))
 
 ((identifier) @constant.builtin
  (#any-of? @constant.builtin "Some" "None" "Ok" "Err"))

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -5,7 +5,7 @@
 (identifier) @variable
 
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^this$"))
+ (#lua-match? @variable.builtin "^this$"))
 
 (interpolation) @none
 
@@ -16,7 +16,7 @@
 ; an uppercased method as a constant if used with no params.
 ; Introducing highlighting for those specific cases, is probably
 ; best way to resolve the issue.
-((identifier) @constant (#match? @constant "^[A-Z]"))
+((identifier) @constant (#lua-match? @constant "^[A-Z]"))
 
 ;; types
 
@@ -56,10 +56,10 @@
 ((stable_identifier (identifier) @namespace))
 
 ((import_declaration
-  path: (identifier) @type) (#match? @type "^[A-Z]"))
-((stable_identifier (identifier) @type) (#match? @type "^[A-Z]"))
+  path: (identifier) @type) (#lua-match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#lua-match? @type "^[A-Z]"))
 
-((import_selectors (identifier) @type) (#match? @type "^[A-Z]"))
+((import_selectors (identifier) @type) (#lua-match? @type "^[A-Z]"))
 
 ; method invocation
 
@@ -73,14 +73,14 @@
 
 ((call_expression
    function: (identifier) @constructor)
- (#match? @constructor "^[A-Z]"))
+ (#lua-match? @constructor "^[A-Z]"))
 
 (generic_function
   function: (identifier) @function)
 
 (
   (identifier) @function.builtin
-  (#match? @function.builtin "^super$")
+  (#lua-match? @function.builtin "^super$")
 )
 
 ; function definitions
@@ -96,7 +96,7 @@
 
 (field_expression field: (identifier) @property)
 (field_expression value: (identifier) @type
- (#match? @type "^[A-Z]"))
+ (#lua-match? @type "^[A-Z]"))
 
 (infix_expression operator: (identifier) @operator)
 (infix_expression operator: (operator_identifier) @operator)

--- a/queries/teal/injections.scm
+++ b/queries/teal/injections.scm
@@ -7,7 +7,7 @@
   )
 
   (#eq? @_cdef_identifier "cdef")
-  (#match? @c "^[\"']")
+  (#lua-match? @c "^[\"']")
   (#offset! @c 0 1 0 -1)
 )
 
@@ -20,7 +20,7 @@
   )
 
   (#eq? @_cdef_identifier "cdef")
-  (#match? @c "^\\[\\[")
+  (#lua-match? @c "^%[%[")
   (#offset! @c 0 2 0 -2)
 )
 

--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -1,6 +1,6 @@
 (identifier) @variable
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z_0-9]*$"))
+ (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 
 ;; Keywords
 


### PR DESCRIPTION
as string.find is much quicker than vim.regex:match*


Benchmarks from @muniter on [matrix](https://app.element.io/#/room/#nvim-dev:matrix.org) :

> So I was curious about Lua vs Vim regex/patterns and did some benchmark, non scientific but seems like Lua patterns are well as expected super fast.
>
> 123456NVIM v0.6.0-dev+631-ga6788a979
Build type: Debug
LuaJIT 2.1.0-beta3
>
> Ryzen 7 2700X
> Linux Kernel 5.14.16
>
> Benchmark Simple substring `iz` in `this is amazing` n: 10000000
>
> ```
> Vim regex      : 1.217601
> Lua string.find: 0.002445
> ```
>
> Benchmark Simple pattern l:`%d%d%d%l` v:`\d\d\d\l` `this is ama(231c)zing` n: 1000000
>
> ```
> Vim regex      : 1.275099
> Lua string.find: 0.158496
> ```
>
> Benchmark Greedy star `2.*` `this is ama(231c)zing` n: 1000000
>
> ```
> Vim regex      : 1.265414
> Lua string.find: 0.140929
> ```
>
> Benchmark Greedy with sets and anchored `[^c]*$` `this is ama(231c)zing` n: 1000000
>
> ```
> Vim regex      : 2.517587
> Lua string.find: 1.219898
> ```
>
> Benchmark Non greedy matching v:`(.{-})` l:`%(.-%)` `this is (ama(231)zing)` n: 1000000
>
> ```
> Vim regex      : 1.20204
> Lua string.find: 0.172419
> ```
>
> Took the benchmark setup from http://lua-users.org/wiki/ObjectBenchmarkTests

