### PR TITLE
OCaml use @constant.builtin for built in constants

### DIFF
--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -71,7 +71,9 @@
 ; Constants
 ;----------
 
-[(boolean) (unit)] @constant
+(unit) @constant.builtin
+
+(boolean) @boolean
 
 [(number) (signed_number)] @number
 


### PR DESCRIPTION
That's what most other languages do.