### PR TITLE
Fix go indents

### DIFF
--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -1,6 +1,5 @@
 [
   (import_declaration)
-  (function_declaration)
   (const_declaration)
   (var_declaration)
   (type_declaration)

--- a/tests/indent/go/issue-2369.go
+++ b/tests/indent/go/issue-2369.go
@@ -1,0 +1,14 @@
+// https://github.com/nvim-treesitter/nvim-treesitter/issues/2369
+package main
+
+import "fmt"
+
+func goodIndent(param string) {
+	fmt.Println("typing o here works as expected")
+}
+
+func badIndent(
+	param string, // this is the difference
+) {
+	fmt.Println("typing o here triggers bad indent")
+}

--- a/tests/indent/go_spec.lua
+++ b/tests/indent/go_spec.lua
@@ -1,0 +1,21 @@
+local Runner = require("tests.indent.common").Runner
+--local XFAIL = require("tests.indent.common").XFAIL
+
+local run = Runner:new(it, "tests/indent/go", {
+  tabstop = 4,
+  shiftwidth = 4,
+  softtabstop = 4,
+  expandtab = false,
+})
+
+describe("indent Python:", function()
+  describe("whole file:", function()
+    run:whole_file(".", {
+      expected_failures = {},
+    })
+  end)
+
+  describe("new line:", function()
+    --run:new_line("issue-2369.go", { on_line = 1, text = "arg3,", indent = 19 })
+  end)
+end)


### PR DESCRIPTION
A quick fix for #2369. But I tested on #2333 that does an additional reparse on newline. There's more stuff to do on the Go queries but this should solve the problem reported in the issue.

Fixes #2369.

The indent on functions is already covered by `block`.

@primalmotion
