### PR TITLE
Remove Python docstring injections

### DIFF
--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -5,22 +5,4 @@
  (#eq? @_re "re")
  (#lua-match? @regex "^r.*"))
 
-; Module docstring
-((module . (expression_statement (string) @rst))
- (#offset! @rst 0 3 0 -3))
-
-; Class docstring
-((class_definition
-  body: (block . (expression_statement (string) @rst)))
- (#offset! @rst 0 3 0 -3))
-
-; Function/method docstring
-((function_definition
-  body: (block . (expression_statement (string) @rst)))
- (#offset! @rst 0 3 0 -3))
-
-; Attribute docstring
-(((expression_statement (assignment)) . (expression_statement (string) @rst))
- (#offset! @rst 0 3 0 -3))
-
 (comment) @comment


### PR DESCRIPTION
These injections lead to inconsistent highlighting since some edge cases aren't handled (as mentioned in the [PR description that introduced the injections][0]). Besides, not all Python projects use reStructuredText syntax in docstrings.

If someone still wants to use them, they can extend the base injection queries through [`after/queries/`][1] or enable them with `vim.treesitter.set_query`.

See also: https://github.com/nvim-treesitter/nvim-treesitter/pull/1204

[0]: https://github.com/nvim-treesitter/nvim-treesitter/pull/917
[1]: https://github.com/nvim-treesitter/nvim-treesitter/tree/ad69e2528ac382b7cbf28f1ac7ee450981734ab0#adding-queries