### PR TITLE
OCaml string format specifiers

### DIFF
--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -88,7 +88,7 @@
 [
   (conversion_specification)
   (pretty_printing_indication)
-] @punctuation.special
+] @string.special
 
 ; Keywords
 ;---------


### PR DESCRIPTION
For string format specifiers use @string.special instead of @punctuation.special.