### PR TITLE
Add more filetypes for treesitter-markdown

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -15,6 +15,8 @@ local filetype_to_parsername = {
   cls = "latex",
   sty = "latex",
   OpenFOAM = "foam",
+  pandoc = "markdown",
+  rmd = "markdown",
 }
 
 local list = setmetatable({}, {


### PR DESCRIPTION
There are several markdown filetypes that are common that all support the same syntax. This adds `md`, `rmd`, and `pandoc` to all be matched to the `markdown` treesitter parser.