### PR TITLE
fix: properly select name in revision archive (#2466)

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -179,7 +179,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
     local url = repo.url:gsub(".git$", "")
 
     local folder_rev = revision
-    if is_github and revision:match('^v%d') then
+    if is_github and revision:match "^v%d" then
       folder_rev = revision:sub(2)
     end
 

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -178,6 +178,11 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
     local path_sep = utils.get_path_sep()
     local url = repo.url:gsub(".git$", "")
 
+    local folder_rev = revision
+    if is_github and revision:match('^v%d') then
+      folder_rev = revision:sub(2)
+    end
+
     return {
       M.select_install_rm_cmd(cache_folder, project_name .. "-tmp"),
       {
@@ -213,7 +218,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
       },
       M.select_rm_file_cmd(cache_folder .. path_sep .. project_name .. ".tar.gz"),
       M.select_mv_cmd(
-        utils.join_path(project_name .. "-tmp", url:match "[^/]-$" .. "-" .. revision),
+        utils.join_path(project_name .. "-tmp", url:match "[^/]-$" .. "-" .. folder_rev),
         project_name,
         cache_folder
       ),


### PR DESCRIPTION
In #2466 we found that if a revision/tag name is something like 'v0.3.0', the `select_download_commands` creates a `mv` command that doesn't work properly for github. The bug results from github using the suffix `-0.3.0` instead of `-v0.3.0` in the tag archive. I tested:

- v1
- ~~v.a~~
- ~~va~~
- ~~v.1~~
- v1.1
- v1.a

The crossed out names did not exhibit this behavior, so it looks like if there's anything matching `^v\d`, then the `v` is removed.

This patch applies that behavior to github only.