### PR TITLE
chore(latex): update parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -150,7 +150,7 @@
     "revision": "a4f71eb9b8c9b19ded3e0e9470be4b1b77c2b569"
   },
   "latex": {
-    "revision": "6f796b700c69a8af28132e84ed6d0c8f0c17a5e2"
+    "revision": "f112e7ab87061a5338259d9773f917e55053b149"
   },
   "ledger": {
     "revision": "0cdeb0e51411a3ba5493662952c3039de08939ca"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -747,11 +747,11 @@ list.beancount = {
 list.latex = {
   install_info = {
     url = "https://github.com/latex-lsp/tree-sitter-latex",
-    files = { "src/parser.c" },
+    files = { "src/parser.c", "src/scanner.c" },
   },
   filetype = "tex",
   used_by = { "cls", "sty" },
-  maintainers = { "@theHamsta by asking @clason" },
+  maintainers = { "@theHamsta, @clason" },
 }
 
 list.bibtex = {
@@ -760,7 +760,7 @@ list.bibtex = {
     files = { "src/parser.c" },
   },
   filetype = "bib",
-  maintainers = { "@theHamsta by asking @clason" },
+  maintainers = { "@theHamsta, @clason" },
 }
 
 list.zig = {

--- a/queries/latex/folds.scm
+++ b/queries/latex/folds.scm
@@ -7,6 +7,7 @@
   (paragraph)
   (subparagraph)
 
-  (environment)
+  (generic_environment)
+  (comment_environment)
   (displayed_equation)
 ] @fold

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -4,10 +4,10 @@
  (inline_formula)
 ] @text.math
 
-;; This highlights the whole environment like vimtex does
-((environment
+((generic_environment
   (begin
-   name: (word) @_env)) @text.math
+   name: (curly_group_text
+           (text) @_env))) @text.math
    (#any-of? @_env
       "displaymath" "displaymath*"
       "equation" "equation*"
@@ -20,8 +20,27 @@
       "gather" "gather*"
       "flalign" "flalign*"))
 
+;; File inclusion commands
 [
-  (generic_command_name)
+  "\\documentclass"
+  "\\usepackage"
+  "\\input"
+  "\\include"
+  "\\subfile"
+  "\\subfileinclude"
+  "\\subfileinclude"
+  "\\includegraphics"
+  "\\addbibresource"
+  "\\bibliography"
+  "\\includesvg"
+  "\\includeinkscape"
+  "\\usepgflibrary"
+  "\\usetikzlibrary"
+] @include
+
+;; Definitions
+[
+  (command_name)
   "\\newcommand"
   "\\renewcommand"
   "\\DeclareRobustCommand"
@@ -41,127 +60,97 @@
   "\\newacronym"
 ] @function.macro
 
+;; References (labels)
 [
-    "\\ref"
-    "\\eqref"
-    "\\vref"
-    "\\Vref"
-    "\\autoref"
-    "\\pageref"
-    "\\cref"
-    "\\Cref"
-    "\\cref*"
-    "\\Cref*"
-    "\\namecref"
-    "\\nameCref"
-    "\\lcnamecref"
-    "\\namecrefs"
-    "\\nameCrefs"
-    "\\lcnamecrefs"
-    "\\labelcref"
-    "\\labelcpageref"
-    "\\crefrange"
-    "\\crefrange"
-    "\\Crefrange"
-    "\\Crefrange"
-    "\\crefrange*"
-    "\\crefrange*"
-    "\\Crefrange*"
-    "\\Crefrange*"
+  "\\ref"
+  "\\eqref"
+  "\\vref"
+  "\\Vref"
+  "\\autoref"
+  "\\pageref"
+  "\\cref"
+  "\\Cref"
+  "\\cref*"
+  "\\Cref*"
+  "\\namecref"
+  "\\nameCref"
+  "\\lcnamecref"
+  "\\namecrefs"
+  "\\nameCrefs"
+  "\\lcnamecrefs"
+  "\\labelcref"
+  "\\labelcpageref"
+  "\\crefrange"
+  "\\crefrange"
+  "\\Crefrange"
+  "\\Crefrange"
+  "\\crefrange*"
+  "\\crefrange*"
+  "\\Crefrange*"
+  "\\Crefrange*"
 ] @function.macro
 
+;; References (bibliography)
 [
-    "\\cite"
-    "\\cite*"
-    "\\Cite"
-    "\\nocite"
-    "\\citet"
-    "\\citep"
-    "\\citet*"
-    "\\citep*"
-    "\\citeauthor"
-    "\\citeauthor*"
-    "\\Citeauthor"
-    "\\Citeauthor*"
-    "\\citetitle"
-    "\\citetitle*"
-    "\\citeyear"
-    "\\citeyear*"
-    "\\citedate"
-    "\\citedate*"
-    "\\citeurl"
-    "\\fullcite"
-    "\\citeyearpar"
-    "\\citealt"
-    "\\citealp"
-    "\\citetext"
-    "\\parencite"
-    "\\parencite*"
-    "\\Parencite"
-    "\\footcite"
-    "\\footfullcite"
-    "\\footcitetext"
-    "\\textcite"
-    "\\Textcite"
-    "\\smartcite"
-    "\\Smartcite"
-    "\\supercite"
-    "\\autocite"
-    "\\Autocite"
-    "\\autocite*"
-    "\\Autocite*"
-    "\\volcite"
-    "\\Volcite"
-    "\\pvolcite"
-    "\\Pvolcite"
-    "\\fvolcite"
-    "\\ftvolcite"
-    "\\svolcite"
-    "\\Svolcite"
-    "\\tvolcite"
-    "\\Tvolcite"
-    "\\avolcite"
-    "\\Avolcite"
-    "\\notecite"
-    "\\notecite"
-    "\\pnotecite"
-    "\\Pnotecite"
-    "\\fnotecite"
+  "\\cite"
+  "\\cite*"
+  "\\Cite"
+  "\\nocite"
+  "\\citet"
+  "\\citep"
+  "\\citet*"
+  "\\citep*"
+  "\\citeauthor"
+  "\\citeauthor*"
+  "\\Citeauthor"
+  "\\Citeauthor*"
+  "\\citetitle"
+  "\\citetitle*"
+  "\\citeyear"
+  "\\citeyear*"
+  "\\citedate"
+  "\\citedate*"
+  "\\citeurl"
+  "\\fullcite"
+  "\\citeyearpar"
+  "\\citealt"
+  "\\citealp"
+  "\\citetext"
+  "\\parencite"
+  "\\parencite*"
+  "\\Parencite"
+  "\\footcite"
+  "\\footfullcite"
+  "\\footcitetext"
+  "\\textcite"
+  "\\Textcite"
+  "\\smartcite"
+  "\\Smartcite"
+  "\\supercite"
+  "\\autocite"
+  "\\Autocite"
+  "\\autocite*"
+  "\\Autocite*"
+  "\\volcite"
+  "\\Volcite"
+  "\\pvolcite"
+  "\\Pvolcite"
+  "\\fvolcite"
+  "\\ftvolcite"
+  "\\svolcite"
+  "\\Svolcite"
+  "\\tvolcite"
+  "\\Tvolcite"
+  "\\avolcite"
+  "\\Avolcite"
+  "\\notecite"
+  "\\notecite"
+  "\\pnotecite"
+  "\\Pnotecite"
+  "\\fnotecite"
 ] @function.macro
 
-[
-    "\\ref"
-    "\\vref"
-    "\\Vref"
-    "\\autoref"
-    "\\pageref"
-    "\\cref"
-    "\\Cref"
-    "\\cref*"
-    "\\Cref*"
-    "\\namecref"
-    "\\nameCref"
-    "\\lcnamecref"
-    "\\namecrefs"
-    "\\nameCrefs"
-    "\\lcnamecrefs"
-    "\\labelcref"
-    "\\labelcpageref"
-] @function.macro
-
-
-[
-    "\\crefrange"
-    "\\crefrange"
-    "\\Crefrange"
-    "\\Crefrange"
-    "\\crefrange*"
-    "\\crefrange*"
-    "\\Crefrange*"
-    "\\Crefrange*"
-] @function.macro
-
-
+;; References (glossary)
 [
   "\\gls"
   "\\Gls"
@@ -211,7 +200,7 @@
   "\\GLSuservi"
 ] @function.macro
 
-
+;; Acronyms
 [
   "\\acrshort"
   "\\Acrshort"
@@ -258,28 +247,45 @@
   "\\Glsentryfullpl"
 ] @function.macro
 
-(comment) @comment
-
-(bracket_group) @parameter
-
-[(math_operator) "="] @operator
-
+;; General syntax
 [
-  "\\usepackage"
-  "\\documentclass"
-  "\\input"
-  "\\include"
-  "\\subfile"
-  "\\subfileinclude"
-  "\\subfileinclude"
-  "\\includegraphics"
-  "\\addbibresource"
-  "\\bibliography"
-  "\\includesvg"
-  "\\includeinkscape"
-  "\\usepgflibrary"
-  "\\usetikzlibrary"
-] @include
+ (line_comment)
+ (block_comment)
+ (comment_environment)
+] @comment
+
+(brack_group) @parameter
+
+[(operator) "="] @operator
+
+"\\item" @punctuation.special
+
+((word) @punctuation.delimiter
+(#eq? @punctuation.delimiter "&"))
+
+["$" "\\[" "\\]" "\\(" "\\)"] @punctuation.delimiter
+
+(label_definition
+ name: (_) @text.reference)
+(label_reference_range
+ from: (_) @text.reference
+ to: (_) @text.reference)
+(label_reference
+ names: (_) @text.reference)
+(label_number
+ name: (_) @text.reference
+ number: (_) @text.reference)
+
+(citation
+ keys: (curly_group_text_list) @text.reference)
+
+(key_value_pair
+  key: (_) @parameter
+  value: (_))
+
+["[" "]" "{" "}"] @punctuation.bracket ; "(" ")" has no syntactical meaning in LaTeX
+
+;; Sectioning
 
 [
   "\\part"
@@ -305,101 +311,74 @@
   "\\addpart*"
   "\\addchap*"
   "\\addsec*"
-] @type
-
-"\\item" @punctuation.special
-
-((word) @punctuation.delimiter
-(#eq? @punctuation.delimiter "&"))
-
-["$" "\\[" "\\]" "\\(" "\\)"] @punctuation.delimiter
-
-(label_definition
- name: (_) @text.reference)
-(label_reference
- label: (_) @text.reference)
-(equation_label_reference
- label: (_) @text.reference)
-(label_reference
- label: (_) @text.reference)
-(label_number
- label: (_) @text.reference)
-
-(citation
- key: (word) @text.reference)
-
-(key_val_pair
-  key: (_) @parameter
-  value: (_))
-
-["[" "]" "{" "}"] @punctuation.bracket ;"(" ")" is has no special meaning in LaTeX
+] @namespace
 
 (chapter
-  text: (brace_group) @text.title)
+  text: (curly_group) @text.title)
 
 (part
-  text: (brace_group) @text.title)
+  text: (curly_group) @text.title)
 
 (section
-  text: (brace_group) @text.title)
+  text: (curly_group) @text.title)
 
 (subsection
-  text: (brace_group) @text.title)
+  text: (curly_group) @text.title)
 
 (subsubsection
-  text: (brace_group) @text.title)
+  text: (curly_group) @text.title)
 
 (paragraph
-  text: (brace_group) @text.title)
+  text: (curly_group) @text.title)
 
 (subparagraph
-  text: (brace_group) @text.title)
+  text: (curly_group) @text.title)
 
