### PR TITLE
fix(php) match magic and single letter constants

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -82,7 +82,9 @@
 (relative_scope) @variable.builtin
 
 ((name) @constant
- (#vim-match? @constant "^_?[A-Z][A-Z\d_]+$"))
+ (#vim-match? @constant "^_?[A-Z][A-Z\d_]*$"))
+((name) @constant.builtin
+ (#vim-match? @constant.builtin "^__[A-Z][A-Z\d_]+__$"))
 
 (const_declaration (const_element (name) @constant))
 


### PR DESCRIPTION
Matches [magic constants](https://www.php.net/manual/en/language.constants.magic.php) like `__LINE__`, `__METHOD__` and constants with only a single letter.
