### PR TITLE
feat(vim): highlight default parameters

### DIFF
--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -36,6 +36,7 @@
 (function_declaration name: (_) @function)
 (call_expression function: (identifier) @function)
 (function_declaration parameters: (parameters (identifier) @parameter))
+(function_declaration parameters: (parameters (default_parameter (identifier) @parameter)))
 
 [ (bang) (spread) (at) ] @punctuation.special
 


### PR DESCRIPTION
Support to tree-sitter-viml was added with https://github.com/vigoux/tree-sitter-viml/pull/57