### PR TITLE
Elixir highlights and injection updates

### DIFF
--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -180,7 +180,7 @@
       ] operator: "/" right: (integer) @operator)
   ])
 
-; Sigils
+; Non-String Sigils
 (sigil
   "~" @string.special
   ((sigil_name) @string.special) @_sigil_name
@@ -189,6 +189,7 @@
   ((sigil_modifiers) @string.special)?
   (#not-any-of? @_sigil_name "s" "S"))
 
+; String Sigils
 (sigil
   "~" @string
   ((sigil_name) @string) @_sigil_name
@@ -203,7 +204,8 @@
   operator: "@"
   operand: [
     (identifier)
-    (call target: (identifier) @constant)]) @constant
+    (call target: (identifier))
+  ] @constant) @constant
 
 ; Documentation
 (unary_operator
@@ -214,4 +216,10 @@
       (string)
       (boolean)
       (charlist)
+      (sigil
+        "~" @comment
+        ((sigil_name) @comment)
+        quoted_start: _ @comment
+        (quoted_content) @comment
+        quoted_end: _ @comment)
     ] @comment))) @comment

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -1,21 +1,43 @@
-(sigil
-  (sigil_name) @_sigil_name
-  (quoted_content) @surface
-(#eq? @_sigil_name "F"))
+; Comments
+(comment) @comment
 
+; Documentation
+(unary_operator
+  operator: "@"
+  operand: (call
+    target: ((identifier) @_identifier (#any-of? @_identifier "moduledoc" "typedoc" "shortdoc" "doc"))
+    (arguments [
+      (string (quoted_content) @markdown)
+      (sigil (quoted_content) @markdown)
+    ])))
+
+; HEEx
 (sigil
   (sigil_name) @_sigil_name
   (quoted_content) @heex
 (#eq? @_sigil_name "H"))
 
+; Surface
+(sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @surface
+(#eq? @_sigil_name "F"))
+
+; Zigler
 (sigil
   (sigil_name) @_sigil_name
   (quoted_content) @zig
-(#eq? @_sigil_name "Z"))
+(#any-of? @_sigil_name "z" "Z"))
 
+; Regex
 (sigil
   (sigil_name) @_sigil_name
   (quoted_content) @regex
 (#any-of? @_sigil_name "r" "R"))
 
-(comment) @comment
+; Jason
+(sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @json
+(#any-of? @_sigil_name "j" "J"))
+


### PR DESCRIPTION
Hello! This PR makes the following adjustments to the highlighting and language injection queries for Elixir:
* Injects markdown into [Elixir documentation](https://hexdocs.pm/elixir/writing-documentation.html#markdown)
* Injects JSON into [Jason sigils](https://hexdocs.pm/jason/1.3.0/Jason.Sigil.html)
* Adds the missing lower-case `z` sigil for Zigler injections
* Fixes a bug where module attributes are not highlighted properly outside of their initial definition (see images below)
* Fixes a bug where the string sigil is not highlighted as documentation

## Screenshots
![module-attribute](https://user-images.githubusercontent.com/6548350/150723576-ae8e95fa-25aa-49e5-b748-c72a350c7b4b.png)
Module attribute highlights on master

![module-attribute-fix](https://user-images.githubusercontent.com/6548350/150723582-19f10fdc-3626-4b9c-8a77-7fa83d78ab04.png)
Module attribute highlights on this branch

