### PR TITLE
fix: Don't require node for gdscript.

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -672,7 +672,6 @@ list.gdscript = {
   install_info = {
     url = "https://github.com/PrestonKnopp/tree-sitter-gdscript",
     files = { "src/parser.c", "src/scanner.cc" },
-    requires_generate_from_grammar = true,
   },
   readme_name = "Godot (gdscript)",
   maintainers = { "@Shatur95" },


### PR DESCRIPTION
The upstream repo has pre-generated bindings at:
https://github.com/PrestonKnopp/tree-sitter-gdscript/tree/master/src
