### PR TITLE
Adds extra args to utils.setup_commands to add custom func args

### DIFF
--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -17,7 +17,7 @@ end
 ---
 ---@param mod string, Name of the module that resides in the heirarchy - nvim-treesitter.module
 ---@param commands table, Command list for the module
----         _ {command_name} Name of the vim user defined command, Keys:
+---         - {command_name} Name of the vim user defined command, Keys:
 ---             - {run}: (function) callback function that needs to be executed
 ---             - {f_args}: (string, default <f-args>)
 ---                 - type of arguments that needs to be passed to the vim command

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -10,6 +10,41 @@ function M.notify(msg, log_level, opts)
   vim.notify(msg, log_level, vim.tbl_extend("force", default_opts, opts or {}))
 end
 
+--- Define user defined vim command which calls nvim-treesitter module function
+---     - If module name is 'mod', it should be defined in hierarchy 'nvim-treesitter.mod'
+---     - A table with name 'commands' should be defined in 'mod' which needs to be passed as
+---       the commands param of this function
+---
+---@param mod string, Name of the module that resides in the heirarchy - nvim-treesitter.module
+---@param commands table, Command list for the module
+---         _ {command_name} Name of the vim user defined command, Keys:
+---             - {run}: (function) callback function that needs to be executed
+---             - {f_args}: (string, default <f-args>)
+---                 - type of arguments that needs to be passed to the vim command
+---             - {args}: (string, optional)
+---                 - vim command attributes
+---
+---Example:
+---  If module is nvim-treesitter.custom_mod
+---  <pre>
+---  M.commands = {
+---      custom_command = {
+---          run = M.module_function,
+---          f_args = "<f-args>",
+---          args = {
+---              "-range"
+---          }
+---      }
+---  }
+---
+---  utils.setup_commands("custom_mod", require("nvim-treesitter.custom_mod").commands)
+---  </pre>
+---
+---  Will generate command :
+---  <pre>
+---  command! -range custom_command \
+---      lua require'nvim-treesitter.custom_mod'.commands.custom_command['run<bang>'](<f-args>)
+---  </pre>
 function M.setup_commands(mod, commands)
   for command_name, def in pairs(commands) do
     local f_args = def.f_args or "<f-args>"

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -12,10 +12,12 @@ end
 
 function M.setup_commands(mod, commands)
   for command_name, def in pairs(commands) do
+    local f_args = def.f_args or '<f-args>'
     local call_fn = string.format(
-      "lua require'nvim-treesitter.%s'.commands.%s['run<bang>'](<f-args>)",
+      "lua require'nvim-treesitter.%s'.commands.%s['run<bang>'](%s)",
       mod,
-      command_name
+      command_name,
+      f_args
     )
     local parts = vim.tbl_flatten {
       "command!",

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -12,7 +12,7 @@ end
 
 function M.setup_commands(mod, commands)
   for command_name, def in pairs(commands) do
-    local f_args = def.f_args or '<f-args>'
+    local f_args = def.f_args or "<f-args>"
     local call_fn = string.format(
       "lua require'nvim-treesitter.%s'.commands.%s['run<bang>'](%s)",
       mod,


### PR DESCRIPTION
As a user of the nvim-treesitter I wanted to add a command through `nvim-treesitter.utils.setup_commands` that receives the ranges like below

```
command! -range MyFun :lua require'..'.myFun(<line1>, <line2>)
```

Current implementation limits the `myFun` arguments to be only `<f-args>`.

This PR adds an extra argument to `nvim-treesitter.utils.setup_commands` - `f_args`, so that the user can add their own required argument types to their functions