### PR TITLE
fix(modules): enabling disabling per buffer and globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Each module can also be enabled or disabled interactively through the following 
 ```vim
 :TSBufEnable {module} " enable module on current buffer
 :TSBufDisable {module} " disable module on current buffer
-:TSEnableAll {module} [{ft}] " enable module on every buffer. If filetype is specified, enable only for this filetype.
-:TSDisableAll {module} [{ft}] " disable module on every buffer. If filetype is specified, disable only for this filetype.
+:TSEnable {module} [{ft}] " enable module on every buffer. If filetype is specified, enable only for this filetype.
+:TSDisable {module} [{ft}] " disable module on every buffer. If filetype is specified, disable only for this filetype.
 :TSModuleInfo [{module}] " list information about modules state for each filetype
 ```
 

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -269,8 +269,8 @@ Toggle (enable if disabled, disable if enabled) {module} on the current
 buffer.
 A list of modules can be found at |:TSModuleInfo|
 
-								*:TSEnableAll*
-:TSEnableAll {module} [{language}]~
+								*:TSEnable*
+:TSEnable {module} [{language}]~
 
 Enable {module} for the session.
 If {language} is specified, enable module for the session only for this
@@ -278,8 +278,8 @@ particular language.
 A list of modules can be found at |:TSModuleInfo|
 A list of languages can be found at |:TSInstallInfo|
 
-							       *:TSDisableAll*
-:TSDisableAll {module} [{language}]~
+							       *:TSDisable*
+:TSDisable {module} [{language}]~
 
 Disable {module} for the session.
 If {language} is specified, disable module for the session only for this
@@ -287,8 +287,8 @@ particular language.
 A list of modules can be found at |:TSModuleInfo|
 A list of languages can be found at |:TSInstallInfo|
 
-								*:TSToggleAll*
-:TSToggleAll {module} [{language}]~
+								*:TSToggle*
+:TSToggle {module} [{language}]~
 
 Toggle (enable if disabled, disable if enabled) {module} for the session.
 If {language} is specified, toggle module for the session only for this


### PR DESCRIPTION
When a module is disabled by default in the config, running TSBufEnable will not enable the module because the `is_enabled` function will always return false, thus the module not being enabled.
Also, disabling/enabling the buffers is flaky.

This commit adds per buffer check when the module is not disabled. It also makes the enable and disable more indempotent.

I've also renamed TS*All to TS*.

Fixes #2754