### PR TITLE
New make parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [llvm](https://github.com/benwilliamgraham/tree-sitter-llvm) (maintained by @benwilliamgraham)
 - [x] [lua](https://github.com/MunifTanjim/tree-sitter-lua) (maintained by @muniftanjim)
 - [x] [m68k](https://github.com/grahambates/tree-sitter-m68k) (maintained by @grahambates)
-- [x] [make](https://github.com/alemuller/tree-sitter-make) (maintained by @lewis6991)
+- [x] [make](https://github.com/alemuller/tree-sitter-make) (maintained by @alemuller, @lewis6991)
 - [x] [markdown](https://github.com/MDeiml/tree-sitter-markdown) (experimental, maintained by @MDeiml)
 - [x] [markdown_inline](https://github.com/MDeiml/tree-sitter-markdown) (experimental, maintained by @MDeiml)
 - [x] [ninja](https://github.com/alemuller/tree-sitter-ninja) (maintained by @alemuller)

--- a/lockfile.json
+++ b/lockfile.json
@@ -189,7 +189,7 @@
     "revision": "41284e89ef7bf711d2bd879c6205a9e94fd93a38"
   },
   "make": {
-    "revision": "a4b9187417d6be349ee5fd4b6e77b4172c6827dd"
+    "revision": "8881e0dc005862fa6954f1c67ecceacd53daa633"
   },
   "markdown": {
     "revision": "142a5b4a1b092b64c9f5db8f11558f9dd4009a1b"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -982,10 +982,10 @@ list.prisma = {
 list.make = {
   install_info = {
     url = "https://github.com/alemuller/tree-sitter-make",
-    branch = "main",
-    files = { "src/parser.c" },
+    branch = "master",
+    files = { "src/parser.c", "src/scanner.c" },
   },
-  maintainers = { "@lewis6991" },
+  maintainers = { "@alemuller", "@lewis6991" },
 }
 
 list.rasi = {

--- a/queries/make/highlights.scm
+++ b/queries/make/highlights.scm
@@ -1,120 +1,373 @@
-(comment) @comment
+;; Names
+;; =====
+(variable) @variable
+(filename) @string
+(library)  @string.special
+(pattern
+ . "%" @operator) @type
 
-(conditional
- (_ [
+(function_expansion
+  function: _ @function)
+
+(text) @text
+(quote) @string
+
+;; Keywords
+;; ========
+[
+  "include"
+  "sinclude"
+  "vpath"
+] @include
+
+[
+  "private"
+  "define"
+  "undefine"
+  "export"
+  "unexport"
+  "override"
+] @keyword
+
+[
   "ifeq"
-  "else"
   "ifneq"
   "ifdef"
   "ifndef"
- ] @conditional)
- "endif" @conditional)
+  "else"
+  "endif"
+] @conditional
 
-(rule (targets
-       (word) @function.builtin
-       (#any-of? @function.builtin
-        ".DEFAULT"
-        ".SUFFIXES"
-        ".DEFAULT"
-        ".DELETE_ON_ERROR"
-        ".EXPORT_ALL_VARIABLES"
-        ".IGNORE"
-        ".INTERMEDIATE"
-        ".LOW_RESOLUTION_TIME"
-        ".NOTPARALLEL"
-        ".ONESHELL"
-        ".PHONY"
-        ".POSIX"
-        ".PRECIOUS"
-        ".SECONDARY"
-        ".SECONDEXPANSION"
-        ".SILENT"
-        ".SUFFIXES")))
+;; Punctuation
+;; ===========
+[
+  "$"
+  "$$"
+] @punctuation.special
 
-(rule ["&:" ":" "::"] @operator)
+[
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket
 
-(export_directive "export" @keyword)
-(override_directive "override" @keyword)
-(include_directive ["include" "-include"] @include)
+[
+  "\""
+  "'"
+  ","
+] @punctuation.delimiter
 
+[
+  ; rule separator
+  ":"
+  "::"
+  "&:"
+  "&::"
+  "|"
+  ";"
+  ; assignment operator
+  "="
+  "?="
+  "+="
+  ":="
+  "::="
+  "!="
+  ; special prefix
+  "+" ; recurse
+  "-" ; silent
+  "@" ; noerror
+] @operator
+
+;; Override
+;; --------
+(directories                           ":"  @_clean @punctuation.delimiter)
+(variable_reference     [ "(" ")" "{" "}" ] @_clean @punctuation.special)
+(substitution_reference [ "(" ")" "{" "}" ] @_clean @punctuation.special)
+(function_expansion     [ "(" ")" "{" "}" ] @_clean @punctuation.special)
+
+;; Others
+;; ------
+(recipeprefix) @character
+
+;; Variables
+;; =========
+
+;; Special assignment
+;; ------------------
 (variable_assignment
- (word) @symbol)
-(variable_assignment [
- "?="
- ":="
- "+="
- "="
- ] @operator)
+   name: ((variable) @_c (#eq? @_c ".RECIPEPREFIX"))
+  value: (text) @character)
+
+;; Naming convention
+;; -----------------
+((variable) @_clean @constant
+   (#match? @_clean "^(LINT|COMPILE|LINK|PREPROCESS|OBJ|CHECKOUT)[.,]"))
+
+((variable) @_clean @constant
+   (#match? @_clean "FLAGS$"))
+
+((variable) @_clean @constant
+   (#match? @_clean "^CMAKE_"))
+
+((variable) @constant
+  (#any-of? @constant
+      "INSTALL"
+      "INSTALL_PROGRAM"
+      "INSTALL_DATA"
+      "DESTDIR"
+      "prefix"
+      "exec_prefix"
+      "bindir"
+      "sbindir"
+      "libexecdir"
+      "datarootdir"
+      "datadir"
+      "sysconfdir"
+      "sharedstatedir"
+      "localstatedir"
+      "runstatedir"
+      "includedir"
+      "oldincludedir"
+      "docdir"
+      "infodir"
+      "htmldir"
+      "dvidir"
+      "pdfdir"
+      "psdir"
+      "libdir"
+      "lispdir"
+      "localedir"
+      "mandir"
+      "man1dir"
+      "man2dir"
+      "manext"
+      "man1ext"
+      "man2ext"
+      "srcdir"))
+
+;; Special variables
+;; -----------------
+((variable) @_clean @constant.macro
+  (#any-of? @_clean
+      ;; automatic variables
+      "@" "@D" "@F"
+      "%" "%D" "%F"
+      "*" "*D" "*F"
+      "<" "<D" "<F"
+      "?" "?D" "?F"
+      "^" "^D" "^F"
+      "+" "+D" "+F"
+      "^" "|"  "_"
+      ;;
+      "VPATH"
+      ;;
+      ".DEFAULT_GOAL"
+      ".RECIPEPREFIX"
+      ".VARIABLES"
+      ".FEATURES"
+      ".INCLUDE_DIRS"
+      ".EXTRA_PREREQS"
+      ".LOADED"
+      ".SHELLFLAGS"
+      ".SHELLSTATUS"
+      ".LIBPATTERNS"))
+
+;; Built-ins variables
+;; -------------------
+((variable) @_clean @constant.builtin
+  (#any-of? @_clean
+      "VPATH"
+      "CURDIR"
+      "SUFFIXES"
+      "SHELL"
+      "MAKESHELL"
+      "COMSPEC"
+      "MAKE"
+      "MAKE_COMMAND"
+      "MAKE_VERSION"
+      "MAKEFLAGS"
+      "MAKEFILES"
+      "MAKEFILE_LIST"
+      "MAKE_HOST"
+      "MAKE_RESTARTS"
+      "MAKE_TERMOUT"
+      "MAKE_TERMERR"
+      "MAKELEVEL"
+      "MAKELEVEL_NAME"
+      "GNUMAKEFLAGS"
+      "MAKECMDGOALS"
+      "MAKEOVERRIDES"
+      ;;
+      "RM"
+      "LD"
+      ;; compilers
+      "AR"
+      "AS"
+      "CO"
+      "CC"
+      "CPP"
+      "CXX"
+      "FC"
+      "F77"
+      "GET"
+      "LEX"
+      "LINT" 
+      "M2C"
+      "OBJC"
+      "PC"
+      "MAKEINFO"
+      "TEX"
+      "TEXI2DVI"
+      "YACC" 
+      "TANGLE"
+      "CTANGLE"
+      "WEAVE"
+      "CWEAVE"
+      ;;
+      "LINK.c"
+      "LINK.C"
+      "LINK.cc"
+      "LINK.cpp"
+      "LINK.f"
+      "LINK.F"
+      "LINK.m"
+      "LINK.o"
+      "LINK.p"
+      "LINK.r"
+      "LINK.s"
+      "LINK.S"
+      ;; flags
+      "ARFLAGS"
+      "ASFLAGS"
+      "CFLAGS"
+      "COFLAGS"
+      "CPPFLAGS"
+      "CXXFLAGS"
+      "DEFFLAGS"
+      "F77FLAGS"
+      "FFLAGS"
+      "GFLAGS"
+      "GNUMAKEFLAGS"
+      "LDFLAGS"
+      "LFLAGS"
+      "LINTFLAGS"
+      "M2FLAGS"
+      "MAKEFLAGS"
+      "MFLAGS"
+      "MODFLAGS"
+      "OBJCFLAGS"
+      "PFLAGS"
+      "RFLAGS"
+      "YFLAGS"
+      "TEXI2DVI_FLAGS"
+      "MAKEINFO_FLAGS"
+      ;;
+      "OUTPUT_OPTION"
+      "SCCS_OUTPUT_OPTION"
+      ;;
+      "COMPILE.c"
+      "COMPILE.C"
+      "COMPILE.cc"
+      "COMPILE.cpp"
+      "COMPILE.def"
+      "COMPILE.f"
+      "COMPILE.F"
+      "COMPILE.m"
+      "COMPILE.mod"
+      "COMPILE.p"
+      "COMPILE.r"
+      "COMPILE.s"
+      "COMPILE.S"
+      "CHECKOUT,v"
+      "YACC.y"
+      "YACC.m"
+      "LEX.l"
+      "LEX.m"
+      "LINT.c"
+      ;;
+      "PREPROCESS.S"
+      "PREPROCESS.F"
+      "PREPROCESS.r"
+      ;;
+      "LOADLIBES"
+      "LDLIBS"
+      ;;
+      "TARGET_ARCH"
+      "TARGET_MACH"))
+
+;; Targets
+;; =======
+
+;; Naming convention
+;; -----------------
+(targets
+  (filename) @_clean @symbol
+   (#any-of? @_clean
+      "all"
+      "install"
+      "install-html"
+      "install-dvi"
+      "install-pdf"
+      "install-ps"
+      "uninstall"
+      "install-strip"
+      "clean"
+      "distclean"
+      "mostlyclean"
+      "maintainer-clean"
+      "TAGS"
+      "info"
+      "dvi"
+      "html"
+      "pdf"
+      "ps"
+      "dist"
+      "check"
+      "installcheck"
+      "installdirs"))
 
 
-(variable_assignment
- (word) @variable.builtin
- (#any-of? @variable.builtin
-  ".DEFAULT_GOAL"
-  ".EXTRA_PREREQS"
-  ".FEATURES"
-  ".INCLUDE_DIRS"
-  ".RECIPEPREFIX"
-  ".SHELLFLAGS"
-  ".VARIABLES"
-  "MAKEARGS"
-  "MAKEFILE_LIST"
-  "MAKEFLAGS"
-  "MAKE_RESTARTS"
-  "MAKE_TERMERR"
-  "MAKE_TERMOUT"
-  "SHELL"
- )
- )
+;; Special targets
+;; ---------------
+(targets
+  (filename) @_clean @string.special
+   (#any-of? @_clean
+      ".SUFFIXES"
+      ".PRECIOUS"
+      ".LOW_RESOLUTION_TIME"
+      ".PHONY"
+      ".INTERMEDIATE"
+      ".SECONDARY"
+      ".EXPORT_ALL_VARIABLES"
+      ".IGNORE"
+      ".SILENT"
+      ".NOTPARALLEL"
+      ".DELETE_ON_ERROR"
+      ".POSIX"
+      ".SECONDEXPANSION"
+      ".ONESHELL"
+      ".DEFAULT"))
 
+;; Functions
+;; =========
+(function_expansion
+  function: (name) @_fn (#eq? @_fn "info")
+            (arguments) @text.note)
 
+(function_expansion
+  function: (name) @_fn (#eq? @_fn "warning")
+            (arguments) @text.warning)
 
-; Use string to match bash
-(variable_reference (word) @string ) @operator
+(function_expansion
+  function: (name) @_fn (#eq? @_fn "error")
+            (arguments) @text.danger)
 
+;; Others
+;; =====
+[
+  (comment)
+  (split)
+] @comment
 
-(shell_function
- ["$" "(" ")"] @operator
- "shell" @function.builtin
- )
-
-(function_call ["$" "(" ")"] @operator)
-
-(function_call [
- "subst"
- "patsubst"
- "strip"
- "findstring"
- "filter"
- "filter-out"
- "sort"
- "word"
- "words"
- "wordlist"
- "firstword"
- "lastword"
- "dir"
- "notdir"
- "suffix"
- "basename"
- "addsuffix"
- "addprefix"
- "join"
- "wildcard"
- "realpath"
- "abspath"
- "error"
- "warning"
- "info"
- "origin"
- "flavor"
- "foreach"
- "if"
- "or"
- "and"
- "call"
- "eval"
- "file"
- "value"
- ] @function.builtin
-)
+(ERROR) @error

--- a/queries/make/injections.scm
+++ b/queries/make/injections.scm
@@ -1,4 +1,11 @@
 (comment) @comment
 
-(shell_text) @bash
-(shell_command) @bash
+(shell_code) @bash
+
+(variable_assignment
+  operator: "!="
+     value: (text) @bash)
+
+(function_expansion
+  function: (name) @_fn (#eq? @_fn "shell")
+            (arguments) @bash)


### PR DESCRIPTION
I rewrote the makefile parser. This new version is at the branch `master` instead of `main`.

Captures

Variables
- `@variable` default variable
- `@constant` names following make's naming convention
- `@constant.macro`  special variables
- `@constant.builtins` builtin variables

Targets
- `@string` filename
- `@string.special` special targets
- `@type` patterns
- `@symbols` targets using naming convention (all, clean, etc)

I've an one issue.

The following queries are matching all `function_expansion`. They work as expected on tree-sitter-cli.
```
(function_expansion
  function: (name) @_fn (#eq? @_fn "info")
            (arguments) @text.note)

(function_expansion
  function: (name) @_fn (#eq? @_fn "warning")
            (arguments) @text.warning)

(function_expansion
  function: (name) @_fn (#eq? @_fn "error")
            (arguments) @text.danger)

```

The same query on injections seems to work correctly.

```
(function_expansion
  function: (name) @_fn (#eq? @_fn "shell")
            (arguments) @bash)
```