### PR TITLE
feat(indent): Implement basic indent for gdscript.

### DIFF
--- a/queries/gdscript/indents.scm
+++ b/queries/gdscript/indents.scm
@@ -1,0 +1,24 @@
+[
+  (if_statement)
+
+  (for_statement)
+  (while_statement)
+
+  (parenthesized_expression)
+
+  (function_definition)
+  (class_definition)
+] @indent
+
+((argument_list) @aligned_indent
+ (#set! "delimiter" "()"))
+((parameters) @aligned_indent
+ (#set! "delimiter" "()"))
+
+[
+  ")"
+  "]"
+  "}"
+  (elif_clause)
+  (else_clause)
+] @branch

--- a/tests/indent/gdscript/basic_blocks.gd
+++ b/tests/indent/gdscript/basic_blocks.gd
@@ -1,0 +1,16 @@
+extends Node
+
+func _ready():
+	var x := 2
+	for i in range(x):
+		prints(i)
+
+	while x > 0:
+		print(x)
+
+	if x > 0:
+		print("if test")
+	elif x < 0:
+		print("if test")
+	else:
+		print("if test")

--- a/tests/indent/gdscript_spec.lua
+++ b/tests/indent/gdscript_spec.lua
@@ -1,0 +1,20 @@
+local Runner = require("tests.indent.common").Runner
+
+local run = Runner:new(it, "tests/indent/gdscript", {
+  tabstop = 4,
+  shiftwidth = 4,
+  softtabstop = 0,
+  expandtab = false,
+})
+
+describe("indent GDScript:", function()
+  describe("whole file:", function()
+    run:whole_file(".", {
+      expected_failures = {},
+    })
+  end)
+
+  describe("new line:", function()
+    run:new_line("basic_blocks.gd", { on_line = 1, text = "var member := 0", indent = 0 })
+  end)
+end)


### PR DESCRIPTION
Indent is not handled correctly when adding new lines.
It seems that functions/loops/etc. are not recognized until they have at
least one indented block.

For example, if you enter a newline after `func foo():`, the cursor will
not be indented. If you manually indent and add a line like `pass`,
e.g.:

```
func foo():
    pass
```

now any insertions above or below `pass` will be indented correctly.
This might be an issue with the grammar, as it seems to apply to highlights
as well.

The following will not be highligted

```
func foo():
```

However, the following will be:

```
func foo():
    pass
```
