### PR TITLE
fix(vim): fix highlight for pattern

### DIFF
--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -142,8 +142,8 @@
 (integer_literal) @number
 (float_literal) @float
 (comment) @comment
-(pattern
-  (pattern_multi) @string.regex) @string.special
+(pattern) @string.special
+(pattern_multi) @string.regex
 (filename) @string
 ((scoped_identifier
   (scope) @_scope . (identifier) @boolean)


### PR DESCRIPTION
Allow pattern to not contain pattern_multi node to be highlighted