### PR TITLE
highlights(python): highlight static and classmethod as builtin function

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -82,6 +82,8 @@
           "iter" "len" "list" "locals" "map" "max" "memoryview" "min" "next" "object" "oct" "open" "ord" "pow"
           "print" "property" "range" "repr" "reversed" "round" "set" "setattr" "slice" "sorted" "staticmethod" "str"
           "sum" "super" "tuple" "type" "vars" "zip" "__import__"))
+((decorator (identifier) @function.builtin)
+ (#any-of? @function.builtin "classmethod" "staticmethod"))
 
 ;; Function definitions
 


### PR DESCRIPTION
I don't know if this is desired, but technically these decorators are built-in functions, as of https://docs.python.org/3/library/functions.html.