### PR TITLE
chore!: deprecate ensure_installed=maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ All modules are disabled by default and need to be activated explicitly in your 
 
 ```lua
 require'nvim-treesitter.configs'.setup {
-  -- One of "all", "maintained" (parsers with maintainers), or a list of languages
-  ensure_installed = "maintained",
+  -- A list of parser names, or "all"
+  ensure_installed = { "c", "lua", "rust" },
 
-  -- Install languages synchronously (only applied to `ensure_installed`)
+  -- Install parsers synchronously (only applied to `ensure_installed`)
   sync_install = false,
 
-  -- List of parsers to ignore installing
+  -- List of parsers to ignore installing (for "all")
   ignore_install = { "javascript" },
 
   highlight = {
@@ -150,9 +150,8 @@ For `nvim-treesitter` to support a specific feature for a specific language requ
 
 The following is a list of languages for which a parser can be installed through `:TSInstall`; a checked box means that `nvim-treesitter` also contains queries at least for the `highlight` module.
 
-Experimental parsers are parsers that are maintained, but not stable enough for
-daily use yet. They are excluded from automatic installation when
-`ensure_installed` is set to `"maintained"`.
+Experimental parsers are parsers that have a maintainer but are not stable enough for
+daily use yet.
 
 We are looking for maintainers to add more parsers and to write query files for their languages. Check our [tracking issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/2282) for open language requests.
 

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -39,13 +39,13 @@ To enable supported features, put this in your `init.lua` file:
 
 >
   require'nvim-treesitter.configs'.setup {
-    -- One of "all", "maintained" (parsers with maintainers), or a list of languages
-    ensure_installed = "maintained",
+    -- A list of parser names, or "all"
+    ensure_installed = { "c", "lua", "rust" },
 
-    -- Install languages synchronously (only applied to `ensure_installed`)
+    -- Install parsers synchronously (only applied to `ensure_installed`)
     sync_install = false,
 
-    -- List of parsers to ignore installing
+    -- List of parsers to ignore installing (for "all")
     ignore_install = { "javascript" },
 
     highlight = {

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1042,6 +1042,10 @@ function M.available_parsers()
 end
 
 function M.maintained_parsers()
+  require("nvim-treesitter.utils").notify(
+    "ensure_installed='maintained' will be removed April 30, 2022. Specify parsers explicitly or use 'all'.",
+    vim.log.levels.WARN
+  )
   local has_tree_sitter_cli = vim.fn.executable "tree-sitter" == 1 and vim.fn.executable "node" == 1
   return vim.tbl_filter(function(lang)
     return M.list[lang].maintainers


### PR DESCRIPTION
With the increasing number of parsers added to `nvim-treesitter`, the label "maintained" has stopped being a useful distinction, as just having a maintainer listed at time of inclusion does not entail any stability guarantee implied by this label. Users should explicitly specify the list of parsers that they want to use according to their risk tolerance, or use `ensure_installed = 'all'` if they insist on drinking from the firehose (not recommended!)

Deprecation period is until April 30; hopefully that will leave enough time for the ecosystem to adapt.
The warning is emitted from `parsers.maintained_parsers()` in the hope that this will be most visible (and not break CI).

@theHamsta @vigoux @kyazdani42 
