### PR TITLE
Supercollider update: add support for const and fix indent bugs

### DIFF
--- a/queries/supercollider/highlights.scm
+++ b/queries/supercollider/highlights.scm
@@ -64,7 +64,7 @@
 [
 "arg"
 "classvar"
-; "const"
+"const"
 ; "super"
 ; "this"
 "var"

--- a/queries/supercollider/indents.scm
+++ b/queries/supercollider/indents.scm
@@ -1,8 +1,18 @@
 [
-  (collection)
-  (parameter_call_list)
   (function_block)
-  (code_block)
+  (binary_expression)
+  (collection)
+  (indexed_collection)
+  (parameter_call_list)
+  (function_call)
+  (class_def)
+  (classvar)
+  (const)
+  (instance_var)
+  (variable_definition)
+  (variable_definition_sequence (variable_definition))
+  (control_structure)
+  (return_statement)
 ] @indent
 
 [
@@ -14,3 +24,8 @@
   "["
   "]"
 ] @branch
+
+[
+  (block_comment)
+  (line_comment)
+] @ignore


### PR DESCRIPTION
replaces https://github.com/nvim-treesitter/nvim-treesitter/pull/2392 and https://github.com/nvim-treesitter/nvim-treesitter/pull/2393