### PR TITLE
Don't use the Bash grammar for Zsh files

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -203,7 +203,7 @@ list.bash = {
     url = "https://github.com/tree-sitter/tree-sitter-bash",
     files = { "src/parser.c", "src/scanner.cc" },
   },
-  used_by = { "zsh", "PKGBUILD" },
+  used_by = { "PKGBUILD" },
   filetype = "sh",
   maintainers = { "@TravonteD" },
 }


### PR DESCRIPTION
Zsh and Bash are not interchangeable, so using the Bash parser for Zsh causes a lot of issues. See <https://github.com/nvim-treesitter/nvim-treesitter/issues/655#issuecomment-978036615>.