### PR TITLE
highlights(python): decorators as @annotation

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -46,14 +46,28 @@
               "UserWarning" "DeprecationWarning" "PendingDeprecationWarning" "SyntaxWarning" "RuntimeWarning"
               "FutureWarning" "ImportWarning" "UnicodeWarning" "BytesWarning" "ResourceWarning"))
 
-; Function calls
+;; Decorators
 
-(decorator) @function
-((decorator (attribute (identifier) @function))
- (#match? @function "^([A-Z])@!.*$"))
-(decorator) @function
-((decorator (identifier) @function)
- (#match? @function "^([A-Z])@!.*$"))
+; Ex: @cache
+(decorator
+  (identifier) @annotation)
+
+; Ex: @functools.cache
+((decorator
+   (attribute) @annotation)
+ (#set! "priority" 105))
+
+; Ex: @lru_cache(maxsize=128)
+((decorator
+  (call function: (identifier) @annotation))
+ (#set! "priority" 105))
+
+; Ex: @functools.lru_cache(maxsize=128)
+((decorator
+   (call function: (attribute) @annotation))
+ (#set! "priority" 105))
+
+;; Function calls
 
 (call
   function: (identifier) @function)


### PR DESCRIPTION
This patch delivers couple improvements at once to the way how
decorators are highlighted in Python. Here they are:

 * Highlight decorators with parameters (function call).
 * Highlight decorators that are attributes with any nested level.
 
Below are some screenshots

![nord](https://user-images.githubusercontent.com/166626/146644208-7970dd60-ae78-458d-bc8a-8030d9e08a07.png)
![tokyonight](https://user-images.githubusercontent.com/166626/146644212-b9f8d871-2037-4460-9024-f5fcd85a4e4d.png)

Screenshots on the right with changes from this patch.