### PR TITLE
Add support for Rust's `"yield"`

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -191,7 +191,10 @@
 ] @keyword
 
 "fn" @keyword.function
-"return" @keyword.return
+[
+  "return"
+  "yield"
+] @keyword.return
 
 (type_cast_expression "as" @keyword.operator)
 


### PR DESCRIPTION
~~Port the lastest update parser PR (without llvm).~~

An interesting feature in this change-set is that Rust adds the keyword `yield` (https://github.com/tree-sitter/tree-sitter-rust/pull/110)