### PR TITLE
ci: skip swift check on neovim stable

### DIFF
--- a/.github/workflows/check-query-files-and-compilation.yml
+++ b/.github/workflows/check-query-files-and-compilation.yml
@@ -84,7 +84,14 @@ jobs:
         run: cp -r ~/AppData/Local/nvim/pack/nvim-treesitter/start/nvim-treesitter/parser/* parser
         shell: bash
 
+       # NOTE: this is a temporary workaround to skip swift tests on ubuntu
+       # stable and should be removed once neovim 0.7 is released.
+      - if: matrix.os == 'ubuntu-latest' && matrix.nvim_tag == 'stable'
+        run: echo "SKIP_SWIFT_CHECK=TRUE" >> $GITHUB_ENV
+
       - name: Check query files (Unix)
+        env:
+          SKIP_SWIFT_CHECK: ${{ env.SKIP_SWIFT_CHECK }}
         if: matrix.os != 'windows-2022'
         run: nvim --headless -c "luafile ./scripts/check-queries.lua" -c "q"
 

--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -44,28 +44,32 @@ local function do_check()
   io_print "::group::Check parsers"
 
   for _, lang in pairs(parsers) do
-    timings[lang] = {}
-    for _, query_type in pairs(query_types) do
-      local before = vim.loop.hrtime()
-      local ok, query = pcall(queries.get_query, lang, query_type)
-      local after = vim.loop.hrtime()
-      local duration = after - before
-      table.insert(timings, { duration = duration, lang = lang, query_type = query_type })
-      io_print("Checking " .. lang .. " " .. query_type .. string.format(" (%.02fms)", duration * 1e-6))
-      if not ok then
-        vim.api.nvim_err_writeln(query)
-        last_error = query
-      else
-        if query then
-          for _, capture in ipairs(query.captures) do
-            local is_valid = (
-                vim.startswith(capture, "_") -- Helpers.
-                or vim.tbl_contains(captures[query_type], capture)
-              )
-            if not is_valid then
-              local error = string.format("(x) Invalid capture @%s in %s for %s.", capture, query_type, lang)
-              io_print(error)
-              last_error = error
+    -- NOTE: this is a temporary workaround to skip swift tests on ubuntu
+    -- stable and should be removed once neovim 0.7 is released.
+    if vim.fn.getenv "SKIP_SWIFT_CHECK" == vim.NIL or lang ~= "swift" then
+      timings[lang] = {}
+      for _, query_type in pairs(query_types) do
+        local before = vim.loop.hrtime()
+        local ok, query = pcall(queries.get_query, lang, query_type)
+        local after = vim.loop.hrtime()
+        local duration = after - before
+        table.insert(timings, { duration = duration, lang = lang, query_type = query_type })
+        io_print("Checking " .. lang .. " " .. query_type .. string.format(" (%.02fms)", duration * 1e-6))
+        if not ok then
+          vim.api.nvim_err_writeln(query)
+          last_error = query
+        else
+          if query then
+            for _, capture in ipairs(query.captures) do
+              local is_valid = (
+                  vim.startswith(capture, "_") -- Helpers.
+                  or vim.tbl_contains(captures[query_type], capture)
+                )
+              if not is_valid then
+                local error = string.format("(x) Invalid capture @%s in %s for %s.", capture, query_type, lang)
+                io_print(error)
+                last_error = error
+              end
             end
           end
         end


### PR DESCRIPTION
This is meant as a temporary workaround until neovim 0.7 is released.

More context: https://github.com/nvim-treesitter/nvim-treesitter/issues/2313#issuecomment-1025258357
