### PR TITLE
highlights(pascal): Highlight variables

### DIFF
--- a/queries/pascal/highlights.scm
+++ b/queries/pascal/highlights.scm
@@ -228,6 +228,11 @@
 (literalNumber)   @number
 (literalString)   @string
 
+; -- Identifiers
+
+; Unless a more specific rule applies, treat identifiers as variables
+(identifier) @variable
+
 ; -- Comments
 (comment)         @comment
 (pp)              @function.macro
@@ -277,7 +282,7 @@
 
 ; -- Type usage
 
-(typeref) @type
+(typeref (_) @type)
 
 ; -- Constant usage
 


### PR DESCRIPTION
Assume that any identifiers that aren't function calls, types, fields or constants are variables. This is consistent with the highlighting definitions for other languages (tested with C and Python). Some themes (e.g. zenbones) make use of this information and they don't look quite right unless we set those groups.

Before:
![image](https://user-images.githubusercontent.com/2358109/147698770-b192ed96-b206-49fd-985e-f937fbe5bfde.png)

After:
![image](https://user-images.githubusercontent.com/2358109/147698806-9f71b138-1728-4c43-89ea-4da92278f86a.png)
