### PR TITLE
fix(prisma): highlight "type" keyword

### DIFF
--- a/queries/prisma/highlights.scm
+++ b/queries/prisma/highlights.scm
@@ -5,6 +5,7 @@
  "enum"
  "generator"
  "model"
+ "type"
 ] @keyword
 
 [


### PR DESCRIPTION
Highlight the `type` keyword used in the new [composite types](https://www.prisma.io/docs/concepts/components/prisma-client/composite-types) syntax and in the deprecated type aliases.