### PR TITLE
svelte query and lockfile updated

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -279,7 +279,7 @@
     "revision": "f4586b35ac8548667a9aaa4eae44456c1f43d032"
   },
   "svelte": {
-    "revision": "c61a7ec4cbf9cce1ec2143293c9707b20134bf7c"
+    "revision": "84c90ee15f851e1541c25c86e8a4338f5b4d5af2"
   },
   "swift": {
     "revision": "897df54ad1b2d103dcab3df94f335fceefa230dc"

--- a/queries/svelte/indents.scm
+++ b/queries/svelte/indents.scm
@@ -3,6 +3,8 @@
   (if_statement)
   (each_statement)
   (await_statement)
+  (script_element)
+  (style_element)
 ] @indent
 
 [


### PR DESCRIPTION
### Updated changes to the Tree-sitter grammar: 

- Added compilation fix for MacOS, Node v16
- removed Zig dependencies
- npm package upgradation
- dot html tags https://github.com/Himujjal/tree-sitter-svelte/issues/25
- added const expr and latest wasm generated https://github.com/Himujjal/tree-sitter-svelte/commit/46611dee846718a370639933aee32f22c6fc0ed4
- added indent to script element and style element https://github.com/Himujjal/tree-sitter-svelte/commit/ad07069c8087807048b96dbb96def24159a19899

https://github.com/Himujjal/tree-sitter-svelte/releases/tag/v0.10.0
https://github.com/Himujjal/tree-sitter-svelte/releases/tag/v0.10.1
