### PR TITLE
feat(utils): add ignore_injected_langs parameter to get_node_at_cursor

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -124,7 +124,7 @@ function M.get_named_children(node)
   return nodes
 end
 
-function M.get_node_at_cursor(winnr)
+function M.get_node_at_cursor(winnr, ignore_injected_langs)
   winnr = winnr or 0
   local cursor = api.nvim_win_get_cursor(winnr)
   local cursor_range = { cursor[1] - 1, cursor[2] }
@@ -134,7 +134,7 @@ function M.get_node_at_cursor(winnr)
   if not root_lang_tree then
     return
   end
-  local root = M.get_root_for_position(cursor_range[1], cursor_range[2], root_lang_tree)
+  local root = M.get_root_for_position(cursor_range[1], cursor_range[2], root_lang_tree, ignore_injected_langs)
 
   if not root then
     return
@@ -143,7 +143,7 @@ function M.get_node_at_cursor(winnr)
   return root:named_descendant_for_range(cursor_range[1], cursor_range[2], cursor_range[1], cursor_range[2])
 end
 
-function M.get_root_for_position(line, col, root_lang_tree)
+function M.get_root_for_position(line, col, root_lang_tree, exclude_child_trees)
   if not root_lang_tree then
     if not parsers.has_parser() then
       return
@@ -152,7 +152,12 @@ function M.get_root_for_position(line, col, root_lang_tree)
     root_lang_tree = parsers.get_parser()
   end
 
-  local lang_tree = root_lang_tree:language_for_range { line, col, line, col }
+  local lang_tree
+  if exclude_child_trees then
+    lang_tree = root_lang_tree
+  else
+    lang_tree = root_lang_tree:language_for_range { line, col, line, col }
+  end
 
   for _, tree in ipairs(lang_tree:trees()) do
     local root = tree:root()

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -134,7 +134,19 @@ function M.get_node_at_cursor(winnr, ignore_injected_langs)
   if not root_lang_tree then
     return
   end
-  local root = M.get_root_for_position(cursor_range[1], cursor_range[2], root_lang_tree, ignore_injected_langs)
+
+  local root
+  if ignore_injected_langs then
+    for _, tree in ipairs(root_lang_tree:trees()) do
+      local tree_root = tree:root()
+      if tree_root and M.is_in_node_range(tree_root, cursor_range[1], cursor_range[2]) then
+        root = tree_root
+        break
+      end
+    end
+  else
+    root = M.get_root_for_position(cursor_range[1], cursor_range[2], root_lang_tree)
+  end
 
   if not root then
     return
@@ -143,7 +155,7 @@ function M.get_node_at_cursor(winnr, ignore_injected_langs)
   return root:named_descendant_for_range(cursor_range[1], cursor_range[2], cursor_range[1], cursor_range[2])
 end
 
-function M.get_root_for_position(line, col, root_lang_tree, exclude_child_trees)
+function M.get_root_for_position(line, col, root_lang_tree)
   if not root_lang_tree then
     if not parsers.has_parser() then
       return
@@ -152,12 +164,7 @@ function M.get_root_for_position(line, col, root_lang_tree, exclude_child_trees)
     root_lang_tree = parsers.get_parser()
   end
 
-  local lang_tree
-  if exclude_child_trees then
-    lang_tree = root_lang_tree
-  else
-    lang_tree = root_lang_tree:language_for_range { line, col, line, col }
-  end
+  local lang_tree = root_lang_tree:language_for_range { line, col, line, col }
 
   for _, tree in ipairs(lang_tree:trees()) do
     local root = tree:root()


### PR DESCRIPTION
I wasn't sure whether to open this up on Zulip or here, but decided here since the code change is so small. Let me know if you want me to take it over there instead 🙏 

**Context**
I was digging into romgrk/nvim-treesitter-context#62 and tracked down the bug to this function: 

```lua
function M.get_parent_matches()
  if not parsers.has_parser() then return nil end

  -- FIXME: use TS queries when possible
  -- local matches = ts_query.get_capture_matches(0, '@scope.node', 'locals')

  local current = ts_utils.get_node_at_cursor()
  if not current then return end

  local parent_matches = {}
  local filetype = api.nvim_buf_get_option(0, 'filetype')
  local lines = 0
  local last_row = -1
  local first_visible_line = api.nvim_call_function('line', { 'w0' })

  while current ~= nil do
    local position = {current:start()}
    local row = position[1]

    if is_valid(current, filetype)
        and row > 0
        and row < (first_visible_line - 1)
        and row ~= last_row then
      table.insert(parent_matches, current)

      if row ~= last_row then
        lines = lines + 1
        last_row = position[1]
      end
      if config.max_lines > 0 and lines >= config.max_lines then
        break
      end
    end
    current = current:parent()
  end

  return parent_matches
end
```

which is quite simple in what it does. It just starts at the cursor and keeps checking the parent of the current node until there is no parent anymore, deciding whether to save the node depending on whether its visible or not.

The issue arises when the cursor is on a comment, in which case `ts_utils.get_node_at_cursor()` is returning a node from the injected `comment` language tree rather than the `lua` tree. When traversing this node's parents, we obviously don't get the same results as we were getting from the nodes from the `lua` tree.

You can see this in this example:
```lua
local tsutils = require 'nvim-treesitter.ts_utils'

-- comment
local x = 2

local comment_root = tsutils.get_root_for_position(2, 1)
local assign_root = tsutils.get_root_for_position(3, 1)

print(comment_root:type(), comment_root:range())
print(assign_root:type(), assign_root:range())
```

which outputs
```
source 2 0 2 10
chunk 0 0 10 0
```

showing the root that we get from the comment line (`comment` tree) spans only that line, whereas the one from the assign line (`lua` tree) spans the whole file


**Solution**
This PR adds a `ignore_injected_langs` parameter to `get_node_at_cursor` (and similar to `get_root_for_position`) which allows us to get the node under the cursor for the lang of the root tree rather than checking any child trees.

Not 100% sold on the naming, but i think the idea of either wanting to get the inner most injected language node (what `language_for_range` used by `get_root_for_position` does i think) or the outer most language node (what this addition does) feels ok. wdyt?