### PR TITLE
refacto: deprecate used_by in parsers.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,9 +355,16 @@ parser_config.zimbu = {
     generate_requires_npm = false, -- if stand-alone parser without npm dependencies
     requires_generate_from_grammar = false, -- if folder contains pre-generated src/parser.c
   },
-  filetype = "zu", -- if filetype does not agrees with parser name
-  used_by = {"bar", "baz"} -- additional filetypes that use this parser
+  filetype = "zu", -- if filetype does not match the parser name
 }
+EOF
+```
+
+If you wish to set a specific parser for a filetype, you should extend the `filetype_to_parsername` table:
+```vim
+lua <<EOF
+local ft_to_parser = require"nvim-treesitter.parser".filetype_to_parsername
+filetype_to_parsername.someft = "python" -- the someft filetype will use the python parser and queries.
 EOF
 ```
 

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -136,12 +136,6 @@ function M.get_at_path(tbl, path)
   return result
 end
 
--- Prints a warning message
--- @param text the text message
-function M.print_warning(text)
-  api.nvim_command(string.format([[echohl WarningMsg | echo "%s" | echohl None]], text))
-end
-
 function M.set_jump()
   vim.cmd "normal! m'"
 end


### PR DESCRIPTION
TODO: should i create a public function to modify this list instead of providing the user with the table ?

- remove print_warning function from utils.lua (unused)
- cleanup some functions in parsers.lua (shadowing parameters and wrong
  bufnr used).
- log a deprecation notice when using used_by in a parser definition
- default the filetype_to_parsername table to the list of filetypes
  previously in the used_by keys
- update the README to indicate that change

fixes #2373 