### PR TITLE
ci: remove apt update if on workflows where it's not used

### DIFF
--- a/.github/workflows/update-parsers-pr.yml
+++ b/.github/workflows/update-parsers-pr.yml
@@ -20,8 +20,6 @@ jobs:
         env:
           NVIM_TAG: stable
         run: |
-          sudo apt-get update
-          sudo add-apt-repository universe
           wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
           mv ./jq-linux64 /tmp/jq
           chmod +x /tmp/jq

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -16,8 +16,6 @@ jobs:
         env:
           NVIM_TAG: stable
         run: |
-          sudo apt-get update
-          sudo add-apt-repository universe
           wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim.appimage
           chmod u+x nvim.appimage
           mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start


### PR DESCRIPTION
Shaves off 10 seconds per workflow.
