### PR TITLE
refacto: expose a function to set custom capture for the higlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,10 +273,6 @@ lua <<EOF
 require'nvim-treesitter.configs'.setup {
   highlight = {
     enable = true,
-    custom_captures = {
-      -- Highlight the @foo.bar capture group with the "Identifier" highlight group.
-      ["foo.bar"] = "Identifier",
-    },
     -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
     -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
     -- Using this option may slow down your editor, and you may see some duplicate highlights.
@@ -284,6 +280,17 @@ require'nvim-treesitter.configs'.setup {
     additional_vim_regex_highlighting = false,
   },
 }
+EOF
+```
+
+You can add custom highlight captures with:
+
+```vim
+lua <<EOF
+  require"nvim-treesitter.highlight".set_custom_captures {
+    -- Highlight the @foo.bar capture group with the "Identifier" highlight group.
+    ["foo.bar"] = "Identifier",
+  }
 EOF
 ```
 

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -73,7 +73,6 @@ MODULES                                              *nvim-treesitter-modules*
 
 |nvim-treesitter| provides several functionalities via modules (and submodules),
 each module makes use of the query files defined for each language,
-you can add your own queries too, see |nvim-treesitter-query-extensions|.
 
 All modules are disabled by default, and some provide default keymaps.
 Each module corresponds to an entry in the dictionary passed to the
@@ -141,8 +140,6 @@ Supported options:
 
 - enable: `true` or `false`.
 - disable: list of languages.
-- custom_captures: A map of user defined capture groups to highlight groups.
-  See |nvim-treesitter-query-extensions|.
 - additional_vim_regex_highlighting: `true` or `false`, or a list of languages.
   Set this to `true` if you depend on 'syntax' being enabled
   (like for indentation). Using this option may slow down your editor,
@@ -162,6 +159,16 @@ Supported options:
       additional_vim_regex_highlighting = false,
     },
   }
+  EOF
+<
+
+You can also set custom highlight captures
+>
+  lua <<EOF
+    require"nvim-treesitter.highlight".set_custom_captures {
+      -- Highlight the @foo.bar capture group with the "Identifier" highlight group.
+      ["foo.bar"] = "Identifier",
+    }
   EOF
 <
 Note: The api is not stable yet.

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -22,8 +22,9 @@ local is_initialized = false
 local builtin_modules = {
   highlight = {
     module_path = "nvim-treesitter.highlight",
-    enable = false,
+    -- @deprecated: use `highlight.set_custom_captures` instead
     custom_captures = {},
+    enable = false,
     is_supported = function(lang)
       return queries.has_highlights(lang)
     end,

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -114,10 +114,6 @@ local function enable_syntax(bufnr)
   api.nvim_buf_set_option(bufnr, "syntax", "ON")
 end
 
-function M.get_config()
-  return configs.get_module "highlight"
-end
-
 function M.stop(bufnr)
   if ts.highlighter.active[bufnr] then
     ts.highlighter.active[bufnr]:destroy()
@@ -126,18 +122,13 @@ end
 
 function M.start(bufnr, lang)
   local parser = parsers.get_parser(bufnr, lang)
-  local config = M.get_config()
-
-  for k, v in pairs(config.custom_captures) do
-    hlmap[k] = v
-  end
-
   ts.highlighter.new(parser, {})
 end
 
 function M.attach(bufnr, lang)
+  local config = configs.get_module "highlight"
   M.start(bufnr, lang)
-  if should_enable_vim_regex(M.get_config(), lang) then
+  if should_enable_vim_regex(config, lang) then
     enable_syntax(bufnr)
   end
 end
@@ -145,6 +136,12 @@ end
 function M.detach(bufnr)
   M.stop(bufnr)
   enable_syntax(bufnr)
+end
+
+function M.set_custom_captures(captures)
+  for k, v in pairs(captures) do
+    hlmap[k] = v
+  end
 end
 
 return M


### PR DESCRIPTION
BREAKING: remove custom_captures from highlight config.

This allows plugin authors to extend the map. It also avoids settings user configuration specific values during the highlighter initialization (SOC).
Not sure how much value this brings, and might potentially break a lot of people configurations. This is questionable.