### PR TITLE
rust(highlights): fix highlighting of char_literal

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -151,11 +151,11 @@
 (float_literal) @float
 
 [
-  (char_literal)
   (raw_string_literal)
   (string_literal)
 ] @string
 (escape_sequence) @string.escape
+(char_literal) @character
 
 
 ;;; Keywords


### PR DESCRIPTION
Was `@string` instead of `@character`