### PR TITLE
docs: add missing vim table in the example

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -116,7 +116,7 @@ language and buffer number as arguments:
     highlight = {
       enable = true,
       disable = function(lang, bufnr) -- Disable in large C++ buffers
-        return lang == "cpp" and api.nvim_buf_line_count(bufnr) > 50000
+        return lang == "cpp" and vim.api.nvim_buf_line_count(bufnr) > 50000
       end,
     },
   }


### PR DESCRIPTION
Improves clarity for a user that is not familiar with lua api.