### PR TITLE
feat: enable parsers after installation immediately without reload

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -330,6 +330,17 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
         vim.fn.writefile({ revision or "" }, utils.join_path(utils.get_parser_info_dir(), lang .. ".revision"))
       end,
     },
+    { -- auto-attach modules after installation
+      cmd = function()
+        for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+          if parsers.get_buf_lang(buf) == lang then
+            for _, mod in ipairs(require("nvim-treesitter.configs").available_modules()) do
+              require("nvim-treesitter.configs").reattach_module(mod, buf)
+            end
+          end
+        end
+      end,
+    },
   })
   if not from_local_path then
     vim.list_extend(command_list, { shell.select_install_rm_cmd(cache_folder, project_name) })


### PR DESCRIPTION
Addresses #2108 

This creates a nice welcome experience and can be a first step to https://github.com/nvim-treesitter/nvim-treesitter/issues/2108#issuecomment-993642212. You will get nice highlighting in the second when it says "parser for XXX installed"

@wimstefan @HaleTom This will enable the parsers as soon as they are installed without reloading the buffer. So you can use the async installation. We can add an option for auto-install in a  separate PR 