### PR TITLE
ci(tests): download highlight-assertions for faster CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,28 +30,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-
-      - name: Cache .cargo
-        id: cargo-cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ matrix.os }}-rust-cargo-v1
-
       - name: Test Dependencies
         run: |
           mkdir -p ~/.local/share/nvim/site/pack/plenary.nvim/start
           cd ~/.local/share/nvim/site/pack/plenary.nvim/start
           git clone https://github.com/nvim-lua/plenary.nvim
-          ~/.cargo/bin/cargo +nightly install --force --git https://github.com/theHamsta/highlight-assertions --locked
+          curl -L https://github.com/theHamsta/highlight-assertions/releases/download/v0.1.5/highlight-assertions_v0.1.5_x86_64-unknown-linux-gnu.tar.gz | tar -xz
+          cp highlight-assertions /usr/local/bin
 
       - name: Install and prepare Neovim
         env:
@@ -75,4 +60,4 @@ jobs:
           nvim --headless -c "TSInstallSync all" -c "q"
 
       - name: Tests
-        run: PATH=~/.cargo/bin:$PATH ./scripts/run_tests.sh
+        run: PATH=/usr/local/bin:$PATH ./scripts/run_tests.sh


### PR DESCRIPTION
This avoids any Rust build dependencies.