### PR TITLE
WIP: Attempt to fix indentation for Pascal

### DIFF
--- a/queries/pascal/indents.scm
+++ b/queries/pascal/indents.scm
@@ -6,7 +6,7 @@
 	(declProc)
 	(declArgs)
 	(declUses)
-	(declClass)
+	(declType)
 	(exprArgs)
 	(exprSubscript)
 	(exprBrackets)
@@ -14,19 +14,50 @@
 	(recInitializer)
 	(arrInitializer)
 	(defaultValue)
+	(if)
+	(ifElse)
+	(while)
+	(repeat)
+	(for)
+	(foreach)
+	(try)
+	(case)
+	(caseCase)
+	(asm)
+	(block)
 ] @indent
 
-(defProc (block) @indent)
+(block (kEnd) @indent_end)
+(block ";" @indent_end)
+(if ";" @indent_end)
+(ifElse ";" @indent_end)
+(while ";" @indent_end)
+(statement ";" @indent_end)
+(declType ";" @indent_end)
 
 [
+	;(kBegin)
 	(kEnd)
+	(kElse)
 	(kFinally)
 	(kDo)
 	(kUntil)
 	(kExcept)
-	(kElse)
-	(kThen)
 	(declSection)
 	"]"
 	")"
-] @branch
+ ] @branch
+
+(if (block (kBegin) @branch))
+(ifElse (block (kBegin) @branch))
+(for (block (kBegin) @branch))
+(foreach (block (kBegin) @branch))
+(while (block (kBegin) @branch))
+(caseCase (block (kBegin) @branch))
+
+(if (block) @dedent)
+(ifElse (block) @dedent)
+(while (block) @dedent)
+(for (block) @dedent)
+(foreach (block) @dedent)
+(caseCase (block) @dedent)


### PR DESCRIPTION
This is a WIP attempt to update the indents queries for Pascal because they don't work correctly in the latest version of nvim-treesitter. Manual formatting appears to work (needs more testing), but automatic formatting while typing (`indentkeys`) is still broken in many scenarios. As outlined [here](https://github.com/nvim-treesitter/nvim-treesitter/issues/2086#issuecomment-1030844421), this is in part due to the grammar and I am not sure if it can be fixed at the moment.