### PR TITLE
fix: -Os should be used during compilation phase in makefile

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -113,7 +113,7 @@ function M.select_compile_command(repo, cc, compile_location)
         args = {
           "--makefile=" .. utils.join_path(utils.get_package_path(), "scripts", "compile_parsers.makefile"),
           "CC=" .. cc,
-          "CXX_STANDARD=" .. repo.cxx_standard,
+          "CXX_STANDARD=" .. (repo.cxx_standard or 'c++14'),
         },
         cwd = compile_location,
       },

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -113,7 +113,7 @@ function M.select_compile_command(repo, cc, compile_location)
         args = {
           "--makefile=" .. utils.join_path(utils.get_package_path(), "scripts", "compile_parsers.makefile"),
           "CC=" .. cc,
-          "CXX_STANDARD=" .. (repo.cxx_standard or 'c++14'),
+          "CXX_STANDARD=" .. (repo.cxx_standard or "c++14"),
         },
         cwd = compile_location,
       },

--- a/scripts/compile_parsers.makefile
+++ b/scripts/compile_parsers.makefile
@@ -1,13 +1,51 @@
-CC?=cc
-CXX_STANDARD?=c++14
+CFLAGS       ?= -Os -std=c99 -fPIC
+CXXFLAGS     ?= -Os -std=c++14 -fPIC
+LDFLAGS      ?= 
+SRC_DIR      ?= ./src
+DEST_DIR     ?= ./dest
 
-all: parser.so
+ifeq ($(OS),Windows_NT)
+   SHELL       := powershell.exe
+   .SHELLFLAGS := -NoProfile -command
+   CP          := Copy-Item -Recurse -ErrorAction SilentlyContinue
+   MKDIR       := New-Item -ItemType directory -ErrorAction SilentlyContinue
+   TARGET      := parser.dll
+   rmf         = Write-Output $(1) | foreach { if (Test-Path $$_) { Remove-Item -Force } }
+else
+   CP          := cp
+   MKDIR       := mkdir -p
+   TARGET      := parser.so
+   rmf         = rm -rf $(1)
+endif
 
-parser.o: src/parser.c
-	$(CC) -c src/parser.c -std=c99 -Os -fPIC -I./src
+ifneq ($(wildcard $(SRC_DIR)/*.cc),)
+   LDFLAGS += -lstdc++
+endif
 
-scanner.o: src/scanner.cc
-	$(CC) -c src/scanner.cc -std=$(CXX_STANDARD) -Os -fPIC -I./src
+OBJECTS := parser.o
 
-parser.so: parser.o scanner.o
-	$(CC) parser.o scanner.o -o parser.so -shared -lstdc++
+ifneq ($(wildcard $(SRC_DIR)/scanner.*),)
+   OBJECTS += scanner.o
+endif
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	$(CC) $(OBJECTS) -o $(TARGET) -shared $(LDFLAGS)
+
+%.o: $(SRC_DIR)/%.c
+	$(CC) -c $(CFLAGS) -I$(SRC_DIR) -o $@ $<
+
+%.o: $(SRC_DIR)/%.cc
+	$(CC) -c $(CXXFLAGS) -I$(SRC_DIR) -o $@ $<
+
+clean:
+	$(call rmf,$(TARGET) $(OBJECTS))
+
+$(DEST_DIR):
+	@$(MKDIR) $(DEST_DIR)
+
+install: $(TARGET) $(DEST_DIR)
+	$(CP) $(TARGET) $(DEST_DIR)/
+
+.PHONY: clean

--- a/scripts/compile_parsers.makefile
+++ b/scripts/compile_parsers.makefile
@@ -2,9 +2,10 @@
 # compile_parsers.makefile
 #
 
-CFLAGS       ?= -std=c99 -fPIC
-CXXFLAGS     ?= -std=c++14 -fPIC
-LDFLAGS      ?= -Os -shared
+CXX_STANDARD ?= c++14
+CFLAGS       ?= -Os -std=c99 -fPIC
+CXXFLAGS     ?= -Os -std=$(CXX_STANDARD) -fPIC
+LDFLAGS      ?= -shared
 SRC_DIR      ?= ./src
 DEST_DIR     ?= ./dest
 


### PR DESCRIPTION
- also add `CXX_STANDARD` again as it's the only variable used from the Lua side

There might be more errors in the Makefile https://github.com/nvim-treesitter/nvim-treesitter/issues/2463#issue-1125016147 let's see what the problem was there. I would prefer to return back to the basic Makefile we had in the beginning (which already had mentioned error of using the optimization flag during linkage phase)

 https://github.com/nvim-treesitter/nvim-treesitter/issues/2463#issue-1125016147  was related to a `LDFLAGS` which was set in the user's environment and not by our Lua code.