### PR TITLE
highlights(markdown): add conceal to fenced code blocks

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -74,8 +74,9 @@
 (shortcut_link "]" @punctuation.delimiter)
 
 ([
-   (info_string)
-   (fenced_code_block_delimiter)
-   (code_span_delimiter)
- ] @_conceal
- (#set! conceal ""))
+  (info_string)
+  (fenced_code_block_delimiter)
+  (code_span_delimiter)
+  (emphasis_delimiter)
+] @_conceal
+(#set! conceal ""))

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -72,3 +72,10 @@
 
 (shortcut_link "[" @punctuation.delimiter)
 (shortcut_link "]" @punctuation.delimiter)
+
+([
+   (info_string)
+   (fenced_code_block_delimiter)
+   (code_span_delimiter)
+ ] @_conceal
+ (#set! conceal ""))

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -80,3 +80,11 @@
   (emphasis_delimiter)
 ] @_conceal
 (#set! conceal ""))
+
+(inline_link 
+  ["]"] @conceal
+  (#set! conceal " "))
+
+(inline_link 
+  "["  @conceal
+  (#set! conceal ""))


### PR DESCRIPTION
It's interesting that the following would only conceal `_conceal1`
```
(fenced_code_block
  (fenced_code_block_delimiter) @_conceal1
  (info_string) @_conceal2
   (#set! conceal ""))
```