### PR TITLE
ci: rename workflows and jobs to be more consistent

### DIFF
--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -1,4 +1,4 @@
-name: Parser compilation and query file check
+name: Test queries
 
 on:
   push:
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 jobs:
-  check_compilation_unix_like:
+  check_compilation:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_compilation_unix_like:
+  check_compilation:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -1,4 +1,4 @@
-name: Make Parser Update PR
+name: Update lockfile
 
 on:
   schedule:
@@ -8,8 +8,8 @@ on:
       - master
 
 jobs:
-  update-parsers:
-    name: Update parsers
+  update-lockfile:
+    name: Update lockfile
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,4 +1,4 @@
-name: Check README parser info
+name: Update README
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-readme:
-    name: Check README parser info
+    name: Update README
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Feel free to give other suggestions. This isn't a clear improvement but after the fifth time of mixing together the different workflows I thought it might still be worth a shot.