### PR TITLE
feat(vim): highlight default parameters

### DIFF
--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -35,7 +35,8 @@
 ;; Function related
 (function_declaration name: (_) @function)
 (call_expression function: (identifier) @function)
-(function_declaration parameters: (parameters (identifier) @parameter))
+(parameters (identifier) @parameter)
+(default_parameter (identifier) @parameter)
 
 [ (bang) (spread) (at) ] @punctuation.special
 


### PR DESCRIPTION
Support to tree-sitter-viml was added with https://github.com/vigoux/tree-sitter-viml/pull/57