### PR TITLE
Add highlight for quote marker

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -156,7 +156,7 @@
     "revision": "a4b9187417d6be349ee5fd4b6e77b4172c6827dd"
   },
   "markdown": {
-    "revision": "cb10958c05163cd6dc32aa568a6422f34fb0c178"
+    "revision": "77b90aec6306df625821e1eba03924f9543ee05c"
   },
   "nix": {
     "revision": "6d6aaa50793b8265b6a8b6628577a0083d3b923d"

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -45,6 +45,8 @@
   (thematic_break)
 ] @punctuation.special
 
+(block_quote_marker) @punctuation.special
+
 [
   (backslash_escape)
   (hard_line_break)


### PR DESCRIPTION
Implement highlight for block quote markers as discussed in https://github.com/MDeiml/tree-sitter-markdown/issues/20.