### PR TITLE
Only allow yaml block at start of markdown file

### DIFF
--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -6,4 +6,4 @@
 ((html_block) @html)
 ((html_tag) @html)
 
-((thematic_break) (_) @yaml @combined (thematic_break))
+(document . (thematic_break) (_) @yaml @combined (thematic_break))


### PR DESCRIPTION
Two consecutive thematic breaks can cause content to be interpreted as yaml at the moment. This change fixes this by only allowing yaml blocks at the start of markdown files, which is the most common use case anyways.