### PR TITLE
highlights(vala): Reflect upstream refactor

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -282,7 +282,7 @@
     "revision": "e8e8e8dc2745840b036421b4e43286750443cb13"
   },
   "vala": {
-    "revision": "4c31aa2f3c077fa69acc49e5c5a58cd87c704229"
+    "revision": "31a08784cc74b61cb10c5d8314cf8a8aa98aa9a8"
   },
   "verilog": {
     "revision": "8f6b1f357d1231c420404b5f7a368a73c25adfa2"

--- a/queries/vala/highlights.scm
+++ b/queries/vala/highlights.scm
@@ -1,14 +1,23 @@
+; Identifiers
+
+((identifier) @constant (#match? @constant "^[A-Z][A-Z\\d_]+$"))
+
 (namespaced_identifier
   left: [
-    (identifier) @namespace
+    ; Lowercased names in lhs typically are variables, while camel cased are namespaces
+    ; ((identifier) @namespace (#match? @namespace "^[A-Z]+[a-z]+$"))
+    ((identifier) @variable (#match? @variable "^[a-z]"))
     (_)
   ]
   right: [
-    ((identifier) @constructor (#match? @constructor "^[A-Z]*[a-z]+"))
-    ((identifier) @constant (#match? @constant "^[A-Z][A-Z_]*"))
+    ; Lowercased are variables, camel cased are types
+    ; ((identifier) @parameter (#match? @parameter "^[a-z]"))
+    ((identifier) @type (#match? @type "^[A-Z]+[a-z]+$"))
     (_)
   ]
 )
+
+((identifier) @constructor (#match? @constructor "^[A-Z]*[a-z]+"))
 
 ; Pointers
 
@@ -155,9 +164,6 @@
   name: [
   	(identifier) @method
     (generic_identifier (_) @type) 
-    (namespaced_identifier
-        (_) @method .
-    )
   ]
 )
 
@@ -165,9 +171,13 @@
   identifier: [
   	(identifier) @method
     (generic_identifier (_) @type) 
-    (namespaced_identifier
-        (_) @method .
-    )
+  ]
+)
+
+(member_function
+  identifier: [
+  	(identifier) @method
+    (generic_identifier (_) @type)
   ]
 )
 


### PR DESCRIPTION
Note: Some items are commented in `(namespaced_identifier)` due to issue described in #2600.