### PR TITLE
Add support for Pascal

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -594,6 +594,14 @@ list.verilog = {
   experimental = true,
 }
 
+list.pascal = {
+  install_info = {
+    url = "https://github.com/Isopod/tree-sitter-pascal.git",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@isopod" },
+}
+
 -- Parsers for injections
 list.regex = {
   install_info = {

--- a/queries/pascal/folds.scm
+++ b/queries/pascal/folds.scm
@@ -1,0 +1,33 @@
+[
+  (interface)
+  (implementation)
+  (initialization)
+  (finalization)
+
+  (if)
+  (ifElse)
+  (while)
+  (repeat)
+  (for)
+  (foreach)
+  (try)
+  (case)
+  (caseCase)
+  (asm)
+  (with)
+
+  (declVar)
+  (declConst)
+  (declEnum)
+  (declProcRef)
+  (declExports)
+  (declProcRef)
+  (declType)
+  (defProc)
+  (declField)
+  (declProp)
+
+  (comment)
+] @fold
+
+(interface (declProc) @fold)

--- a/queries/pascal/highlights.scm
+++ b/queries/pascal/highlights.scm
@@ -154,6 +154,7 @@
 	(procAttribute)
 
 ] @attribute
+
 (procAttribute (kPublic) @attribute)
 
 ; -- Punctuation & operators
@@ -216,7 +217,7 @@
 [
 	(kTrue)
 	(kFalse)
-] @boolean;
+] @boolean
 
 [
 	(kNil)
@@ -229,7 +230,6 @@
 
 ; -- Comments
 (comment)         @comment
-; -- (pp)              @keyword
 (pp)              @function.macro
 
 ; -- Type declaration
@@ -256,11 +256,11 @@
 
 ; -- Function parameters
 
-(declArg name: (identifier) @variable.parameter)
+(declArg name: (identifier) @parameter)
 
 ; -- Template parameters
 
-(genericArg	name: (identifier) @type.parameter)
+(genericArg	name: (identifier) @parameter)
 (genericArg	type: (typeref) @type)
 
 (declProc name: (genericDot lhs: (identifier) @type))
@@ -273,7 +273,7 @@
 (genericTpl entity: (genericDot (identifier) @type))
 
 ; -- Exception parameters
-(exceptionHandler variable: (identifier) @variable.parameter)
+(exceptionHandler variable: (identifier) @parameter)
 
 ; -- Type usage
 
@@ -284,7 +284,7 @@
 [
 	(caseLabel)
 	(label)
-] @constant;
+] @constant
 
 (procAttribute (identifier) @constant)
 (procExternal (identifier) @constant)
@@ -294,7 +294,6 @@
 ; declared in other units, so the results will be inconsistent)
 
 (declVar name: (identifier) @variable)
-;(declField name: (identifier) @variable)
 (declConst name: (identifier) @constant)
 (declEnumValue name: (identifier) @constant)
 
