### PR TITLE
highlights(haskell): function with type signature

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -110,6 +110,9 @@
 (function
   name: (variable) @function
   patterns: (patterns))
+((signature (fun)) . (function (variable) @function))
+((signature (context (fun))) . (function (variable) @function))
+((signature (forall (context (fun)))) . (function (variable) @function))
 
 (exp_infix (variable) @operator)  ; consider infix functions as operators
 


### PR DESCRIPTION
These are the queries for bindings that have no parameters but have type signatures of a function.

| Before                                                                                                         | After                                                                                                          |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/4299733/149404206-ead4c59e-eaaa-4d06-a79a-ea4bf683a246.png) | ![image](https://user-images.githubusercontent.com/4299733/149404307-db8338c4-437d-44d4-ab54-e2a35ccf1d23.png) |
