### PR TITLE
Improve Haskell highlighting

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -11,6 +11,7 @@
 
 (comment) @comment
 
+
 ;; ----------------------------------------------------------------------------
 ;; Punctuation
 
@@ -72,10 +73,7 @@
   "@"
 ] @operator
 
-(qualified_module (module) @constructor)
-(qualified_type (module) @namespace)
-(qualified_variable (module) @namespace)
-(import (module) @namespace)
+(module) @namespace
 
 [
   (where)
@@ -96,27 +94,34 @@
   "do"
   "mdo"
   "rec"
+  "infix"
+  "infixl"
+  "infixr"
 ] @keyword
 
 
 ;; ----------------------------------------------------------------------------
 ;; Functions and variables
 
-(signature name: (variable) @type)
-(function name: (variable) @function)
-
 (variable) @variable
-"_" @punctuation.special
+(pat_wildcard) @variable
+
+(signature name: (variable) @type)
+(function
+  name: (variable) @function
+  patterns: (patterns))
 
 (exp_infix (variable) @operator)  ; consider infix functions as operators
 
-("@" @namespace)  ; "as" pattern operator, e.g. x@Constructor
+(exp_apply . (exp_name (variable) @function))
+(exp_apply . (exp_name (qualified_variable (variable) @function)))
 
 
 ;; ----------------------------------------------------------------------------
 ;; Types
 
 (type) @type
+(type_variable) @type
 
 (constructor) @constructor
 


### PR DESCRIPTION
Improve highlighting for function declarations, function applications, type signatures, modules, and fixity keywords.


| Before                                                                                                         | After                                                                                                          |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/4299733/148631093-766d3e62-2910-49a5-af49-a9876348d794.png) | ![image](https://user-images.githubusercontent.com/4299733/148631077-4eb259a2-2e24-4984-aad5-0f2b037565e9.png) |
