### PR TITLE
Add LaTeX highlights: addpart, addchap, addsec.

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -141,7 +141,7 @@
     "revision": "a4f71eb9b8c9b19ded3e0e9470be4b1b77c2b569"
   },
   "latex": {
-    "revision": "2c0d03a36ee979bc697f6a9dd119174cf0ef15e0"
+    "revision": "6f796b700c69a8af28132e84ed6d0c8f0c17a5e2"
   },
   "ledger": {
     "revision": "0cdeb0e51411a3ba5493662952c3039de08939ca"

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -289,6 +289,10 @@
   "\\paragraph"
   "\\subparagraph"
 
+  "\\addpart"
+  "\\addchap"
+  "\\addsec"
+
   "\\part*"
   "\\chapter*"
   "\\section*"
@@ -296,6 +300,10 @@
   "\\subsubsection*"
   "\\paragraph*"
   "\\subparagraph*"
+
+  "\\addpart*"
+  "\\addchap*"
+  "\\addsec*"
 ] @type
 
 "\\item" @punctuation.special


### PR DESCRIPTION
Add highlight for the LaTeX sectioning commands `\addpart`, `\addchap`, `\addsec` and their starred variants. Fixes #2236.

This requires the revision of `latex` in `lockfile.json` to be updated to https://github.com/latex-lsp/tree-sitter-latex/commit/6f796b700c69a8af28132e84ed6d0c8f0c17a5e2. But I wasn’t sure if this update should be part of this pull request, and therefore left it out for now.