### PR TITLE
ci: use stable tag for latest nvim release

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -21,20 +21,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2022, macos-latest]
         cc: [ gcc, clang ]
-        nvim_tag: [ v0.6.1 ]
+        nvim_tag: [ stable ]
         exclude:
           - os: ubuntu-latest
             cc: clang
-            nvim_tag: v0.6.1
+            nvim_tag: stable
 
           - os: macos-latest
             cc: gcc
-            nvim_tag: v0.6.1
+            nvim_tag: stable
 
         include:
           - os: windows-2022
             cc: cl
-            nvim_tag: v0.6.1
+            nvim_tag: stable
 
           - os: ubuntu-latest
             cc: gcc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install and prepare Neovim
         env:
-          NVIM_TAG: v0.6.1
+          NVIM_TAG: stable
           TREE_SITTER_CLI_TAG: v0.20.2
         run: |
           bash ./scripts/ci-install-${{ matrix.os }}.sh

--- a/.github/workflows/update-parsers-pr.yml
+++ b/.github/workflows/update-parsers-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Prepare
         env:
-          NVIM_TAG: v0.5.1
+          NVIM_TAG: stable
         run: |
           sudo apt-get update
           sudo add-apt-repository universe

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Prepare
         env:
-          NVIM_TAG: v0.6.1
+          NVIM_TAG: stable
         run: |
           sudo apt-get update
           sudo add-apt-repository universe


### PR DESCRIPTION
so we only need to rebase all old PRs once

@theHamsta 