### PR TITLE
Add indent queries for YANG

### DIFF
--- a/queries/yang/indents.scm
+++ b/queries/yang/indents.scm
@@ -1,5 +1,8 @@
-(block) @indent
-(block "}" @branch)
-
+(module) @indent
+(submodule) @indent
 (statement) @indent
 (statement ";" @indent_end)
+(block "}" @indent_end @branch)
+
+((string) @aligned_indent
+ (#set! "delimiter" "\"\""))

--- a/queries/yang/indents.scm
+++ b/queries/yang/indents.scm
@@ -1,0 +1,5 @@
+(block) @indent
+(block "}" @branch)
+
+(statement) @indent
+(statement ";" @indent_end)

--- a/queries/yang/indents.scm
+++ b/queries/yang/indents.scm
@@ -1,7 +1,9 @@
 (module) @indent
 (submodule) @indent
 (statement) @indent
+(extension_statement) @indent
 (statement ";" @indent_end)
+(extension_statement ";" @indent_end)
 (block "}" @indent_end @branch)
 
 ((string) @aligned_indent


### PR DESCRIPTION
Adds indent queries for YANG.

I tested this locally by running:

```lua
vim.treesitter.set_query("yang", "indents", [[
  (block) @indent
  (block "}" @branch)

  (statement) @indent
  (statement ";" @indent_end)
]])
```

And manually setting `indentexpr=nvim_treesitter#indent()`, and it works great.

---

Is there anything more I need to do to enable indent support for the language in nvim-treesitter, other than provide an indents.scm file?