### PR TITLE
fix(phpdoc) Improve keyword query

### DIFF
--- a/queries/phpdoc/highlights.scm
+++ b/queries/phpdoc/highlights.scm
@@ -34,9 +34,9 @@
   (email_address) @text.uri
 )
 
-[
-  "$"
-  ">"
-  "<"
-  "|"
-]@keyword
+(type_list "|" @keyword)
+(variable_name "$" @keyword)
+(tag
+  (tag_name) @_tag_name
+  ["<" ">"] @keyword
+  (#eq? @_tag_name "@author"))


### PR DESCRIPTION
* Only capture `$` as keyword if it's a variable name, not anywhere else in comment
* `|` only as separator in a type list
* `<` and `>` only for the email in `@author` tags