@@ -343,13 +342,13 @@
 ; (Not ideal: ideally, there would be a way to check if these special
 ; identifiers are shadowed by a local variable)
 (statement ((identifier) @keyword.return
- (#match? @keyword.return "^[eE][xX][iI][tT]$")))
+ (#lua-match? @keyword.return "^[eE][xX][iI][tT]$")))
 (statement (exprCall entity: ((identifier) @keyword.return
- (#match? @keyword.return "^[eE][xX][iI][tT]$"))))
+ (#lua-match? @keyword.return "^[eE][xX][iI][tT]$"))))
 (statement ((identifier) @repeat
- (#match? @repeat "^[bB][rR][eE][aA][kK]$")))
+ (#lua-match? @repeat "^[bB][rR][eE][aA][kK]$")))
 (statement ((identifier) @repeat
- (#match? @repeat "^[cC][oO][nN][tT][iI][nN][uU][eE]$")))
+ (#lua-match? @repeat "^[cC][oO][nN][tT][iI][nN][uU][eE]$")))
 
 ; -- Identifier type inferrence
 

--- a/queries/pascal/highlights.scm
+++ b/queries/pascal/highlights.scm
@@ -1,0 +1,376 @@
+; -- Keywords
+[
+	(kProgram)
+	(kLibrary)
+	(kUnit)
+	(kUses)
+
+	(kBegin)
+	(kEnd)
+	(kAsm)
+
+	(kVar)
+	(kThreadvar)
+	(kConst)
+	(kResourcestring)
+	(kConstref)
+	(kOut)
+	(kType)
+	(kLabel)
+	(kExports)
+
+	(kAbsolute)
+
+	(kProperty)
+	(kRead)
+	(kWrite)
+	(kImplements)
+
+	(kClass)
+	(kInterface)
+	(kObject)
+	(kRecord)
+	(kObjcclass)
+	(kObjccategory)
+	(kObjcprotocol)
+	(kArray)
+	(kFile)
+	(kString)
+	(kSet)
+	(kOf)
+	(kHelper)
+	(kPacked)
+
+	(kInherited)
+
+	(kGeneric)
+	(kSpecialize)
+
+	(kFunction)
+	(kProcedure)
+	(kConstructor)
+	(kDestructor)
+	(kOperator)
+	(kReference)
+
+	(kInterface)
+	(kImplementation)
+	(kInitialization)
+	(kFinalization)
+
+	(kPublished)
+	(kPublic)
+	(kProtected)
+	(kPrivate)
+	(kStrict)
+	(kRequired)
+	(kOptional)
+
+	(kTry)
+	(kExcept)
+	(kFinally)
+	(kRaise)
+	(kOn)
+	(kCase)
+	(kWith)
+	(kGoto)
+] @keyword
+
+[
+	(kFor)
+	(kTo)
+	(kDownto)
+	(kDo)
+	(kWhile)
+	(kRepeat)
+	(kUntil)
+] @repeat
+
+[
+	(kIf)
+	(kThen)
+	(kElse)
+] @conditional
+	
+
+; -- Attributes
+
+[
+	(kDefault)
+	(kIndex)
+	(kNodefault)
+	(kStored)
+
+	(kStatic)
+	(kVirtual)
+	(kAbstract)
+	(kSealed)
+	(kDynamic)
+	(kOverride)
+	(kOverload)
+	(kReintroduce)
+	(kInline)
+
+	(kForward)
+
+	(kStdcall)
+	(kCdecl)
+	(kCppdecl)
+	(kPascal)
+	(kRegister)
+	(kMwpascal)
+	(kExternal)
+	(kName)
+	(kMessage)
+	(kDeprecated)
+	(kExperimental)
+	(kPlatform)
+	(kUnimplemented)
+	(kCvar)
+	(kExport)
+	(kFar)
+	(kNear)
+	(kSafecall)
+	(kAssembler)
+	(kNostackframe)
+	(kInterrupt)
+	(kNoreturn)
+	(kIocheck)
+	(kLocal)
+	(kHardfloat)
+	(kSoftfloat)
+	(kMs_abi_default)
+	(kMs_abi_cdecl)
+	(kSaveregisters)
+	(kSysv_abi_default)
+	(kSysv_abi_cdecl)
+	(kVectorcall)
+	(kVarargs)
+	(kWinapi)
+	(kAlias)
+	(kDelayed)
+
+	(rttiAttributes)
+	(procAttribute)
+
+] @attribute
+(procAttribute (kPublic) @attribute)
+
+; -- Punctuation & operators
+
+[
+	"("
+	")"
+	"["
+	"]"
+] @punctuation.bracket
+
+[
+	";"
+	","
+	":"
+	(kEndDot)
+] @punctuation.delimiter
+
+[
+	".."
+] @punctuation.special
+
+[
+	(kDot)
+	(kAdd)
+	(kSub)
+	(kMul)
+	(kFdiv)
+	(kAssign)
+	(kAssignAdd)
+	(kAssignSub)
+	(kAssignMul)
+	(kAssignDiv)
+	(kEq)
+	(kLt)
+	(kLte)
+	(kGt)
+	(kGte)
+	(kNeq)
+	(kAt)
+	(kHat)
+] @operator
+
+[
+	(kOr)
+	(kXor)
+	(kDiv)
+	(kMod)
+	(kAnd)
+	(kShl)
+	(kShr)
+	(kNot)
+	(kIs)
+	(kAs)
+	(kIn)
+] @keyword.operator
+
+; -- Builtin constants
+
+[
+	(kTrue)
+	(kFalse)
+] @boolean;
+
+[
+	(kNil)
+] @constant.builtin
+
+; -- Literals
+
+(literalNumber)   @number
+(literalString)   @string
+
+; -- Comments
+(comment)         @comment
+; -- (pp)              @keyword
+(pp)              @function.macro
+
+; -- Type declaration
+
+(declType name: (identifier) @type)
+(declType name: (genericTpl entity: (identifier) @type))
+
+; -- Procedure & function declarations
+
+; foobar
+(declProc name: (identifier) @function)
+; foobar<t>
+(declProc name: (genericTpl entity: (identifier) @function))
+; foo.bar
+(declProc name: (genericDot rhs: (identifier) @function))
+; foo.bar<t>
+(declProc name: (genericDot rhs: (genericTpl entity: (identifier) @function)))
+
+; Treat property declarations like functions
+
+(declProp name: (identifier) @function)
+(declProp getter: (identifier) @property)
+(declProp setter: (identifier) @property)
+
+; -- Function parameters
+
+(declArg name: (identifier) @variable.parameter)
+
+; -- Template parameters
+
+(genericArg	name: (identifier) @type.parameter)
+(genericArg	type: (typeref) @type)
+
+(declProc name: (genericDot lhs: (identifier) @type))
+(declType (genericDot (identifier) @type))
+
+(genericDot (genericTpl (identifier) @type))
+(genericDot (genericDot (identifier) @type))
+
+(genericTpl entity: (identifier) @type)
+(genericTpl entity: (genericDot (identifier) @type))
+
+; -- Exception parameters
+(exceptionHandler variable: (identifier) @variable.parameter)
+
+; -- Type usage
+
+(typeref) @type
+
+; -- Constant usage
+
+[
+	(caseLabel)
+	(label)
+] @constant;
+
+(procAttribute (identifier) @constant)
+(procExternal (identifier) @constant)
+
+; -- Variable & constant declarations
+; (This is only questionable because we cannot detect types of identifiers
+; declared in other units, so the results will be inconsistent)
+
+(declVar name: (identifier) @variable)
+;(declField name: (identifier) @variable)
+(declConst name: (identifier) @constant)
+(declEnumValue name: (identifier) @constant)
+
+; -- Fields
+
+(exprDot rhs: (identifier) @property)
+(exprDot rhs: (exprDot)    @property)
+(declClass   (declField name:(identifier) @property))
+(declSection (declField name:(identifier) @property))
+(declSection (declVars (declVar   name:(identifier) @property)))
+
+(recInitializerField name:(identifier) @property)
+
+
+;;; ---------------------------------------------- ;;;
+;;; EVERYTHING BELOW THIS IS OF QUESTIONABLE VALUE ;;;
+;;; ---------------------------------------------- ;;;
+
+
+; -- Procedure name in calls with parentheses
+; (Pascal doesn't require parentheses for procedure calls, so this will not
+; detect all calls)
+
+; foobar
+(exprCall entity: (identifier) @function)
+; foobar<t>
+(exprCall entity: (exprTpl entity: (identifier) @function))
+; foo.bar
+(exprCall entity: (exprDot rhs: (identifier) @function))
+; foo.bar<t>
+(exprCall entity: (exprDot rhs: (exprTpl entity: (identifier) @function)))
+
+(inherited) @function
+
+; -- Heuristic for procedure/function calls without parentheses
+; (If a statement consists only of an identifier, assume it's a procedure)
+; (This will still not match all procedure calls, and also may produce false
+; positives in rare cases, but only for nonsensical code)
+
+(statement (identifier) @function)
+(statement (exprDot rhs: (identifier) @function))
+(statement (exprTpl entity: (identifier) @function))
+(statement (exprDot rhs: (exprTpl entity: (identifier) @function)))
+
+; -- Break, Continue & Exit
+; (Not ideal: ideally, there would be a way to check if these special
+; identifiers are shadowed by a local variable)
+(statement ((identifier) @keyword.return
+ (#match? @keyword.return "^[eE][xX][iI][tT]$")))
+(statement (exprCall entity: ((identifier) @keyword.return
+ (#match? @keyword.return "^[eE][xX][iI][tT]$"))))
+(statement ((identifier) @repeat
+ (#match? @repeat "^[bB][rR][eE][aA][kK]$")))
+(statement ((identifier) @repeat
+ (#match? @repeat "^[cC][oO][nN][tT][iI][nN][uU][eE]$")))
+
+; -- Identifier type inferrence
+
+; VERY QUESTIONABLE: Highlighting of identifiers based on spelling
+(exprBinary ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(exprUnary ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(assignment rhs: ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(exprBrackets ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(exprParens ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(exprDot rhs: ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(exprTpl args: ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(exprArgs ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(declEnumValue ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+(defaultValue ((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))

--- a/queries/pascal/indents.scm
+++ b/queries/pascal/indents.scm
@@ -1,0 +1,32 @@
+[
+	(statement)
+	(declVars)
+	(declConsts)
+	(declTypes)
+	(declProc)
+	(declArgs)
+	(declUses)
+	(declClass)
+	(exprArgs)
+	(exprSubscript)
+	(exprBrackets)
+	(exprParens)
+	(recInitializer)
+	(arrInitializer)
+	(defaultValue)
+] @indent
+
+(defProc (block) @indent)
+
+[
+	(kEnd)
+	(kFinally)
+	(kDo)
+	(kUntil)
+	(kExcept)
+	(kElse)
+	(kThen)
+	(declSection)
+	"]"
+	")"
+] @branch

--- a/queries/pascal/injections.scm
+++ b/queries/pascal/injections.scm
@@ -1,2 +1,4 @@
 (comment) @comment
-(asmBody) @asm
+; There is no parser for assembly language yet. Add an injection here when we
+; have a parser.
+; (asmBody) @asm

--- a/queries/pascal/injections.scm
+++ b/queries/pascal/injections.scm
@@ -1,0 +1,2 @@
+(comment) @comment
+(asmBody) @asm

--- a/queries/pascal/locals.scm
+++ b/queries/pascal/locals.scm
@@ -1,25 +1,25 @@
 
-(root)                                   @local.scope
+(root)                                   @scope
 
-(defProc)                                @local.scope
-(lambda)                                 @local.scope
-(interface   (declProc)                  @local.scope)
-(declSection (declProc)                  @local.scope)
-(declClass   (declProc)                  @local.scope)
-(declHelper  (declProc)                  @local.scope)
-(declProcRef)                            @local.scope
+(defProc)                                @scope
+(lambda)                                 @scope
+(interface   (declProc)                  @scope)
+(declSection (declProc)                  @scope)
+(declClass   (declProc)                  @scope)
+(declHelper  (declProc)                  @scope)
+(declProcRef)                            @scope
 
-(exceptionHandler)                       @local.scope
-(exceptionHandler variable: (identifier) @local.definition)
+(exceptionHandler)                       @scope
+(exceptionHandler variable: (identifier) @definition)
 
-(declArg          name: (identifier)     @local.definition)
-(declVar          name: (identifier)     @local.definition)
-(declConst        name: (identifier)     @local.definition)
-(declLabel        name: (identifier)     @local.definition)
-(genericArg       name: (identifier)     @local.definition)
-(declEnumValue    name: (identifier)     @local.definition)
-(declType         name: (identifier)     @local.definition)
-(declType         name: (genericTpl entity: (identifier)     @local.definition))
+(declArg          name: (identifier)     @definition)
+(declVar          name: (identifier)     @definition)
+(declConst        name: (identifier)     @definition)
+(declLabel        name: (identifier)     @definition)
+(genericArg       name: (identifier)     @definition)
+(declEnumValue    name: (identifier)     @definition)
+(declType         name: (identifier)     @definition)
+(declType         name: (genericTpl entity: (identifier)     @definition))
 
-(declProc         name: (identifier)     @local.definition)
-(identifier)                             @local.reference
+(declProc         name: (identifier)     @definition)
+(identifier)                             @reference

--- a/queries/pascal/locals.scm
+++ b/queries/pascal/locals.scm
@@ -1,0 +1,25 @@
+
+(root)                                   @local.scope
+
+(defProc)                                @local.scope
+(lambda)                                 @local.scope
+(interface   (declProc)                  @local.scope)
+(declSection (declProc)                  @local.scope)
+(declClass   (declProc)                  @local.scope)
+(declHelper  (declProc)                  @local.scope)
+(declProcRef)                            @local.scope
+
+(exceptionHandler)                       @local.scope
+(exceptionHandler variable: (identifier) @local.definition)
+
+(declArg          name: (identifier)     @local.definition)
+(declVar          name: (identifier)     @local.definition)
+(declConst        name: (identifier)     @local.definition)
+(declLabel        name: (identifier)     @local.definition)
+(genericArg       name: (identifier)     @local.definition)
+(declEnumValue    name: (identifier)     @local.definition)
+(declType         name: (identifier)     @local.definition)
+(declType         name: (genericTpl entity: (identifier)     @local.definition))
+
+(declProc         name: (identifier)     @local.definition)
+(identifier)                             @local.reference


### PR DESCRIPTION
What it says in the title. This grammar works for Delphi and Freepascal. Since I wrote it from scratch, it's probably not 100% complete, but 99%. At least it's a lot better than the default regex highlighter. You can find some screenshots [here](https://github.com/Isopod/tree-sitter-pascal#screenshots).

Supported queries:
- highlights
- scope
- injections
- indents
- folds