### PR TITLE
r(highlights): fix default_parameter

### DIFF
--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -15,7 +15,9 @@
 (identifier) @variable
 
 (formal_parameters (identifier) @parameter)
-(formal_parameters (default_parameter (identifier) @parameter))
+(formal_parameters
+ (default_parameter name: (identifier) @parameter))
+
 ; Operators
 [
  "="


### PR DESCRIPTION
Highlight only the `identifier` in the `name` field