### PR TITLE
Add c injection for cgo comments

### DIFF
--- a/queries/go/injections.scm
+++ b/queries/go/injections.scm
@@ -1,1 +1,6 @@
+((comment) @c (#offset! @c 1 0 0 -2)
+  (import_declaration
+    (import_spec path: (interpreted_string_literal) @_import_path))
+  (#eq? @_import_path "\"C\""))
+
 (comment) @comment


### PR DESCRIPTION
Adds C highlighting for [cgo](https://pkg.go.dev/cmd/cgo) ([example of code](https://github.com/kraftwerk28/gost/blob/master/blocks/rxkbcommon/rxkbcommon.go#L3-L34)). Though it only works for multiline comment `/* */`, because single line comment doesn't "merge" into a single TS node.