### PR TITLE
Fix: use maintained parser for Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) (maintained by @madskjeldgaard)
 - [x] [surface](https://github.com/connorlay/tree-sitter-surface) (maintained by @connorlay)
 - [x] [svelte](https://github.com/Himujjal/tree-sitter-svelte) (maintained by @elianiva)
-- [ ] [swift](https://github.com/tree-sitter/tree-sitter-swift)
+- [x] [swift](https://github.com/alex-pinkus/tree-sitter-swift)
 - [x] [teal](https://github.com/euclidianAce/tree-sitter-teal) (maintained by @euclidianAce)
 - [x] [tlaplus](https://github.com/tlaplus-community/tree-sitter-tlaplus) (maintained by @ahelwer)
 - [x] [toml](https://github.com/ikatyang/tree-sitter-toml) (maintained by @tk-shirasaka)

--- a/lockfile.json
+++ b/lockfile.json
@@ -237,7 +237,7 @@
     "revision": "98274d94ec33e994e8354d9ddfdef58cca471294"
   },
   "swift": {
-    "revision": "a22fa5e19bae50098e2252ea96cba3aba43f4c58"
+    "revision": "05e21aac6b3abefd94cf7f01665390307820eecd"
   },
   "teal": {
     "revision": "fcc5f6f4d194dede4e676834ff28a506e39e17b4"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -370,9 +370,10 @@ list.ocamllex = {
 
 list.swift = {
   install_info = {
-    url = "https://github.com/tree-sitter/tree-sitter-swift",
-    files = { "src/parser.c" },
+    url = "https://github.com/alex-pinkus/tree-sitter-swift",
+    files = { "src/parser.c", "src/scanner.c" },
     requires_generate_from_grammar = true,
+    generate_requires_npm = true,
   },
 }
 

--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -1,0 +1,130 @@
+; Identifiers
+(attribute) @variable
+(simple_identifier) @variable
+(type_identifier) @type
+(self_expression) @variable.builtin
+
+; Declarations
+"func" @keyword.function
+[
+  (visibility_modifier)
+  (member_modifier)
+  (function_modifier)
+  (property_modifier)
+  (parameter_modifier)
+  (inheritance_modifier)
+] @keyword
+
+(function_declaration (simple_identifier) @method)
+(function_declaration ["init" @constructor])
+(throws) @keyword
+(async) @keyword
+(where_keyword) @keyword
+(parameter external_name: (simple_identifier) @parameter)
+(parameter name: (simple_identifier) @parameter)
+(type_parameter (type_identifier) @parameter)
+(inheritance_constraint (identifier (simple_identifier) @parameter))
+(equality_constraint (identifier (simple_identifier) @parameter))
+
+["typealias" "struct" "class" "enum" "protocol" "extension"] @keyword
+
+(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property))))
+(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property)))
+
+(import_declaration ["import" @include])
+
+(enum_entry ["case" @keyword])
+
+; Function calls
+(call_expression (simple_identifier) @function) ; foo()
+(call_expression ; foo.bar.baz(): highlight the baz()
+  (navigation_expression
+    (navigation_suffix (simple_identifier) @function)))
+((navigation_expression
+   (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
+   (#lua-match? @type "^[A-Z]"))
+
+(directive) @function.macro
+(diagnostic) @function.macro
+
+; Statements
+(for_statement ["for" @repeat])
+(for_statement ["in" @repeat])
+(for_statement item: (simple_identifier) @variable)
+(else) @keyword
+(as_operator) @keyword
+
+["while" "repeat" "continue" "break"] @repeat
+
+["let" "var"] @keyword
+(non_binding_pattern (simple_identifier) @variable)
+
+(guard_statement ["guard" @conditional])
+(if_statement ["if" @conditional])
+(switch_statement ["switch" @conditional])
+(switch_entry ["case" @keyword])
+(switch_entry ["fallthrough" @keyword])
+(switch_entry (default_keyword) @keyword)
+"return" @keyword.return
+
+["do" (throw_keyword) (catch_keyword)] @keyword
+
+(statement_label) @label
+
+; Comments
+(comment) @comment
+(multiline_comment) @comment
+
+; String literals
+(line_str_text) @string
+(str_escaped_char) @string
+(multi_line_str_text) @string
+(raw_str_part) @string
+(raw_str_end_part) @string
+(raw_str_interpolation_start) @punctuation.special
+["\"" "\"\"\""] @string
+
+; Lambda literals
+(lambda_literal ["in" @keyword.operator])
+
+; Basic literals
+[
+ (integer_literal)
+ (hex_literal)
+ (oct_literal)
+ (bin_literal)
+] @number
+(real_literal) @float
+(boolean_literal) @boolean
+"nil" @variable.builtin
+
+; Operators
+(custom_operator) @operator
+[
+ "try"
+ "try?"
+ "try!"
+ "!"
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "="
+ "+="
+ "-="
+ "*="
+ "/="
+ "<"
+ ">"
+ "<="
+ ">="
+ "++"
+ "--"
+ "&"
+ "~"
+ "%="
+ "!="
+ "!=="
+ "==="
+] @operator

--- a/queries/swift/locals.scm
+++ b/queries/swift/locals.scm
@@ -1,0 +1,18 @@
+(import_declaration (identifier) @definition.import)
+(function_declaration name: (simple_identifier) @definition.function)
+
+; Scopes
+[
+ (statements)
+ (for_statement)
+ (while_statement)
+ (repeat_while_statement)
+ (do_statement)
+ (if_statement)
+ (guard_statement)
+ (switch_statement)
+ (property_declaration)
+ (function_declaration)
+ (class_declaration)
+ (protocol_declaration)
+] @scope


### PR DESCRIPTION
The upstream parser https://github.com/tree-sitter/tree-sitter-swift is marked as abandoned in favor of https://github.com/alex-pinkus/tree-sitter-swift/, so use this.

Caution: This parser requires generating the grammar via `npm install`, which takes quite a while, pulls in ~100 Mb of dependencies, and results in a 3.1 Mb parser. 

I also mostly copied the queries from that repo verbatim; they likely need adapting, and I'd appreciate help on this from someone who is familiar with Swift (and Scheme). Changes I've made:

* `@function.method` -> `@method`

@theHamsta 

closes #271