### PR TITLE
highlights(cpp): Add operator cast highlight

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -61,6 +61,7 @@
  (#lua-match? @constructor "^[A-Z]"))
 
 (operator_name) @function
+"operator" @function
 "static_assert" @function.builtin
 
 (call_expression
@@ -71,7 +72,7 @@
               name: (qualified_identifier
                       name: (identifier) @function)))
 (call_expression
-  function: 
+  function:
       (qualified_identifier
         name: (qualified_identifier
               name: (qualified_identifier


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/language/cast_operator for reference.

Before 

![grafik](https://user-images.githubusercontent.com/29653149/156189079-d34b1085-03ec-4971-afda-a3515e490079.png)

After

![grafik](https://user-images.githubusercontent.com/29653149/156189548-4983a1bc-5f12-44a7-8761-30689e60725a.png)