### PR TITLE
Fix get_node_text

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -21,7 +21,10 @@ function M.get_node_text(node, bufnr)
   if start_row ~= end_row then
     local lines = api.nvim_buf_get_lines(bufnr, start_row, end_row + 1, false)
     lines[1] = string.sub(lines[1], start_col + 1)
-    lines[#lines] = string.sub(lines[#lines], 1, end_col)
+    -- end_row might be just after the last line. In this case the last line is not truncated.
+    if #lines == end_row - start_row then
+      lines[#lines] = string.sub(lines[#lines], 1, end_col)
+    end
     return lines
   else
     local line = api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1]


### PR DESCRIPTION
I noticed a small error with `get_ndoe_text` in `ts_utils.lua`. Whenever the range of the node is until the end of the file, the last line will be completely truncated.

This is because the last line returned by `nvim_buf_get_lines` is not actually the line with index `end_row` since the biggest line index is `end_row - 1`.