### PR TITLE
Fix language injection for markdown code blocks

### DIFF
--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -1,5 +1,6 @@
 (fenced_code_block
-  (info_string) @language
+  (info_string
+    (language) @language)
   (code_fence_content) @content)
 
 ((html_block) @html)


### PR DESCRIPTION
Related to https://github.com/MDeiml/tree-sitter-markdown/issues/14. I introduced a new node in my grammar which is only the language part of the info string. We need to change the injection query to use this new node.

I'm not familiar with how nvim-treesitter chooses the commit from which to install a language. I think the node is not part of the commit that is currently used. Is it safe to reference it in the query files like this? Or do I need to trigger some other process first, so the newest commit of the parser gets used?