### PR TITLE
Add support for HEEx 0.3.x

### DIFF
--- a/queries/heex/highlights.scm
+++ b/queries/heex/highlights.scm
@@ -1,16 +1,13 @@
-(text) @text
-(comment) @comment
-(doctype) @constant
-
-; HEEx attributes are highlighted as HTML attributes
-(attribute_name) @tag.attribute
-(quoted_attribute_value) @string
-
+; HEEx tag and component delimiters
 [
   "%>"
+  "--%>"
+  "-->"
   "/>"
   "<!"
+  "<!--"
   "<"
+  "<%!--"
   "<%"
   "<%#"
   "<%%="
@@ -21,13 +18,34 @@
   "}"
 ] @tag.delimiter
 
-[
-  "="
-] @operator
+; HEEx operators
+"=" @operator
 
-; HEEx tags are highlighted as HTML
+; HEEx inherits the DOCTYPE tag from HTML
+(doctype) @constant
+
+; HEEx tags are highlighted as HTML tags
 (tag_name) @tag
 
-; HEEx components are highlighted as types (Elixir modules)
-(component_name) @type
+; HEEx comments are highlighted as such
+(comment) @comment
 
+; HEEx text content is treated as markup
+(text) @text
+
+; Tree-sitter parser errors
+(ERROR) @error
+
+; HEEx attributes are highlighted as HTML attributes
+(attribute_name) @tag.attribute
+[
+  (attribute_value)
+  (quoted_attribute_value)
+] @string
+
+; HEEx components are highlighted as modules and function calls
+(component_name [
+  (module) @type
+  (function) @function
+  "." @punctuation.delimiter
+])

--- a/queries/heex/indents.scm
+++ b/queries/heex/indents.scm
@@ -1,4 +1,4 @@
-; HEEx  indents like HTML
+; HEEx indents like HTML
 [
   (component)
   (tag)

--- a/queries/heex/injections.scm
+++ b/queries/heex/injections.scm
@@ -1,10 +1,10 @@
-; TODO: once @combined is fixed for all modules, replace this with the two queries below
-(expression_value) @elixir
+; HEEx directives can span multiple interpolated lines of Elixir
+(directive [
+  (expression_value) 
+  (partial_expression_value)
+] @elixir @combined)  
 
-; Directives are combined to support do blocks
-; (directive (expression_value) @elixir @combined)
-
-; Expressions are not combined, as they exist separately from do blocks
-; (expression (expression_value) @elixir)
+; HEEx Elixir expressions are always within a tag or component
+(expression (expression_value) @elixir)
 
 (comment) @comment

--- a/queries/heex/locals.scm
+++ b/queries/heex/locals.scm
@@ -1,0 +1,11 @@
+; HEEx tags and components are references
+[
+  (tag_name)
+  (component_name)
+] @reference
+
+; Create a new scope within each HEEx tag or component
+[
+  (tag)
+  (component)
+] @scope


### PR DESCRIPTION
This PR makes the following changes to support version [0.3.x](https://github.com/connorlay/tree-sitter-heex/blob/main/CHANGELOG.md#030) of tree-sitter-heex:
* Improved support for Elixir injections that span multiple lines of HEEx
* Adds a `locals.scm` query file for HEEx
* Adds more accurate highlighting of HEEx function components
* Adds support for multi-line HEEx comments `<%!-- --%>`
* Adds support for HTML comments `<!-- -->`