### PR TITLE
Fix Java indentation for method chaining

### DIFF
--- a/queries/java/indents.scm
+++ b/queries/java/indents.scm
@@ -11,6 +11,8 @@
   (formal_parameters)
 ] @indent
 
+(expression_statement (method_invocation) @indent)
+
 [
   "("
   ")"
@@ -22,7 +24,6 @@
 
 [
   "}"
-  ")"
 ] @indent_end
 
 (line_comment) @ignore

--- a/tests/indent/java/method_chaining.java
+++ b/tests/indent/java/method_chaining.java
@@ -1,0 +1,6 @@
+public class Foo {
+  void foo() {
+    new StringBuilder()
+      .append("a")
+  }
+}

--- a/tests/indent/java_spec.lua
+++ b/tests/indent/java_spec.lua
@@ -30,6 +30,6 @@ describe("indent Java:", function()
       XFAIL
     )
     run:new_line("issue_2583.java", { on_line = 4, text = "int x = 1;", indent = 4 })
-    run:new_line("method_chaining.java", { on_line = 4, text = ".append(\"b\");", indent = 6 })
+    run:new_line("method_chaining.java", { on_line = 4, text = '.append("b");', indent = 6 })
   end)
 end)

--- a/tests/indent/java_spec.lua
+++ b/tests/indent/java_spec.lua
@@ -30,5 +30,6 @@ describe("indent Java:", function()
       XFAIL
     )
     run:new_line("issue_2583.java", { on_line = 4, text = "int x = 1;", indent = 4 })
+    run:new_line("method_chaining.java", { on_line = 4, text = ".append(\"b\");", indent = 6 })
   end)
 end)


### PR DESCRIPTION
Solves an issue where Java indent was dedented one too far while method chaining.

### Issue

```java
public class Testo {
    void foo() {
        new StringBuilder()
            .append("a") // add newline here
        |<-- cursor ends up here
    }
}
```

### Expected behavior

```java
public class Testo {
    void foo() {
        new StringBuilder()
            .append("a") // add newline here
            |<-- cursor should be here
    }
}
```