### PR TITLE
Various fixes to queries/perl/*

### DIFF
--- a/queries/perl/folds.scm
+++ b/queries/perl/folds.scm
@@ -1,0 +1,12 @@
+[
+  (function_definition)
+  (if_statement)
+  (unless_statement)
+  (while_statement)
+  (until_statement)
+  (for_statement_1)
+  (for_statement_2)
+  (foreach_statement)
+  (standalone_block)
+  (pod_statement)
+] @fold

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -1,84 +1,115 @@
-; Variables
-(variable_declaration
-  .
-  (scope) @keyword)
+; Misc keywords
 [
-(single_var_declaration)
-(scalar_variable)
-(array_variable)
-(hash_variable)
-(hash_variable)
+  "my" "our" "local"
+  "next" "last" "redo"
+  "goto"
+  "package"
+;  "do"
+;  "eval"
+] @keyword
+
+; Keywords for including
+[ "use" "no" "require" ] @include
+
+; Keywords that mark conditional statements
+[ "if" "elsif" "unless" "else" ] @conditional
+
+; Keywords that mark repeating loops
+[ "while" "until" "for" "foreach" ] @repeat
+
+; Keyword for return expressions
+[ "return" ] @keyword.return
+
+; Keywords for phaser blocks
+; TODO: Ideally these would be @keyword.phaser but vim-treesitter doesn't
+;   have such a thing yet
+[ "BEGIN" "CHECK" "UNITCHECK" "INIT" "END" ] @keyword.function
+
+; Keywords to define a function
+[ "sub" ] @keyword.function
+
+; Lots of builtin functions, except tree-sitter-perl doesn't emit most of
+;   these yet
+;[
+;  "print" "printf" "sprintf" "say"
+;  "push" "pop" "shift" "unshift" "splice"
+;  "exists" "delete" "keys" "values"
+;  "each"
+;] @function.builtin
+
+; Keywords that are regular infix operators
+[
+  "and" "or" "not" "xor"
+  "eq" "ne" "lt" "le" "ge" "gt" "cmp"
+] @keyword.operator
+
+; Variables
+[
+  (scalar_variable)
+  (array_variable)
+  (hash_variable)
 ] @variable
 
-
+; Special builtin variables
 [
-(package_name)
-(special_scalar_variable)
-(special_array_variable)
-(special_hash_variable)
-(special_literal)
-(super)
-] @constant
-
-(
-  [
-  (package_name)
+  (special_scalar_variable)
+  (special_array_variable)
+  (special_hash_variable)
+  (special_literal)
   (super)
-  ]
-  .
-  ("::" @operator)
-)
+] @variable.builtin
 
-(comments) @comment
-(pod_statement) @comment
-
+; Integer numbers
 [
-(use_no_statement)
-(use_no_feature_statement)
-(use_no_if_statement)
-(use_no_version)
-(use_constant_statement)
-(use_parent_statement)
-] @include
+  (integer)
+  (hexadecimal)
+] @number
+
+; Float numbers
+[
+  (floating_point)
+  (scientific_notation)
+] @float
+
+; version sortof counts as a kind of multipart integer
+(version) @constant
+
+; Package names are types
+(package_name) @type
+
+; The special SUPER:: could be called a namespace. It isn't really but it
+;   should highlight differently and we might as well do it this way
+(super) @namespace
+
+; Comments are comments
+(comments) @comment
+
+; POD should be handled specially with its own embedded subtype but for now
+;   we'll just have to do this.
+(pod_statement) @text
+
+(method_invocation
+  function_name: (identifier) @method)
+(call_expression
+  function_name: (identifier) @function)
+
+;; ----------
 
 (use_constant_statement
   constant: (identifier) @constant)
 
-[
-"require"
-] @include
-
-(method_invocation
-  .
-  (identifier) @variable)
-
-(method_invocation
-  (arrow_operator)
-  .
-  (identifier) @function)
-(method_invocation
-  function_name: (identifier) @function)
 (named_block_statement
   function_name: (identifier) @function)
 
-(call_expression
-  function_name: (identifier) @function)
 (function_definition
   name: (identifier) @function)
+
 [
 (function)
 (map)
 (grep)
 (bless)
 ] @function
-
-[
-"return"
-"sub"
-"package"
-"BEGIN"
-"END"
-] @keyword.function
 
 [
 "("
@@ -92,7 +123,7 @@
 
 [
 "=~"
-"or"
+"!~"
 "="
 "=="
 "+"
@@ -119,10 +150,6 @@
 
 (type_glob
   (identifier) @variable)
-(
-  (scalar_variable)
-  .
-  ("->" @operator))
 
 [
 (word_list_qw)
@@ -149,25 +176,6 @@
 (end_delimiter)
 (ellipsis_statement)
 ] @punctuation.delimiter
-
-[
-(integer)
-(floating_point)
-(scientific_notation)
-(hexadecimal)
-] @number
-
-[
-(if_statement)
-(unless_statement)
-(if_simple_statement)
-(unless_simple_statement)
-] @conditional
-
-(foreach_statement) @repeat
-(foreach_statement
-  .
-  (scope) @keyword)
 
 (function_attribute) @field
 


### PR DESCRIPTION
* Recognise many more keywords
* Assign highlight groups to control keywords, not entire structures
* Add some folding rules

Verymuch a work-in-progress as many bigger fixes will require improvements in `tree-sitter-perl`, but this is a good start.