### PR TITLE
feat: add vimdoc parser and queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -299,6 +299,9 @@
   "vim": {
     "revision": "c9d70082af14988842eb071c6c0b07e8d1d993ac"
   },
+  "help": {
+    "revision": "5e4851189b3d005275263cfc7f5a4a6ea2dbdf9b"
+  },
   "vue": {
     "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -827,6 +827,16 @@ list.vim = {
   maintainers = { "@vigoux" },
 }
 
+list.help = {
+  install_info = {
+    url = "https://github.com/vigoux/tree-sitter-vimdoc",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  filetype = "help",
+  maintainers = { "@vigoux" },
+  experimental = true,
+}
+
 list.json5 = {
   install_info = {
     url = "https://github.com/Joakker/tree-sitter-json5",

--- a/queries/help/highlights.scm
+++ b/queries/help/highlights.scm
@@ -1,0 +1,14 @@
+(headline) @text.title
+(column_heading) @text.title
+(tag
+   "*" @conceal (#set! conceal "")
+   name: (_) @label)
+(option
+   "'" @conceal (#set! conceal "")
+   name: (_) @text.literal)
+(hotlink
+   "|" @conceal (#set! conceal "")
+   destination: (_) @text.uri)
+(backtick
+   "`" @conceal (#set! conceal "")
+   content: (_) @string)


### PR DESCRIPTION
Using @bfredl's shiny new `conceal` support on master. The captures are open for bike shedding.

I've add injection support for Lua in codeblocks, which (of course) tries to highlight all code as Lua, even if it's Vimscript (or just plain text). I don't think it's possible to be any smarter about it; it's up for debate whether this is an improvement over no highlighting at all. (I think... maybe?) 

I'm marking this as experimental since there seem to be some issues with the scanner (things like `"*"` and `:lua` after a backtick). @vigoux 