### PR TITLE
highlights(Pascal): Fix highlighting of types

### DIFF
--- a/queries/pascal/highlights.scm
+++ b/queries/pascal/highlights.scm
@@ -228,12 +228,20 @@
 (literalNumber)   @number
 (literalString)   @string
 
-; -- Identifiers
+; -- Variables
 
-; Unless a more specific rule applies, treat identifiers as variables
-(identifier) @variable
+(exprBinary (identifier) @variable)
+(exprUnary (identifier) @variable)
+(assignment (identifier) @variable)
+(exprBrackets (identifier) @variable)
+(exprParens (identifier) @variable)
+(exprDot (identifier) @variable)
+(exprTpl (identifier) @variable)
+(exprArgs (identifier) @variable)
+(defaultValue (identifier) @variable)
 
 ; -- Comments
+
 (comment)         @comment
 (pp)              @function.macro
 
@@ -278,11 +286,12 @@
 (genericTpl entity: (genericDot (identifier) @type))
 
 ; -- Exception parameters
+
 (exceptionHandler variable: (identifier) @parameter)
 
 ; -- Type usage
 
-(typeref (_) @type)
+(typeref) @type
 
 ; -- Constant usage
 

--- a/tests/query/highlights/pascal/test.pas
+++ b/tests/query/highlights/pascal/test.pas
@@ -1,0 +1,39 @@
+program foobar;
+// ^ keyword
+
+var
+// <- keyword
+  foo: bar;
+// ^ variable
+//     ^ type
+  foo: foo.bar<t>;
+// ^ variable
+//     ^ type
+//         ^ type
+//             ^ type
+begin
+// ^ keyword
+  foo := bar;
+// ^ variable
+//       ^ variable
+  foo;
+// ^ function
+  foo();
+// ^ function
+  foo(bar(xyz));
+// ^ function
+//    ^ function
+//        ^ variable
+  xx + yy;
+// ^ variable
+//     ^ variable
+  xx := y + z + func(a, b, c);
+// ^ variable
+//      ^ variable
+//          ^ variable
+//              ^ function
+//                   ^ variable
+//                      ^ variable
+//                         ^ variable
+end.
+// <- keyword


### PR DESCRIPTION
#2176 inadvertently broke highlighting of types consisting of more than one identifier (such as `Foo.Bar` or `TFoo<T>`). I fixed it in this PR. I also added a test so it doesn't happen again.