### PR TITLE
Fix fennel function scope

### DIFF
--- a/queries/fennel/locals.scm
+++ b/queries/fennel/locals.scm
@@ -14,8 +14,10 @@
    "while" "if" "when" "do" "collect" "icollect" "accumulate")
 )
 
-(fn name: (symbol) @definition.function)
-(lambda name: (symbol) @definition.function)
+(fn name: (symbol) @definition.function
+  (#set! definition.function.scope "parent"))
+(lambda name: (symbol) @definition.function
+  (#set! definition.function.scope "parent"))
 
 ; TODO: use @definition.parameter for parameters
 (binding (symbol) @definition.var)


### PR DESCRIPTION
The current `locals.scm` for fennel binds a function's name only inside of the function itself. Setting the scope to "parent" is consistent with fennel's scoping.