### PR TITLE
refactor(installer): more modular makefile

### DIFF
--- a/scripts/compile_parsers.makefile
+++ b/scripts/compile_parsers.makefile
@@ -9,15 +9,16 @@ SRC_DIR      ?= ./src
 DEST_DIR     ?= ./dest
 
 ifeq ($(OS),Windows_NT)
-   MKDIR  ?= mkdir
-   RM     ?= cmd /C rmdir /Q /S
-   CP     ?= copy
-   TARGET ?= parser.dll
+   SHELL       := powershell.exe
+   .SHELLFLAGS := -NoProfile
+   RM          := Remove-Item -Force
+   CP          := Copy-Item -Recurse
+   MKDIR       := New-Item -ItemType directory
+   TARGET      := parser.dll
 else
-   MKDIR  ?= mkdir -p
-   RM     ?= rm -rf
-   CP     ?= cp
-   TARGET ?= parser.so
+   RM          := rm -rf
+   CP          := cp
+   TARGET      := parser.so
 endif
 
 ifneq ($(wildcard src/*.cc),)
@@ -38,13 +39,13 @@ $(TARGET): $(OBJECTS)
 	$(CC) -c $(CXXFLAGS) -I$(SRC_DIR) -o $@ $<
 
 clean:
-	$(RM) $(OBJECTS) $(TARGET)
+	$(foreach file, $(OBJECTS), $(RM) $(file))
+	$(RM) $(TARGET)
 
-install: $(TARGET)
-	$(MKDIR) $(DEST_DIR)
+$(DEST_DIR):
+	test -d $(DEST_DIR) || $(MKDIR) $(DEST_DIR)
+
+install: $(TARGET) $(DEST_DIR)
 	$(CP) $^ $(DEST_DIR)
 
-uninstall:
-	$(RM) $(DEST_DIR)/$(TARGET)
-
-.PHONY: clean uninstall
+.PHONY: clean


### PR DESCRIPTION
- support both scanner.cc and scanner.c
- allow complete override for (`$CFLAGS`,`$CXXFLAGS`,`$LDFLAGS`)
- add `clean` target
- add `install` target
- add windows support

Tested on:
- Arch Linux
	```console
	$ make --version
	  GNU Make 4.3
	  Built for x86_64-pc-linux-gnu
	  Copyright (C) 1988-2020 Free Software Foundation, Inc.
	  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
	  This is free software: you are free to change and redistribute it.
	  There is NO WARRANTY, to the extent permitted by law.
	```
- MSYS2/Windows11
	```console
	  $ make --version
	  GNU Make 4.3
	  Built for x86_64-pc-msys
	  Copyright (C) 1988-2020 Free Software Foundation, Inc.
	  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
	  This is free software: you are free to change and redistribute it.
	  There is NO WARRANTY, to the extent permitted by law.
	```
