### PR TITLE
parsers: Add todotxt parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -411,6 +411,17 @@ list.c_sharp = {
   maintainers = { "@Luxed" },
 }
 
+list.todotxt = {
+  install_info = {
+    url = "https://github.com/arnarg/tree-sitter-todotxt.git",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  filetype = "todotxt",
+  maintainers = { "@arnarg" },
+  experimental = true,
+}
+
 list.typescript = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-typescript",

--- a/queries/todotxt/highlights.scm
+++ b/queries/todotxt/highlights.scm
@@ -1,0 +1,6 @@
+(done_task) @comment
+(task (priority) @keyword)
+(task (date) @comment)
+(task (kv) @comment)
+(task (project) @string)
+(task (context) @type)


### PR DESCRIPTION
Adds a parser for the todo.txt syntax along with highlighting. Syntax can be found here: https://github.com/todotxt/todo.txt#todotxt-format-rules

As this syntax doesn't necessary map well to highlight names that exist in colorschemes available I mapped them to highlight names that look good (e.g. makes sense that a done task is greyed out so `@comment` made sense to me).

With my coloscheme ([gruvbox.nvim](https://github.com/ellisonleao/gruvbox.nvim/)) it looks like this:
![Screenshot from 2022-02-28 14-10-44](https://user-images.githubusercontent.com/1291396/155989924-01517fec-3747-4e80-b805-75e5d5227b7b.png)
