### PR TITLE
highlights(python): Improve self and cls highlight

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -133,7 +133,7 @@
 (none) @constant.builtin
 [(true) (false)] @boolean
 ((identifier) @variable.builtin
- (#lua-match? @variable.builtin "^self$"))
+ (#eq? @variable.builtin "self"))
 
 (integer) @number
 (float) @float
@@ -275,12 +275,15 @@
       name: (identifier) @constructor)))
  (#any-of? @constructor "__new__" "__init__"))
 
-; First parameter of a method is self or cls.
+; First parameter of a classmethod is cls.
 ((class_definition
   body: (block
-          (function_definition
-            parameters: (parameters . (identifier) @variable.builtin))))
- (#any-of? @variable.builtin "self" "obj" "class"))
+          (decorated_definition
+            (decorator (identifier) @_decorator)
+            definition: (function_definition
+              parameters: (parameters . (identifier) @variable.builtin)))))
+ (#eq? @variable.builtin "cls")
+ (#eq? @_decorator "classmethod"))
 
 ;; Error
 (ERROR) @error


### PR DESCRIPTION
1. This function simplifies an unnecessary lua-match usage.
2. Fixes an accidental change, where "cls" was changed to "class" (fe4f320b66)
3. ~~Match functions, which have have a decorator.~~
4. ~~But exclude @staticmethod~~
5. Only highlight "cls" as @variable.builtin when the decorator is @classmethod

This might be a bit to complicated and some of this not to useful,
as this existing rule:

```scm
 ((identifier) @variable.builtin
  (#eq? @variable.builtin "self"))
```

overwrites the queries anyway.

**EDIT**: Remove queries, which duplicate highlights of the above query. 