### PR TITLE
folds(c): fold at compound_statement

### DIFF
--- a/queries/c/folds.scm
+++ b/queries/c/folds.scm
@@ -13,5 +13,6 @@
  (preproc_else)
  (preproc_ifdef)
  (initializer_list)
+ (compound_statement)
 ] @fold
 


### PR DESCRIPTION
Enables folding local blocks like so:

```c
void f() {
    // this can now be folded
    {
        // ...
        // ...
    }

    // this can now be folded too
    {
        // ...
        // ...
    }
}
```