### PR TITLE
feat: specify ABI version for generate on newer tree-sitter CLI

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -5,6 +5,7 @@ local queries = require "nvim-treesitter.query"
 local info = require "nvim-treesitter.info"
 local shell = require "nvim-treesitter.shell_command_selectors"
 local install = require "nvim-treesitter.install"
+local utils = require "nvim-treesitter.utils"
 
 local health_start = vim.fn["health#report_start"]
 local health_ok = vim.fn["health#report_ok"]
@@ -24,13 +25,9 @@ local function install_health()
         .. " not required for :TSInstall)"
     )
   else
-    local handle = io.popen "tree-sitter  -V"
-    local result = handle:read "*a"
-    handle:close()
-    local version = vim.split(result, "\n")[1]:match "[^tree%psitter].*"
     health_ok(
       "`tree-sitter` found "
-        .. (version or "(unknown version)")
+        .. (utils.ts_cli_version() or "(unknown version)")
         .. " (parser generator, only needed for :TSInstallFromGrammar)"
     )
   end

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -193,4 +193,13 @@ function M.to_func(a)
   return type(a) == "function" and a or M.constant(a)
 end
 
+function M.ts_cli_version()
+  if fn.executable "tree-sitter" == 1 then
+    local handle = io.popen "tree-sitter  -V"
+    local result = handle:read "*a"
+    handle:close()
+    return vim.split(result, "\n")[1]:match "[^tree%psitter ].*"
+  end
+end
+
 return M


### PR DESCRIPTION
 Check tree-sitter CLI version and if > 0.20.3 and generating a parser from grammar, use `--abi=vim.treesitter.language_version`.

Besides being able to opt-in to newer ABI benefits, this is a necessary workaround for an upstream bug with 0.20.3, where `parser.h` is not generated if the (optional) `--abi` flag is omitted.