### PR TITLE
Add OpenFOAM parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)
 - [x] [fish](https://github.com/ram02z/tree-sitter-fish) (maintained by @ram02z)
-- [x] [foam](https://github.com/FoamScience/tree-sitter-foam) (maintained by @FoamScience)
+- [x] [foam](https://github.com/FoamScience/tree-sitter-foam) (experimental, maintained by @FoamScience)
 - [ ] [fortran](https://github.com/stadelmanma/tree-sitter-fortran)
 - [x] [fusion](https://gitlab.com/jirgn/tree-sitter-fusion.git) (maintained by @jirgn)
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by @Shatur95)

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [erlang](https://github.com/AbstractMachinesLab/tree-sitter-erlang) (maintained by @ostera)
 - [x] [fennel](https://github.com/travonted/tree-sitter-fennel) (maintained by @TravonteD)
 - [x] [fish](https://github.com/ram02z/tree-sitter-fish) (maintained by @ram02z)
+- [x] [foam](https://github.com/FoamScience/tree-sitter-foam) (maintained by @FoamScience)
 - [ ] [fortran](https://github.com/stadelmanma/tree-sitter-fortran)
 - [x] [fusion](https://gitlab.com/jirgn/tree-sitter-fusion.git) (maintained by @jirgn)
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by @Shatur95)

--- a/after/ftdetect/foam.vim
+++ b/after/ftdetect/foam.vim
@@ -1,0 +1,13 @@
+" Last Change: 2021 Dec 13
+
+function! s:foamFile(path)
+    let l:lines = getline(1, 10)
+    for line in lines
+        if match(line, 'FoamFile') >= 0
+            set filetype=foam
+        endif
+    endfor
+endfunction
+
+autocmd BufNewFile,BufRead * call s:foamFile(expand("%"))
+autocmd FileType cpp call s:foamFile(expand("%"))

--- a/after/ftdetect/foam.vim
+++ b/after/ftdetect/foam.vim
@@ -9,5 +9,5 @@ function! s:foamFile(path)
     endfor
 endfunction
 
-autocmd BufNewFile,BufRead * call s:foamFile(expand("%"))
+autocmd FileType BufNewFile,BufRead *Dict,*Properties,fvSchemes,fvSolution,*/constant/g,*/0/* call s:foamFile(expand("%"))
 autocmd FileType cpp call s:foamFile(expand("%"))

--- a/after/ftdetect/foam.vim
+++ b/after/ftdetect/foam.vim
@@ -9,5 +9,5 @@ function! s:foamFile(path)
     endfor
 endfunction
 
-autocmd FileType BufNewFile,BufRead *Dict,*Properties,fvSchemes,fvSolution,*/constant/g,*/0/* call s:foamFile(expand("%"))
+autocmd BufNewFile,BufRead *Dict,*Properties,fvSchemes,fvSolution,*/constant/g,*/0/* call s:foamFile(expand("%"))
 autocmd FileType cpp call s:foamFile(expand("%"))

--- a/after/ftdetect/foam.vim
+++ b/after/ftdetect/foam.vim
@@ -1,13 +1,26 @@
-" Last Change: 2021 Dec 13
+" Last Change: 2022 Jan 08
 
 function! s:foamFile(path)
-    let l:lines = getline(1, 10)
+    " Return if file type already set
+    if (&filetype == 'foam')
+        return
+    endif
+
+    let l:lines = getline(1, 15)
+    let l:f = -1
+    let l:o = -1
     for line in lines
-        if match(line, 'FoamFile') >= 0
-            set filetype=foam
+        if (match(line, 'FoamFile') >= 0)
+            let l:f = index(lines, line)
+        endif
+        if (match(line, 'object') >= 0)
+            let l:o = index(lines, line)
         endif
     endfor
+    if ((l:o >= 0) && (l:f) && (l:o > l:f))
+        set filetype=foam
+    endif
 endfunction
 
-autocmd BufNewFile,BufRead *Dict,*Properties,fvSchemes,fvSolution,*/constant/g,*/0/* call s:foamFile(expand("%"))
 autocmd FileType cpp call s:foamFile(expand("%"))
+autocmd BufNewFile,BufRead *Dict,*Properties,fvSchemes,fvSolution,*/constant/g,*/0/* call s:foamFile(expand("%"))

--- a/lockfile.json
+++ b/lockfile.json
@@ -65,6 +65,9 @@
   "fish": {
     "revision": "04e54ab6585dfd4fee6ddfe5849af56f101b6d4f"
   },
+  "foam": {
+    "revision": "93ca3fe62c9ddbe7027dc51922547f6564fbd4e3"
+  },
   "fortran": {
     "revision": "f0f2f100952a353e64e26b0fa710b4c296d7af13"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -66,7 +66,7 @@
     "revision": "04e54ab6585dfd4fee6ddfe5849af56f101b6d4f"
   },
   "foam": {
-    "revision": "93ca3fe62c9ddbe7027dc51922547f6564fbd4e3"
+    "revision": "4662b2548b37a2a9229cc9549861b5390a107a38"
   },
   "fortran": {
     "revision": "f0f2f100952a353e64e26b0fa710b4c296d7af13"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -846,6 +846,21 @@ list.rasi = {
   maintainers = { "@Fymyte" },
 }
 
+list.foam = {
+  install_info = {
+    url = "https://github.com/FoamScience/tree-sitter-foam",
+    branch = "master",
+    files = {"src/parser.c", "src/scanner.cc"},
+    generate_requires_npm = true,
+  },
+  maintainers = { "@FoamScience" },
+  filetype = "foam",
+  used_by = {"OpenFOAM"},
+  -- Queries might change over time on the grammar's side
+  -- Otherwise everything runs fine
+  experimental = true,
+}
+
 local M = {
   list = list,
 }

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -850,8 +850,7 @@ list.foam = {
   install_info = {
     url = "https://github.com/FoamScience/tree-sitter-foam",
     branch = "master",
-    files = { "src/parser.c", "src/scanner.cc" },
-    generate_requires_npm = true,
+    files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@FoamScience" },
   filetype = "foam",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -850,12 +850,12 @@ list.foam = {
   install_info = {
     url = "https://github.com/FoamScience/tree-sitter-foam",
     branch = "master",
-    files = {"src/parser.c", "src/scanner.cc"},
+    files = { "src/parser.c", "src/scanner.cc" },
     generate_requires_npm = true,
   },
   maintainers = { "@FoamScience" },
   filetype = "foam",
-  used_by = {"OpenFOAM"},
+  used_by = { "OpenFOAM" },
   -- Queries might change over time on the grammar's side
   -- Otherwise everything runs fine
   experimental = true,

--- a/queries/foam/folds.scm
+++ b/queries/foam/folds.scm
@@ -1,0 +1,7 @@
+[
+    (comment)
+    (list)
+    (dict_core)
+] @fold
+
+(code (code_body)* @fold)

--- a/queries/foam/highlights.scm
+++ b/queries/foam/highlights.scm
@@ -37,7 +37,7 @@
 ;; Literal numbers and strings
 (number_literal) @float
 (string_literal) @string
-(escape_sequence) @escape
+(escape_sequence) @string.escape
 
 ;; Treat [m^2 s^-2] the same as if it was put in numbers format
 (dimensions dimension: (identifier) @float)
@@ -52,8 +52,11 @@
   "}"
   "#{"
   "#}"
+] @punctuation.bracket
+
+[
   ";"
-] @punctuation
+] @punctuation.delimiter
 
 ;; Special identifiers
 ([(identifier) "on" "off" "true" "false" "yes" "no"] @constant.builtin

--- a/queries/foam/highlights.scm
+++ b/queries/foam/highlights.scm
@@ -1,0 +1,61 @@
+;; Comments
+(comment) @comment
+
+;; Generic Key-value pairs and dictionary keywords
+(key_value
+    keyword: (identifier) @function
+)
+(dict
+    key: (identifier) @type
+)
+
+;; Macros
+(macro
+    "$" @conditional
+    (prev_scope)* @conditional
+    (identifier)* @namespace
+)
+
+
+;; Directives
+"#" @conditional
+(preproc_call
+    directive: (identifier)* @conditional
+    argument: (identifier)* @namespace
+)
+(
+    (preproc_call
+        argument: (identifier)* @namespace
+    ) @conditional
+    (#match? @conditional "ifeq")
+)
+(
+    (preproc_call) @conditional
+    (#match? @conditional "(else|endif)")
+)
+
+;; Literal numbers and strings
+(number_literal) @float
+(string_literal) @string
+(escape_sequence) @escape
+
+;; Treat [m^2 s^-2] the same as if it was put in numbers format
+(dimensions dimension: (identifier) @float)
+
+;; Punctuation
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "#{"
+  "#}"
+  ";"
+] @punctuation
+
+;; Special identifiers
+([(identifier) "on" "off" "true" "false" "yes" "no"] @attribute
+(#match? @attribute "^(uniform|non-uniform|and|or|on|off|true|false|yes|no)$")
+)

--- a/queries/foam/highlights.scm
+++ b/queries/foam/highlights.scm
@@ -56,6 +56,6 @@
 ] @punctuation
 
 ;; Special identifiers
-([(identifier) "on" "off" "true" "false" "yes" "no"] @attribute
-(#match? @attribute "^(uniform|non-uniform|and|or|on|off|true|false|yes|no)$")
+([(identifier) "on" "off" "true" "false" "yes" "no"] @constant.builtin
+(#match? @constant.builtin "^(uniform|non-uniform|and|or|on|off|true|false|yes|no)$")
 )

--- a/queries/foam/indents.scm
+++ b/queries/foam/indents.scm
@@ -1,0 +1,11 @@
+[
+  "{"
+  "}"
+] @branch
+
+[(dict) (key_value)] @indent
+
+
+[
+  (comment)
+] @ignore

--- a/queries/foam/injections.scm
+++ b/queries/foam/injections.scm
@@ -1,0 +1,9 @@
+;; Pass code blocks to Cpp highlighter
+(code (code_body) @cpp)
+
+;; Pass identifiers to Go highlighter (Cheating I know)
+;;((identifier) @lua)
+
+;; Highlight regex syntax inside literal strings
+((string_literal) @regex)
+

--- a/queries/foam/locals.scm
+++ b/queries/foam/locals.scm
@@ -1,0 +1,6 @@
+(dict) @scope
+
+(dict key: (_) @definition.type)
+
+(key_value keyword: (_) @definition.parameter)
+(key_value value: (macro (identifier)*)* @reference)

--- a/queries/foam/textobjects.scm
+++ b/queries/foam/textobjects.scm
@@ -1,8 +1,0 @@
-(dict) @class.outer
-((dict_core) @class.inner)
-((key_value value: _? @_start (_)* _? @parameter.inner)
-    (#make-range! "function.inner" @_start @parameter.inner)) @function.outer
-(code (_)* @class.inner) @class.outer
-((comment) @_start ((comment)+) @_end
- (#make-range! "comment.outer" @_start @_end))
-(comment) @comment.inner

--- a/queries/foam/textobjects.scm
+++ b/queries/foam/textobjects.scm
@@ -1,0 +1,8 @@
+(dict) @class.outer
+((dict_core) @class.inner)
+((key_value value: _? @_start (_)* _? @parameter.inner)
+    (#make-range! "function.inner" @_start @parameter.inner)) @function.outer
+(code (_)* @class.inner) @class.outer
+((comment) @_start ((comment)+) @_end
+ (#make-range! "comment.outer" @_start @_end))
+(comment) @comment.inner


### PR DESCRIPTION
Adding support for the [OpenFOAM](https://openfoam.org/) file format using [this grammar](https://github.com/FoamScience/tree-sitter-foam) which supports:
- highlights
- indents (* basic)
- locals, injections
- folds
- text-objects