### PR TITLE
highlights(cpp): Highlight method with nested qualified_identifier

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -51,6 +51,10 @@
 (function_declarator
       declarator: (qualified_identifier
         name: (identifier) @function))
+(function_declarator
+      declarator: (qualified_identifier
+        name: (qualified_identifier
+          name: (identifier) @function)))
 ((function_declarator
       declarator: (qualified_identifier
         name: (identifier) @constructor))


### PR DESCRIPTION
so that methods like these are correctly highlighted

```cpp

class A {
    class B {
       void foo();
    };
};

void A::B::foo() {
//         ^^^
}
```

This only increases the nesting level by one.
AFAIK, arbitrary nesting is difficult to do with current queries.

But this nesting is a pretty common case