### PR TITLE
goto_node: normalize range for nvim_win_set_cursor

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -374,19 +374,15 @@ function M.goto_node(node, goto_end, avoid_set_jump)
   if not avoid_set_jump then
     utils.set_jump()
   end
-  local range = { node:range() }
+  local range = { M.get_vim_range { node:range() } }
   local position
   if not goto_end then
     position = { range[1], range[2] }
   else
-    -- ranges are exclusive: -1 character!
-    if range[4] == 0 then
-      position = { range[3] - 1, -1 }
-    else
-      position = { range[3], range[4] - 1 }
-    end
+    position = { range[3], range[4] }
   end
-  api.nvim_win_set_cursor(0, { position[1] + 1, position[2] })
+  -- Position is 1, 0 indexed.
+  api.nvim_win_set_cursor(0, { position[1], position[2] - 1 })
 end
 
 return M


### PR DESCRIPTION
Looks like neovim doesn't accept -1 on nvim_win_set_cursor.
It's listed as an exception on `:h api-indexing`.

Fixes https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/149