### PR TITLE
highlights(lua): `next` as builtin function

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -150,6 +150,9 @@
     "rawequal" "rawget" "rawset" "require" "select" "setfenv" "setmetatable"
     "tonumber" "tostring" "type" "unpack" "xpcall"))
 
+;; built-in next function
+(next) @function.builtin
+
 ;; Parameters
 (parameters
   (identifier) @parameter)

--- a/tests/query/highlights/lua/test.lua
+++ b/tests/query/highlights/lua/test.lua
@@ -1,0 +1,13 @@
+local a = { 1, 2, 3, 4, 5 }
+--          ^ TSNumber    ^ TSPunctBracket
+--    ^ TSVariable
+
+local _ = next(a)
+--          ^ TSFuncBuiltin
+-- ^ TSKeyword
+
+_ = next(a)
+--   ^ TSFuncBuiltin
+
+next(a)
+-- ^ TSFuncBuiltin


### PR DESCRIPTION
This PR fixes the `next` built-in highlight. The current `function_call > identifier` query doesn't work as the `next` has its own node, I guess.

![image](https://user-images.githubusercontent.com/24727447/145854108-f457023f-d7c0-4e12-a127-548039344a60.png)
