### PR TITLE
indents(ecma): use auto indent on (ERROR)

### DIFF
--- a/queries/ecma/indents.scm
+++ b/queries/ecma/indents.scm
@@ -49,3 +49,5 @@
   (comment)
   (template_string)
 ] @ignore
+
+(ERROR) @auto

--- a/tests/indent/ecma/issue-2515.js
+++ b/tests/indent/ecma/issue-2515.js
@@ -1,0 +1,16 @@
+function test() {
+  return [
+    {
+      test: "test",
+      test_one: "test",
+    },
+    {
+      test: "test",
+      test_one: "test",
+    },
+    {
+      test: "test",
+      test_one: "test",
+    },
+  ];
+}

--- a/tests/indent/javascript_spec.lua
+++ b/tests/indent/javascript_spec.lua
@@ -107,5 +107,9 @@ describe("indent JavaScript:", function()
     do
       run:new_line("ecma/variable.js", { on_line = info[1], text = "hello()", indent = info[2] }, info[3], info[4])
     end
+
+    for _, line in ipairs { 2, 6 } do
+      run:new_line("ecma/issue-2515.js", { on_line = line, text = "{}", indent = 4 })
+    end
   end)
 end)


### PR DESCRIPTION
Fixes #2515

Probably, "auto" is a good strategy when we are within a syntax error.