### PR TITLE
fix(util): pass offset_encoding to apply_text_edits

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -331,7 +331,7 @@ function M.swap_nodes(node_or_range1, node_or_range2, bufnr, cursor_to_second)
 
   local edit1 = { range = range1, newText = table.concat(text2, "\n") }
   local edit2 = { range = range2, newText = table.concat(text1, "\n") }
-  vim.lsp.util.apply_text_edits({ edit1, edit2 }, bufnr)
+  vim.lsp.util.apply_text_edits({ edit1, edit2 }, bufnr, "utf-8")
 
   if cursor_to_second then
     utils.set_jump()


### PR DESCRIPTION
Offset encoding is a mandatory argument to `vim.lsp.util.apply_text_edits` since https://github.com/neovim/neovim/commit/bc722c8a74766e14aff3a8e2fc46db72ed864053; this function is used for `swap_nodes`. Since we are always within a Neovim context, we can just pass `"utf-8"`.

Fixes #2248 