### PR TITLE
highlights(c): don't highlight type qualifiers in declarations as types

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -133,8 +133,6 @@
  (type_descriptor)
 ] @type
 
-(declaration (type_qualifier) @type)
-(cast_expression type: (type_descriptor) @type)
 (sizeof_expression value: (parenthesized_expression (identifier) @type))
 
 ((identifier) @constant


### PR DESCRIPTION
@theHamsta This just takes out highlighting of `type_qualifier` as a `@type` as part of a declaration. Qualifiers themselves aren't really types. The one for the cast expression was unnecessary since all `type_descriptors` are already highlighted as types.