### PR TITLE
chore: remove most ftdetect plugins

### DIFF
--- a/ftdetect/fusion.vim
+++ b/ftdetect/fusion.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.fusion setfiletype fusion

--- a/ftdetect/gdresource.vim
+++ b/ftdetect/gdresource.vim
@@ -1,2 +1,0 @@
-autocmd BufRead,BufNewFile *.tscn setlocal ft=gdresource
-autocmd BufRead,BufNewFile *.tres setlocal ft=gdresource

--- a/ftdetect/gdscript.vim
+++ b/ftdetect/gdscript.vim
@@ -1,1 +1,0 @@
-autocmd BufNewFile,BufRead *.gd set ft=gdscript

--- a/ftdetect/glimmer.vim
+++ b/ftdetect/glimmer.vim
@@ -1,1 +1,0 @@
-autocmd BufNewFile,BufRead *.hbs set ft=handlebars

--- a/ftdetect/glsl.vim
+++ b/ftdetect/glsl.vim
@@ -1,1 +1,0 @@
-autocmd BufNewFile,BufRead *.glsl set filetype=glsl

--- a/ftdetect/gowork.vim
+++ b/ftdetect/gowork.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile go.work set filetype=gowork

--- a/ftdetect/graphql.vim
+++ b/ftdetect/graphql.vim
@@ -1,1 +1,0 @@
-autocmd BufNewFile,BufRead *.graphql,*.graphqls,*.gql setfiletype graphql

--- a/ftdetect/hack.vim
+++ b/ftdetect/hack.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.hack,*.hackpartial setfiletype hack

--- a/ftdetect/hcl.vim
+++ b/ftdetect/hcl.vim
@@ -1,2 +1,1 @@
-autocmd BufRead,BufNewFile *.hcl set filetype=hcl
 autocmd BufRead,BufNewFile *.tf,*.tfvars set filetype=terraform

--- a/ftdetect/heex.vim
+++ b/ftdetect/heex.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile *.heex set filetype=heex

--- a/ftdetect/hjson.vim
+++ b/ftdetect/hjson.vim
@@ -1,1 +1,0 @@
-autocmd BufNewFile,BufRead *.hjson set filetype=hjson

--- a/ftdetect/json5.vim
+++ b/ftdetect/json5.vim
@@ -1,1 +1,0 @@
-autocmd BufNewFile,BufRead *.json5 set ft=json5

--- a/ftdetect/ledger.vim
+++ b/ftdetect/ledger.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.ldg,*.ledger,*.journal setfiletype ledger

--- a/ftdetect/nix.vim
+++ b/ftdetect/nix.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.nix setfiletype nix

--- a/ftdetect/prisma.vim
+++ b/ftdetect/prisma.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.prisma set filetype=prisma

--- a/ftdetect/pug.vim
+++ b/ftdetect/pug.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile *.pug		setlocal filetype=pug

--- a/ftdetect/ql.vim
+++ b/ftdetect/ql.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.ql,*.qll setfiletype ql

--- a/ftdetect/surface.vim
+++ b/ftdetect/surface.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile *.sface set filetype=surface

--- a/ftdetect/teal.vim
+++ b/ftdetect/teal.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.tl setfiletype teal

--- a/ftdetect/tlaplus.vim
+++ b/ftdetect/tlaplus.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile *.tla set filetype=tla

--- a/ftdetect/yang.vim
+++ b/ftdetect/yang.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile *.yang set filetype=yang


### PR DESCRIPTION
Native support for Neovim will be added in https://github.com/neovim/neovim/pull/17180
Most other filetypes are added in https://github.com/neovim/neovim/pull/17182

Should we remove the ftplugin now or just collect them in this PR and merge on release of the Neovim stable?

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/2342
Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/2259