### PR TITLE
fix(php): change query for @constructor group

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -55,8 +55,9 @@
 ((name) @constant
  (#vim-match? @constant "^_?[A-Z][A-Z\d_]+$"))
 
-((name) @constructor
- (#lua-match? @constructor "^[A-Z]"))
+(method_declaration
+    name: (name) @constructor
+    (#eq? @constructor "__construct"))
 
 ((name) @variable.builtin
  (#eq? @variable.builtin "this"))


### PR DESCRIPTION
If I understand correctly, the @constructor group should match definition of constructor method.
That way it will highlight name of the method.