### PR TITLE
feat(fusion): update highlight queries and some tests

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -69,7 +69,7 @@
     "revision": "f0f2f100952a353e64e26b0fa710b4c296d7af13"
   },
   "fusion": {
-    "revision": "bee23e8728845a651a1d70211310c1247134b801"
+    "revision": "14cc1e5535a7b6469c49c21b4c877d31befa2a29"
   },
   "gdscript": {
     "revision": "eed1595d830407b49775aa33b871a9400e5a44e6"

--- a/queries/fusion/highlights.scm
+++ b/queries/fusion/highlights.scm
@@ -23,8 +23,9 @@
 
 )
 (include_statement
-  "include" @include
-  ":" @punctuation.delimiter
+  [
+   "include"
+  ] @include
   (source_file) @text.uri
 )
 
@@ -32,14 +33,14 @@
   "namespace" @keyword
   (alias_namespace) @namespace)
 
-(identifier_type
+(type
   name: (type_name) @type)
 
 ; tokens
 ; ------
 
 [
-  (identifier_package)
+  (package_name)
   (alias_namespace)
 ] @namespace
 
@@ -83,3 +84,5 @@
  "."
  "?"
 ] @punctuation.delimiter
+
+

--- a/tests/query/highlights/fusion/basic.fusion
+++ b/tests/query/highlights/fusion/basic.fusion
@@ -3,11 +3,11 @@ include: SomeFile.fusion
 //     ^punctuation.delimiter
 //       ^text.uri
 
-namespace ns = Neos.Fusion.Space
+namespace: ns = Neos.Fusion.Space
 //<- keyword
-//        ^namespace
-//           ^operator
-//             ^namespace
+//         ^namespace
+//            ^operator
+//              ^namespace
 
 prototype(MyType) < prototype(ns:SuperType) {
 //<-keyword


### PR DESCRIPTION
Hey,
sorry for the inconvenience. I did not expect you update the lockfile regularly. Hope this will not happen often.
I updated some parts of the grammar and this broke compatibility to nvim-treesitter queries.

Is there a way we can link the queries in the grammar repo as default?
relates to #2088 