### PR TITLE
fix(ci): make highlight test working with markdown

### DIFF
--- a/tests/query/highlights/markdown/test.md
+++ b/tests/query/highlights/markdown/test.md
@@ -1,41 +1,28 @@
 # H1
-
-<!--
-^ TSPunctSpecial
--->
+<!-- <- TSPunctSpecial -->
 
 ## H2
-
-<!--
-^ TSPunctSpecial
--->
+<!-- <- TSPunctSpecial -->
 
 - Item 1
 - Item 2
-
-<!--
-^ TSPunctSpecial
--->
+<!-- <- TSPunctSpecial -->
 
 1. Item 1
 2. Item 2
+<!-- <- TSPunctSpecial -->
 
-<!--
- ^ TSPunctSpecial
--->
-
-![image_description](https://example.com/image.jpg "awesome image title")
-
-<!--
-    ^ TSTextReference           ^ TSURI                     ^ TSLiteral
- ^ TSPunctDelimiter                                                     ^ TSPunctDelimiter
-^ TSPunctSpecial
--->
+----![image_description](https://example.com/image.jpg "awesome image title")
+<!--  ^ TSTextReference                                                   -->
+<!--                              ^ TSURI                                 -->
+<!--                                                          ^ TSLiteral -->
+<!--^ TSPunctDelimiter                                                    -->
+<!-- ^ TSPunctDelimiter                                                   -->
+<!--                                                                        ^ TSPunctDelimiter -->
 
 [link_text](#local_reference "link go brr...")
-
-<!--
-                ^ TSURI
-    ^ TSTextReference           ^ TSLiteral
-^ TSPunctDelimiter                           ^ TSPunctDelimiter
--->
+<!-- ^ TSTextReference                                                    --> 
+<!--                 ^ TSURI                                              -->
+<!--                            ^ TSLiteral                               -->
+<!-- <- TSPunctDelimiter                                                  -->
+<!--                                         ^ TSPunctDelimiter           -->

--- a/tests/query/highlights_spec.lua
+++ b/tests/query/highlights_spec.lua
@@ -4,6 +4,10 @@ local utils = require "nvim-treesitter.utils"
 local ts_utils = require "nvim-treesitter.ts_utils"
 local parsers = require "nvim-treesitter.parsers"
 
+local COMMENT_NODES = {
+  markdown = "html_block",
+}
+
 local function check_assertions(file)
   local buf = vim.fn.bufadd(file)
   vim.fn.bufload(file)
@@ -14,15 +18,25 @@ local function check_assertions(file)
     '"highlight-assertions" not executable!'
       .. ' Get it via "cargo install --git https://github.com/theHamsta/highlight-assertions"'
   )
+  local comment_node = COMMENT_NODES[lang] or "comment"
   local assertions = vim.fn.json_decode(
     vim.fn.system(
-      "highlight-assertions -p '" .. utils.get_parser_install_dir() .. "/" .. lang .. ".so'" .. " -s '" .. file .. "'"
+      "highlight-assertions -p '"
+        .. utils.get_parser_install_dir()
+        .. "/"
+        .. lang
+        .. ".so'"
+        .. " -s '"
+        .. file
+        .. "' -c "
+        .. comment_node
     )
   )
   local parser = parsers.get_parser(buf, lang)
 
   local self = highlighter.new(parser, {})
 
+  assert.True(#assertions > 0, "No assertions detected!")
   for _, assertion in ipairs(assertions) do
     local row = assertion.position.row
     local col = assertion.position.column


### PR DESCRIPTION
Make tests with markdown (no actual comment nodes) working after merging #2209. Not a nice solution, though.