### PR TITLE
fix: off-by-one errors in indent calculation

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -54,7 +54,8 @@ function M.get_indent(lnum)
     return -1
   end
 
-  local root, _, lang_tree = tsutils.get_root_for_position(lnum, 0, parser)
+  -- get_root_for_position is 0-based.
+  local root, _, lang_tree = tsutils.get_root_for_position(lnum - 1, 0, parser)
 
   -- Not likely, but just in case...
   if not root then
@@ -114,8 +115,10 @@ function M.get_indent(lnum)
   local prev_row = node:start()
 
   while node do
-    -- do not indent if we are inside an @ignore block
-    if q.ignores[node_fmt(node)] and node:start() < lnum - 1 and node:end_() > lnum - 1 then
+    -- Do not indent if we are inside an @ignore block.
+    -- If a node spans from L1,C1 to L2,C2, we know that lines where L1 < line <= L2 would
+    -- have their indentations contained by the node.
+    if q.ignores[node_fmt(node)] and node:start() < lnum - 1 and lnum - 1 <= node:end_() then
       return -1
     end
 

--- a/tests/indent/python_spec.lua
+++ b/tests/indent/python_spec.lua
@@ -13,14 +13,10 @@ describe("indent Python:", function()
     run:whole_file(".", {
       expected_failures = {
         "./aligned_indent.py",
-        "./basic_blocks.py",
         "./branches.py",
-        "./control_flow.py",
         "./hanging_indent.py",
         "./join_lines.py",
         "./nested_collections.py",
-        "./strings.py",
-        "./control_flow.py",
       },
     })
   end)


### PR DESCRIPTION
Fix #1987

Python tests have covered this, especially https://github.com/nvim-treesitter/nvim-treesitter/blob/63a88c873f3643aad9208488765dc53618edd40e/tests/indent/python/strings.py#L13-L17