### PR TITLE
Remove .heex ftdetect

### DIFF
--- a/ftdetect/heex.vim
+++ b/ftdetect/heex.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile *.heex set filetype=heex


### PR DESCRIPTION
This is built straight into Neovim now and is no longer needed.

PR: https://github.com/neovim/neovim/pull/17182/files
