### PR TITLE
Fix slow startup times for markdown grammar

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -56,12 +56,12 @@
 (image "[" @punctuation.delimiter)
 (image "]" @punctuation.delimiter)
 (image "(" @punctuation.delimiter)
-(image ")" @punctuation.delimiter)
+; (image ")" @punctuation.delimiter)
 
 (inline_link "[" @punctuation.delimiter)
 (inline_link "]" @punctuation.delimiter)
 (inline_link "(" @punctuation.delimiter)
-(inline_link ")" @punctuation.delimiter)
+; (inline_link ")" @punctuation.delimiter)
 
 (shortcut_link "[" @punctuation.delimiter)
 (shortcut_link "]" @punctuation.delimiter)


### PR DESCRIPTION
As discussed in #2206 this is only a temporary fix. The problem seems to resolve itself with newer versions of treesitter.