### PR TITLE
Add a missing LaTeX hightlight.

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -43,6 +43,7 @@
 
 [
     "\\ref"
+    "\\eqref"
     "\\vref"
     "\\Vref"
     "\\autoref"


### PR DESCRIPTION
Add `\eqref` to the list of referencing commands. Fixes #2242.