### PR TITLE
ci: drop windows+clang

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -31,6 +31,10 @@ jobs:
             cc: gcc
             nvim_tag: stable
 
+          - os: windows-2022
+            cc: clang
+            nvim_tag: stable
+
         include:
           - os: windows-2022
             cc: cl


### PR DESCRIPTION
takes significantly longer than other combinations

probably easier now to just list the allowed combinations?