### PR TITLE
highlights(php): fix and add missing highlights

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -10,6 +10,23 @@
  ] @type.builtin
 (named_type (name)) @type
 (named_type (qualified_name)) @type
+(class_declaration
+  name: (name) @type)
+(base_clause
+  [(name) (qualified_name)] @type)
+(enum_declaration
+  name: (name) @type)
+(interface_declaration
+  name: (name) @type)
+(namespace_use_clause
+  [(name) (qualified_name)] @type)
+(class_interface_clause
+  [(name) (qualified_name)] @type)
+(scoped_call_expression
+  scope: [(name) (qualified_name)] @type)
+(class_constant_access_expression
+  . [(name) (qualified_name)] @type
+  (name) @constant)
 
 ; Functions
 
@@ -37,6 +54,12 @@
 (nullsafe_member_call_expression
     name: (name) @method)
 
+; Parameters
+[
+  (simple_parameter)
+  (variadic_parameter)
+] @parameter
+
 ; Member
 
 (property_element
@@ -58,17 +81,25 @@
 ((name) @constructor
  (#lua-match? @constructor "^[A-Z]"))
 
+(const_declaration (const_element (name) @constant))
+
 ((name) @variable.builtin
  (#eq? @variable.builtin "this"))
 
-(variable_name) @variable
+; Namespace
+(namespace_definition
+  name: (namespace_name) @namespace)
 
+; Conditions ( ? : )
+(conditional_expression) @conditional
 ; Basic tokens
 
 [
  (string)
  (heredoc)
+ (shell_command_expression) ; backtick operator: `ls -la`
  ] @string
+(encapsed_string (escape_sequence) @string.escape)
 
 (boolean) @boolean
 (null) @constant.builtin
@@ -76,10 +107,15 @@
 (float) @float
 (comment) @comment
 
+(named_label_statement) @label
 ; Keywords
 
 [
+ "and"
  "as"
+ "instanceof"
+ "or"
+ "xor"
 ] @keyword.operator
 
 [
@@ -92,19 +128,19 @@
  "abstract"
  "break"
  "class"
+ "clone"
  "const"
- "continue"
  "declare"
  "default"
  "echo"
- "unset"
  "enddeclare"
+ "enum"
  "extends"
  "final"
  "global"
+ "goto"
  "implements"
  "insteadof"
- "instanceof"
  "interface"
  "namespace"
  "new"
@@ -113,9 +149,13 @@
  "public"
  "static"
  "trait"
+ "unset"
  ] @keyword
 
-"return" @keyword.return
+[
+  "return"
+  "yield"
+] @keyword.return
 
 [
  "case"
@@ -126,9 +166,11 @@
  "if"
  "switch"
  "match"
+  "??"
  ] @conditional
 
 [
+ "continue"
  "do"
  "endfor"
  "endforeach"
@@ -156,7 +198,6 @@
 [
  ","
  ";"
- "."
  ] @punctuation.delimiter
 
 [
@@ -173,14 +214,17 @@
 [
   "="
 
+  "."
   "-"
   "*"
   "/"
   "+"
   "%"
+  "**"
 
   "~"
   "|"
+  "^"
   "&"
   "<<"
   ">>"
@@ -194,6 +238,7 @@
   "<="
   ">="
   ">"
+  "<>"
   "=="
   "!="
   "==="
@@ -203,15 +248,24 @@
   "&&"
   "||"
 
+  ".="
   "-="
   "+="
   "*="
   "/="
   "%="
-  "|="
+  "**="
   "&="
+  "|="
+  "^="
+  "<<="
+  ">>="
+  "??="
   "--"
   "++"
+
+  "@"
+  "::"
 ] @operator
 
 (ERROR) @error


### PR DESCRIPTION
@theHamsta As mentioned in #2207 here are a couple of additions for PHP

 * **@type**: added class and interface names in declarations, `use` statements and static method calls
 * **@parameter** parameters in method and function declarations
 * **@const** constant declarations and accesses
 * **@namespace** namespace names
 * **@conditional** added ternary operator `? :`
 * **@string** added backtick expressions
 * **@string.escape** escape expressions like `\n` in strings
 * **@label** goto labels
 
Also added some keywords and operators and moved some things e.g. the `.` operator to **@operators**
