### PR TITLE
Add an lalrpop parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [JSON with comments](https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git) (maintained by @WhyNotHugo)
 - [x] [julia](https://github.com/tree-sitter/tree-sitter-julia) (maintained by @mroavi, @theHamsta)
 - [x] [kotlin](https://github.com/fwcd/tree-sitter-kotlin) (maintained by @SalBakraa)
+- [x] [lalrpop](https://github.com/traxys/tree-sitter-lalrpop) (maintained by @traxys)
 - [x] [latex](https://github.com/latex-lsp/tree-sitter-latex) (maintained by @theHamsta, @clason)
 - [x] [ledger](https://github.com/cbarrete/tree-sitter-ledger) (maintained by @cbarrete)
 - [x] [llvm](https://github.com/benwilliamgraham/tree-sitter-llvm) (maintained by @benwilliamgraham)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -920,6 +920,15 @@ list.vala = {
   maintainers = { "@matbme" },
 }
 
+list.lalrpop = {
+  install_info = {
+    url = "https://github.com/traxys/tree-sitter-lalrpop",
+    branch = "master",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@traxys" },
+}
+
 local M = {
   list = list,
   filetype_to_parsername = filetype_to_parsername,

--- a/queries/lalrpop/highlights.scm
+++ b/queries/lalrpop/highlights.scm
@@ -1,0 +1,57 @@
+[
+ 	"pub"
+	"grammar"
+	"match"
+	"extern"
+	"type"
+	"enum"
+] @keyword
+
+[
+ 	"+"
+	"*"
+	"?"
+] @operator
+
+(grammar_type_params
+	"<" @punctuation.bracket
+	">" @punctuation.bracket)
+
+(symbol
+	"<" @punctuation.bracket
+	">" @punctuation.bracket)
+
+(binding_symbol
+	"<" @punctuation.bracket
+	">" @punctuation.bracket)
+
+(binding_symbol
+	name: (identifier) @parameter)
+
+(bare_symbol
+  (macro 
+    ((macro_id) @function)))
+
+(bare_symbol
+  (identifier) @function)
+
+(nonterminal_name
+  (macro_id) @function)
+
+(nonterminal_name
+  (identifier) @function)
+
+(nonterminal
+  (type_ref) @type)
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+
+";" @punctuation.delimiter
+
+(lifetime (identifier) @label)
+
+(string_literal) @string
+(regex_literal) @string

--- a/queries/lalrpop/locals.scm
+++ b/queries/lalrpop/locals.scm
@@ -1,0 +1,5 @@
+(nonterminal_name 
+  (macro_id) @definition.function)
+
+(nonterminal_name
+  (identifier) @definition.function)


### PR DESCRIPTION
LALRPOP is a parser generator for Rust. This only parses the LALRPOP
side of the generator, not the nearly-rust code of the actions.

I made the grammar, it's my first grammar so if you see any glaring issues, feel free to comment.