### PR TITLE
Update tree-sitter-haskell

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -427,7 +427,7 @@ list.supercollider = {
 list.haskell = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-haskell",
-    files = { "src/parser.c", "src/scanner.cc" },
+    files = { "src/parser.c", "src/scanner.c" },
   },
 }
 


### PR DESCRIPTION
tree-sitter-haskell has recently moved to a new  c based scanner, making installs using `:TSinstall` fail.