### PR TITLE
ci: fix cache path for rust cargo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,15 +40,18 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ./.cargo/
-          key: v1.0.4
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ matrix.os }}-rust-cargo-v1
 
       - name: Test Dependencies
         run: |
           mkdir -p ~/.local/share/nvim/site/pack/plenary.nvim/start
           cd ~/.local/share/nvim/site/pack/plenary.nvim/start
           git clone https://github.com/nvim-lua/plenary.nvim
-          ~/.cargo/bin/cargo +nightly install --git https://github.com/theHamsta/highlight-assertions --locked
+          ~/.cargo/bin/cargo +nightly install --force --git https://github.com/theHamsta/highlight-assertions --locked
 
       - name: Install and prepare Neovim
         env:


### PR DESCRIPTION
Decreases the time for Test Dependencies to half. 

**Before**:

![image](https://user-images.githubusercontent.com/8050659/150653061-64c797a9-f6f1-4506-8aaf-712e1d33d84d.png)

**After**:

![image](https://user-images.githubusercontent.com/8050659/150653267-c5c2f61d-7502-4a41-901f-3eba5e1b9c5c.png)
