### PR TITLE
ci: mark automated PRs as draft

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Linting and style checking
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   luacheck:

--- a/.github/workflows/update-parsers-pr.yml
+++ b/.github/workflows/update-parsers-pr.yml
@@ -54,3 +54,4 @@ jobs:
           title: Update lockfile.json
           branch: update-lockfile-pr
           base: ${{ github.head_ref }}
+          draft: true

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -39,3 +39,4 @@ jobs:
           title: Update README
           branch: update-readme-pr
           base: ${{ github.head_ref }}
+          draft: true


### PR DESCRIPTION
The required checks can be initiated by marking the PR is ready for
review.
