### PR TITLE
github: Fix typo in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/highlighting_issue.yml
+++ b/.github/ISSUE_TEMPLATE/highlighting_issue.yml
@@ -14,7 +14,7 @@ body:
         - I have inspected the syntax tree using https://github.com/nvim-treesitter/playground and made sure
           that no `ERROR` nodes are in the syntax tree. nvim-treesitter can not guarantee correct highlighting in the
           presence of `ERROR`s -- in this case, please report the bug directly at corresponding parser's repository. (You can find all repository URLs in [README.md](https://github.com/nvim-treesitter/nvim-treesitter#supported-languages).)
-        - I have used `:TSHighlightCapturesUnderCursor` from https://github.com/nvim-treesitter/playground to inspect which highlight groups Neovim is using and that legacy syntax highlighting is interfering (i.e., what you are observing is actual tree-sitter highlighting).
+        - I have used `:TSHighlightCapturesUnderCursor` from https://github.com/nvim-treesitter/playground to inspect which highlight groups Neovim is using and that legacy syntax highlighting is not interfering (i.e., what you are observing is actual tree-sitter highlighting).
 
   - type: textarea
     attributes:


### PR DESCRIPTION
Unless I'm reading that the wrong way, we want to _“inspect which [...] and that legacy syntax highlighting is **not** interfering`_.