### PR TITLE
Add highlight for block comments

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -67,7 +67,7 @@
  (identifier)) @symbol
 
 ;; Parsing error! foo (::Type) gets parsed as two quote expressions
-(argument_list 
+(argument_list
   (quote_expression
     (quote_expression
       (identifier) @type)))
@@ -123,7 +123,10 @@
 
 (function_definition ["function" "end"] @keyword.function)
 
-(comment) @comment
+[
+  (comment)
+  (block_comment)
+] @comment
 
 [
   "const"

--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -2,4 +2,7 @@
 ; ((triple_string) @markdown
 ;   (#offset! @markdown 0 3 0 -3))
 
-(comment) @comment
+[
+  (comment)
+  (block_comment)
+] @comment


### PR DESCRIPTION
Currently, block comments are not highlighted in julia. 

This pull requests aims at adding highlight for block comments.