### PR TITLE
ci: make io_print accept nil as input argument

### DIFF
--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -3,6 +3,9 @@
 -- Equivalent to print(), but this will ensure consistent output regardless of
 -- operating system.
 local function io_print(text)
+  if not text then
+    text = ""
+  end
   io.write(text, "\n")
 end
 


### PR DESCRIPTION
Convert nil to an empty string, which mimicks the behavior of standard
print
