### PR TITLE
RegExp, GraphQL, Markdown in HTML; HTML and CSS in JS

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -2,38 +2,25 @@
   (#match? @_jsdoc_comment "^/\\*\\*[^\\*].*\\*/")) @jsdoc)
 
 (comment) @comment
+(regex_pattern) @regex
 
 (call_expression
  function: ((identifier) @language)
  arguments: ((template_string) @content
    (#offset! @content 0 1 0 -1)))
 
+; TODO: map tag names to languages
 (call_expression
  function: ((identifier) @_name
    (#eq? @_name "gql"))
  arguments: ((template_string) @graphql
    (#offset! @graphql 0 1 0 -1)))
 
-; html`<input value="hello"/>`
-(call_expression
- function: ((identifier) @_name
-   (#eq? @_name "html"))
- arguments: ((template_string) @html
-   (#offset! @html 0 1 0 -1)))
-
 (call_expression
  function: ((identifier) @_name
    (#eq? @_name "hbs"))
  arguments: ((template_string) @glimmer
    (#offset! @glimmer 0 1 0 -1)))
-
-; css`:host { display: none; }`
-(call_expression
- function: (member_expression
-   object: (identifier) @_name
-     (#eq? @_name "css"))
- arguments: ((template_string) @css
-   (#offset! @css 0 1 0 -1)))
 
 ; styled.div`<css>`
 (call_expression
@@ -61,7 +48,6 @@
  arguments: ((template_string) @css
    (#offset! @css 0 1 0 -1)))
 
-
 ; styled(Component).attrs({ prop: "foo" })`<css>`
 (call_expression
  function: (call_expression
@@ -71,8 +57,6 @@
         (#eq? @_name "styled"))))
  arguments: ((template_string) @css
    (#offset! @css 0 1 0 -1)))
-
-(regex_pattern) @regex
 
 ((comment) @_gql_comment
   (#eq? @_gql_comment "/* GraphQL */")

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -14,11 +14,26 @@
  arguments: ((template_string) @graphql
    (#offset! @graphql 0 1 0 -1)))
 
+; html`<input value="hello"/>`
+(call_expression
+ function: ((identifier) @_name
+   (#eq? @_name "html"))
+ arguments: ((template_string) @html
+   (#offset! @html 0 1 0 -1)))
+
 (call_expression
  function: ((identifier) @_name
    (#eq? @_name "hbs"))
  arguments: ((template_string) @glimmer
    (#offset! @glimmer 0 1 0 -1)))
+
+; css`:host { display: none; }`
+(call_expression
+ function: (member_expression
+   object: (identifier) @_name
+     (#eq? @_name "css"))
+ arguments: ((template_string) @css
+   (#offset! @css 0 1 0 -1)))
 
 ; styled.div`<css>`
 (call_expression

--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -6,7 +6,50 @@
    (quoted_attribute_value (attribute_value) @css))
  (#eq? @_attr "style"))
 
-((script_element
-  (raw_text) @javascript))
-
 (comment) @comment
+
+(element
+   (self_closing_tag
+      (tag_name) @_tagname (#eq? @_tagname "input")
+      ((attribute
+          (attribute_name) @_attr
+          (quoted_attribute_value (attribute_value) @regex)))
+       (#eq? @_attr "pattern")))
+
+(element
+   (start_tag
+      (tag_name) @_tagname (#eq? @_tagname "input")
+      ((attribute
+          (attribute_name) @_attr
+          (quoted_attribute_value (attribute_value) @regex)))
+       (#eq? @_attr "pattern")))
+
+(script_element
+   (start_tag
+      ((attribute
+           (attribute_name) @_attr (#eq? @_attr "type")
+           (quoted_attribute_value (attribute_value) @_type))
+        (#any-of? @_type "module" "application/javascript")))
+   (raw_text) @javascript)
+
+(script_element
+   (start_tag
+      ((attribute (attribute_name) @_attr (#not-eq? @_attr "type"))))
+   (raw_text) @javascript)
+
+(script_element
+   (start_tag
+      ((attribute
+           (attribute_name) @_attr (#eq? @_attr "type")
+           (quoted_attribute_value (attribute_value) @_type))
+    (#eq? @_type "application/graphql")))
+   (raw_text) @graphql)
+
+(script_element
+   (start_tag
+      ((attribute
+           (attribute_name) @_attr (#eq? @_attr "type")
+           (quoted_attribute_value (attribute_value) @_type))
+     (#eq? @_type "text/markdown")))
+   (raw_text) @markdown)
+

--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -1,11 +1,14 @@
+; <style>
 ((style_element
   (raw_text) @css))
 
+; <div style=".some-css { display: none; }">
 ((attribute
    (attribute_name) @_attr
    (quoted_attribute_value (attribute_value) @css))
  (#eq? @_attr "style"))
 
+; <!-- comments -->
 (comment) @comment
 
 ; <input pattern="[0-9]">
@@ -16,6 +19,7 @@
           (attribute_name) @_attr
           (quoted_attribute_value (attribute_value) @regex)
        (#eq? @_attr "pattern")))))
+; <input pattern=[0-9]>
 (element
    (_
       (tag_name) @_tagname (#eq? @_tagname "input")
@@ -24,15 +28,18 @@
           (attribute_value) @regex
        (#eq? @_attr "pattern")))))
 
+; <script>
+(script_element
+   (start_tag (tag_name) .)
+   (raw_text) @javascript)
+
 ; <script async defer>
 (script_element
    (start_tag
       ((attribute (attribute_name) @_attr (#not-eq? @_attr "type"))))
    (raw_text) @javascript)
 
-; should work but chokes on the negation...
-; (script_element !attribute (raw_text) @javascript)
-
+; <script type="${someJsMimetype}">
 (script_element
    (start_tag
       ((attribute

--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -8,33 +8,42 @@
 
 (comment) @comment
 
+; <input pattern="[0-9]">
 (element
-   (self_closing_tag
+   (_
       (tag_name) @_tagname (#eq? @_tagname "input")
       ((attribute
           (attribute_name) @_attr
-          (quoted_attribute_value (attribute_value) @regex)))
-       (#eq? @_attr "pattern")))
+          (quoted_attribute_value (attribute_value) @regex)
+       (#eq? @_attr "pattern")))))
+(element
+   (_
+      (tag_name) @_tagname (#eq? @_tagname "input")
+      ((attribute
+          (attribute_name) @_attr
+          (attribute_value) @regex
+       (#eq? @_attr "pattern")))))
 
-(element
+; <script async defer>
+(script_element
    (start_tag
-      (tag_name) @_tagname (#eq? @_tagname "input")
-      ((attribute
-          (attribute_name) @_attr
-          (quoted_attribute_value (attribute_value) @regex)))
-       (#eq? @_attr "pattern")))
+      ((attribute (attribute_name) @_attr (#not-eq? @_attr "type"))))
+   (raw_text) @javascript)
+
+; should work but chokes on the negation...
+; (script_element !attribute (raw_text) @javascript)
 
 (script_element
    (start_tag
       ((attribute
            (attribute_name) @_attr (#eq? @_attr "type")
            (quoted_attribute_value (attribute_value) @_type))
-        (#any-of? @_type "module" "application/javascript")))
-   (raw_text) @javascript)
-
-(script_element
-   (start_tag
-      ((attribute (attribute_name) @_attr (#not-eq? @_attr "type"))))
+        (#any-of? @_type "module"
+                         "application/ecmascript"
+                         "application/javascript"
+                         "text/ecmascript"
+                         "text/javascript"
+        )))
    (raw_text) @javascript)
 
 (script_element
@@ -52,4 +61,5 @@
            (quoted_attribute_value (attribute_value) @_type))
      (#eq? @_type "text/markdown")))
    (raw_text) @markdown)
+
 

--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -51,6 +51,14 @@
       ((attribute
            (attribute_name) @_attr (#eq? @_attr "type")
            (quoted_attribute_value (attribute_value) @_type))
+    (#eq? @_type "application/json")))
+   (raw_text) @json)
+
+(script_element
+   (start_tag
+      ((attribute
+           (attribute_name) @_attr (#eq? @_attr "type")
+           (quoted_attribute_value (attribute_value) @_type))
     (#eq? @_type "application/graphql")))
    (raw_text) @graphql)
 


### PR DESCRIPTION
- [x] HTML: add regexp for input patterns (closes #2569)
- [x] HTML: add `<script type="application/graphql">`
- [x] HTML: add `<script type="application/json">`
- [x] HTML: add `<script type="text/markdown">`
- [x] HTML: `<script async defer>` parses as JS
- [x] HTML: `<script>` still parses as js
- [x] JS: add `html` as HTML embed for tagged template literals
- [x] JS: add `css` as CSS embed for tagged template literals

<img width="761" alt="Screen Shot 2022-02-24 at 20 49 30" src="https://user-images.githubusercontent.com/1466420/155638360-bbdd4f1f-2cf1-44b9-8d95-7b305c10d05a.png">

## Notes and Questions to Reviewers:
- I haven't yet figured out how to express "a script_element with no attribute child", i.e. `<script>` so plain scripts are broken
- ~~I'm not sure why markdown isn't working~~ PEBCAK - installed the parser and it's fine
- I listed input twice, ~~once for the self-closing variant, another for the start_tag variant.~~ once for the quoted attribute value and once for unquoted (this is legal HTML) Is it possible to alternate (`OR`, i.e. `||` in js syntax) on the node type?


