### PR TITLE
Add support for new golang `go.work` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [go](https://github.com/tree-sitter/tree-sitter-go) (maintained by @theHamsta, @WinWisely268)
 - [x] [Godot Resources (gdresource)](https://github.com/PrestonKnopp/tree-sitter-godot-resource) (maintained by @pierpo)
 - [x] [gomod](https://github.com/camdencheek/tree-sitter-go-mod) (maintained by @camdencheek)
+- [x] [gowork](https://github.com/omertuc/tree-sitter-go-work) (maintained by @omertuc)
 - [x] [graphql](https://github.com/bkegley/tree-sitter-graphql) (maintained by @bkegley)
 - [ ] [haskell](https://github.com/tree-sitter/tree-sitter-haskell)
 - [x] [hcl](https://github.com/MichaHoffmann/tree-sitter-hcl) (maintained by @MichaHoffmann)

--- a/ftdetect/gowork.vim
+++ b/ftdetect/gowork.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile go.work set filetype=gowork

--- a/lockfile.json
+++ b/lockfile.json
@@ -89,6 +89,9 @@
   "gomod": {
     "revision": "3cbcb572109ea0bc476a292208722c326c9e6c3a"
   },
+  "gowork": {
+    "revision": "aafab008b4c855f20871cb978e41cf3b94466c70"
+  },
   "graphql": {
     "revision": "5e66e961eee421786bdda8495ed1db045e06b5fe"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -184,6 +184,16 @@ list.gomod = {
   filetype = "gomod",
 }
 
+list.gowork = {
+  install_info = {
+    url = "https://github.com/omertuc/tree-sitter-go-work",
+    branch = "main",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@omertuc" },
+  filetype = "gowork",
+}
+
 list.graphql = {
   install_info = {
     url = "https://github.com/bkegley/tree-sitter-graphql",

--- a/queries/gomod/injections.scm
+++ b/queries/gomod/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment

--- a/queries/gowork/highlights.scm
+++ b/queries/gowork/highlights.scm
@@ -1,0 +1,14 @@
+[
+  "replace"
+  "go"
+  "use"
+] @keyword
+
+"=>" @operator
+
+(comment) @comment
+
+[
+(version)
+(go_version)
+] @string

--- a/queries/gowork/injections.scm
+++ b/queries/gowork/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment


### PR DESCRIPTION
The new golang 1.18 version (currently in beta) [introduced](https://github.com/golang/go/issues/45713) a new file type
called `go.work`.

This commit adds support for the syntax of that file using the https://github.com/omertuc/tree-sitter-go-work repository

That repository is heavily based on previous work in the https://github.com/camdencheek/tree-sitter-go-mod repository, with a few
minor changes to make it work on the very similar `go.work` files.