### PR TITLE
perf: load parsers' list on demand

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -337,7 +337,7 @@ M.commands = {
 -- @param lang: the language of the buffer (string)
 -- @param bufnr: the bufnr (number)
 function M.is_enabled(mod, lang, bufnr)
-  if not parsers.list[lang] or not parsers.has_parser(lang) then
+  if not parsers.has_parser(lang) then
     return false
   end
 

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -43,13 +43,11 @@ local function get_job_status()
 end
 
 local function get_parser_install_info(lang, validate)
-  local parser_config = parsers.get_parser_configs()[lang]
+  local install_info = parsers.get_parser_install_info(lang)
 
-  if not parser_config then
+  if not install_info then
     return error("Parser not available for language " .. lang)
   end
-
-  local install_info = parser_config.install_info
 
   if validate then
     vim.validate {

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -912,9 +912,7 @@ list.norg = {
   maintainers = { "@JoeyGrajciar", "@vhyrro", "@mrossinek" },
 }
 
-local M = {
-  list = list,
-}
+local M = {}
 
 function M.ft_to_lang(ft)
   local result = ft_to_parsername[ft]
@@ -926,27 +924,38 @@ function M.ft_to_lang(ft)
   end
 end
 
+function M.get_parser_configs()
+  return list
+end
+
+function M.get_parser_config(lang)
+  return list[lang]
+end
+
+function M.get_parser_install_info(lang)
+  return list[lang] and list[lang].install_info
+end
+
+local function parser_requires_grammer(lang)
+  return M.get_parser_install_info(lang).requires_generate_from_grammar
+end
+
 function M.available_parsers()
   if vim.fn.executable "tree-sitter" == 1 and vim.fn.executable "node" == 1 then
-    return vim.tbl_keys(M.list)
+    return vim.tbl_keys(M.get_parser_configs())
   else
     return vim.tbl_filter(function(p)
-      return not M.list[p].install_info.requires_generate_from_grammar
-    end, vim.tbl_keys(M.list))
+      return not parser_requires_grammer(p)
+    end, vim.tbl_keys(M.get_parser_configs()))
   end
 end
 
 function M.maintained_parsers()
   local has_tree_sitter_cli = vim.fn.executable "tree-sitter" == 1 and vim.fn.executable "node" == 1
   return vim.tbl_filter(function(lang)
-    return M.list[lang].maintainers
-      and not M.list[lang].experimental
-      and (has_tree_sitter_cli or not M.list[lang].install_info.requires_generate_from_grammar)
+    local parser = M.get_parser_config(lang)
+    return parser.maintainers and not parser.experimental and (has_tree_sitter_cli or not parser_requires_grammer(lang))
   end, M.available_parsers())
-end
-
-function M.get_parser_configs()
-  return M.list
 end
 
 local parser_files

--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -18,7 +18,7 @@ local function extract_captures()
   end
 
   -- Complete captures for injections.
-  local parsers = vim.tbl_keys(require("nvim-treesitter.parsers").list)
+  local parsers = vim.tbl_keys(require("nvim-treesitter.parsers").get_parser_configs())
   for _, lang in pairs(parsers) do
     table.insert(captures["injections"], lang)
   end

--- a/tests/unit/parsers_spec.lua
+++ b/tests/unit/parsers_spec.lua
@@ -4,43 +4,32 @@ local parsers = require "nvim-treesitter.parsers"
 describe("maintained_parsers", function()
   before_each(function()
     stub(vim.fn, "executable")
+    stub(parsers, "get_parser_config")
+    stub(parsers, "get_parser_configs")
   end)
 
   after_each(function()
     vim.fn.executable:clear()
+    parsers.get_parser_config:clear()
+    parsers.get_parser_configs:clear()
   end)
 
   it("does not return experimental parsers", function()
-    local old_list = parsers.list
-    parsers.list = {
-      c = {
-        install_info = {
-          url = "https://github.com/tree-sitter/tree-sitter-c",
-          files = { "src/parser.c" },
-        },
-        maintainers = { "@vigoux" },
+    local mock_c_parser = {
+      install_info = {
+        url = "https://github.com/tree-sitter/tree-sitter-c",
+        files = { "src/parser.c" },
       },
-      d = {
-        install_info = {
-          url = "https://github.com/CyberShadow/tree-sitter-d",
-          files = { "src/parser.c", "src/scanner.cc" },
-          requires_generate_from_grammar = true,
-        },
-        maintainers = { "@nawordar" },
-        experimental = true,
-      },
-      haskell = {
-        install_info = {
-          url = "https://github.com/tree-sitter/tree-sitter-haskell",
-          files = { "src/parser.c", "src/scanner.cc" },
-        },
-      },
+      maintainers = { "@vigoux" },
     }
 
-    local expected = { "c" }
+    local mock_list = {
+      c = mock_c_parser,
+    }
 
-    assert.same(parsers.maintained_parsers(), expected)
+    parsers.get_parser_config.returns(mock_c_parser)
+    parsers.get_parser_configs.returns(mock_list)
 
-    parsers.list = old_list
+    assert.same(parsers.maintained_parsers(), vim.tbl_keys(mock_list))
   end)
 end)


### PR DESCRIPTION
Add a new `get_parser_config()` to allow for better abstraction. This avoids hard-coding the structure of parsers-data, e.g. `install_info.url`, `maintainers`, etc.

Benefits:
- only load the list when needed
- easier stubbing for testing since there's no global list that needs to be modified anymore.
