### PR TITLE
highlights(markdown): highlight link_text as @text.reference

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -20,6 +20,7 @@
 (link_destination) @text.uri
 
 (link_label) @text.reference
+(link_text) @text.reference
 
 [
   (list_marker_plus)


### PR DESCRIPTION
Allow targeting the text part of a link:
```markdown
[this part](https://a.a)
```

Ref: https://github.com/mcchrish/zenbones.nvim/pull/64#issuecomment-996518952