### PR TITLE
ci: do not set any secrets for stylua

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,5 +27,4 @@ jobs:
     - name: Lint with stylua
       uses: JohnnyMorganz/stylua-action@1.0.0
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
         args: --check .


### PR DESCRIPTION
I'm pretty sure no tokens are required for running stylua