### PR TITLE
Added fix for incorrect Java indentation after a closing "}" in a method declaration

### DIFF
--- a/queries/java/indents.scm
+++ b/queries/java/indents.scm
@@ -19,4 +19,9 @@
   "]"
 ] @branch
 
+[
+  "}"
+  ")"
+] @indent_end
+
 [(block_comment) (line_comment)] @ignore

--- a/tests/indent/java/issue_2571.java
+++ b/tests/indent/java/issue_2571.java
@@ -1,0 +1,6 @@
+// https://github.com/nvim-treesitter/nvim-treesitter/issues/2571
+class Testo {
+  void foo() {
+    System.out.println("foo");
+  }
+}

--- a/tests/indent/java/method.java
+++ b/tests/indent/java/method.java
@@ -1,0 +1,2 @@
+public class Method {
+}

--- a/tests/indent/java_spec.lua
+++ b/tests/indent/java_spec.lua
@@ -20,4 +20,3 @@ describe("indent Java:", function()
     run:new_line("issue_2571.java", { on_line = 5, text = "void bar() {}", indent = 2 })
   end)
 end)
-

--- a/tests/indent/java_spec.lua
+++ b/tests/indent/java_spec.lua
@@ -1,0 +1,23 @@
+local Runner = require("tests.indent.common").Runner
+--local XFAIL = require("tests.indent.common").XFAIL
+
+local run = Runner:new(it, "tests/indent/java", {
+  tabstop = 2,
+  shiftwidth = 2,
+  softtabstop = 0,
+  expandtab = true,
+})
+
+describe("indent Java:", function()
+  describe("whole file:", function()
+    run:whole_file(".", {
+      expected_failures = {},
+    })
+  end)
+
+  describe("new line:", function()
+    run:new_line("method.java", { on_line = 1, text = "void foo() {}", indent = 2 })
+    run:new_line("issue_2571.java", { on_line = 5, text = "void bar() {}", indent = 2 })
+  end)
+end)
+


### PR DESCRIPTION
Similar to #2555, I noticed that the `queries/java/indets.scm` file was missing an `@indent_end` definition. This PR adds one in.

Fixes #2571