### PR TITLE
chore: format with stylua 0.12.0

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,3 +1,6 @@
+column_width = 120
+line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2
-no_call_parentheses = true
+quote_style = "AutoPreferDouble"
+call_parentheses = "None"

--- a/tests/indent/javascript_spec.lua
+++ b/tests/indent/javascript_spec.lua
@@ -17,78 +17,94 @@ describe("indent JavaScript:", function()
   end)
 
   describe("new line:", function()
-    for _, info in ipairs {
-      { 1, 2 },
-      { 2, 4 },
-      { 3, 4 },
-    } do
+    for _, info in
+      ipairs {
+        { 1, 2 },
+        { 2, 4 },
+        { 3, 4 },
+      }
+    do
       run:new_line("ecma/binary_expression.js", { on_line = info[1], text = "//", indent = info[2] }, info[3], info[4])
     end
 
-    for _, info in ipairs {
-      { 4, 2 },
-      { 6, 0 },
-    } do
+    for _, info in
+      ipairs {
+        { 4, 2 },
+        { 6, 0 },
+      }
+    do
       run:new_line("ecma/callback.js", { on_line = info[1], text = "//", indent = info[2] }, info[3], info[4])
     end
 
-    for _, info in ipairs {
-      { 2, 2 },
-      { 5, 2 },
-      { 7, 0 },
-      { 12, 4 },
-      { 18, 2 },
-      { 19, 2 },
-      { 20, 2 },
-      { 25, 2 },
-    } do
+    for _, info in
+      ipairs {
+        { 2, 2 },
+        { 5, 2 },
+        { 7, 0 },
+        { 12, 4 },
+        { 18, 2 },
+        { 19, 2 },
+        { 20, 2 },
+        { 25, 2 },
+      }
+    do
       run:new_line("ecma/func.js", { on_line = info[1], text = "//", indent = info[2] }, info[3], info[4])
     end
 
-    for _, info in ipairs {
-      { 1, 2 },
-      { 2, 2 },
-      { 3, 2 },
-      { 5, 4 },
-      { 6, 4 },
-      { 8, 2 },
-      { 9, 2 },
-      { 12, 2 },
-      { 13, 0 },
-    } do
+    for _, info in
+      ipairs {
+        { 1, 2 },
+        { 2, 2 },
+        { 3, 2 },
+        { 5, 4 },
+        { 6, 4 },
+        { 8, 2 },
+        { 9, 2 },
+        { 12, 2 },
+        { 13, 0 },
+      }
+    do
       run:new_line("ecma/if_else.js", { on_line = info[1], text = "hello()", indent = info[2] }, info[3], info[4])
     end
 
-    for _, info in ipairs {
-      { 2, 2 },
-      { 5, 0 },
-    } do
+    for _, info in
+      ipairs {
+        { 2, 2 },
+        { 5, 0 },
+      }
+    do
       run:new_line("ecma/object.js", { on_line = info[1], text = "//", indent = info[2] }, info[3], info[4])
     end
 
-    for _, info in ipairs {
-      { 3, 6 },
-      { 4, 6 },
-    } do
+    for _, info in
+      ipairs {
+        { 3, 6 },
+        { 4, 6 },
+      }
+    do
       run:new_line("ecma/ternary.js", { on_line = info[1], text = "//", indent = info[2] }, info[3], info[4])
     end
 
-    for _, info in ipairs {
-      { 1, 2 },
-      { 2, 2 },
-      { 3, 2 },
-      { 4, 2 },
-      { 5, 2 },
-      { 6, 2 },
-      { 7, 0 },
-    } do
+    for _, info in
+      ipairs {
+        { 1, 2 },
+        { 2, 2 },
+        { 3, 2 },
+        { 4, 2 },
+        { 5, 2 },
+        { 6, 2 },
+        { 7, 0 },
+      }
+    do
       run:new_line("ecma/try_catch.js", { on_line = info[1], text = "hello()", indent = info[2] }, info[3], info[4])
     end
 
-    for _, info in ipairs {
-      { 1, 2 },
-      { 2, 0 },
-    } do
+    for _, info in
+      ipairs {
+        { 1, 2 },
+        { 2, 0 },
+      }
+    do
       run:new_line("ecma/variable.js", { on_line = info[1], text = "hello()", indent = info[2] }, info[3], info[4])
     end
   end)


### PR DESCRIPTION
also made some changes to the the config:

* change deprecated option `no_call_parentheses = true` -> `call_parentheses = "None"`
* fixed some (default) settings for reproducibility and clarity.