### PR TITLE
fix(makefile): add forgotten CXX_STANDARD again

### DIFF
--- a/scripts/compile_parsers.makefile
+++ b/scripts/compile_parsers.makefile
@@ -1,5 +1,6 @@
 CFLAGS       ?= -Os -std=c99 -fPIC
-CXXFLAGS     ?= -Os -std=c++14 -fPIC
+CXX_STANDARD ?= c++14
+CXXFLAGS     ?= -Os -std=$(CXX_STANDARD) -fPIC
 LDFLAGS      ?= 
 SRC_DIR      ?= ./src
 DEST_DIR     ?= ./dest


### PR DESCRIPTION
Apparently, I forgot the `CXX_STANDARD` again after editing the makefile