### PR TITLE
injections(yaml): inject bash on key "run"

### DIFF
--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -1,1 +1,10 @@
 (comment) @comment
+
+(block_mapping_pair
+  key: (flow_node) @_run (#eq? @_run "run")
+  value: (flow_node
+           (plain_scalar) @bash))
+
+(block_mapping_pair
+  key: (flow_node) @_run (#eq? @_run "run")
+  value: (block_node) @bash (#offset! @bash 0 0 0 0))

--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -1,10 +1,19 @@
 (comment) @comment
 
+;; Github actions ("run") / Gitlab CI ("scripts")
 (block_mapping_pair
-  key: (flow_node) @_run (#eq? @_run "run")
+  key: (flow_node) @_run (#any-of? @_run "run" "script")
   value: (flow_node
            (plain_scalar) @bash))
 
 (block_mapping_pair
-  key: (flow_node) @_run (#eq? @_run "run")
-  value: (block_node) @bash (#offset! @bash 0 0 0 0))
+  key: (flow_node) @_run (#any-of? @_run "run" "script")
+  value: (block_node
+           (block_scalar) @bash (#offset! @bash 0 0 0 0)))
+
+(block_mapping_pair
+  key: (flow_node) @_run (#any-of? @_run "run" "script")
+  value: (block_node
+           (block_sequence
+             (block_sequence_item
+               (flow_node) @bash))))


### PR DESCRIPTION
Yaml is often used for CI. This applies an heuristic that strings after a "run" key are bash scripts. Note that `((` from bash were missing (separate PR).

![image](https://user-images.githubusercontent.com/7189118/143680229-4c2daf65-9649-4a2a-a2a4-5a5b82f26098.png)

before:

![image](https://user-images.githubusercontent.com/7189118/143680570-35850366-0f84-44c5-a519-2ac08c5b1749.png)
