### PR TITLE
injections(lua): inject query into vim.treesitter.query.set_query lua calls

### DIFF
--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -11,4 +11,9 @@
   arguments: (arguments (string content: _ @vim)))
   (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec"))
 
+((function_call
+  name: (_) @_vimcmd_identifier
+  arguments: (arguments (string content: _ @query) .))
+  (#eq? @_vimcmd_identifier "vim.treesitter.query.set_query"))
+
 (comment) @comment


### PR DESCRIPTION
Inspired by the existing injections for viml, this PR adds one for the tree-sitter query language when calling `vim.treesitter.query.set_query`. Note this only applies to the third string argument, which is the query string itself.

![image](https://user-images.githubusercontent.com/6548350/162019151-fc08b275-a3a4-435f-9e94-4913b34ce053.png)
