### PR TITLE
zig: work around for hang neovim

### DIFF
--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -60,17 +60,15 @@ exception: "!" @exception
   (#eq? @variable.builtin "_")
 )
 
-(PtrTypeStart "c" @variable.builtin)
+; (PtrTypeStart "c" @variable.builtin)
 
-(
-  (ContainerDeclType
-    [
-      (ErrorUnionExpr)
-      "enum"
-    ]
-  )
-  (ContainerField (IDENTIFIER) @constant)
-)
+; (
+;   (ContainerDeclType
+;       (ErrorUnionExpr)
+;       ; "enum"
+;   )
+;   (ContainerField (IDENTIFIER) @constant)
+; )
 
 field_constant: (IDENTIFIER) @constant
 


### PR DESCRIPTION
Because two query below cause hanging neovim. I don't know what's cause the problem yet. It had been worked really well until now.
```
(PtrTypeStart "c" @variable.builtin)
(
  (ContainerDeclType
    [
      (ErrorUnionExpr)
      "enum"
    ]
  )
  (ContainerField (IDENTIFIER) @constant)
)
```