### PR TITLE
feat: add `install_info.lock` & `install_info.ref`

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -66,17 +66,20 @@ local function load_lockfile()
   lockfile = vim.fn.filereadable(filename) == 1 and vim.fn.json_decode(vim.fn.readfile(filename)) or {}
 end
 
-local function get_revision(lang)
-  if #lockfile == 0 then
-    load_lockfile()
+local function git_ls_remote(remote_url)
+  -- I'm sure this can be done in an async way with iter_cmd
+  local lines = vim.fn.systemlist("git ls-remote " .. remote_url)
+  local refs = {}
+  for _, line in ipairs(lines) do
+    local line_values = vim.split(line, "\t")
+    local ref = table.remove(line_values, 2)
+    refs[ref] = line_values
   end
+  return refs
+end
 
-  local install_info = get_parser_install_info(lang)
-  if install_info.revision then
-    return install_info.revision
-  end
-
-  return (lockfile[lang] and lockfile[lang].revision)
+local function get_install_info_remote_sha(install_info)
+  return git_ls_remote(install_info.url)[install_info.ref or 'HEAD'][1]
 end
 
 local function get_installed_revision(lang)
@@ -84,6 +87,26 @@ local function get_installed_revision(lang)
   if vim.fn.filereadable(lang_file) == 1 then
     return vim.fn.readfile(lang_file)[1]
   end
+end
+
+local function get_revision(lang)
+  if #lockfile == 0 then
+    load_lockfile()
+  end
+
+  local install_info = get_parser_install_info(lang)
+  local lock = install_info.lock
+  if lock == true then
+    return get_installed_revision(lang)
+  end
+  if install_info.revision then
+    return install_info.revision
+  end
+  if lock == 'remote' then
+    return get_install_info_remote_sha(install_info)
+  end
+
+  return (lockfile[lang] and lockfile[lang].revision)
 end
 
 local function is_installed(lang)
@@ -513,8 +536,7 @@ function M.write_lockfile(verbose, skip_langs)
 
   for _, v in ipairs(sorted_parsers) do
     if not vim.tbl_contains(skip_langs, v.name) then
-      -- I'm sure this can be done in aync way with iter_cmd
-      local sha = vim.split(vim.fn.systemlist("git ls-remote " .. v.parser.install_info.url)[1], "\t")[1]
+      local sha = get_install_info_remote_sha(v.parser.install_info)
       lockfile[v.name] = { revision = sha }
       if verbose then
         print(v.name .. ": " .. sha)


### PR DESCRIPTION
Together, they allow for completely locking a revision to the currently installed revision or following the revision of a ref of the remote.

By unsetting `install_info.lock`, the revision will revert back to whatever the lockfile specifies.

This also allows nvim-treesitter to use packer-updated grammars more easily (call `packer.use()` with `cond = false` to never pollute your runtime files). (packer's local clones can keep calls to `git ls-remote` from blocking too much.)

I investigated calling `git ls-remote` in an async way for a bit as mentioned by the existing comment, but `iter_cmd` currently does not support operating on the output of a command, and I think I'd have to heavily restructure callers of `get_revision()`. In any case, this patch does introduce more synchronous blocking to existing configurations.

Example for a packer-managed local override to an existing parser:

```lua
require('packer').startup({function(use)
  use({'vigoux/tree-sitter-viml', cond = {false}})
  use({'nvim-treesitter/nvim-treesitter',
    config = {function ()
      local packer_package_root = require('packer').config.package_root
      local join_paths = require('packer.util').join_paths
      local function get_packer_opt_package_path(...)
        return join_paths(packer_package_root, 'packer', 'opt', ...)
      end

      local treesitter_parser_configs = require('nvim-treesitter.parsers').get_parser_configs()
      treesitter_parser_configs.vim.install_info.url = get_packer_opt_package_path('tree-sitter-viml')
      treesitter_parser_configs.vim.install_info.lock = 'remote'

      require('nvim-treesitter.configs').setup_config({
        ensure_installed = 'maintained',
        sync_install = false,
      })
    end},
    run = {':TSUpdate'},
  })
end})
```