### PR TITLE
highlights(lua): don't highlight arguments as parameters

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -161,8 +161,6 @@
 
 ;; Functions
 
-(arguments (identifier) @parameter)
-
 (parameters (identifier) @parameter)
 
 (function_call name: (identifier) @function)


### PR DESCRIPTION
This is not done in any other language. Before it would highlight the first `a` in `foo(a, a + b)` as parameter while the second `a` has the normal `variable` highlight. 