### PR TITLE
fix: SuperCollider. Remove pi_statement from highlight to sync up with upstream change

### DIFF
--- a/queries/supercollider/highlights.scm
+++ b/queries/supercollider/highlights.scm
@@ -6,7 +6,7 @@
 (block_comment) @comment
 
 ; Argument definition
-(argument name: (identifier) @parameter) 
+(argument name: (identifier) @parameter)
 
 ; Variables
 (local_var name: (identifier) @variable)
@@ -20,11 +20,11 @@
   name: (variable) @function)
 
 ; For function calls
-(named_argument 
-  name: (identifier) @property) 
+(named_argument
+  name: (identifier) @property)
 
 ; Methods
-(method_call 
+(method_call
         name: (method_name) @method)
 
 ; Classes
@@ -32,7 +32,6 @@
 
 ; Literals
 (number) @number
-(pi_statement) @constant.builtin
 (float) @float
 
 (string) @string
@@ -60,7 +59,6 @@
 "%"
 "="
 ] @operator
-
 
 ; Keywords
 [


### PR DESCRIPTION
This removes the pi_statement from the highlights query to reflect the same change upstream in the grammar. And some whitespace was removed.