### PR TITLE
ci: bump neovim and tree-sitter cli to latest version

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -9,20 +9,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2022, macos-latest]
         cc: [ gcc, clang ]
-        nvim_tag: [ v0.6.0 ]
+        nvim_tag: [ v0.6.1 ]
         exclude:
           - os: macos-latest
             cc: gcc
-            nvim_tag: v0.6.0
+            nvim_tag: v0.6.1
 
         include:
           - os: windows-2022
             cc: cl
-            nvim_tag: v0.6.0
+            nvim_tag: v0.6.1
 
           - os: macos-latest
             cc: gcc-10
-            nvim_tag: v0.6.0
+            nvim_tag: v0.6.1
 
           - os: ubuntu-latest
             cc: gcc
@@ -40,7 +40,7 @@ jobs:
       - name: Install and prepare Neovim
         env:
           NVIM_TAG: ${{ matrix.nvim_tag }}
-          TREE_SITTER_CLI_TAG: v0.20.1
+          TREE_SITTER_CLI_TAG: v0.20.2
         run: |
           bash ./scripts/ci-install-${{ matrix.os }}.sh
 

--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -23,6 +23,10 @@ jobs:
         cc: [ gcc, clang ]
         nvim_tag: [ v0.6.1 ]
         exclude:
+          - os: ubuntu-latest
+            cc: clang
+            nvim_tag: v0.6.1
+
           - os: macos-latest
             cc: gcc
             nvim_tag: v0.6.1
@@ -30,10 +34,6 @@ jobs:
         include:
           - os: windows-2022
             cc: cl
-            nvim_tag: v0.6.1
-
-          - os: macos-latest
-            cc: gcc-10
             nvim_tag: v0.6.1
 
           - os: ubuntu-latest

--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -1,6 +1,18 @@
 name: Parser compilation and query file check
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'master'
+
+# Cancel any in-progress CI runs for a PR if it is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   check_compilation_unix_like:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Install and prepare Neovim
         env:
-          NVIM_TAG: v0.6.0
-          TREE_SITTER_CLI_TAG: v0.20.1
+          NVIM_TAG: v0.6.1
+          TREE_SITTER_CLI_TAG: v0.20.2
         run: |
           bash ./scripts/ci-install-${{ matrix.os }}.sh
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,18 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'master'
+
+# Cancel any in-progress CI runs for a PR if it is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   check_compilation_unix_like:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Prepare
         env:
-          NVIM_TAG: v0.6.0
+          NVIM_TAG: v0.6.1
         run: |
           sudo apt-get update
           sudo add-apt-repository universe


### PR DESCRIPTION
possibly want to wait to update to tree-sitter 0.21.0 (or whatever the upcoming version is)

also simplify tests:
* only run on push to master _or_ PR opened/synchronized
* cancel in-progress workflows for updated PRs
* only run ubuntu-latest+gcc+nightly on draft PRs
* only run ubuntu+gcc and macos+clang (plus windows x 3)