### PR TITLE
ci: bump tree-sitter to 0.20.4

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install and prepare Neovim
         env:
           NVIM_TAG: ${{ matrix.nvim_tag }}
-          TREE_SITTER_CLI_TAG: v0.20.3
+          TREE_SITTER_CLI_TAG: v0.20.4
         run: |
           bash ./scripts/ci-install-${{ matrix.os }}.sh
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install and prepare Neovim
         env:
           NVIM_TAG: stable
-          TREE_SITTER_CLI_TAG: v0.20.3
+          TREE_SITTER_CLI_TAG: v0.20.4
         run: |
           bash ./scripts/ci-install-${{ matrix.os }}.sh
 


### PR DESCRIPTION
fixes issues with `parser.h` not being generated