### PR TITLE
Improve vue

### DIFF
--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -2,8 +2,8 @@
 (erroneous_end_tag_name) @error
 (comment) @comment
 (attribute_name) @tag.attribute
-(attribute_value) @string
-(quoted_attribute_value) @string
+(attribute
+  (quoted_attribute_value) @string)
 (text) @text
 
 ((element (start_tag (tag_name) @_tag) (text) @text.title)

--- a/queries/vue/highlights.scm
+++ b/queries/vue/highlights.scm
@@ -1,20 +1,23 @@
 ; inherits: html_tags
 
 [
-  (template_element)
-  (directive_attribute)
   (directive_dynamic_argument)
   (directive_dynamic_argument_value)
-  (component)
 ] @tag
 
-(element) @string
 (interpolation) @punctuation.special
 (interpolation
   (raw_text) @none)
 
+(directive_name) @tag.attribute
+
+(directive_attribute
+  (quoted_attribute_value) @punctuation.special)
+
+(directive_attribute
+  (quoted_attribute_value (attribute_value) @none))
+
 [
   (directive_modifier)
-  (directive_name)
   (directive_argument)
 ] @method


### PR DESCRIPTION
Closes #1646 

For colorschemes that heavily makes use of bold and italics, the inheriting factor makes the highlights unpleasant. Solution is to make the targets more specific rather than the whole `template_element` or `element`.

## Tokyonight

<img width="666" alt="Screen Shot 2021-12-18 at 3 55 37 PM" src="https://user-images.githubusercontent.com/7200153/146633973-8383f3b3-0884-4c80-977e-63481afe2933.png">
<img width="666" alt="Screen Shot 2021-12-18 at 3 54 48 PM" src="https://user-images.githubusercontent.com/7200153/146633980-bc011948-8f81-45b5-a00f-b15f2d2162ff.png">


## Zenbones

<img width="666" alt="Screen Shot 2021-12-18 at 3 55 14 PM" src="https://user-images.githubusercontent.com/7200153/146633988-b48fa164-9122-4139-92d5-f56f7a04f7fb.png">
<img width="666" alt="Screen Shot 2021-12-18 at 3 54 17 PM" src="https://user-images.githubusercontent.com/7200153/146633992-aa44003d-d443-401b-9cac-63e272f54b7d.png">

