### PR TITLE
Update Elixir indents to take advantage of new features

### DIFF
--- a/queries/elixir/indents.scm
+++ b/queries/elixir/indents.scm
@@ -1,18 +1,23 @@
 [
-  (arguments)
+  (block)
   (do_block)
   (list)
   (map)
+  (stab_clause)
   (tuple)
+  (arguments)
 ] @indent
 
 [
   ")"
   "]"
-  "end"
+  "after"
+  "catch"
+  "else"
+  "rescue"
   "}"
-  (after_block)
-  (else_block)
-  (rescue_block)
-  (catch_block)
-] @branch
+  "end"
+] @indent_end @branch
+
+; Elixir pipelines are not indented, but other binary operator chains are
+((binary_operator operator: _ @_operator) @indent (#not-eq? @_operator "|>"))


### PR DESCRIPTION
This PR updates the `indents.scm` queries for Elixir to better match what is produced by `mix format`, the official Elixir code formatter. For example, the first argument to a pipeline now matches the indentation level of each pipeline step:

On `master` this is how pipelines are indented:
```elixir
a
  |> b()
  |> c()
```

In this PR they are now indented like this:
```elixir
a
|> b()
|> c()
```