### PR TITLE
Add support for re2c parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [ql](https://github.com/tree-sitter/tree-sitter-ql) (maintained by @pwntester)
 - [x] [Tree-sitter query language](https://github.com/nvim-treesitter/tree-sitter-query) (maintained by @steelsojka)
 - [x] [r](https://github.com/r-lib/tree-sitter-r) (maintained by @jimhester)
+- [x] [re2c](https://github.com/alemuller/tree-sitter-re2c/) (maintained by @alemuller)
 - [x] [regex](https://github.com/tree-sitter/tree-sitter-regex) (maintained by @theHamsta)
 - [x] [rst](https://github.com/stsewd/tree-sitter-rst) (maintained by @stsewd)
 - [x] [ruby](https://github.com/tree-sitter/tree-sitter-ruby) (maintained by @TravonteD)

--- a/ftdetect/re2c.vim
+++ b/ftdetect/re2c.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.re set filetype=re2c

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -211,7 +211,6 @@ list.re2c = {
   maintainers = { "@alemuller" },
 }
 
-
 list.ruby = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ruby",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -202,6 +202,16 @@ list.graphql = {
   maintainers = { "@bkegley" },
 }
 
+list.re2c = {
+  install_info = {
+    url = "https://github.com/alemuller/tree-sitter-re2c",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  maintainers = { "@alemuller" },
+}
+
+
 list.ruby = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ruby",

--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -1,3 +1,7 @@
 (preproc_arg) @c
 
+((comment) @re2c
+ (#match? @re2c "\\\*!(.*:)?re2c")
+ (#offset! @re2c 0 2 0 -2))
+
 (comment) @comment

--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -1,7 +1,3 @@
 (preproc_arg) @c
 
-((comment) @re2c
- (#match? @re2c "\\\*!(.*:)?re2c")
- (#offset! @re2c 0 2 0 -2))
-
 (comment) @comment

--- a/queries/cpp/injections.scm
+++ b/queries/cpp/injections.scm
@@ -1,3 +1,7 @@
 (preproc_arg) @cpp
 
+((comment) @re2c
+ (#match? @re2c "\\\*!(.*:)?re2c")
+ (#offset! @re2c 0 2 0 -2))
+
 (comment) @comment

--- a/queries/re2c/folds.scm
+++ b/queries/re2c/folds.scm
@@ -1,0 +1,4 @@
+[
+  (body)
+  (action)
+] @fold

--- a/queries/re2c/highlights.scm
+++ b/queries/re2c/highlights.scm
@@ -1,0 +1,168 @@
+;;
+;; Punctuations
+;; ============
+[
+  ":"
+  ";"
+  ","
+  "-"
+] @punctuation.delimiter
+
+[
+  "="
+  "=>"
+  ":=>"
+  "/"
+  "|"
+  "\\"
+  "^"
+] @operator
+
+[
+  "*"
+  "+"
+  "?"
+] @repeat
+
+[
+  "{" "}"
+  "[" "]"
+  "(" ")"
+  "<" ">"
+] @punctuation.bracket
+
+(repetition
+  (limits
+    ["{" "}"] @clean @repeat))
+
+[
+  "!"
+  "@"
+  "#"
+] @punctuation.special
+
+;;
+;; Keywords
+;; ========
+[
+  "re2c"
+  "!re2c"
+  "!local"
+  "!rules"
+] @namespace
+
+[
+  "!max"
+  "!maxnmatch"
+  "!mtags"
+  "!stags"
+  "!getstate"
+  "!header"
+] @keyword
+
+[
+  "!use"
+  "!include"
+] @include
+
+;;
+;; Constants
+;; =========
+[
+  "ignore"
+  "substitute"
+  "fail"
+  "default"
+  "custom"
+  "match-empty"
+  "match-none"
+  "error"
+  "functions"
+  "free-form"
+  "format"
+  "separator"
+] @constant.builtin
+
+[
+  "."
+  (default)
+  (end_of_input)
+] @constant.macro
+
+
+(condition
+  (any) @clean @constant.macro)
+
+[
+  "flags"
+  "define"
+  "cond"
+  "label"
+  "variable"
+  "yych"
+  "state"
+  "yybm"
+  "cgoto"
+  "api"
+  "tags"
+  "indent"
+  "yyfill"
+  "eof"
+  "sentinel"
+  "condprefix"
+  "condenumprefix"
+  "labelprefix"
+  "startlabel"
+] @keyword
+
+;;
+;; Names
+;; =============
+(name) @type
+
+(block_name) @constant
+
+(label) @label
+
+(option_name) @constant.builtin
+
+((option_name) @clean @constant.macro
+ (#match? @clean "^YY" ))
+
+;;
+;; Literals
+;; -------
+(regex) @string.regex
+
+[
+  (dstring) ; case   sensitive
+  (sstring) ; case insensitive
+] @string
+
+[
+  (quote)
+  (ctrl_code)
+  (code_unit)
+] @string.escape
+
+(number) @number
+
+[
+  "on"
+  "off"
+] @boolean
+
+[
+  (stag)
+  (mtag)
+] @property
+
+;;
+;; Comments and error
+;; ==================
+[
+  (comment)
+  (ignore_block)
+] @comment
+
+(ERROR) @error

--- a/queries/re2c/highlights.scm
+++ b/queries/re2c/highlights.scm
@@ -46,18 +46,17 @@
 ;; ========
 [
   "re2c"
-  "!re2c"
-  "!local"
-  "!rules"
+  "local"
+  "rules"
 ] @namespace
 
 [
-  "!max"
-  "!maxnmatch"
-  "!mtags"
-  "!stags"
-  "!getstate"
-  "!header"
+  "max"
+  "maxnmatch"
+  "mtags"
+  "stags"
+  "getstate"
+; "header"
 ] @keyword
 
 [

--- a/queries/re2c/indents.scm
+++ b/queries/re2c/indents.scm
@@ -1,0 +1,6 @@
+(re2c) @indent
+
+[
+ (comment)
+ (linedir)
+] @ignore

--- a/queries/re2c/injections.scm
+++ b/queries/re2c/injections.scm
@@ -1,0 +1,1 @@
+(code_block) @c @combined

--- a/queries/re2c/injections.scm
+++ b/queries/re2c/injections.scm
@@ -1,1 +1,3 @@
-(code_block) @c @combined
+(re2c
+  (host_lang) @_c
+  (#match? @_c "^[ \t]*#include")) @c

--- a/queries/re2c/locals.scm
+++ b/queries/re2c/locals.scm
@@ -1,0 +1,1 @@
+(body) @scope


### PR DESCRIPTION
The re2c is a lexer generator. It is a language that only exists inside comment blocks.

The language can be injected into C (and other languages that support C syntax), Go and Rust.

Examples:
* [re2c/examples/c/*.re](https://github.com/skvadrik/re2c/tree/master/examples/c)
* [ninja/src/*.in.cc](https://github.com/ninja-build/ninja/blob/master/src/)

The official repo uses `.re` extensions (not only for `.c`, but for other filetypes as well). Use `set ft=c` to highlight. 

I have some issues.
1. The re2c should inject the `filetype` it is being injected on. For example, when re2c is being injected in a c file, the `(code_block)` should be injected with `@c`. If the file is .go, it should inject `@go`. And so on.
2. I also have issues writing the indentation when there is a injected block. Try to indent try to indent [depfile_parser.in.cc](https://github.com/ninja-build/ninja/blob/master/src/depfile_parser.in.cc)) to see what happens.
3. I couldn't get folding to work. I'd like to know if is possible to fold sequence of the same blocks. Something like `(configuration)+ @fold`.

How I can fix those issues?

Because the first issue, I only wrote injections for c and cpp so you could see the issues I'm having with the examples above.

---

Some other notes.

The re2c parser expects the input not to include `/*` and `*/`. So, if using `set ft=re2c` start with the exclamation point. They were not included in the grammar saves some kb and improves the error recovery. 

re2c uses the same comment syntax from C. Comments inside `(code_block) are parsed as re2c comments (easier to write the rule that seeks the matching closing brace -- that works really well, btw).

The `(ignore_block)` has a greedy regex. The official lexer matches `[^\0]`. My version don't match the '*/' to make sure it is not going over the C file (even thought this is probably not an issue).

