### PR TITLE
fix: bump phpdoc parser to 0.0.6

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -189,7 +189,7 @@
     "revision": "57f855461aeeca73bd4218754fb26b5ac143f98f"
   },
   "phpdoc": {
-    "revision": "f54431c26f8625f31c1622425680f6f157061e72"
+    "revision": "52c0fbf581d0fc2d29696dbbd4fca99a73082210"
   },
   "pioasm": {
     "revision": "924aadaf5dea2a6074d72027b064f939acf32e20"


### PR DESCRIPTION
closes #2323 

(lockfile PR is still stalled by viml parser...)