### PR TITLE
ci: ignore solidity for lockfile update

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Update parsers
         env:
-          SKIP_LOCKFILE_UPDATE_FOR_LANGS: verilog,gleam
+          SKIP_LOCKFILE_UPDATE_FOR_LANGS: verilog,gleam,solidity
         run: |
           ./nvim.appimage --headless -c "luafile ./scripts/write-lockfile.lua" -c "q"
           # Pretty print


### PR DESCRIPTION
parser needs to be built from non-standard branch, which fails CI

@YongJieYongJie 