### PR TITLE
Add highlight for markdown delimiters

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -156,7 +156,7 @@
     "revision": "a4b9187417d6be349ee5fd4b6e77b4172c6827dd"
   },
   "markdown": {
-    "revision": "77b90aec6306df625821e1eba03924f9543ee05c"
+    "revision": "330ecab87a3e3a7211ac69bbadc19eabecdb1cca"
   },
   "nix": {
     "revision": "6d6aaa50793b8265b6a8b6628577a0083d3b923d"

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -16,12 +16,16 @@
 [
   (code_span)
   (link_title)
+  (indented_code_block)
+  (fenced_code_block)
 ] @text.literal
 
 [
-  (indented_code_block)
-  (fenced_code_block)
+  (emphasis_delimiter)
+  (code_span_delimiter)
+  (fenced_code_block_delimiter)
 ] @punctuation.delimiter
+
 (code_fence_content) @none
 
 (emphasis) @text.emphasis


### PR DESCRIPTION
Add highlight to markdown for delimiters for
* fenced code blocks
* code spans
* emphasis
as discussed in https://github.com/MDeiml/tree-sitter-markdown/issues/20