### PR TITLE
folds(c): fold raw `compound_statement`s

### DIFF
--- a/queries/c/folds.scm
+++ b/queries/c/folds.scm
@@ -13,6 +13,7 @@
  (preproc_else)
  (preproc_ifdef)
  (initializer_list)
- (compound_statement)
 ] @fold
 
+ (compound_statement
+  (compound_statement) @fold)


### PR DESCRIPTION
This will fold in particular around raw braces
as reported in #2359 while avoiding to have double folds
at functions+braces. E.g.
```cpp
void foo()
{
    foo();
}
```
would only have one fold for the whole function. While we would still have folding at naked braces.


```cpp
void foo()
{
    // Section 1: we need to keep foo section for bar section separated
    {
          foo();
    }
   
    // Section 2:  bar does the actual work
    {
          bar();
    }

}
```

This is probably just a personal preference as some people might want to have double folds in such situation. 