### PR TITLE
chore: run parser update at least daily

### DIFF
--- a/.github/workflows/update-parsers-pr.yml
+++ b/.github/workflows/update-parsers-pr.yml
@@ -1,6 +1,8 @@
 name: Make Parser Update PR
 
 on:
+  schedule:
+    - cron: '30 6 * * *'
   push:
     branches:
       - master


### PR DESCRIPTION
This runs the update-parsers workflow every day (at 6:30 UTC, for no particular reason except before local morning) in addition to after each push to master. This ensures that we'll see parser updates even when nothing gets merged for a while.