### PR TITLE
feat(vlang): initial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ in the `install_info` table for you parser config.
 Queries are what `nvim-treesitter` uses to extract information from the syntax tree;
 they are located in the `queries/{language}/*` runtime directories (see `:h rtp`),
 like the `queries` folder of this plugin, e.g. `queries/{language}/{locals,highlights,textobjects}.scm`.
-Other modules may require additional queries such as `folding.scm`. You can find a 
+Other modules may require additional queries such as `folding.scm`. You can find a
 list of all supported capture names in [CONTRIBUTING.md](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#parser-configurations).
 
 All queries found in the runtime directories will be combined.

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1068,6 +1068,17 @@ list.proto = {
   filetype = "proto",
 }
 
+list.v = {
+  install_info = {
+    url = "~/sources/vls/tree_sitter_v",
+    files = { "src/parser.c", "src/scanner.c" },
+    generate_requires_npm = false,
+    requires_generate_from_grammar = false,
+  },
+  filetype = "vlang",
+  maintainers = { "@tami5" },
+}
+
 local M = {
   list = list,
   filetype_to_parsername = filetype_to_parsername,

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1070,8 +1070,9 @@ list.proto = {
 
 list.v = {
   install_info = {
-    url = "~/sources/vls/tree_sitter_v",
+    url = "https://github.com/vlang/vls",
     files = { "src/parser.c", "src/scanner.c" },
+    location = "tree-sitter-v/tree_sitter_v",
     generate_requires_npm = false,
     requires_generate_from_grammar = false,
   },

--- a/queries/v/folds.scm
+++ b/queries/v/folds.scm
@@ -1,8 +1,6 @@
-;; WARNING: Doesn't seems to work ..
 [(function_declaration)
  (const_declaration)
  (type_declaration)
- (var_declaration)
  (import_declaration)
  (if_expression)
  (struct_declaration)] @fold

--- a/queries/v/folds.scm
+++ b/queries/v/folds.scm
@@ -1,0 +1,8 @@
+;; WARNING: Doesn't seems to work ..
+[(function_declaration)
+ (const_declaration)
+ (type_declaration)
+ (var_declaration)
+ (import_declaration)
+ (if_expression)
+ (struct_declaration)] @fold

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -22,7 +22,7 @@
   (#not-has-parent? @_parent call_expression special_call_expression)))
 
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^err$"))
+ (#match? @variable.builtin "^(err|macos|linux|windows)$"))
 
 ;; C: TODO: fixme make `C`.exten highlighted as variable.builtin
 ; ((binded_identifier) @content

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -3,8 +3,17 @@
 
 ;; Identifiers -------------------
 (import_path) @namespace
-[(module_identifier) ] @variable.builtin
-[(identifier)] @variable
+(module_identifier) @variable.builtin
+(identifier) @variable
+(interpreted_string_literal) @string
+(string_interpolation) @none
+
+; TODO: Have differnt highlight to make then standout + highlight }{$ as special
+; ((string_interpolation
+;   (identifier) @constant
+;   "$" @punctuation.special
+;   "${" @punctuation.special
+;   "}" @punctuation.special))
 
 [(type_identifier) (array_type) (pointer_type)] @type
 
@@ -371,8 +380,6 @@
 ;; Literals
 
 (int_literal) @number
-
-(interpreted_string_literal) @string
 
 (rune_literal) @string
 

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -1,0 +1,387 @@
+;; reference https://github.com/vlang/vls
+;; rev: c3e9874fa6c3b38beaa50d53aff4967403e251a4
+
+;; Identifiers -------------------
+(import_path) @namespace
+[(module_identifier) ] @variable.builtin
+[(identifier)] @variable
+
+[(type_identifier) (array_type) (pointer_type)] @type
+
+(field_identifier) @property
+
+(builtin_type) @type.builtin
+
+(parameter_declaration
+  name: (identifier) @parameter)
+
+(const_spec
+  name: (identifier) @constant)
+
+((((selector_expression field: (identifier) @property)) @_parent
+  (#not-has-parent? @_parent call_expression special_call_expression)))
+
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^err$"))
+
+;; C: TODO: fixme make `C`.exten highlighted as variable.builtin
+; ((binded_identifier) @content
+;  (#offset! @content 0 3 0 -1)
+;  (#match? @content "^C$"))
+
+;; Function calls ----------------
+(call_expression
+  function: (identifier) @function)
+
+(((_
+   function: (selector_expression field: (identifier) @function)
+   arguments: (_) @_args)
+  (#not-has-type? @_args arguments_list)))
+
+((call_expression
+  function: (binded_identifier name: (identifier) @function)
+  @function))
+
+
+;; Function definitions ---------
+(function_declaration
+  name: (identifier) @function)
+
+(function_declaration
+  receiver: (parameter_list)
+  name: (identifier) @method)
+
+((function_declaration
+  (binded_identifier name: (identifier) @function)
+  @function))
+
+;; Keywords
+
+[
+ "as"
+ "asm"
+ "assert"
+ "const"
+ "defer"
+ "else"
+ "enum"
+ "$for"
+ "go"
+ "goto"
+ "if"
+ "$if"
+ "import"
+ "in"
+ "!in"
+ "interface"
+ "is"
+ "!is"
+ "lock"
+ "match"
+ "module"
+ "mut"
+ "or"
+ "pub"
+ "rlock"
+ "select"
+ "struct"
+ "type"
+ "unsafe"]
+ ;; Either not supported or will be droped
+ ;"atomic"
+ ;"break"
+ ; "continue"
+ ;"shared"
+ ;"static"
+ ;"union"
+@keyword
+
+"fn" @keyword.function
+"return" @keyword.return
+"for" @repeat
+
+; "import" @include ;; note: comment out b/c of import_path @namespace
+
+[ (true) (false)] @boolean
+
+
+
+;; Conditionals ----------------
+[ "else" "if"] @conditional
+
+;; Operators ----------------
+[ "." "," ":" ";"] @punctuation.delimiter
+
+[ "(" ")" "{" "}" "[" "]"] @punctuation.bracket
+
+(array) @punctuation.bracket
+
+[
+ "++"
+ "--"
+
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+
+ "~"
+ "&"
+ "|"
+ "^"
+
+ "!"
+ "&&"
+ "||"
+ "!="
+
+ "<<"
+ ">>"
+
+ "<"
+ ">"
+ "<="
+ ">="
+
+ "+="
+ "-="
+ "*="
+ "/="
+ "&="
+ "|="
+ "^="
+ "<<="
+ ">>="
+
+ "="
+ ":="
+ "=="
+
+ "?"
+ "<-"
+ "$"
+ ".."
+ "..."]
+@operator
+
+;; Builtin Functions, maybe redundant with (builtin_type)
+((identifier) @function.builtin
+ (#any-of? @function.builtin
+    "eprint"
+    "eprintln"
+    "error"
+    "exit"
+    "panic"
+    "print"
+    "println"
+    "after"
+    "after_char"
+    "all"
+    "all_after"
+    "all_after_last"
+    "all_before"
+    "all_before_last"
+    "any"
+    "ascii_str"
+    "before"
+    "bool"
+    "byte"
+    "byterune"
+    "bytes"
+    "bytestr"
+    "c_error_number_str"
+    "capitalize"
+    "clear"
+    "clone"
+    "clone_to_depth"
+    "close"
+    "code"
+    "compare"
+    "compare_strings"
+    "contains"
+    "contains_any"
+    "contains_any_substr"
+    "copy"
+    "count"
+    "cstring_to_vstring"
+    "delete"
+    "delete_last"
+    "delete_many"
+    "ends_with"
+    "eprint"
+    "eprintln"
+    "eq_epsilon"
+    "error"
+    "error_with_code"
+    "exit"
+    "f32"
+    "f32_abs"
+    "f32_max"
+    "f32_min"
+    "f64"
+    "f64_max"
+    "fields"
+    "filter"
+    "find_between"
+    "first"
+    "flush_stderr"
+    "flush_stdout"
+    "free"
+    "gc_check_leaks"
+    "get_str_intp_u32_format"
+    "get_str_intp_u64_format"
+    "grow_cap"
+    "grow_len"
+    "hash"
+    "hex"
+    "hex2"
+    "hex_full"
+    "i16"
+    "i64"
+    "i8"
+    "index"
+    "index_after"
+    "index_any"
+    "index_byte"
+    "insert"
+    "int"
+    "is_alnum"
+    "is_bin_digit"
+    "is_capital"
+    "is_digit"
+    "is_hex_digit"
+    "is_letter"
+    "is_lower"
+    "is_oct_digit"
+    "is_space"
+    "is_title"
+    "is_upper"
+    "isnil"
+    "join"
+    "join_lines"
+    "keys"
+    "last"
+    "last_index"
+    "last_index_byte"
+    "length_in_bytes"
+    "limit"
+    "malloc"
+    "malloc_noscan"
+    "map"
+    "match_glob"
+    "memdup"
+    "memdup_noscan"
+    "move"
+    "msg"
+    "panic"
+    "panic_error_number"
+    "panic_lasterr"
+    "panic_optional_not_set"
+    "parse_int"
+    "parse_uint"
+    "pointers"
+    "pop"
+    "prepend"
+    "print"
+    "print_backtrace"
+    "println"
+    "proc_pidpath"
+    "ptr_str"
+    "push_many"
+    "realloc_data"
+    "reduce"
+    "repeat"
+    "repeat_to_depth"
+    "replace"
+    "replace_each"
+    "replace_once"
+    "reverse"
+    "reverse_in_place"
+    "runes"
+    "sort"
+    "sort_by_len"
+    "sort_ignore_case"
+    "sort_with_compare"
+    "split"
+    "split_any"
+    "split_into_lines"
+    "split_nth"
+    "starts_with"
+    "starts_with_capital"
+    "str"
+    "str_escaped"
+    "str_intp"
+    "str_intp_g32"
+    "str_intp_g64"
+    "str_intp_rune"
+    "str_intp_sq"
+    "str_intp_sub"
+    "strg"
+    "string_from_wide"
+    "string_from_wide2"
+    "strip_margin"
+    "strip_margin_custom"
+    "strlong"
+    "strsci"
+    "substr"
+    "substr_ni"
+    "substr_with_check"
+    "title"
+    "to_lower"
+    "to_upper"
+    "to_wide"
+    "tos"
+    "tos2"
+    "tos3"
+    "tos4"
+    "tos5"
+    "tos_clone"
+    "trim"
+    "trim_left"
+    "trim_pr"
+    "try_pop"
+    "try_push"
+    "utf32_decode_to_buffer"
+    "utf32_to_str"
+    "utf32_to_str_no_malloc"
+    "utf8_char_len"
+    "utf8_getchar"
+    "utf8_str_len"
+    "utf8_str_visible_length"
+    "utf8_to_utf32"
+    "v_realloc"
+    "vbytes"
+    "vcalloc"
+    "vcalloc_noscan"
+    "vmemcmp"
+    "vmemcpy"
+    "vmemmove"
+    "vmemset"
+    "vstring"
+    "vstring_literal"
+    "vstring_literal_with_len"
+    "vstring_with_len"
+    "vstrlen"
+    "vstrlen_char"
+    "winapi_lasterr_str"))
+
+
+;; Literals
+
+(int_literal) @number
+
+(interpreted_string_literal) @string
+
+(rune_literal) @string
+
+(escape_sequence) @string.escape
+
+(float_literal) @float
+
+[(true) (false)] @boolean
+
+(ERROR) @error
+
+(comment) @comment
+

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -64,6 +64,7 @@
  "const"
  "defer"
  "else"
+ "$else"
  "enum"
  "$for"
  "go"

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -33,6 +33,7 @@
 ((identifier) @variable.builtin
  (#match? @variable.builtin "^(err|macos|linux|windows)$"))
 
+(attribute_declaration) @attribute
 ;; C: TODO: fixme make `C`.exten highlighted as variable.builtin
 ; ((binded_identifier) @content
 ;  (#offset! @content 0 3 0 -1)
@@ -67,37 +68,50 @@
 ;; Keywords
 
 [
+  "import"
+  "module"
+] @include
+
+[
+  "match"
+  "if"
+  "$if"
+  "else"
+  "$else"
+] @conditional
+
+[
+  "for" @repeat
+  "$for"
+] @repeat
+
+[
  "as"
+ "in"
+ "!in"
+ "or"
+ "is"
+ "!is"
+] @keyword.operator
+
+[
  "asm"
  "assert"
  "const"
  "defer"
- "else"
- "$else"
  "enum"
- "$for"
  "go"
  "goto"
- "if"
- "$if"
- "import"
- "in"
- "!in"
  "interface"
- "is"
- "!is"
  "lock"
- "match"
- "module"
  "mut"
- "or"
  "pub"
  "rlock"
- "select"
  "struct"
  "type"
- "unsafe"]
- ;; Either not supported or will be droped
+ "unsafe"
+]
+ ;; Either not supported or will be dropped
  ;"atomic"
  ;"break"
  ; "continue"
@@ -108,11 +122,10 @@
 
 "fn" @keyword.function
 "return" @keyword.return
-"for" @repeat
 
 ; "import" @include ;; note: comment out b/c of import_path @namespace
 
-[ (true) (false)] @boolean
+[ (true) (false) ] @boolean
 
 
 

--- a/queries/v/indents.scm
+++ b/queries/v/indents.scm
@@ -1,0 +1,18 @@
+[(import_declaration
+  (const_declaration)
+  (var_declaration)
+  (type_declaration)
+  (literal_value)
+  (type_initializer)
+  (block)
+  (map)
+  (call_expression)
+  (parameter_list))]
+@indent
+
+[ "}"]
+@branch
+
+(parameter_list ")" @branch)
+
+(comment) @ignore

--- a/queries/v/indents.scm
+++ b/queries/v/indents.scm
@@ -1,13 +1,12 @@
-[(import_declaration
-  (const_declaration)
-  (var_declaration)
-  (type_declaration)
-  (literal_value)
-  (type_initializer)
-  (block)
-  (map)
-  (call_expression)
-  (parameter_list))]
+[(import_declaration)
+ (const_declaration)
+ (type_declaration)
+ (literal_value)
+ (type_initializer)
+ (block)
+ (map)
+ (call_expression)
+ (parameter_list)]
 @indent
 
 [ "}"]

--- a/queries/v/injections.scm
+++ b/queries/v/injections.scm
@@ -1,0 +1,6 @@
+(comment) @comment
+;; asm_statement if asm ever highlighted :)
+
+;; #include <...>
+(hash_statement) @c
+

--- a/queries/v/locals.scm
+++ b/queries/v/locals.scm
@@ -15,12 +15,12 @@
 (type_identifier) @reference
 
 ((call_expression function: (identifier) @reference)
- (set! reference.kind "call"))
+ (#set! reference.kind "call"))
 
 ((call_expression
    function: (selector_expression
-                field: (identifier) @function))
- (set! reference.kind "call"))
+                field: (identifier) @definition.function))
+ (#set! reference.kind "call"))
 
 (source_file) @scope
 (function_declaration) @scope

--- a/queries/v/locals.scm
+++ b/queries/v/locals.scm
@@ -1,0 +1,29 @@
+((function_declaration
+     name: (identifier) @definition.function)) ;@function
+
+(short_var_declaration
+  left: (expression_list
+          (identifier) @definition.var))
+
+((function_declaration
+  name: (binded_identifier
+          name: (identifier) @definition.function)))
+
+(const_declaration (const_spec (identifier) @definition.var))
+
+(identifier) @reference
+(type_identifier) @reference
+
+((call_expression function: (identifier) @reference)
+ (set! reference.kind "call"))
+
+((call_expression
+   function: (selector_expression
+                field: (identifier) @function))
+ (set! reference.kind "call"))
+
+(source_file) @scope
+(function_declaration) @scope
+(if_expression) @scope
+(block) @scope
+(for_statement) @scope


### PR DESCRIPTION
Add support for vlang filetypes.

- [ ] Highlight `C` as builtin variable. This is FFI in vlang land,
  where C act like extern and access c functions. The vlang parser differentiate between C function calls and normal function callas as well as c and vlang arguments but I believe  highlighting C as builtin variable is sufficient indicator for now. I  tried to use `offset!` but failed. Any suggestions?
- [x] Set up parser url. the vlang parser is located within [vls] repo. Is installing from nested repo supported? `tree_sitter_v/src/parser.c`?
- [ ] correctly parse `string_interpolation`
- [ ] keyword shouldn't be highlighted when they are arguments or they are initialized/defined in scope?

[vls]: https://github.com/vlang/vls/tree/master/tree_sitter_v

cc @elianiva @theHamsta
