### PR TITLE
improve markdown highlighting

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -13,14 +13,14 @@
   (setext_h2_underline)
 ] @punctuation.special
 
-(code_fence_content) @none
+
+(code_span) @text.literal
 
 [
   (indented_code_block)
-  (fenced_code_block)
-  (code_span)
-] @text.literal
-
+  (fenced_code_block) 
+] @punctuation.delimiter
+(code_fence_content) @none
 
 (emphasis) @text.emphasis
 
@@ -44,3 +44,11 @@
   (backslash_escape)
   (hard_line_break)
 ] @string.escape
+
+
+(inline_link "[" @punctuation.delimiter)
+(inline_link "]" @punctuation.delimiter)
+(inline_link "(" @punctuation.delimiter)
+(inline_link ")" @punctuation.delimiter)
+(shortcut_link "[" @punctuation.delimiter)
+(shortcut_link "]" @punctuation.delimiter)

--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -4,3 +4,5 @@
 
 ((html_block) @html)
 ((html_tag) @html)
+
+((thematic_break) (_) @yaml @combined (thematic_break))


### PR DESCRIPTION
This PR improves the markdown highlighting by assigning TSPunctDelimiter group to the brackets used in links and fenced blocks. It also add support for yaml frontmatter