### PR TITLE
feat(java)(highlights): add missing highlights for `@type`

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -90,6 +90,12 @@
 (constructor_declaration
   name: (identifier) @type)
 (type_identifier) @type
+((method_invocation
+  object: (identifier) @type)
+ (#lua-match? @type "^[A-Z]"))
+((method_reference
+  . (identifier) @type)
+ (#lua-match? @type "^[A-Z]"))
 
 
 


### PR DESCRIPTION
Fix:  https://github.com/tree-sitter/tree-sitter-java/issues/94
PR: https://github.com/tree-sitter/tree-sitter-java/pull/95