### PR TITLE
Highlight markdown `uri_autolink` as `@text.uri`

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -32,7 +32,10 @@
 
 (strong_emphasis) @text.strong
 
-(link_destination) @text.uri
+[
+  (link_destination)
+  (uri_autolink)
+] @text.uri
 
 [
   (link_label)


### PR DESCRIPTION
Auto links (e.g. `<https://github.com>`) should be highlighted as URIs