### PR TITLE
ci/apt related fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Prepare
         run: |
           sudo apt-get update
-          sudo apt install luarocks -y
+          sudo apt-get install luarocks -y
           sudo luarocks install luacheck
 
       - name: Run Luacheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Prepare
         run: |
           sudo apt-get update
-          sudo add-apt-repository universe
           sudo apt install luarocks -y
           sudo luarocks install luacheck
 

--- a/scripts/ci-install-ubuntu-latest.sh
+++ b/scripts/ci-install-ubuntu-latest.sh
@@ -1,5 +1,3 @@
-sudo apt-get update
-sudo add-apt-repository universe
 wget -O - https://github.com/tree-sitter/tree-sitter/releases/download/${TREE_SITTER_CLI_TAG}/tree-sitter-linux-x64.gz | gunzip -c > tree-sitter
 sudo cp ./tree-sitter /usr/bin/tree-sitter
 sudo chmod uog+rwx /usr/bin/tree-sitter


### PR DESCRIPTION
- ci: remove unnecessary apt calls
- ci: use apt-get instead of apt to avoid warnings from apt
