### PR TITLE
highlights(cpp): fix function highlighting of Foo::bar::baz()

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -60,6 +60,16 @@
 (call_expression
   function: (qualified_identifier
               name: (identifier) @function))
+(call_expression
+  function: (qualified_identifier
+              name: (qualified_identifier
+                      name: (identifier) @function)))
+(call_expression
+  function: 
+      (qualified_identifier
+        name: (qualified_identifier
+              name: (qualified_identifier
+                      name: (identifier) @function))))
 
 (call_expression
   function: (field_expression

--- a/tests/query/highlights/cpp/static-namespace-functions.cpp
+++ b/tests/query/highlights/cpp/static-namespace-functions.cpp
@@ -1,0 +1,12 @@
+// Issue #2396
+
+int main()                                                                
+{                                                                         
+  B::foo();                                                                 
+  //  ^ @function
+  Foo::A::foo();                                                            
+  //       ^ @function
+  Foo::a::A::foo();                                                            
+  //          ^ @function
+  return 0;                                                                 
+}    


### PR DESCRIPTION
Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/2396

An instance of the classical nesting problem. It could be solved by `#has-ancestor?` but we're currently trying to remove it.

