### PR TITLE
ci: lock nix parser

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Update parsers
         env:
-          SKIP_LOCKFILE_UPDATE_FOR_LANGS: verilog,gleam
+          SKIP_LOCKFILE_UPDATE_FOR_LANGS: verilog,gleam,norg
         run: |
           ./nvim.appimage --headless -c "luafile ./scripts/write-lockfile.lua" -c "q"
           # Pretty print


### PR DESCRIPTION
The current revision of https://github.com/cstrahan/tree-sitter-nix fails our CI Windows test, even after updating all the queries.

Lock it for now until somebody can unblock https://github.com/nvim-treesitter/nvim-treesitter/pull/2668 so the lockfile update PR can go through without manual intervention every time.

@leo60228