-((environment
+(generic_environment
   (begin
-   name: (word) @_frame)
-   (brace_group
-        child: (text) @text.title))
- (#eq? @_frame "frame"))
+    name: (curly_group_text
+            (text) @text.environment.name)
+    (#any-of? @text.environment.name "frame"))
+  .
+  (curly_group (_) @text.title))
 
-((generic_command
-  name:(generic_command_name) @_name
-  arg: (brace_group
+((command
+  command: (command_name) @_name
+  arg: (curly_group
           (text) @text.title))
  (#eq? @_name "\\frametitle"))
 
 ;; Formatting
+((command
+  command: (command_name) @_name
+  arg: (curly_group (_) @text.emphasis))
+  (#eq? @_name "\\emph"))
 
-((generic_command
-  name:(generic_command_name) @_name
-  arg: (_) @text.emphasis)
- (#eq? @_name "\\emph"))
+((command
+  command: (command_name) @_name
+  arg: (curly_group (_) @text.emphasis))
+  (#match? @_name "^(\\\\textit|\\\\mathit)$"))
 
-((generic_command
-  name:(generic_command_name) @_name
-  arg: (_) @text.emphasis)
- (#match? @_name "^(\\\\textit|\\\\mathit)$"))
+((command
+  command: (command_name) @_name
+  arg: (curly_group (_) @text.strong))
+  (#match? @_name "^(\\\\textbf|\\\\mathbf)$"))
 
-((generic_command
-  name:(generic_command_name) @_name
-  arg: (_) @text.strong)
- (#match? @_name "^(\\\\textbf|\\\\mathbf)$"))
-
-((generic_command
-  name:(generic_command_name) @_name
+((command
+  command: (command_name) @_name
   .
-  arg: (_) @text.uri)
+  arg: (curly_group (_) @text.uri))
  (#match? @_name "^(\\\\url|\\\\href)$"))
 
-(ERROR) @error
-
+;; General environments
 [
   "\\begin"
   "\\end"
 ] @text.environment
 
 (begin
- name: (_) @text.environment.name
+ name: (curly_group_text
+         (text) @text.environment.name)
   (#not-any-of? @text.environment.name
       "displaymath" "displaymath*"
       "equation" "equation*"
@@ -413,7 +392,8 @@
       "flalign" "flalign*"))
 
 (end
- name: (_) @text.environment.name
+ name: (curly_group_text
+         (text) @text.environment.name)
   (#not-any-of? @text.environment.name
       "displaymath" "displaymath*"
       "equation" "equation*"
@@ -425,3 +405,5 @@
       "alignat" "alignat*"
       "gather" "gather*"
       "flalign" "flalign*"))
+
+(ERROR) @error

--- a/queries/latex/injections.scm
+++ b/queries/latex/injections.scm
@@ -1,1 +1,9 @@
-(comment) @comment
+[
+ (line_comment)
+ (block_comment)
+ (comment_environment)
+] @comment
+
+(pycode_environment
+  code: (source_code) @python
+)


### PR DESCRIPTION
This is a significant refactor, but with the patient help of @pfoerster, I got the queries back in pretty much the same shape they were in before. Some now possible improvements are left on the table:

* the `\section` etc. commands are now part of the grammar and can (and should) be captured as such
* same for new commands, references, glossary entries etc.
* injections for `pycode`, `minted`, etc. environments (as a future PR).

(Although there might be difficulties with those since they are defined via anonymous nodes.)
