### PR TITLE
feat: add curly interpolation support for astro

### DIFF
--- a/queries/astro/highlights.scm
+++ b/queries/astro/highlights.scm
@@ -1,3 +1,5 @@
 ; inherits: html
 
 [ "---" ] @punctuation.delimiter
+
+[ "{" "}" ] @punctuation.special

--- a/queries/astro/injections.scm
+++ b/queries/astro/injections.scm
@@ -1,4 +1,7 @@
 ; inherits: html
 
 ((frontmatter
-   (raw_text) @typescript))
+    (raw_text) @typescript))
+
+((interpolation
+    (raw_text) @tsx))


### PR DESCRIPTION
I realised I forgot to add curly brace interpolation support in astro (e.g. `<p> {"Hi"} </p>`, JSX-style), so I added it. Here are the new queries to take advantage of this.