### PR TITLE
fix: generate viml parser from grammar

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -782,6 +782,7 @@ list.vim = {
   install_info = {
     url = "https://github.com/vigoux/tree-sitter-viml",
     files = { "src/parser.c", "src/scanner.c" },
+    requires_generate_from_grammar = true,
   },
   filetype = "vim",
   maintainers = { "@vigoux" },


### PR DESCRIPTION
temporarily force viml parser to be generated from grammar, unblocking lockfile update PRs and CI

can be removed when general ABI compat infrastructure is in place

@vigoux 