### PR TITLE
Upgrade to tree-sitter-heex v0.4.0 and support slots

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -111,7 +111,7 @@
     "revision": "3cb7fc28247efbcb2973b97e71c78838ad98a583"
   },
   "heex": {
-    "revision": "d8b5b9f016cd3c7b0ee916cf031d9a2188c0fc44"
+    "revision": "592e22292a367312c35e13de7fdb888f029981d6"
   },
   "hjson": {
     "revision": "02fa3b79b3ff9a296066da6277adfc3f26cbc9e0"

--- a/queries/heex/folds.scm
+++ b/queries/heex/folds.scm
@@ -1,5 +1,6 @@
-; HEEx folds similar to HTML
+; HEEx tags, components, and slots fold similar to HTML
 [
-  (tag)
   (component)
+  (tag)
+  (slot)
 ] @fold

--- a/queries/heex/highlights.scm
+++ b/queries/heex/highlights.scm
@@ -1,4 +1,4 @@
-; HEEx tag and component delimiters
+; HEEx delimiters
 [
   "%>"
   "--%>"
@@ -13,19 +13,18 @@
   "<%%="
   "<%="
   "</"
+  "</:"
+  "<:"
   ">"
   "{"
   "}"
 ] @tag.delimiter
 
-; HEEx operators
+; HEEx operators are highlighted as such
 "=" @operator
 
 ; HEEx inherits the DOCTYPE tag from HTML
 (doctype) @constant
-
-; HEEx tags are highlighted as HTML tags
-(tag_name) @tag
 
 ; HEEx comments are highlighted as such
 (comment) @comment
@@ -35,6 +34,12 @@
 
 ; Tree-sitter parser errors
 (ERROR) @error
+
+; HEEx tags and slots are highlighted as HTML
+[
+ (tag_name) 
+ (slot_name) 
+] @tag
 
 ; HEEx attributes are highlighted as HTML attributes
 (attribute_name) @tag.attribute

--- a/queries/heex/indents.scm
+++ b/queries/heex/indents.scm
@@ -1,11 +1,20 @@
-; HEEx indents like HTML
+; HEEx tags, components, and slots indent like HTML
 [
   (component)
+  (slot)
   (tag)
 ] @indent
 
-; Dedent at the end of each tag
+; Dedent at the end of each tag, component, and slot
 [
-  (end_tag)
   (end_component)
-] @branch
+  (end_slot)
+  (end_tag)
+] @branch @dedent
+
+; Self-closing tags and components should not change
+; indentation level of sibling nodes
+[
+  (self_closing_component)
+  (self_closing_tag)
+] @auto

--- a/queries/heex/injections.scm
+++ b/queries/heex/injections.scm
@@ -7,4 +7,5 @@
 ; HEEx Elixir expressions are always within a tag or component
 (expression (expression_value) @elixir)
 
+; HEEx comments
 (comment) @comment

--- a/queries/heex/locals.scm
+++ b/queries/heex/locals.scm
@@ -1,11 +1,13 @@
-; HEEx tags and components are references
+; HEEx tags, components, and slots are references
 [
-  (tag_name)
   (component_name)
+  (slot_name)
+  (tag_name)
 ] @reference
 
-; Create a new scope within each HEEx tag or component
+; Create a new scope within each HEEx tag, component, and slot
 [
-  (tag)
   (component)
+  (slot)
+  (tag)
 ] @scope


### PR DESCRIPTION
See https://github.com/connorlay/tree-sitter-heex/pull/10 for associated changes to tree-sitter-heex

This PR upgrades the lockfile to target tree-sitter-heex v0.4.0 and adds support for HEEx [Slots](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#module-slots).