### PR TITLE
Add tree-sitter-eex parser for (L)EEx files

### DIFF
--- a/ftdetect/eex.vim
+++ b/ftdetect/eex.vim
@@ -1,2 +1,0 @@
-au BufRead,BufNewFile *.eex set filetype=eex
-au BufRead,BufNewFile *.leex set filetype=eex

--- a/ftdetect/eex.vim
+++ b/ftdetect/eex.vim
@@ -1,0 +1,2 @@
+au BufRead,BufNewFile *.eex set filetype=eex
+au BufRead,BufNewFile *.leex set filetype=eex

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -343,6 +343,16 @@ list.surface = {
   maintainers = { "@connorlay" },
 }
 
+list.eex = {
+  install_info = {
+    url = "https://github.com/connorlay/tree-sitter-eex",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  filetype = "eex",
+  maintainers = { "@connorlay" },
+}
+
 list.heex = {
   install_info = {
     url = "https://github.com/connorlay/tree-sitter-heex",

--- a/queries/eex/highlights.scm
+++ b/queries/eex/highlights.scm
@@ -1,0 +1,15 @@
+[
+  "%>"
+  "--%>"
+  "<%!--"
+  "<%"
+  "<%#"
+  "<%%="
+  "<%="
+] @tag.delimiter
+
+; EEx comments are highlighted as such
+(comment) @comment
+
+; Tree-sitter parser errors
+(ERROR) @error

--- a/queries/eex/injections.scm
+++ b/queries/eex/injections.scm
@@ -1,0 +1,5 @@
+; EEx expressions are Elixir
+(expression) @elixir
+
+; EEx expressions can span multiple interpolated lines
+(partial_expression) @elixir @combined

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -10,6 +10,11 @@
 
 (sigil
   (sigil_name) @_sigil_name
+  (quoted_content) @eex
+(#any-of? @_sigil_name "E" "L"))
+
+(sigil
+  (sigil_name) @_sigil_name
   (quoted_content) @zig
 (#eq? @_sigil_name "Z"))
 


### PR DESCRIPTION
Related to https://github.com/nvim-treesitter/nvim-treesitter/issues/1352

This PR adds support for EEx and LEEx files with [tree-sitter-eex](https://github.com/connorlay/tree-sitter-eex). Unlike HEEx, EEx does not make any assumptions about what language it is injecting Elixir into. The addition of this parser to nvim-treesitter should improve the experience of using Neovim and Tree Sitter on older Phoenix applications that have not migrated to HEEx yet, as well as other usages of EEx that do not target HTML.