### PR TITLE
refactor(ci): standalone lockfile

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -1,5 +1,6 @@
 {
   "bash": {
+    "abi": 13,
     "filetype": "sh",
     "maintainers": [
       "@TravonteD"
@@ -8,6 +9,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-bash"
   },
   "beancount": {
+    "abi": 13,
     "filetype": "beancount",
     "maintainers": [
       "@polarmutex"
@@ -16,6 +18,7 @@
     "url": "https://github.com/polarmutex/tree-sitter-beancount"
   },
   "bibtex": {
+    "abi": 13,
     "filetype": "bib",
     "maintainers": [
       "@theHamsta by asking @clason"
@@ -24,6 +27,7 @@
     "url": "https://github.com/latex-lsp/tree-sitter-bibtex"
   },
   "c": {
+    "abi": 13,
     "filetype": "c",
     "maintainers": [
       "@vigoux"
@@ -32,6 +36,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-c"
   },
   "c_sharp": {
+    "abi": 13,
     "filetype": "cs",
     "maintainers": [
       "@Luxed"
@@ -40,6 +45,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-c-sharp"
   },
   "clojure": {
+    "abi": 13,
     "filetype": "clojure",
     "maintainers": [
       "@sogaiu"
@@ -48,14 +54,16 @@
     "url": "https://github.com/sogaiu/tree-sitter-clojure"
   },
   "cmake": {
+    "abi": 13,
     "filetype": "cmake",
     "maintainers": [
       "@uyha"
     ],
-    "revision": "5020572408a386d5d2dfac3516584f5edda7a49b"
+    "revision": "5020572408a386d5d2dfac3516584f5edda7a49b",
     "url": "https://github.com/uyha/tree-sitter-cmake"
   },
   "comment": {
+    "abi": 13,
     "filetype": "comment",
     "maintainers": [
       "@stsewd"
@@ -64,14 +72,16 @@
     "url": "https://github.com/stsewd/tree-sitter-comment"
   },
   "commonlisp": {
+    "abi": 13,
     "filetype": "lisp",
     "maintainers": [
       "@theHamsta"
     ],
-    "revision": "4fd115d3bb7046cd094f21bfe5766c302dbf64cd",
+    "revision": "c7e814975ab0d0d04333d1f32391c41180c58919",
     "url": "https://github.com/theHamsta/tree-sitter-commonlisp"
   },
   "cpp": {
+    "abi": 13,
     "filetype": "cpp",
     "maintainers": [
       "@theHamsta"
@@ -80,6 +90,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-cpp"
   },
   "css": {
+    "abi": 13,
     "filetype": "css",
     "maintainers": [
       "@TravonteD"
@@ -88,6 +99,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-css"
   },
   "cuda": {
+    "abi": 13,
     "filetype": "cuda",
     "maintainers": [
       "@theHamsta"
@@ -96,6 +108,7 @@
     "url": "https://github.com/theHamsta/tree-sitter-cuda"
   },
   "d": {
+    "abi": "NA",
     "filetype": "d",
     "maintainers": [
       "@nawordar"
@@ -104,6 +117,7 @@
     "url": "https://github.com/CyberShadow/tree-sitter-d"
   },
   "dart": {
+    "abi": 13,
     "filetype": "dart",
     "maintainers": [
       "@Akin909"
@@ -112,6 +126,7 @@
     "url": "https://github.com/UserNobody14/tree-sitter-dart"
   },
   "devicetree": {
+    "abi": 13,
     "filetype": "dts",
     "maintainers": [
       "@jedrzejboczar"
@@ -120,14 +135,16 @@
     "url": "https://github.com/joelspadin/tree-sitter-devicetree"
   },
   "dockerfile": {
+    "abi": 13,
     "filetype": "dockerfile",
     "maintainers": [
       "@camdencheek"
     ],
-    "revision": "28ac8596bab00b2dac9a76deaa9c4cb2b22642fd",
+    "revision": "d34a0cebd094e830bdd2106a28cb2f1fb22401d8",
     "url": "https://github.com/camdencheek/tree-sitter-dockerfile"
   },
   "dot": {
+    "abi": 13,
     "filetype": "dot",
     "maintainers": [
       "@rydesun"
@@ -136,6 +153,7 @@
     "url": "https://github.com/rydesun/tree-sitter-dot"
   },
   "eex": {
+    "abi": 13,
     "filetype": "eex",
     "maintainers": [
       "@connorlay"
@@ -144,6 +162,7 @@
     "url": "https://github.com/connorlay/tree-sitter-eex"
   },
   "elixir": {
+    "abi": 13,
     "filetype": "elixir",
     "maintainers": [
       "@jonatanklosko"
@@ -152,12 +171,14 @@
     "url": "https://github.com/elixir-lang/tree-sitter-elixir"
   },
   "elm": {
+    "abi": 13,
     "filetype": "elm",
     "maintainers": [],
-    "revision": "bd50ccf66b42c55252ac8efc1086af4ac6bab8cd",
+    "revision": "6575badb926ca1664a7c2a4d9023f9c731316628",
     "url": "https://github.com/elm-tooling/tree-sitter-elm"
   },
   "erlang": {
+    "abi": 13,
     "filetype": "erlang",
     "maintainers": [
       "@ostera"
@@ -166,6 +187,7 @@
     "url": "https://github.com/AbstractMachinesLab/tree-sitter-erlang"
   },
   "fennel": {
+    "abi": 13,
     "filetype": "fennel",
     "maintainers": [
       "@TravonteD"
@@ -174,6 +196,7 @@
     "url": "https://github.com/travonted/tree-sitter-fennel"
   },
   "fish": {
+    "abi": 13,
     "filetype": "fish",
     "maintainers": [
       "@ram02z"
@@ -182,6 +205,7 @@
     "url": "https://github.com/ram02z/tree-sitter-fish"
   },
   "foam": {
+    "abi": 13,
     "filetype": "foam",
     "maintainers": [
       "@FoamScience"
@@ -190,12 +214,14 @@
     "url": "https://github.com/FoamScience/tree-sitter-foam"
   },
   "fortran": {
+    "abi": 13,
     "filetype": "fortran",
     "maintainers": [],
     "revision": "f0f2f100952a353e64e26b0fa710b4c296d7af13",
     "url": "https://github.com/stadelmanma/tree-sitter-fortran"
   },
   "fusion": {
+    "abi": "NA",
     "filetype": "fusion",
     "maintainers": [
       "@jirgn"
@@ -204,6 +230,7 @@
     "url": "https://gitlab.com/jirgn/tree-sitter-fusion.git"
   },
   "gdscript": {
+    "abi": 13,
     "filetype": "gdscript",
     "maintainers": [
       "@Shatur95"
@@ -212,14 +239,16 @@
     "url": "https://github.com/PrestonKnopp/tree-sitter-gdscript"
   },
   "glimmer": {
+    "abi": 13,
     "filetype": "handlebars",
     "maintainers": [
       "@alexlafroscia"
     ],
-    "revision": "2644d7db571fe36204fdfcf8eed7bfa97f32c25a",
+    "revision": "96722abc203a69901e1f416cdc4f82faf468b60d",
     "url": "https://github.com/alexlafroscia/tree-sitter-glimmer"
   },
   "glsl": {
+    "abi": 13,
     "filetype": "glsl",
     "maintainers": [
       "@theHamsta"
@@ -228,6 +257,7 @@
     "url": "https://github.com/theHamsta/tree-sitter-glsl"
   },
   "go": {
+    "abi": 13,
     "filetype": "go",
     "maintainers": [
       "@theHamsta",
@@ -237,6 +267,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-go"
   },
   "godot_resource": {
+    "abi": 13,
     "filetype": "gdresource",
     "maintainers": [
       "@pierpo"
@@ -245,6 +276,7 @@
     "url": "https://github.com/PrestonKnopp/tree-sitter-godot-resource"
   },
   "gomod": {
+    "abi": 13,
     "filetype": "gomod",
     "maintainers": [
       "@camdencheek"
@@ -253,6 +285,7 @@
     "url": "https://github.com/camdencheek/tree-sitter-go-mod"
   },
   "gowork": {
+    "abi": 13,
     "filetype": "gowork",
     "maintainers": [
       "@omertuc"
@@ -261,6 +294,7 @@
     "url": "https://github.com/omertuc/tree-sitter-go-work"
   },
   "graphql": {
+    "abi": 13,
     "filetype": "graphql",
     "maintainers": [
       "@bkegley"
@@ -269,18 +303,21 @@
     "url": "https://github.com/bkegley/tree-sitter-graphql"
   },
   "hack": {
+    "abi": 13,
     "filetype": "hack",
     "maintainers": [],
     "revision": "4770eb21a36307c156cfd2555ddd8e10c304fdc3",
     "url": "https://github.com/slackhq/tree-sitter-hack"
   },
   "haskell": {
+    "abi": 13,
     "filetype": "haskell",
     "maintainers": [],
     "revision": "d6ccd2d9c40bdec29fee0027ef04fe5ff1ae4ceb",
     "url": "https://github.com/tree-sitter/tree-sitter-haskell"
   },
   "hcl": {
+    "abi": 13,
     "filetype": "hcl",
     "maintainers": [
       "@MichaHoffmann"
@@ -289,6 +326,7 @@
     "url": "https://github.com/MichaHoffmann/tree-sitter-hcl"
   },
   "heex": {
+    "abi": 13,
     "filetype": "heex",
     "maintainers": [
       "@connorlay"
@@ -297,6 +335,7 @@
     "url": "https://github.com/connorlay/tree-sitter-heex"
   },
   "hjson": {
+    "abi": 13,
     "filetype": "hjson",
     "maintainers": [
       "@winston0410"
@@ -305,6 +344,7 @@
     "url": "https://github.com/winston0410/tree-sitter-hjson"
   },
   "hocon": {
+    "abi": 13,
     "filetype": "hocon",
     "maintainers": [
       "@antosha417"
@@ -313,6 +353,7 @@
     "url": "https://github.com/antosha417/tree-sitter-hocon"
   },
   "html": {
+    "abi": 13,
     "filetype": "html",
     "maintainers": [
       "@TravonteD"
@@ -321,6 +362,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-html"
   },
   "http": {
+    "abi": 13,
     "filetype": "http",
     "maintainers": [
       "@NTBBloodbath"
@@ -329,6 +371,7 @@
     "url": "https://github.com/NTBBloodbath/tree-sitter-http"
   },
   "java": {
+    "abi": 13,
     "filetype": "java",
     "maintainers": [
       "@p00f"
@@ -337,6 +380,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-java"
   },
   "javascript": {
+    "abi": 13,
     "filetype": "javascript",
     "maintainers": [
       "@steelsojka"
@@ -345,6 +389,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-javascript"
   },
   "jsdoc": {
+    "abi": 13,
     "filetype": "jsdoc",
     "maintainers": [
       "@steelsojka"
@@ -353,6 +398,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-jsdoc"
   },
   "json": {
+    "abi": 13,
     "filetype": "json",
     "maintainers": [
       "@steelsojka"
@@ -361,6 +407,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-json"
   },
   "json5": {
+    "abi": 13,
     "filetype": "json5",
     "maintainers": [
       "@Joakker"
@@ -369,6 +416,7 @@
     "url": "https://github.com/Joakker/tree-sitter-json5"
   },
   "jsonc": {
+    "abi": "NA",
     "filetype": "jsonc",
     "maintainers": [
       "@WhyNotHugo"
@@ -377,6 +425,7 @@
     "url": "https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git"
   },
   "julia": {
+    "abi": 13,
     "filetype": "julia",
     "maintainers": [
       "@mroavi",
@@ -386,6 +435,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-julia"
   },
   "kotlin": {
+    "abi": 13,
     "filetype": "kotlin",
     "maintainers": [
       "@SalBakraa"
@@ -394,6 +444,7 @@
     "url": "https://github.com/fwcd/tree-sitter-kotlin"
   },
   "latex": {
+    "abi": 13,
     "filetype": "tex",
     "maintainers": [
       "@theHamsta by asking @clason"
@@ -402,6 +453,7 @@
     "url": "https://github.com/latex-lsp/tree-sitter-latex"
   },
   "ledger": {
+    "abi": 13,
     "filetype": "ledger",
     "maintainers": [
       "@cbarrete"
@@ -410,6 +462,7 @@
     "url": "https://github.com/cbarrete/tree-sitter-ledger"
   },
   "llvm": {
+    "abi": 13,
     "filetype": "llvm",
     "maintainers": [
       "@benwilliamgraham"
@@ -418,14 +471,16 @@
     "url": "https://github.com/benwilliamgraham/tree-sitter-llvm"
   },
   "lua": {
+    "abi": 13,
     "filetype": "lua",
     "maintainers": [
       "@muniftanjim"
     ],
-    "revision": "2e372ad0af8c6a68ba39f107a2edc9e3fc19ecf1",
+    "revision": "547184a6cfcc900fcac4a2a56538fa8bcdb293e6",
     "url": "https://github.com/MunifTanjim/tree-sitter-lua"
   },
   "make": {
+    "abi": 13,
     "filetype": "make",
     "maintainers": [
       "@lewis6991"
@@ -434,12 +489,14 @@
     "url": "https://github.com/alemuller/tree-sitter-make"
   },
   "markdown": {
+    "abi": 13,
     "filetype": "markdown",
     "maintainers": [],
     "revision": "8bee14c30ecadd55c2d65633973b4e81f93525e0",
     "url": "https://github.com/MDeiml/tree-sitter-markdown"
   },
   "ninja": {
+    "abi": 13,
     "filetype": "ninja",
     "maintainers": [
       "@alemuller"
@@ -448,6 +505,7 @@
     "url": "https://github.com/alemuller/tree-sitter-ninja"
   },
   "nix": {
+    "abi": 13,
     "filetype": "nix",
     "maintainers": [
       "@leo60228"
@@ -456,6 +514,7 @@
     "url": "https://github.com/cstrahan/tree-sitter-nix"
   },
   "norg": {
+    "abi": 13,
     "filetype": "norg",
     "maintainers": [
       "@JoeyGrajciar",
@@ -466,6 +525,7 @@
     "url": "https://github.com/nvim-neorg/tree-sitter-norg"
   },
   "ocaml": {
+    "abi": "NA",
     "filetype": "ocaml",
     "maintainers": [
       "@undu"
@@ -474,6 +534,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-ocaml"
   },
   "ocaml_interface": {
+    "abi": "NA",
     "filetype": "ocamlinterface",
     "maintainers": [
       "@undu"
@@ -482,6 +543,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-ocaml"
   },
   "ocamllex": {
+    "abi": 11,
     "filetype": "ocamllex",
     "maintainers": [
       "@undu"
@@ -490,6 +552,7 @@
     "url": "https://github.com/atom-ocaml/tree-sitter-ocamllex"
   },
   "pascal": {
+    "abi": "NA",
     "filetype": "pascal",
     "maintainers": [
       "@isopod"
@@ -498,6 +561,7 @@
     "url": "https://github.com/Isopod/tree-sitter-pascal.git"
   },
   "perl": {
+    "abi": 13,
     "filetype": "perl",
     "maintainers": [
       "@ganezdragon"
@@ -506,6 +570,7 @@
     "url": "https://github.com/ganezdragon/tree-sitter-perl"
   },
   "php": {
+    "abi": 13,
     "filetype": "php",
     "maintainers": [
       "@tk-shirasaka"
@@ -514,14 +579,16 @@
     "url": "https://github.com/tree-sitter/tree-sitter-php"
   },
   "phpdoc": {
+    "abi": 12,
     "filetype": "phpdoc",
     "maintainers": [
       "@mikehaertl"
     ],
-    "revision": "52c0fbf581d0fc2d29696dbbd4fca99a73082210",
+    "revision": "4460793c1549da1830a178eba295a0c12c83ac2a",
     "url": "https://github.com/claytonrcarter/tree-sitter-phpdoc"
   },
   "pioasm": {
+    "abi": 13,
     "filetype": "pioasm",
     "maintainers": [
       "@leo60228"
@@ -530,6 +597,7 @@
     "url": "https://github.com/leo60228/tree-sitter-pioasm"
   },
   "prisma": {
+    "abi": 13,
     "filetype": "prisma",
     "maintainers": [
       "@elianiva"
@@ -538,6 +606,7 @@
     "url": "https://github.com/victorhqc/tree-sitter-prisma"
   },
   "pug": {
+    "abi": 13,
     "filetype": "pug",
     "maintainers": [
       "@zealot128"
@@ -546,15 +615,17 @@
     "url": "https://github.com/zealot128/tree-sitter-pug"
   },
   "python": {
+    "abi": 13,
     "filetype": "python",
     "maintainers": [
       "@stsewd",
       "@theHamsta"
     ],
-    "revision": "24b530ca158d2782ea9046e756057a412e16b52f",
+    "revision": "ed0fe62e55dc617ed9dec8817ebf771aa7cf3c42",
     "url": "https://github.com/tree-sitter/tree-sitter-python"
   },
   "ql": {
+    "abi": 13,
     "filetype": "ql",
     "maintainers": [
       "@pwntester"
@@ -563,6 +634,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-ql"
   },
   "query": {
+    "abi": 13,
     "filetype": "query",
     "maintainers": [
       "@steelsojka"
@@ -571,14 +643,16 @@
     "url": "https://github.com/nvim-treesitter/tree-sitter-query"
   },
   "r": {
+    "abi": 13,
     "filetype": "r",
     "maintainers": [
       "@jimhester"
     ],
-    "revision": "d9868735e401e4870a3d4422790b585fea3faec8",
+    "revision": "c19e54de252d5573cc2a762a030957074526fe99",
     "url": "https://github.com/r-lib/tree-sitter-r"
   },
   "rasi": {
+    "abi": 13,
     "filetype": "rasi",
     "maintainers": [
       "@Fymyte"
@@ -587,6 +661,7 @@
     "url": "https://github.com/Fymyte/tree-sitter-rasi"
   },
   "regex": {
+    "abi": 13,
     "filetype": "regex",
     "maintainers": [
       "@theHamsta"
@@ -595,6 +670,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-regex"
   },
   "rst": {
+    "abi": 13,
     "filetype": "rst",
     "maintainers": [
       "@stsewd"
@@ -603,14 +679,16 @@
     "url": "https://github.com/stsewd/tree-sitter-rst"
   },
   "ruby": {
+    "abi": 13,
     "filetype": "ruby",
     "maintainers": [
       "@TravonteD"
     ],
-    "revision": "888e2e563ed3b43c417f17e57f7e29c39ce9aeea",
+    "revision": "1ebfdb288842dae5a9233e2509a135949023dd82",
     "url": "https://github.com/tree-sitter/tree-sitter-ruby"
   },
   "rust": {
+    "abi": 13,
     "filetype": "rust",
     "maintainers": [
       "@vigoux"
@@ -619,6 +697,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-rust"
   },
   "scala": {
+    "abi": 13,
     "filetype": "scala",
     "maintainers": [
       "@stevanmilic"
@@ -627,6 +706,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-scala"
   },
   "scss": {
+    "abi": 13,
     "filetype": "scss",
     "maintainers": [
       "@elianiva"
@@ -635,6 +715,7 @@
     "url": "https://github.com/serenadeai/tree-sitter-scss"
   },
   "sparql": {
+    "abi": 13,
     "filetype": "sparql",
     "maintainers": [
       "@bonabeavis"
@@ -643,14 +724,16 @@
     "url": "https://github.com/BonaBeavis/tree-sitter-sparql"
   },
   "supercollider": {
+    "abi": 13,
     "filetype": "supercollider",
     "maintainers": [
       "@madskjeldgaard"
     ],
-    "revision": "a7201b61779be59ac0fc0d118746c886dbc3edbd",
+    "revision": "cd5004d456a356e9e4a16d62506729a4f1880a46",
     "url": "https://github.com/madskjeldgaard/tree-sitter-supercollider"
   },
   "surface": {
+    "abi": 13,
     "filetype": "sface",
     "maintainers": [
       "@connorlay"
@@ -659,6 +742,7 @@
     "url": "https://github.com/connorlay/tree-sitter-surface"
   },
   "svelte": {
+    "abi": 13,
     "filetype": "svelte",
     "maintainers": [
       "@elianiva"
@@ -667,12 +751,14 @@
     "url": "https://github.com/Himujjal/tree-sitter-svelte"
   },
   "swift": {
+    "abi": "NA",
     "filetype": "swift",
     "maintainers": [],
     "revision": "9ee2d8c29600425b64e7b173b2224033a0f99d0c",
     "url": "https://github.com/alex-pinkus/tree-sitter-swift"
   },
   "teal": {
+    "abi": "NA",
     "filetype": "teal",
     "maintainers": [
       "@euclidianAce"
@@ -681,14 +767,16 @@
     "url": "https://github.com/euclidianAce/tree-sitter-teal"
   },
   "tlaplus": {
+    "abi": 13,
     "filetype": "tla",
     "maintainers": [
       "@ahelwer"
     ],
-    "revision": "f99f369f4b907108ac35cc49a56b7c8602f8332d",
+    "revision": "258ad755168251d0f633b8db2c8a6214a08f6626",
     "url": "https://github.com/tlaplus-community/tree-sitter-tlaplus"
   },
   "toml": {
+    "abi": 13,
     "filetype": "toml",
     "maintainers": [
       "@tk-shirasaka"
@@ -697,6 +785,7 @@
     "url": "https://github.com/ikatyang/tree-sitter-toml"
   },
   "tsx": {
+    "abi": "NA",
     "filetype": "typescriptreact",
     "maintainers": [
       "@steelsojka"
@@ -705,6 +794,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-typescript"
   },
   "turtle": {
+    "abi": 13,
     "filetype": "turtle",
     "maintainers": [
       "@bonabeavis"
@@ -713,6 +803,7 @@
     "url": "https://github.com/BonaBeavis/tree-sitter-turtle"
   },
   "typescript": {
+    "abi": "NA",
     "filetype": "typescript",
     "maintainers": [
       "@steelsojka"
@@ -721,6 +812,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-typescript"
   },
   "verilog": {
+    "abi": 12,
     "filetype": "verilog",
     "maintainers": [
       "@zegervdv"
@@ -729,6 +821,7 @@
     "url": "https://github.com/tree-sitter/tree-sitter-verilog"
   },
   "vim": {
+    "abi": 13,
     "filetype": "vim",
     "maintainers": [
       "@vigoux"
@@ -737,6 +830,7 @@
     "url": "https://github.com/vigoux/tree-sitter-viml"
   },
   "vue": {
+    "abi": 13,
     "filetype": "vue",
     "maintainers": [
       "@WhyNotHugo"
@@ -745,6 +839,7 @@
     "url": "https://github.com/ikatyang/tree-sitter-vue"
   },
   "yaml": {
+    "abi": 13,
     "filetype": "yaml",
     "maintainers": [
       "@stsewd"
@@ -753,6 +848,7 @@
     "url": "https://github.com/ikatyang/tree-sitter-yaml"
   },
   "yang": {
+    "abi": 13,
     "filetype": "yang",
     "maintainers": [
       "@Hubro"
@@ -761,6 +857,7 @@
     "url": "https://github.com/Hubro/tree-sitter-yang"
   },
   "zig": {
+    "abi": 13,
     "filetype": "zig",
     "maintainers": [
       "@maxxnino"

--- a/lockfile.json
+++ b/lockfile.json
@@ -1,293 +1,774 @@
 {
   "bash": {
-    "revision": "275effdfc0edce774acf7d481f9ea195c6c403cd"
+    "filetype": "sh",
+    "maintainers": [
+      "@TravonteD"
+    ],
+    "revision": "275effdfc0edce774acf7d481f9ea195c6c403cd",
+    "url": "https://github.com/tree-sitter/tree-sitter-bash"
   },
   "beancount": {
-    "revision": "78b8ddca3ab774573a4e3bf64eabd79e9452cea9"
+    "filetype": "beancount",
+    "maintainers": [
+      "@polarmutex"
+    ],
+    "revision": "78b8ddca3ab774573a4e3bf64eabd79e9452cea9",
+    "url": "https://github.com/polarmutex/tree-sitter-beancount"
   },
   "bibtex": {
-    "revision": "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34"
+    "filetype": "bib",
+    "maintainers": [
+      "@theHamsta by asking @clason"
+    ],
+    "revision": "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34",
+    "url": "https://github.com/latex-lsp/tree-sitter-bibtex"
   },
   "c": {
-    "revision": "e348e8ec5efd3aac020020e4af53d2ff18f393a9"
+    "filetype": "c",
+    "maintainers": [
+      "@vigoux"
+    ],
+    "revision": "e348e8ec5efd3aac020020e4af53d2ff18f393a9",
+    "url": "https://github.com/tree-sitter/tree-sitter-c"
   },
   "c_sharp": {
-    "revision": "352a4630c81a7a5cbd3bc67327743bd8d38f2dd2"
+    "filetype": "cs",
+    "maintainers": [
+      "@Luxed"
+    ],
+    "revision": "352a4630c81a7a5cbd3bc67327743bd8d38f2dd2",
+    "url": "https://github.com/tree-sitter/tree-sitter-c-sharp"
   },
   "clojure": {
-    "revision": "39bf0977d223879436c1425fe6bfeb3bcfd86f92"
+    "filetype": "clojure",
+    "maintainers": [
+      "@sogaiu"
+    ],
+    "revision": "39bf0977d223879436c1425fe6bfeb3bcfd86f92",
+    "url": "https://github.com/sogaiu/tree-sitter-clojure"
   },
   "cmake": {
+    "filetype": "cmake",
+    "maintainers": [
+      "@uyha"
+    ],
     "revision": "5020572408a386d5d2dfac3516584f5edda7a49b"
+    "url": "https://github.com/uyha/tree-sitter-cmake"
   },
   "comment": {
-    "revision": "6975eb268f42df2afc313f96c0693e284685dba7"
+    "filetype": "comment",
+    "maintainers": [
+      "@stsewd"
+    ],
+    "revision": "6975eb268f42df2afc313f96c0693e284685dba7",
+    "url": "https://github.com/stsewd/tree-sitter-comment"
   },
   "commonlisp": {
-    "revision": "4fd115d3bb7046cd094f21bfe5766c302dbf64cd"
+    "filetype": "lisp",
+    "maintainers": [
+      "@theHamsta"
+    ],
+    "revision": "4fd115d3bb7046cd094f21bfe5766c302dbf64cd",
+    "url": "https://github.com/theHamsta/tree-sitter-commonlisp"
   },
   "cpp": {
-    "revision": "656d7ea44b2b0daece78791e30281e283f30001e"
+    "filetype": "cpp",
+    "maintainers": [
+      "@theHamsta"
+    ],
+    "revision": "656d7ea44b2b0daece78791e30281e283f30001e",
+    "url": "https://github.com/tree-sitter/tree-sitter-cpp"
   },
   "css": {
-    "revision": "a03f1d2d1dfbf6f8e0fdca5f9ff030228241eb57"
+    "filetype": "css",
+    "maintainers": [
+      "@TravonteD"
+    ],
+    "revision": "a03f1d2d1dfbf6f8e0fdca5f9ff030228241eb57",
+    "url": "https://github.com/tree-sitter/tree-sitter-css"
   },
   "cuda": {
-    "revision": "14cd86e18ba45e327017de5b3e0f8d8f7f8e98ec"
+    "filetype": "cuda",
+    "maintainers": [
+      "@theHamsta"
+    ],
+    "revision": "14cd86e18ba45e327017de5b3e0f8d8f7f8e98ec",
+    "url": "https://github.com/theHamsta/tree-sitter-cuda"
   },
   "d": {
-    "revision": "c2fbf21bd3aa45495fe13247e040ad5815250032"
+    "filetype": "d",
+    "maintainers": [
+      "@nawordar"
+    ],
+    "revision": "c2fbf21bd3aa45495fe13247e040ad5815250032",
+    "url": "https://github.com/CyberShadow/tree-sitter-d"
   },
   "dart": {
-    "revision": "6a25376685d1d47968c2cef06d4db8d84a70025e"
+    "filetype": "dart",
+    "maintainers": [
+      "@Akin909"
+    ],
+    "revision": "6a25376685d1d47968c2cef06d4db8d84a70025e",
+    "url": "https://github.com/UserNobody14/tree-sitter-dart"
   },
   "devicetree": {
-    "revision": "fa70098cd70393f84785f85cdc6a45299b59cd5b"
+    "filetype": "dts",
+    "maintainers": [
+      "@jedrzejboczar"
+    ],
+    "revision": "fa70098cd70393f84785f85cdc6a45299b59cd5b",
+    "url": "https://github.com/joelspadin/tree-sitter-devicetree"
   },
   "dockerfile": {
-    "revision": "d34a0cebd094e830bdd2106a28cb2f1fb22401d8"
+    "filetype": "dockerfile",
+    "maintainers": [
+      "@camdencheek"
+    ],
+    "revision": "28ac8596bab00b2dac9a76deaa9c4cb2b22642fd",
+    "url": "https://github.com/camdencheek/tree-sitter-dockerfile"
   },
   "dot": {
-    "revision": "92877bac7033e409ccfb3f07fe28ef1dfd359457"
+    "filetype": "dot",
+    "maintainers": [
+      "@rydesun"
+    ],
+    "revision": "92877bac7033e409ccfb3f07fe28ef1dfd359457",
+    "url": "https://github.com/rydesun/tree-sitter-dot"
+  },
+  "eex": {
+    "filetype": "eex",
+    "maintainers": [
+      "@connorlay"
+    ],
+    "revision": "f742f2fe327463335e8671a87c0b9b396905d1d1",
+    "url": "https://github.com/connorlay/tree-sitter-eex"
   },
   "eex": {
     "revision": "f742f2fe327463335e8671a87c0b9b396905d1d1"
   },
   "elixir": {
-    "revision": "de20391afe5cb03ef1e8a8e43167e7b58cc52869"
+    "filetype": "elixir",
+    "maintainers": [
+      "@jonatanklosko"
+    ],
+    "revision": "de20391afe5cb03ef1e8a8e43167e7b58cc52869",
+    "url": "https://github.com/elixir-lang/tree-sitter-elixir"
   },
   "elm": {
-    "revision": "6575badb926ca1664a7c2a4d9023f9c731316628"
+    "filetype": "elm",
+    "maintainers": [],
+    "revision": "bd50ccf66b42c55252ac8efc1086af4ac6bab8cd",
+    "url": "https://github.com/elm-tooling/tree-sitter-elm"
   },
   "erlang": {
-    "revision": "9d5fd0c329280a156bf7614a49dc5e8c58cc037c"
+    "filetype": "erlang",
+    "maintainers": [
+      "@ostera"
+    ],
+    "revision": "9d5fd0c329280a156bf7614a49dc5e8c58cc037c",
+    "url": "https://github.com/AbstractMachinesLab/tree-sitter-erlang"
   },
   "fennel": {
-    "revision": "fce4331731a960077ff5f98939bc675179f1908a"
+    "filetype": "fennel",
+    "maintainers": [
+      "@TravonteD"
+    ],
+    "revision": "fce4331731a960077ff5f98939bc675179f1908a",
+    "url": "https://github.com/travonted/tree-sitter-fennel"
   },
   "fish": {
-    "revision": "04e54ab6585dfd4fee6ddfe5849af56f101b6d4f"
+    "filetype": "fish",
+    "maintainers": [
+      "@ram02z"
+    ],
+    "revision": "04e54ab6585dfd4fee6ddfe5849af56f101b6d4f",
+    "url": "https://github.com/ram02z/tree-sitter-fish"
   },
   "foam": {
-    "revision": "fdb7f14b885abfc4df57728c9b2a2f2ad24d3cb7"
+    "filetype": "foam",
+    "maintainers": [
+      "@FoamScience"
+    ],
+    "revision": "fdb7f14b885abfc4df57728c9b2a2f2ad24d3cb7",
+    "url": "https://github.com/FoamScience/tree-sitter-foam"
   },
   "fortran": {
-    "revision": "f0f2f100952a353e64e26b0fa710b4c296d7af13"
+    "filetype": "fortran",
+    "maintainers": [],
+    "revision": "f0f2f100952a353e64e26b0fa710b4c296d7af13",
+    "url": "https://github.com/stadelmanma/tree-sitter-fortran"
   },
   "fusion": {
-    "revision": "19db2f47ba4c3a0f6238d4ae0e2abfca16e61dd6"
+    "filetype": "fusion",
+    "maintainers": [
+      "@jirgn"
+    ],
+    "revision": "19db2f47ba4c3a0f6238d4ae0e2abfca16e61dd6",
+    "url": "https://gitlab.com/jirgn/tree-sitter-fusion.git"
   },
   "gdscript": {
-    "revision": "2a6abdaa47fcb91397e09a97c7433fd995ea46c6"
+    "filetype": "gdscript",
+    "maintainers": [
+      "@Shatur95"
+    ],
+    "revision": "2a6abdaa47fcb91397e09a97c7433fd995ea46c6",
+    "url": "https://github.com/PrestonKnopp/tree-sitter-gdscript"
   },
   "glimmer": {
-    "revision": "96722abc203a69901e1f416cdc4f82faf468b60d"
+    "filetype": "handlebars",
+    "maintainers": [
+      "@alexlafroscia"
+    ],
+    "revision": "2644d7db571fe36204fdfcf8eed7bfa97f32c25a",
+    "url": "https://github.com/alexlafroscia/tree-sitter-glimmer"
   },
   "glsl": {
-    "revision": "ffb93961426926554a0ba4a389ea6e9d6fafdea9"
+    "filetype": "glsl",
+    "maintainers": [
+      "@theHamsta"
+    ],
+    "revision": "ffb93961426926554a0ba4a389ea6e9d6fafdea9",
+    "url": "https://github.com/theHamsta/tree-sitter-glsl"
   },
   "go": {
-    "revision": "0fa917a7022d1cd2e9b779a6a8fc5dc7fad69c75"
+    "filetype": "go",
+    "maintainers": [
+      "@theHamsta",
+      "@WinWisely268"
+    ],
+    "revision": "0fa917a7022d1cd2e9b779a6a8fc5dc7fad69c75",
+    "url": "https://github.com/tree-sitter/tree-sitter-go"
   },
   "godot_resource": {
-    "revision": "b6ef0768711086a86b3297056f9ffb5cc1d77b4a"
+    "filetype": "gdresource",
+    "maintainers": [
+      "@pierpo"
+    ],
+    "revision": "b6ef0768711086a86b3297056f9ffb5cc1d77b4a",
+    "url": "https://github.com/PrestonKnopp/tree-sitter-godot-resource"
   },
   "gomod": {
-    "revision": "3cbcb572109ea0bc476a292208722c326c9e6c3a"
+    "filetype": "gomod",
+    "maintainers": [
+      "@camdencheek"
+    ],
+    "revision": "3cbcb572109ea0bc476a292208722c326c9e6c3a",
+    "url": "https://github.com/camdencheek/tree-sitter-go-mod"
   },
   "gowork": {
-    "revision": "6dd9dd79fb51e9f2abc829d5e97b15015b6a8ae2"
+    "filetype": "gowork",
+    "maintainers": [
+      "@omertuc"
+    ],
+    "revision": "6dd9dd79fb51e9f2abc829d5e97b15015b6a8ae2",
+    "url": "https://github.com/omertuc/tree-sitter-go-work"
   },
   "graphql": {
-    "revision": "5e66e961eee421786bdda8495ed1db045e06b5fe"
+    "filetype": "graphql",
+    "maintainers": [
+      "@bkegley"
+    ],
+    "revision": "5e66e961eee421786bdda8495ed1db045e06b5fe",
+    "url": "https://github.com/bkegley/tree-sitter-graphql"
   },
   "hack": {
-    "revision": "4770eb21a36307c156cfd2555ddd8e10c304fdc3"
+    "filetype": "hack",
+    "maintainers": [],
+    "revision": "4770eb21a36307c156cfd2555ddd8e10c304fdc3",
+    "url": "https://github.com/slackhq/tree-sitter-hack"
   },
   "haskell": {
-    "revision": "d6ccd2d9c40bdec29fee0027ef04fe5ff1ae4ceb"
+    "filetype": "haskell",
+    "maintainers": [],
+    "revision": "d6ccd2d9c40bdec29fee0027ef04fe5ff1ae4ceb",
+    "url": "https://github.com/tree-sitter/tree-sitter-haskell"
   },
   "hcl": {
-    "revision": "3cb7fc28247efbcb2973b97e71c78838ad98a583"
+    "filetype": "hcl",
+    "maintainers": [
+      "@MichaHoffmann"
+    ],
+    "revision": "3cb7fc28247efbcb2973b97e71c78838ad98a583",
+    "url": "https://github.com/MichaHoffmann/tree-sitter-hcl"
   },
   "heex": {
-    "revision": "d8b5b9f016cd3c7b0ee916cf031d9a2188c0fc44"
+    "filetype": "heex",
+    "maintainers": [
+      "@connorlay"
+    ],
+    "revision": "d8b5b9f016cd3c7b0ee916cf031d9a2188c0fc44",
+    "url": "https://github.com/connorlay/tree-sitter-heex"
   },
   "hjson": {
-    "revision": "02fa3b79b3ff9a296066da6277adfc3f26cbc9e0"
+    "filetype": "hjson",
+    "maintainers": [
+      "@winston0410"
+    ],
+    "revision": "02fa3b79b3ff9a296066da6277adfc3f26cbc9e0",
+    "url": "https://github.com/winston0410/tree-sitter-hjson"
   },
   "hocon": {
-    "revision": "5b4688cc57c773e69fe7dfc3f6b83c054557f4f1"
+    "filetype": "hocon",
+    "maintainers": [
+      "@antosha417"
+    ],
+    "revision": "5b4688cc57c773e69fe7dfc3f6b83c054557f4f1",
+    "url": "https://github.com/antosha417/tree-sitter-hocon"
   },
   "html": {
-    "revision": "161a92474a7bb2e9e830e48e76426f38299d99d1"
+    "filetype": "html",
+    "maintainers": [
+      "@TravonteD"
+    ],
+    "revision": "161a92474a7bb2e9e830e48e76426f38299d99d1",
+    "url": "https://github.com/tree-sitter/tree-sitter-html"
   },
   "http": {
-    "revision": "bfddd16b1cf78e0042fd1f6846a179f76a254e20"
+    "filetype": "http",
+    "maintainers": [
+      "@NTBBloodbath"
+    ],
+    "revision": "bfddd16b1cf78e0042fd1f6846a179f76a254e20",
+    "url": "https://github.com/NTBBloodbath/tree-sitter-http"
   },
   "java": {
-    "revision": "a24ae7d16de3517bff243a87d087d0b4877a65c5"
+    "filetype": "java",
+    "maintainers": [
+      "@p00f"
+    ],
+    "revision": "a24ae7d16de3517bff243a87d087d0b4877a65c5",
+    "url": "https://github.com/tree-sitter/tree-sitter-java"
   },
   "javascript": {
-    "revision": "fdeb68ac8d2bd5a78b943528bb68ceda3aade2eb"
+    "filetype": "javascript",
+    "maintainers": [
+      "@steelsojka"
+    ],
+    "revision": "fdeb68ac8d2bd5a78b943528bb68ceda3aade2eb",
+    "url": "https://github.com/tree-sitter/tree-sitter-javascript"
   },
   "jsdoc": {
-    "revision": "189a6a4829beb9cdbe837260653b4a3dfb0cc3db"
+    "filetype": "jsdoc",
+    "maintainers": [
+      "@steelsojka"
+    ],
+    "revision": "189a6a4829beb9cdbe837260653b4a3dfb0cc3db",
+    "url": "https://github.com/tree-sitter/tree-sitter-jsdoc"
   },
   "json": {
-    "revision": "203e239408d642be83edde8988d6e7b20a19f0e8"
+    "filetype": "json",
+    "maintainers": [
+      "@steelsojka"
+    ],
+    "revision": "203e239408d642be83edde8988d6e7b20a19f0e8",
+    "url": "https://github.com/tree-sitter/tree-sitter-json"
   },
   "json5": {
-    "revision": "5dd5cdc418d9659682556b6adca2dd9ace0ac6d2"
+    "filetype": "json5",
+    "maintainers": [
+      "@Joakker"
+    ],
+    "revision": "5dd5cdc418d9659682556b6adca2dd9ace0ac6d2",
+    "url": "https://github.com/Joakker/tree-sitter-json5"
   },
   "jsonc": {
-    "revision": "02b01653c8a1c198ae7287d566efa86a135b30d5"
+    "filetype": "jsonc",
+    "maintainers": [
+      "@WhyNotHugo"
+    ],
+    "revision": "02b01653c8a1c198ae7287d566efa86a135b30d5",
+    "url": "https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git"
   },
   "julia": {
-    "revision": "12ea597262125fc22fd2e91aa953ac69b19c26ca"
+    "filetype": "julia",
+    "maintainers": [
+      "@mroavi",
+      "@theHamsta"
+    ],
+    "revision": "12ea597262125fc22fd2e91aa953ac69b19c26ca",
+    "url": "https://github.com/tree-sitter/tree-sitter-julia"
   },
   "kotlin": {
-    "revision": "a4f71eb9b8c9b19ded3e0e9470be4b1b77c2b569"
+    "filetype": "kotlin",
+    "maintainers": [
+      "@SalBakraa"
+    ],
+    "revision": "a4f71eb9b8c9b19ded3e0e9470be4b1b77c2b569",
+    "url": "https://github.com/fwcd/tree-sitter-kotlin"
   },
   "latex": {
-    "revision": "6f796b700c69a8af28132e84ed6d0c8f0c17a5e2"
+    "filetype": "tex",
+    "maintainers": [
+      "@theHamsta by asking @clason"
+    ],
+    "revision": "6f796b700c69a8af28132e84ed6d0c8f0c17a5e2",
+    "url": "https://github.com/latex-lsp/tree-sitter-latex"
   },
   "ledger": {
-    "revision": "0cdeb0e51411a3ba5493662952c3039de08939ca"
+    "filetype": "ledger",
+    "maintainers": [
+      "@cbarrete"
+    ],
+    "revision": "0cdeb0e51411a3ba5493662952c3039de08939ca",
+    "url": "https://github.com/cbarrete/tree-sitter-ledger"
   },
   "llvm": {
-    "revision": "3b213925b9c4f42c1acfe2e10bfbb438d9c6834d"
+    "filetype": "llvm",
+    "maintainers": [
+      "@benwilliamgraham"
+    ],
+    "revision": "3b213925b9c4f42c1acfe2e10bfbb438d9c6834d",
+    "url": "https://github.com/benwilliamgraham/tree-sitter-llvm"
   },
   "lua": {
-    "revision": "547184a6cfcc900fcac4a2a56538fa8bcdb293e6"
+    "filetype": "lua",
+    "maintainers": [
+      "@muniftanjim"
+    ],
+    "revision": "2e372ad0af8c6a68ba39f107a2edc9e3fc19ecf1",
+    "url": "https://github.com/MunifTanjim/tree-sitter-lua"
   },
   "make": {
-    "revision": "a4b9187417d6be349ee5fd4b6e77b4172c6827dd"
+    "filetype": "make",
+    "maintainers": [
+      "@lewis6991"
+    ],
+    "revision": "a4b9187417d6be349ee5fd4b6e77b4172c6827dd",
+    "url": "https://github.com/alemuller/tree-sitter-make"
   },
   "markdown": {
-    "revision": "8bee14c30ecadd55c2d65633973b4e81f93525e0"
+    "filetype": "markdown",
+    "maintainers": [],
+    "revision": "8bee14c30ecadd55c2d65633973b4e81f93525e0",
+    "url": "https://github.com/MDeiml/tree-sitter-markdown"
   },
   "ninja": {
-    "revision": "0a95cfdc0745b6ae82f60d3a339b37f19b7b9267"
+    "filetype": "ninja",
+    "maintainers": [
+      "@alemuller"
+    ],
+    "revision": "0a95cfdc0745b6ae82f60d3a339b37f19b7b9267",
+    "url": "https://github.com/alemuller/tree-sitter-ninja"
   },
   "nix": {
-    "revision": "6d6aaa50793b8265b6a8b6628577a0083d3b923d"
+    "filetype": "nix",
+    "maintainers": [
+      "@leo60228"
+    ],
+    "revision": "6d6aaa50793b8265b6a8b6628577a0083d3b923d",
+    "url": "https://github.com/cstrahan/tree-sitter-nix"
   },
   "norg": {
-    "revision": "c4be6addec0a8ada234684ced6c928189fd399af"
+    "filetype": "norg",
+    "maintainers": [
+      "@JoeyGrajciar",
+      "@vhyrro",
+      "@mrossinek"
+    ],
+    "revision": "c4be6addec0a8ada234684ced6c928189fd399af",
+    "url": "https://github.com/nvim-neorg/tree-sitter-norg"
   },
   "ocaml": {
-    "revision": "23d419ba45789c5a47d31448061557716b02750a"
+    "filetype": "ocaml",
+    "maintainers": [
+      "@undu"
+    ],
+    "revision": "23d419ba45789c5a47d31448061557716b02750a",
+    "url": "https://github.com/tree-sitter/tree-sitter-ocaml"
   },
   "ocaml_interface": {
-    "revision": "23d419ba45789c5a47d31448061557716b02750a"
+    "filetype": "ocamlinterface",
+    "maintainers": [
+      "@undu"
+    ],
+    "revision": "23d419ba45789c5a47d31448061557716b02750a",
+    "url": "https://github.com/tree-sitter/tree-sitter-ocaml"
   },
   "ocamllex": {
-    "revision": "ac1d5957e719d49bd6acd27439b79843e4daf8ed"
+    "filetype": "ocamllex",
+    "maintainers": [
+      "@undu"
+    ],
+    "revision": "ac1d5957e719d49bd6acd27439b79843e4daf8ed",
+    "url": "https://github.com/atom-ocaml/tree-sitter-ocamllex"
   },
   "pascal": {
-    "revision": "2fd40f477d3e2794af152618ccfac8d92eb72a66"
+    "filetype": "pascal",
+    "maintainers": [
+      "@isopod"
+    ],
+    "revision": "2fd40f477d3e2794af152618ccfac8d92eb72a66",
+    "url": "https://github.com/Isopod/tree-sitter-pascal.git"
   },
   "perl": {
-    "revision": "ab2b39439f2fc82fd5ea0b7e08509760d4cbacd5"
+    "filetype": "perl",
+    "maintainers": [
+      "@ganezdragon"
+    ],
+    "revision": "ab2b39439f2fc82fd5ea0b7e08509760d4cbacd5",
+    "url": "https://github.com/ganezdragon/tree-sitter-perl"
   },
   "php": {
-    "revision": "57f855461aeeca73bd4218754fb26b5ac143f98f"
+    "filetype": "php",
+    "maintainers": [
+      "@tk-shirasaka"
+    ],
+    "revision": "57f855461aeeca73bd4218754fb26b5ac143f98f",
+    "url": "https://github.com/tree-sitter/tree-sitter-php"
   },
   "phpdoc": {
-    "revision": "4460793c1549da1830a178eba295a0c12c83ac2a"
+    "filetype": "phpdoc",
+    "maintainers": [
+      "@mikehaertl"
+    ],
+    "revision": "52c0fbf581d0fc2d29696dbbd4fca99a73082210",
+    "url": "https://github.com/claytonrcarter/tree-sitter-phpdoc"
   },
   "pioasm": {
-    "revision": "924aadaf5dea2a6074d72027b064f939acf32e20"
+    "filetype": "pioasm",
+    "maintainers": [
+      "@leo60228"
+    ],
+    "revision": "924aadaf5dea2a6074d72027b064f939acf32e20",
+    "url": "https://github.com/leo60228/tree-sitter-pioasm"
   },
   "prisma": {
-    "revision": "74a721e8eed1a4a25cf495d45974ba24f315f81a"
+    "filetype": "prisma",
+    "maintainers": [
+      "@elianiva"
+    ],
+    "revision": "74a721e8eed1a4a25cf495d45974ba24f315f81a",
+    "url": "https://github.com/victorhqc/tree-sitter-prisma"
   },
   "pug": {
-    "revision": "5875f9a7d94836708119b0a1102bb5792e8bf673"
+    "filetype": "pug",
+    "maintainers": [
+      "@zealot128"
+    ],
+    "revision": "5875f9a7d94836708119b0a1102bb5792e8bf673",
+    "url": "https://github.com/zealot128/tree-sitter-pug"
   },
   "python": {
-    "revision": "ed0fe62e55dc617ed9dec8817ebf771aa7cf3c42"
+    "filetype": "python",
+    "maintainers": [
+      "@stsewd",
+      "@theHamsta"
+    ],
+    "revision": "24b530ca158d2782ea9046e756057a412e16b52f",
+    "url": "https://github.com/tree-sitter/tree-sitter-python"
   },
   "ql": {
-    "revision": "8e7fd7e638d4a0ec7a792ee16b19dbc6407aa810"
+    "filetype": "ql",
+    "maintainers": [
+      "@pwntester"
+    ],
+    "revision": "8e7fd7e638d4a0ec7a792ee16b19dbc6407aa810",
+    "url": "https://github.com/tree-sitter/tree-sitter-ql"
   },
   "query": {
-    "revision": "5217c6805c09f8fc00ed13d17d5fcb791437aee6"
+    "filetype": "query",
+    "maintainers": [
+      "@steelsojka"
+    ],
+    "revision": "5217c6805c09f8fc00ed13d17d5fcb791437aee6",
+    "url": "https://github.com/nvim-treesitter/tree-sitter-query"
   },
   "r": {
-    "revision": "c19e54de252d5573cc2a762a030957074526fe99"
+    "filetype": "r",
+    "maintainers": [
+      "@jimhester"
+    ],
+    "revision": "d9868735e401e4870a3d4422790b585fea3faec8",
+    "url": "https://github.com/r-lib/tree-sitter-r"
   },
   "rasi": {
-    "revision": "e2961f02244c068a67549adf896b0779e4a29516"
+    "filetype": "rasi",
+    "maintainers": [
+      "@Fymyte"
+    ],
+    "revision": "e2961f02244c068a67549adf896b0779e4a29516",
+    "url": "https://github.com/Fymyte/tree-sitter-rasi"
   },
   "regex": {
-    "revision": "e1cfca3c79896ff79842f057ea13e529b66af636"
+    "filetype": "regex",
+    "maintainers": [
+      "@theHamsta"
+    ],
+    "revision": "e1cfca3c79896ff79842f057ea13e529b66af636",
+    "url": "https://github.com/tree-sitter/tree-sitter-regex"
   },
   "rst": {
-    "revision": "b74770c0166f28c1a0ab293513a78712ca1c338b"
+    "filetype": "rst",
+    "maintainers": [
+      "@stsewd"
+    ],
+    "revision": "b74770c0166f28c1a0ab293513a78712ca1c338b",
+    "url": "https://github.com/stsewd/tree-sitter-rst"
   },
   "ruby": {
-    "revision": "1ebfdb288842dae5a9233e2509a135949023dd82"
+    "filetype": "ruby",
+    "maintainers": [
+      "@TravonteD"
+    ],
+    "revision": "888e2e563ed3b43c417f17e57f7e29c39ce9aeea",
+    "url": "https://github.com/tree-sitter/tree-sitter-ruby"
   },
   "rust": {
-    "revision": "eeb0702ebdac504b97196577b1dac43c80913d7b"
+    "filetype": "rust",
+    "maintainers": [
+      "@vigoux"
+    ],
+    "revision": "eeb0702ebdac504b97196577b1dac43c80913d7b",
+    "url": "https://github.com/tree-sitter/tree-sitter-rust"
   },
   "scala": {
-    "revision": "0a3dd53a7fc4b352a538397d054380aaa28be54c"
+    "filetype": "scala",
+    "maintainers": [
+      "@stevanmilic"
+    ],
+    "revision": "0a3dd53a7fc4b352a538397d054380aaa28be54c",
+    "url": "https://github.com/tree-sitter/tree-sitter-scala"
   },
   "scss": {
-    "revision": "f3174d3d131eb776f86dfa3d90fe6f7325c0ad9a"
+    "filetype": "scss",
+    "maintainers": [
+      "@elianiva"
+    ],
+    "revision": "f3174d3d131eb776f86dfa3d90fe6f7325c0ad9a",
+    "url": "https://github.com/serenadeai/tree-sitter-scss"
   },
   "sparql": {
-    "revision": "05f949d3c1c15e3261473a244d3ce87777374dec"
+    "filetype": "sparql",
+    "maintainers": [
+      "@bonabeavis"
+    ],
+    "revision": "05f949d3c1c15e3261473a244d3ce87777374dec",
+    "url": "https://github.com/BonaBeavis/tree-sitter-sparql"
   },
   "supercollider": {
-    "revision": "a7201b61779be59ac0fc0d118746c886dbc3edbd"
+    "filetype": "supercollider",
+    "maintainers": [
+      "@madskjeldgaard"
+    ],
+    "revision": "a7201b61779be59ac0fc0d118746c886dbc3edbd",
+    "url": "https://github.com/madskjeldgaard/tree-sitter-supercollider"
   },
   "surface": {
-    "revision": "f4586b35ac8548667a9aaa4eae44456c1f43d032"
+    "filetype": "sface",
+    "maintainers": [
+      "@connorlay"
+    ],
+    "revision": "f4586b35ac8548667a9aaa4eae44456c1f43d032",
+    "url": "https://github.com/connorlay/tree-sitter-surface"
   },
   "svelte": {
-    "revision": "98274d94ec33e994e8354d9ddfdef58cca471294"
+    "filetype": "svelte",
+    "maintainers": [
+      "@elianiva"
+    ],
+    "revision": "98274d94ec33e994e8354d9ddfdef58cca471294",
+    "url": "https://github.com/Himujjal/tree-sitter-svelte"
   },
   "swift": {
-    "revision": "9ee2d8c29600425b64e7b173b2224033a0f99d0c"
+    "filetype": "swift",
+    "maintainers": [],
+    "revision": "9ee2d8c29600425b64e7b173b2224033a0f99d0c",
+    "url": "https://github.com/alex-pinkus/tree-sitter-swift"
   },
   "teal": {
-    "revision": "fcc5f6f4d194dede4e676834ff28a506e39e17b4"
+    "filetype": "teal",
+    "maintainers": [
+      "@euclidianAce"
+    ],
+    "revision": "fcc5f6f4d194dede4e676834ff28a506e39e17b4",
+    "url": "https://github.com/euclidianAce/tree-sitter-teal"
   },
   "tlaplus": {
-    "revision": "f99f369f4b907108ac35cc49a56b7c8602f8332d"
+    "filetype": "tla",
+    "maintainers": [
+      "@ahelwer"
+    ],
+    "revision": "f99f369f4b907108ac35cc49a56b7c8602f8332d",
+    "url": "https://github.com/tlaplus-community/tree-sitter-tlaplus"
   },
   "toml": {
-    "revision": "8bd2056818b21860e3d756b5a58c4f6e05fb744e"
+    "filetype": "toml",
+    "maintainers": [
+      "@tk-shirasaka"
+    ],
+    "revision": "8bd2056818b21860e3d756b5a58c4f6e05fb744e",
+    "url": "https://github.com/ikatyang/tree-sitter-toml"
   },
   "tsx": {
-    "revision": "e8e8e8dc2745840b036421b4e43286750443cb13"
+    "filetype": "typescriptreact",
+    "maintainers": [
+      "@steelsojka"
+    ],
+    "revision": "e8e8e8dc2745840b036421b4e43286750443cb13",
+    "url": "https://github.com/tree-sitter/tree-sitter-typescript"
   },
   "turtle": {
-    "revision": "085437f5cb117703b7f520dd92161140a684f092"
+    "filetype": "turtle",
+    "maintainers": [
+      "@bonabeavis"
+    ],
+    "revision": "085437f5cb117703b7f520dd92161140a684f092",
+    "url": "https://github.com/BonaBeavis/tree-sitter-turtle"
   },
   "typescript": {
-    "revision": "e8e8e8dc2745840b036421b4e43286750443cb13"
+    "filetype": "typescript",
+    "maintainers": [
+      "@steelsojka"
+    ],
+    "revision": "e8e8e8dc2745840b036421b4e43286750443cb13",
+    "url": "https://github.com/tree-sitter/tree-sitter-typescript"
   },
   "verilog": {
-    "revision": "8f6b1f357d1231c420404b5f7a368a73c25adfa2"
+    "filetype": "verilog",
+    "maintainers": [
+      "@zegervdv"
+    ],
+    "revision": "6fae7414fa854b5052bee9111b200e9137797f3d",
+    "url": "https://github.com/tree-sitter/tree-sitter-verilog"
   },
   "vim": {
-    "revision": "bc573ef552adf8bed9e36eb687a0cccf43158634"
+    "filetype": "vim",
+    "maintainers": [
+      "@vigoux"
+    ],
+    "revision": "bc573ef552adf8bed9e36eb687a0cccf43158634",
+    "url": "https://github.com/vigoux/tree-sitter-viml"
   },
   "vue": {
-    "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06"
+    "filetype": "vue",
+    "maintainers": [
+      "@WhyNotHugo"
+    ],
+    "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06",
+    "url": "https://github.com/ikatyang/tree-sitter-vue"
   },
   "yaml": {
-    "revision": "0e36bed171768908f331ff7dff9d956bae016efb"
+    "filetype": "yaml",
+    "maintainers": [
+      "@stsewd"
+    ],
+    "revision": "0e36bed171768908f331ff7dff9d956bae016efb",
+    "url": "https://github.com/ikatyang/tree-sitter-yaml"
   },
   "yang": {
-    "revision": "8e9d175982afcefa3dac8ca20d40d1643accd2bd"
+    "filetype": "yang",
+    "maintainers": [
+      "@Hubro"
+    ],
+    "revision": "8e9d175982afcefa3dac8ca20d40d1643accd2bd",
+    "url": "https://github.com/Hubro/tree-sitter-yang"
   },
   "zig": {
-    "revision": "93331b8bd8b4ebee2b575490b2758f16ad4e9f30"
+    "filetype": "zig",
+    "maintainers": [
+      "@maxxnino"
+    ],
+    "revision": "93331b8bd8b4ebee2b575490b2758f16ad4e9f30",
+    "url": "https://github.com/maxxnino/tree-sitter-zig"
   }
 }

--- a/lockfile.json
+++ b/lockfile.json
@@ -143,9 +143,6 @@
     "revision": "f742f2fe327463335e8671a87c0b9b396905d1d1",
     "url": "https://github.com/connorlay/tree-sitter-eex"
   },
-  "eex": {
-    "revision": "f742f2fe327463335e8671a87c0b9b396905d1d1"
-  },
   "elixir": {
     "filetype": "elixir",
     "maintainers": [

--- a/scripts/abi_version.sh
+++ b/scripts/abi_version.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+DEBUG=
+
+function debug() {
+  if [[ -n "${DEBUG}" ]]; then
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*"
+  fi
+}
+
+################################################################################
+# Get the abi version number from a github remote
+# Arguments:
+#   Repo to be queried, e.g "elm-tooling/tree-sitter-elm"
+# Outputs:
+#   Writes the version number to stdout
+################################################################################
+function get_abi_version() {
+  local repo="$1"
+  local tree_path="repos/${repo}/contents/src"
+  echo "checking $repo at $tree_path"
+  gh api "${tree_path}" --jq '.[] | select(.name="parser.c").download_url' \
+    | xargs curl -LSs \
+    | grep -oP "define LANGUAGE_VERSION \K(\d+)" >&2
+}
+
+################################################################################
+# Update the abi version number for all applicable parsers
+# Arguments:
+#   lockfile path
+# Outputs:
+#   None
+################################################################################
+function update_all_abi() {
+  local -A list=()
+  local lockfile="${1:-lockfile.json}"
+  local repo abi_version temp
+  temp="$(mktemp)"
+
+  while IFS=$" " read -r parser url; do
+    repo=$(echo "${url}" | sed s"#https://github.com/##"g)
+    echo "fetching $parser at: $repo"
+    if [[ -n "${repo}" ]]; then
+      abi_version=$(gh api "repos/${repo}/contents/src" --jq '.[] | select(.name="parser.c").download_url' \
+        | xargs curl -LSs \
+        | grep -oP "define LANGUAGE_VERSION \K(\d+)")
+
+      list+=(["${parser}"]=${abi_version})
+    fi
+  done < <(
+    jq -r '
+    to_entries[]
+    | [ .key, (.value.url) ]
+    | join(" ")
+    ' "${lockfile}"
+  )
+
+  for parser in "${!list[@]}"; do
+    local version=${list[$parser]}
+    debug "$parser ${version}"
+    if [[ -z ${version} ]]; then
+      continue;
+    fi
+    jq ".${parser}.abi=${version}" "${lockfile}" >"${temp}"
+    mv "${temp}" "${lockfile}"
+  done
+}
+
+if [[ -n "$1" ]]; then
+  get_abi_version "$@"
+else
+  update_all_abi "lockfile.json"
+fi

--- a/scripts/write-lockfile.lua
+++ b/scripts/write-lockfile.lua
@@ -94,9 +94,8 @@ local function write_lockfile(verbose, skipped_parers)
     local url = v.parser.install_info.url
     local maintainers = v.parser.maintainers or {}
     local filetype = v.parser.filetype or v.name
-    -- local is_github = repo.url:find("github.com", 1, true)
-    -- local is_gitlab = repo.url:find("gitlab.com", 1, true)
-    -- local revision = repo.revision or repo.branch or "master"
+    local abi = v.parser.abi or "NA"
+    local revision = v.parser.revision or v.parser.branch or "master"
 
     local on_done = function(success, result, errors)
       completed = completed + 1
@@ -106,10 +105,11 @@ local function write_lockfile(verbose, skipped_parers)
       end
       local latest_sha = result:gsub("\tHEAD\n", "")
       locked_parsers[v.name] = {
-        revision = latest_sha,
+        revision = latest_sha or revision,
         url = url,
         maintainers = maintainers,
         filetype = filetype,
+        abi = abi,
       }
     end
 

--- a/scripts/write-lockfile.lua
+++ b/scripts/write-lockfile.lua
@@ -5,6 +5,65 @@ if skip_langs == vim.NIL then
 else
   skip_langs = vim.fn.split(skip_langs, ",")
 end
+
+local ts_install = require "nvim-treesitter.install"
+local utils = require "nvim-treesitter.utils"
+local parsers = require "nvim-treesitter.parsers"
+
 print("Skipping languages: " .. vim.inspect(skip_langs))
-require("nvim-treesitter.install").write_lockfile("verbose", skip_langs)
+
+local filename = utils.join_path(utils.get_package_path(), "lockfile.json")
+
+local locked_parsers = ts_install.load_lockfile()
+
+local function write_lockfile(verbose, skipped_parers)
+  local sorted_parsers = {}
+  -- Load previous lockfile
+  skipped_parers = skipped_parers or {}
+
+  for k, v in pairs(parsers.get_parser_configs()) do
+    table.insert(sorted_parsers, { name = k, parser = v })
+  end
+
+  table.sort(sorted_parsers, function(a, b)
+    return a.name < b.name
+  end)
+
+  local Job = require "plenary.job"
+  local jobs = {}
+
+  for _, v in ipairs(sorted_parsers) do
+    if not vim.tbl_contains(skipped_parers, v.name) then
+      local url = v.parser.install_info.url
+      local maintainers = v.parser.maintainers or {}
+      local filetype = v.parser.filetype or v.name
+      local job = Job:new { command = "git", args = { "ls-remote", url, "HEAD" } }
+      job:after_success(function(this_job)
+        print("checked " .. v.name)
+        local latest_sha = this_job:result()[1]:gsub("\tHEAD", "")
+        locked_parsers[v.name] = {
+          revision = latest_sha,
+          url = url,
+          maintainers = maintainers,
+          filetype = filetype,
+        }
+      end)
+      job:start()
+      table.insert(jobs, job)
+    else
+      print("Skipping " .. v.name)
+    end
+  end
+  Job.join(unpack(jobs))
+
+  if verbose then
+    print(vim.inspect(locked_parsers))
+  end
+
+  local fd = assert(io.open(filename, "w"))
+  fd:write(vim.json.encode(locked_parsers), "\n")
+  fd:flush()
+end
+
+write_lockfile()
 vim.cmd "q"

--- a/scripts/write-lockfile.lua
+++ b/scripts/write-lockfile.lua
@@ -1,4 +1,5 @@
 -- Execute as `nvim --headless -c "luafile ./scripts/write-lockfile.lua"`
+
 local skip_langs = vim.fn.getenv "SKIP_LOCKFILE_UPDATE_FOR_LANGS"
 if skip_langs == vim.NIL then
   skip_langs = {}
@@ -12,49 +13,116 @@ local parsers = require "nvim-treesitter.parsers"
 
 print("Skipping languages: " .. vim.inspect(skip_langs))
 
+local function call_proc(process, opts, cb)
+  local std_output = ""
+  local error_output = ""
+
+  local function onread(handle, is_stderr)
+    return function(err, data)
+      if data then
+        if is_stderr then
+          error_output = (error_output or "") .. data
+        else
+          std_output = (std_output or "") .. data
+        end
+      end
+    end
+  end
+  local uv = vim.loop
+
+  local handle
+
+  local stdout = uv.new_pipe(false)
+  local stderr = uv.new_pipe(false)
+
+  local stdio = { nil, stdout, stderr }
+
+  handle = uv.spawn(
+    process,
+    { args = opts.args, cwd = uv.cwd(), stdio = stdio },
+    vim.schedule_wrap(function(code)
+      if code ~= 0 then
+        stdout:read_stop()
+        stderr:read_stop()
+      end
+
+      local check = uv.new_check()
+      check:start(function()
+        for _, pipe in ipairs(stdio) do
+          if pipe and not pipe:is_closing() then
+            return
+          end
+        end
+        check:stop()
+        handle:close()
+        cb(code, std_output, error_output)
+      end)
+    end)
+  )
+
+  uv.read_start(stdout, onread(handle, false))
+  uv.read_start(stderr, onread(handle, true))
+
+  return handle
+end
+
 local filename = utils.join_path(utils.get_package_path(), "lockfile.json")
 
 local locked_parsers = ts_install.load_lockfile()
 
+local completed = 0
+
 local function write_lockfile(verbose, skipped_parers)
-  local sorted_parsers = {}
+  local requested_parsers = {}
+  local active_jobs = {}
   -- Load previous lockfile
   skipped_parers = skipped_parers or {}
 
   for k, v in pairs(parsers.get_parser_configs()) do
-    table.insert(sorted_parsers, { name = k, parser = v })
-  end
-
-  table.sort(sorted_parsers, function(a, b)
-    return a.name < b.name
-  end)
-
-  local Job = require "plenary.job"
-  local jobs = {}
-
-  for _, v in ipairs(sorted_parsers) do
-    if not vim.tbl_contains(skipped_parers, v.name) then
-      local url = v.parser.install_info.url
-      local maintainers = v.parser.maintainers or {}
-      local filetype = v.parser.filetype or v.name
-      local job = Job:new { command = "git", args = { "ls-remote", url, "HEAD" } }
-      job:after_success(function(this_job)
-        print("checked " .. v.name)
-        local latest_sha = this_job:result()[1]:gsub("\tHEAD", "")
-        locked_parsers[v.name] = {
-          revision = latest_sha,
-          url = url,
-          maintainers = maintainers,
-          filetype = filetype,
-        }
-      end)
-      job:start()
-      table.insert(jobs, job)
+    if not vim.tbl_contains(skipped_parers, k) then
+      table.insert(requested_parsers, { name = k, parser = v })
     else
       print("Skipping " .. v.name)
     end
   end
-  Job.join(unpack(jobs))
+
+  table.sort(requested_parsers, function(a, b)
+    return a.name < b.name
+  end)
+
+  for _, v in ipairs(requested_parsers) do
+    local url = v.parser.install_info.url
+    local maintainers = v.parser.maintainers or {}
+    local filetype = v.parser.filetype or v.name
+    -- local is_github = repo.url:find("github.com", 1, true)
+    -- local is_gitlab = repo.url:find("gitlab.com", 1, true)
+    -- local revision = repo.revision or repo.branch or "master"
+
+    local on_done = function(success, result, errors)
+      completed = completed + 1
+      if not success then
+        print("error: " .. errors)
+        return
+      end
+      local latest_sha = result:gsub("\tHEAD\n", "")
+      locked_parsers[v.name] = {
+        revision = latest_sha,
+        url = url,
+        maintainers = maintainers,
+        filetype = filetype,
+      }
+    end
+
+    local handle = call_proc("git", { args = { "ls-remote", url, "HEAD" } }, on_done)
+    table.insert(active_jobs, handle)
+  end
+
+  print("active: " .. #active_jobs)
+  print("parsers: " .. #requested_parsers)
+
+  vim.wait(#active_jobs * 60 * 1000, function()
+    return completed == #active_jobs
+  end)
 
   if verbose then
     print(vim.inspect(locked_parsers))


### PR DESCRIPTION
- `write_lockfile()` now  ~~uses plenary~~ is now async to create a job pool this leads to the file being generated in <1s
- add other meta-info to the table to make it useful as stand-alone (WIP)

---

This `write_lockfile()` isn't meant for end-users, instead it should be invoked from the CI or manually by devs. Since it may have additional deps that aren't required for using the plugin.