### PR TITLE
highlights: conceal `"` in JSON

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,8 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @attribute for e.g. Python decorators
 ```
 
+@conceal followed by `(#set! conceal "")` for captures that are not used for highlights but only for concealing.
+
 #### Variables
 
 ```
@@ -190,6 +192,10 @@ Used for xml-like tags
 @tag.delimiter
 ```
 
+#### Conceal
+
+@conceal followed by `(#set! conceal "")` for captures that are not used for highlights but only for concealing.
+
 ### Locals
 
 ```
@@ -213,6 +219,7 @@ Used for xml-like tags
 @reference
 @constructor
 ```
+
 
 #### Definition Scope
 

--- a/queries/json/highlights.scm
+++ b/queries/json/highlights.scm
@@ -12,3 +12,5 @@
 "]" @punctuation.bracket
 "{" @punctuation.bracket
 "}" @punctuation.bracket
+
+(("\"" @conceal) (#set! conceal ""))


### PR DESCRIPTION
Fixes #645