### PR TITLE
Add highlighting query for Scss `@for` loops

### DIFF
--- a/queries/scss/highlights.scm
+++ b/queries/scss/highlights.scm
@@ -3,10 +3,17 @@
 [
   "@mixin"
   "@media"
-  "@while"
-  "@each"
   "@include"
 ] @keyword
+
+[
+  "@while"
+  "@each"
+  "@for"
+  "from"
+  "through"
+  "in"
+] @repeat
 
 (single_line_comment) @comment
 (function_name) @function
@@ -28,6 +35,9 @@
 (each_statement (key) @parameter)
 (each_statement (value) @parameter)
 (each_statement (variable_value) @parameter)
+
+(for_statement (variable) @parameter)
+(for_statement (_ (variable_value) @parameter))
 
 (argument) @parameter
 (arguments (variable_value) @parameter)


### PR DESCRIPTION
Add highlighting query for Scss `@for` loops

The Scss language only had highlighting queries for `@each` loops, this
commit adds support for `@for` loops as well.

Also moved all loop-related keywords (including newly added ones) to
`@repeat` rather than `@keyword`

Before:
![image](https://user-images.githubusercontent.com/10882062/161397061-7eb70996-9837-40be-977f-0c351279680e.png)


After:
![image](https://user-images.githubusercontent.com/10882062/161397047-b15a04b8-0ead-43f1-9dfc-79d87ce5d06b.png)
