### PR TITLE
highlights(go): highlight `package_identifier` as `@namespace`

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -7,7 +7,7 @@
 (type_identifier) @type
 (field_identifier) @property
 (identifier) @variable
-(package_identifier) @variable
+(package_identifier) @namespace
 
 (parameter_declaration (identifier) @parameter)
 (variadic_parameter_declaration (identifier) @parameter)


### PR DESCRIPTION
I guess `@namespace` didn't exist the last time I touched the go highlights.


@primalmotion I'm not a go user. Do you think this is appropriate?