### PR TITLE
Change Kotlin parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [json5](https://github.com/Joakker/tree-sitter-json5) (maintained by @Joakker)
 - [x] [JSON with comments](https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git) (maintained by @WhyNotHugo)
 - [x] [julia](https://github.com/tree-sitter/tree-sitter-julia) (maintained by @mroavi, @theHamsta)
-- [x] [kotlin](https://github.com/Joakker/tree-sitter-kotlin) (maintained by @Joakker)
+- [x] [kotlin](https://github.com/fwcd/tree-sitter-kotlin) (maintained by @fwcd)
 - [x] [latex](https://github.com/latex-lsp/tree-sitter-latex) (maintained by @theHamsta by asking @clason)
 - [x] [ledger](https://github.com/cbarrete/tree-sitter-ledger) (maintained by @cbarrete)
 - [x] [llvm](https://github.com/benwilliamgraham/tree-sitter-llvm) (maintained by @benwilliamgraham)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [json5](https://github.com/Joakker/tree-sitter-json5) (maintained by @Joakker)
 - [x] [JSON with comments](https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git) (maintained by @WhyNotHugo)
 - [x] [julia](https://github.com/tree-sitter/tree-sitter-julia) (maintained by @mroavi, @theHamsta)
-- [x] [kotlin](https://github.com/fwcd/tree-sitter-kotlin) (maintained by @fwcd)
+- [x] [kotlin](https://github.com/fwcd/tree-sitter-kotlin) (maintained by @SalBakraa)
 - [x] [latex](https://github.com/latex-lsp/tree-sitter-latex) (maintained by @theHamsta by asking @clason)
 - [x] [ledger](https://github.com/cbarrete/tree-sitter-ledger) (maintained by @cbarrete)
 - [x] [llvm](https://github.com/benwilliamgraham/tree-sitter-llvm) (maintained by @benwilliamgraham)

--- a/lockfile.json
+++ b/lockfile.json
@@ -135,7 +135,7 @@
     "revision": "12ea597262125fc22fd2e91aa953ac69b19c26ca"
   },
   "kotlin": {
-    "revision": "ef3e43522c29a1abbc75313e26a82705eebeef13"
+    "revision": "a4f71eb9b8c9b19ded3e0e9470be4b1b77c2b569"
   },
   "latex": {
     "revision": "2c0d03a36ee979bc697f6a9dd119174cf0ef15e0"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -258,7 +258,7 @@ list.kotlin = {
     branch = "main",
     files = { "src/parser.c", "src/scanner.c" },
   },
-  maintainers = { "@fwcd" },
+  maintainers = { "@SalBakraa" },
 }
 
 list.html = {

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -254,10 +254,11 @@ list.java = {
 
 list.kotlin = {
   install_info = {
-    url = "https://github.com/Joakker/tree-sitter-kotlin",
-    files = { "src/parser.c" },
+    url = "https://github.com/fwcd/tree-sitter-kotlin",
+    branch = "main",
+    files = { "src/parser.c", "src/scanner.c" },
   },
-  maintainers = { "@Joakker" },
+  maintainers = { "@fwcd" },
 }
 
 list.html = {

--- a/queries/kotlin/folds.scm
+++ b/queries/kotlin/folds.scm
@@ -1,0 +1,17 @@
+[
+	(import_list)
+
+	(when_structure_body)
+	(control_structure_body)
+
+	(lambda_literal)
+	(function_body)
+	(primary_constructor)
+	(secondary_constructor)
+	(anonymous_initializer)
+
+	(class_body)
+	(enum_class_body)
+
+	(interpolated_expression)
+] @fold

--- a/queries/kotlin/folds.scm
+++ b/queries/kotlin/folds.scm
@@ -1,7 +1,7 @@
 [
 	(import_list)
 
-	(when_structure_body)
+	(when_expression)
 	(control_structure_body)
 
 	(lambda_literal)

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -1,195 +1,409 @@
+;;; Identifiers
+
+(simple_identifier) @variable
+
+; `it` keyword inside lambdas
+; FIXME: This will highlight the keyword outside of lambdas since tree-sitter
+;        does not allow us to check for arbitrary nestation
+((simple_identifier) @variable.builtin
+(#eq? @variable.builtin "it"))
+
+; `field` keyword inside property getter/setter
+; FIXME: This will highlight the keyword outside of getters and setters
+;        since tree-sitter does not allow us to check for arbitrary nestation
+((simple_identifier) @variable.builtin
+(#eq? @variable.builtin "field"))
+
+; `this` this keyword inside classes
+(this_expression) @variable.builtin
+
+; `super` keyword inside classes
+(super_expression) @variable.builtin
+
+(class_parameter
+	(simple_identifier) @property)
+
+(class_body
+	(property_declaration
+		(variable_declaration
+			(simple_identifier) @property)))
+
+; id_1.id_2.id_3: `id_2` and `id_3` are assumed as object properties
+(_
+	(navigation_suffix
+		(simple_identifier) @property))
+
+; SCREAMING CASE identifiers are assumed to be constants
+((simple_identifier) @constant
+(#lua-match? @constant "^[A-Z][A-Z0-9_]*$"))
+
+(_
+	(navigation_suffix
+		(simple_identifier) @constant
+		(#lua-match? @constant "^[A-Z][A-Z0-9_]*$")))
+
+(enum_entry
+	(simple_identifier) @constant)
+
+(type_identifier) @type
+
+((type_identifier) @type.builtin
+	(#any-of? @type.builtin
+		"Byte"
+		"Short"
+		"Int"
+		"Long"
+		"UByte"
+		"UShort"
+		"UInt"
+		"ULong"
+		"Float"
+		"Double"
+		"Boolean"
+		"Char"
+		"String"
+		"Array"
+		"ByteArray"
+		"ShortArray"
+		"IntArray"
+		"LongArray"
+		"UByteArray"
+		"UShortArray"
+		"UIntArray"
+		"ULongArray"
+		"FloatArray"
+		"DoubleArray"
+		"BooleanArray"
+		"CharArray"
+		"Map"
+		"Set"
+		"List"
+		"EmptyMap"
+		"EmptySet"
+		"EmptyList"
+		"MutableMap"
+		"MutableSet"
+		"MutableList"
+))
+
+(package_header
+	. (identifier)) @namespace
+
+(import_header
+	"import" @include)
+
+; The last `simple_identifier` in a `import_header` will always either be a function
+; or a type. Classes can appear anywhere in the import path, unlike functions
+(import_header
+	(identifier
+		(simple_identifier) @type @import)
+	(import_alias
+		(type_identifier) @type)?
+		(#lua-match? @import "^[A-Z]"))
+
+(import_header
+	(identifier
+		(simple_identifier) @function @import .)
+	(import_alias
+		(type_identifier) @function)?
+		(#lua-match? @import "^[a-z]"))
+
+; TODO: Seperate labeled returns/breaks/continue/super/this
+;       Must be implemented in the parser first
+(label) @label
+
+;;; Function definitions
+
+(function_declaration
+	. (simple_identifier) @function)
+
+(getter
+	("get") @function.builtin)
+(setter
+	("set") @function.builtin)
+
+(primary_constructor) @constructor
+(secondary_constructor
+	("constructor") @constructor)
+
+(constructor_invocation
+	(user_type
+		(type_identifier) @constructor))
+
+(anonymous_initializer
+	("init") @constructor)
+
+(parameter
+	(simple_identifier) @parameter)
+
+(parameter_with_optional_type
+	(simple_identifier) @parameter)
+
+; lambda parameters
+(lambda_literal
+	(lambda_parameters
+		(variable_declaration
+			(simple_identifier) @parameter)))
+
+;;; Function calls
+
+; function()
+(call_expression
+	. (simple_identifier) @function)
+
+; object.function() or object.property.function()
+(call_expression
+	(navigation_expression
+		(navigation_suffix
+			(simple_identifier) @function) . ))
+
+(call_expression
+	. (simple_identifier) @function.builtin
+    (#any-of? @function.builtin
+		"arrayOf"
+		"arrayOfNulls"
+		"byteArrayOf"
+		"shortArrayOf"
+		"intArrayOf"
+		"longArrayOf"
+		"ubyteArrayOf"
+		"ushortArrayOf"
+		"uintArrayOf"
+		"ulongArrayOf"
+		"floatArrayOf"
+		"doubleArrayOf"
+		"booleanArrayOf"
+		"charArrayOf"
+		"emptyArray"
+		"mapOf"
+		"setOf"
+		"listOf"
+		"emptyMap"
+		"emptySet"
+		"emptyList"
+		"mutableMapOf"
+		"mutableSetOf"
+		"mutableListOf"
+		"print"
+		"println"
+		"error"
+		"TODO"
+		"run"
+		"runCatching"
+		"repeat"
+		"lazy"
+		"lazyOf"
+		"enumValues"
+		"enumValueOf"
+		"assert"
+		"check"
+		"checkNotNull"
+		"require"
+		"requireNotNull"
+		"with"
+		"suspend"
+		"synchronized"
+))
+
+;;; Literals
+
 [
-    (comment)
-    (shebang)
+	(comment)
+	(shebang_line)
 ] @comment
 
+(real_literal) @float
 [
-    ":"
-    ","
-    "."
-] @punctuation.delimiter
+	(integer_literal)
+	(long_literal)
+	(hex_literal)
+	(bin_literal)
+	(unsigned_literal)
+] @number
 
 [
-    "("
-    ")"
-    "{"
-    "}"
-] @punctuation.bracket
+	"null" ; should be highlighted the same as booleans
+	(boolean_literal)
+] @boolean
+
+(character_literal) @character
 
 [
-    "class"
-    "object"
-    "fun"
-    "var"
-    "val"
-    "try"
-    "catch"
-    "finally"
+	(line_string_literal)
+	(multi_line_string_literal)
+] @string
+
+; NOTE: Escapes not allowed in multi-line strings
+(line_string_literal (character_escape_seq) @string.escape)
+
+; There are 3 ways to define a regex
+;    - "[abc]?".toRegex()
+(call_expression
+	(navigation_expression
+		([(line_string_literal) (multi_line_string_literal)] @string.regex)
+		(navigation_suffix
+			((simple_identifier) @_function
+			(#eq? @_function "toRegex")))))
+
+;    - Regex("[abc]?")
+(call_expression
+	((simple_identifier) @_function
+	(#eq? @_function "Regex"))
+	(call_suffix
+		(value_arguments
+			(value_argument
+				[ (line_string_literal) (multi_line_string_literal) ] @string.regex))))
+
+;    - Regex.fromLiteral("[abc]?")
+(call_expression
+	(navigation_expression
+		((simple_identifier) @_class
+		(#eq? @_class "Regex"))
+		(navigation_suffix
+			((simple_identifier) @_function
+			(#eq? @_function "fromLiteral"))))
+	(call_suffix
+		(value_arguments
+			(value_argument
+				[ (line_string_literal) (multi_line_string_literal) ] @string.regex))))
+
+;;; Keywords
+
+(type_alias "typealias" @keyword)
+[
+	(class_modifier)
+	(member_modifier)
+	(function_modifier)
+	(property_modifier)
+	(platform_modifier)
+	(variance_modifier)
+	(parameter_modifier)
+	(visibility_modifier)
+	(reification_modifier)
+	(inheritance_modifier)
+]@keyword
+
+[
+	"val"
+	"var"
+	"enum"
+	"class"
+	"object"
+	"interface"
+;	"typeof" ; NOTE: It is reserved for future use
 ] @keyword
 
-"import" @include
+("fun") @keyword.function
 
-"return" @keyword.return
-
-(package_stmt
-    "package" @include)
-(package_path
-    (identifier) @namespace)
-
-(return_expr
-    "return@" @keyword.return
-    label: (identifier) @label)
-(break_expr
-    "break@" @keyword
-    label: (identifier) @label)
-
-(label
-    name: (identifier) @label) @constant
+(jump_expression) @keyword.return
 
 [
-    "for"
-    "do"
-    "while"
+	"if"
+	"else"
+	"when"
+] @conditional
+
+[
+	"for"
+	"do"
+	"while"
 ] @repeat
 
 [
-    "||"
-    "&&"
-    "!="
-    "!=="
-    "=="
-    "==="
-    "<"
-    ">"
-    "<="
-    ">="
-    ".."
-    "+"
-    "-"
-    "%"
-    "*"
-    "/"
+	"try"
+	"catch"
+	"throw"
+	"finally"
+] @exception
+
+
+(annotation
+	"@" @annotation (use_site_target)? @annotation)
+(annotation
+	(user_type
+		(type_identifier) @annotation))
+(annotation
+	(constructor_invocation
+		(user_type
+			(type_identifier) @annotation)))
+
+(file_annotation
+	"@" @annotation "file" @annotation ":" @annotation)
+(file_annotation
+	(user_type
+		(type_identifier) @annotation))
+(file_annotation
+	(constructor_invocation
+		(user_type
+			(type_identifier) @annotation)))
+
+;;; Operators & Punctuation
+
+[
+	"!"
+	"!="
+	"!=="
+	"="
+	"=="
+	"==="
+	">"
+	">="
+	"<"
+	"<="
+	"||"
+	"&&"
+	"+"
+	"++"
+	"+="
+	"-"
+	"--"
+	"-="
+	"*"
+	"*="
+	"/"
+	"/="
+	"%"
+	"%="
+	"?."
+	"?:"
+	"!!"
+	"is"
+	"!is"
+	"in"
+	"!in"
+	"as"
+	"as?"
+	".."
+	"->"
 ] @operator
 
 [
-    "as"
-    "as?"
-    "in"
-] @keyword.operator
-
-(class_decl
-    name: (identifier) @type)
-(class_decl
-    super: (_) @type)
-(object_decl
-    name: (identifier) @type)
-
-(class_param
-    name: (identifier) @parameter
-    type: (_) @type)
-
-(type_constraints
-    "where" @keyword
-    (type_constraint
-        type:  (identifier) @type
-        super: (_) @type))
-
-(property
-    name: (identifier) @property)
-(property
-    type: (_) @type)
-
-(enum_entry
-    name: (identifier) @constant)
-
-(func_decl
-    name: (identifier) @function)
-(func_decl
-    return: (_) @type)
-
-(param_decl
-    name: (identifier) @parameter
-    type: (_) @type)
-
-(type_param
-    name: (identifier) @type)
-
-(call
-    function: (identifier) @function)
-(call
-    function: (selector
-        field: (identifier) @function))
-
-(getter
-    "get" @function.builtin)
-(setter
-    "set" @function.builtin)
-
-((identifier) @function.builtin
-    (#any-of? @function.builtin
-        "arrayOf"
-        "arrayOfNulls"
-        "assert"
-        "booleanArrayOf"
-        "byteArrayOf"
-        "Char"
-        "charArrayOf"
-        "check"
-        "checkNotNull"
-        "doubleArrayOf"
-        "emptyArray"
-        "enumValueOf"
-        "enumValues"
-        "error"
-        "floatArrayOf"
-        "intArrayOf"
-        "lazy"
-        "lazyOf"
-        "longArrayOf"
-        "repeat"
-        "require"
-        "requireNotNull"
-        "run"
-        "runCatching"
-        "shortArrayOf"
-        "suspend"
-        "synchronized"
-        "TODO"
-        "ubyteArrayOf"
-        "UintArray"
-        "uintArrayOf"
-        "ULongArray"
-        "ulongArrayOf"
-        "UShortArray"
-        "ushortArrayOf"
-        "with"
-        "print"
-        "println"
-        "readLine"))
-((identifier) @constant.builtin
-    (#eq? @constant.builtin "it"))
-
-(lambda
-    args: (var_decl
-        name: (identifier) @parameter))
-(lambda
-    args: (var_decl
-        type: (_) @type ))
-
-(binary_expr
-    operator: (identifier) @keyword.operator)
-
-(ERROR) @error
-
-(integer) @number
-(float) @float
-
-(string) @string
-
-"null" @constant
+	"(" ")"
+	"[" "]"
+	"{" "}"
+] @punctuation.bracket
 
 [
-    "true"
-    "false"
-] @boolean
+	"."
+	","
+	";"
+	":"
+	"::"
+] @punctuation.delimiter
 
+; NOTE: `interpolated_identifier`s can be highlighted in any way
+(line_string_literal
+	"$" @punctuation.special
+	(interpolated_identifier) @none)
+(line_string_literal
+	"${" @punctuation.special
+	(interpolated_expression) @none
+	"}" @punctuation.special)
+
+(multi_line_string_literal
+    "$" @punctuation.special
+    (interpolated_identifier) @none)
+(multi_line_string_literal
+	"${" @punctuation.special
+	(interpolated_expression) @none
+	"}" @punctuation.special)

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -318,24 +318,24 @@
 
 
 (annotation
-	"@" @annotation (use_site_target)? @annotation)
+	"@" @attribute (use_site_target)? @attribute)
 (annotation
 	(user_type
-		(type_identifier) @annotation))
+		(type_identifier) @attribute))
 (annotation
 	(constructor_invocation
 		(user_type
-			(type_identifier) @annotation)))
+			(type_identifier) @attribute)))
 
 (file_annotation
-	"@" @annotation "file" @annotation ":" @annotation)
+	"@" @attribute "file" @attribute ":" @attribute)
 (file_annotation
 	(user_type
-		(type_identifier) @annotation))
+		(type_identifier) @attribute))
 (file_annotation
 	(constructor_invocation
 		(user_type
-			(type_identifier) @annotation)))
+			(type_identifier) @attribute)))
 
 ;;; Operators & Punctuation
 

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -96,17 +96,17 @@
 ; or a type. Classes can appear anywhere in the import path, unlike functions
 (import_header
 	(identifier
-		(simple_identifier) @type @import)
+		(simple_identifier) @type @_import)
 	(import_alias
 		(type_identifier) @type)?
-		(#lua-match? @import "^[A-Z]"))
+		(#lua-match? @_import "^[A-Z]"))
 
 (import_header
 	(identifier
-		(simple_identifier) @function @import .)
+		(simple_identifier) @function @_import .)
 	(import_alias
 		(type_identifier) @function)?
-		(#lua-match? @import "^[a-z]"))
+		(#lua-match? @_import "^[a-z]"))
 
 ; TODO: Seperate labeled returns/breaks/continue/super/this
 ;       Must be implemented in the parser first

--- a/queries/kotlin/injections.scm
+++ b/queries/kotlin/injections.scm
@@ -1,1 +1,32 @@
 (comment) @comment
+
+; There are 3 ways to define a regex
+;    - "[abc]?".toRegex()
+(call_expression
+	(navigation_expression
+		([(line_string_literal) (multi_line_string_literal)] @regex)
+		(navigation_suffix
+			((simple_identifier) @_function
+			(#eq? @_function "toRegex")))))
+
+;    - Regex("[abc]?")
+(call_expression
+	((simple_identifier) @_function
+	(#eq? @_function "Regex"))
+	(call_suffix
+		(value_arguments
+			(value_argument
+				[ (line_string_literal) (multi_line_string_literal) ] @regex))))
+
+;    - Regex.fromLiteral("[abc]?")
+(call_expression
+	(navigation_expression
+		((simple_identifier) @_class
+		(#eq? @_class "Regex"))
+		(navigation_suffix
+			((simple_identifier) @_function
+			(#eq? @_function "fromLiteral"))))
+	(call_suffix
+		(value_arguments
+			(value_argument
+				[ (line_string_literal) (multi_line_string_literal) ] @regex))))

--- a/queries/kotlin/locals.scm
+++ b/queries/kotlin/locals.scm
@@ -1,0 +1,83 @@
+;;; Imports
+
+(package_header
+	. (identifier) @definiton.namespace)
+
+(import_header
+	(identifier
+		(simple_identifier) @definition.import .)
+	(import_alias
+		(type_identifier) @definition.import)?)
+
+;;; Functions
+
+(function_declaration
+	. (simple_identifier) @definition.function
+	(#set! "definition.function.scope" "parent"))
+
+(class_body
+	(function_declaration
+		. (simple_identifier) @definition.method)
+	(#set! "definition.method.scope" "parent"))
+
+;;; Variables
+
+(function_declaration
+	(parameter
+		(simple_identifier) @definition.parameter))
+
+(lambda_literal
+	(lambda_parameters
+		(variable_declaration
+			(simple_identifier) @definition.parameter)))
+
+(class_body
+	(property_declaration
+		(variable_declaration
+			(simple_identifier) @definition.field)))
+
+(class_declaration
+	(primary_constructor
+		(class_parameter
+			(simple_identifier) @definition.field)))
+
+(enum_class_body
+	(enum_entry
+		(simple_identifier) @definition.field))
+
+(variable_declaration
+	(simple_identifier) @definition.var)
+
+;;; Types
+
+(class_declaration
+	(type_identifier) @definition.type
+	(#set! "definition.type.scope" "parent"))
+
+(type_alias
+	(type_identifier) @definition.type
+	(#set! "definition.type.scope" "parent"))
+
+;;; Scopes
+
+[
+	(if_expression)
+	(when_expression)
+	(when_entry)
+
+	(for_statement)
+	(while_statement)
+	(do_while_statement)
+
+	(lambda_literal)
+	(function_declaration)
+	(primary_constructor)
+	(secondary_constructor)
+	(anonymous_initializer)
+
+	(class_declaration)
+	(enum_class_body)
+	(enum_entry)
+
+	(interpolated_expression)
+] @scope

--- a/queries/kotlin/locals.scm
+++ b/queries/kotlin/locals.scm
@@ -1,7 +1,7 @@
 ;;; Imports
 
 (package_header
-	. (identifier) @definiton.namespace)
+	. (identifier) @definition.namespace)
 
 (import_header
 	(identifier


### PR DESCRIPTION
Change the Kotlin parser used by nvim-treesitter from [Joakker/tree-sitter-kotlin](https://github.com/Joakker/tree-sitter-kotlin) to [fwcd/tree-sitter-kotlin](https://github.com/fwcd/tree-sitter-kotlin), since the latter parser appears to be more comprehensive and still in-development. Furthermore,  the parser lacked a locals and folds query so these have been added.

Comparison between the two parsers:

![comparison](https://user-images.githubusercontent.com/81700377/148304243-7ec9c8ad-9f44-4b4d-8c13-7a0f166ddcfe.png)

