### PR TITLE
Add capture groups for remaining builtin highlight groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,8 +91,10 @@ effect on highlighting. We will work on improving highlighting in the near futur
 
 ```
 @comment
+@debug
 @error for error `ERROR` nodes.
 @none to disable completely the highlight
+@preproc
 @punctuation.delimiter for `;` `.` `,`
 @punctuation.bracket for `()` or `{}`
 @punctuation.special for symbols with special meaning like `{}` in string interpolation.
@@ -109,6 +111,7 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @string.escape
 @string.special
 @character
+@character.special
 @number
 @boolean
 @float
@@ -142,9 +145,12 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @operator (for symbolic operators, e.g. `+`, `*`)
 @exception (e.g. `throw`, `catch`)
 @include keywords for including modules (e.g. import/from in Python)
+@storageclass
 
 @type
 @type.builtin
+@type.definition
+@type.qualifier
 @namespace for identifiers referring to namespaces
 @symbol for identifiers referring to symbols
 @attribute for e.g. Python decorators
@@ -178,6 +184,8 @@ Mainly for markup languages.
 @text.note
 @text.warning
 @text.danger
+
+@todo
 ```
 
 #### Tags

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -490,6 +490,10 @@ Boolean literals: `True` and `False` in Python.
 `TSCharacter`
 Character literals: `'a'` in C.
 
+						       *hl-TSCharacterSpecial*
+`TSCharacterSpecial`
+Special characters.
+
 								*hl-TSComment*
 `TSComment`
 Line comments and block comments.
@@ -514,6 +518,14 @@ Constants defined by macros: `NULL` in C.
 							    *hl-TSConstructor*
 `TSConstructor`
 Constructor calls and definitions: `{}` in Lua, and Java constructors.
+
+								  *hl-TSDebug*
+`TSDebug`
+Debugging statements.
+
+								 *hl-TSDefine*
+`TSDefine`
+Preprocessor #define statements.
 
 								  *hl-TSError*
 `TSError`
@@ -602,6 +614,10 @@ Parameters of a function.
 `TSParameterReference`
 References to parameters of a function.
 
+								*hl-TSPreProc*
+`TSPreProc`
+Preprocessor #if, #else, #endif, etc.
+
 							       *hl-TSProperty*
 `TSProperty`
 Same as `TSField`.
@@ -621,6 +637,11 @@ Special punctuation that doesn't fit into the previous categories.
 								 *hl-TSRepeat*
 `TSRepeat`
 Keywords related to loops: `for`, `while`, etc.
+
+							     *hl-StorageClass*
+`TSStorageClass`
+Keywords that affect how a variable is stored: `static`, `comptime`, `extern`,
+etc.
 
 								 *hl-TSString*
 `TSString`
@@ -715,6 +736,10 @@ Text representation of a warning note.
 `TSDanger`
 Text representation of a danger note.
 
+								   *hl-TSTodo*
+`TSTodo`
+Anything that needs extra attention, such as keywords like TODO or FIXME.
+
 								   *hl-TSType*
 `TSType`
 Type (and class) definitions and annotations.
@@ -722,6 +747,14 @@ Type (and class) definitions and annotations.
 							    *hl-TSTypeBuiltin*
 `TSTypeBuiltin`
 Built-in types: `i32` in Rust.
+
+							  *hl-TSTypeQualifier*
+`TSTypeQualifier`
+Qualifiers on types, e.g. `const` or `volatile` in C or `mut` in Rust.
+
+							 *hl-TSTypeDefinition*
+`TSTypeDefinition`
+Type definitions, e.g. `typedef` in C.
 
 							       *hl-TSVariable*
 `TSVariable`

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -18,6 +18,7 @@ hlmap["attribute"] = "TSAttribute"
 hlmap["boolean"] = "TSBoolean"
 
 hlmap["character"] = "TSCharacter"
+hlmap["character.special"] = "TSCharacterSpecial"
 
 hlmap["comment"] = "TSComment"
 
@@ -28,6 +29,9 @@ hlmap["constant.builtin"] = "TSConstBuiltin"
 hlmap["constant.macro"] = "TSConstMacro"
 
 hlmap["constructor"] = "TSConstructor"
+
+hlmap["debug"] = "TSDebug"
+hlmap["define"] = "TSDefine"
 
 hlmap["error"] = "TSError"
 hlmap["exception"] = "TSException"
@@ -61,6 +65,8 @@ hlmap["operator"] = "TSOperator"
 hlmap["parameter"] = "TSParameter"
 hlmap["parameter.reference"] = "TSParameterReference"
 
+hlmap["preproc"] = "TSPreProc"
+
 hlmap["property"] = "TSProperty"
 
 hlmap["punctuation.delimiter"] = "TSPunctDelimiter"
@@ -68,6 +74,8 @@ hlmap["punctuation.bracket"] = "TSPunctBracket"
 hlmap["punctuation.special"] = "TSPunctSpecial"
 
 hlmap["repeat"] = "TSRepeat"
+
+hlmap["storageclass"] = "TSStorageClass"
 
 hlmap["string"] = "TSString"
 hlmap["string.regex"] = "TSStringRegex"
@@ -97,8 +105,12 @@ hlmap["text.note"] = "TSNote"
 hlmap["text.warning"] = "TSWarning"
 hlmap["text.danger"] = "TSDanger"
 
+hlmap["todo"] = "TSTodo"
+
 hlmap["type"] = "TSType"
 hlmap["type.builtin"] = "TSTypeBuiltin"
+hlmap["type.qualifier"] = "TSTypeQualifier"
+hlmap["type.definition"] = "TSTypeDefinition"
 
 hlmap["variable"] = "TSVariable"
 hlmap["variable.builtin"] = "TSVariableBuiltin"

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -262,7 +262,7 @@ function M.get_capture_matches(bufnr, captures, query_group, root, lang)
   end
   local strip_captures = {}
   for i, capture in ipairs(captures) do
-    if not capture:sub(1, 1) == "@" then
+    if capture:sub(1, 1) ~= "@" then
       error 'Captures must start with "@"'
       return
     end

--- a/plugin/nvim-treesitter.vim
+++ b/plugin/nvim-treesitter.vim
@@ -39,6 +39,7 @@ highlight default link TSStringRegex String
 highlight default link TSStringEscape SpecialChar
 highlight default link TSStringSpecial SpecialChar
 highlight default link TSCharacter Character
+highlight default link TSCharacterSpecial SpecialChar
 highlight default link TSNumber Number
 highlight default link TSBoolean Boolean
 highlight default link TSFloat Float
@@ -66,9 +67,18 @@ highlight default link TSKeywordFunction Keyword
 highlight default link TSKeywordOperator TSOperator
 highlight default link TSKeywordReturn TSKeyword
 highlight default link TSException Exception
+highlight default link TSDebug Debug
+highlight default link TSDefine Define
+highlight default link TSPreProc PreProc
+highlight default link TSStorageClass StorageClass
+
+highlight default link TSTodo Todo
 
 highlight default link TSType Type
 highlight default link TSTypeBuiltin Type
+highlight default link TSTypeQualifier Type
+highlight default link TSTypeDefinition Typedef
+
 highlight default link TSInclude Include
 
 highlight default link TSVariableBuiltin Special


### PR DESCRIPTION
Some builtin highlight groups (see `:h group-name`) do not yet have
associated capture groups, so add them.

Note that there is a related [PR in neovim][1] to add these groups to the
*default* `hl_map`, but this PR does not depend on that one in any way.

[1]: https://github.com/neovim/neovim/pull/17835
