### PR TITLE
install: use -xc++ -std=c++14 to compile always with c++14

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -66,8 +66,6 @@ jobs:
 
       - name: Check query files (Unix)
         if: matrix.os != 'windows-2022'
-        env:
-          ALLOWED_INSTALLATION_FAILURES: haskell
         run: nvim --headless -c "luafile ./scripts/check-queries.lua" -c "q"
 
       - name: Check query files (Windows)

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -71,6 +71,8 @@ function M.select_compiler_args(repo, compiler)
       "-o",
       "parser.so",
       repo.files,
+      "-xc++",
+      "-std=c++14",
       "-lc",
       "-Isrc",
       "-shared",


### PR DESCRIPTION
Let's see whether this works.