### PR TITLE
chore: deprecate ts_utils.get_node_text

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -341,11 +341,6 @@ get_node_at_cursor(winnr)~
 `winnr` will be 0 if nil.
 Returns the node under the cursor.
 
-						      *ts_utils.get_node_text*
-get_node_text(node, bufnr)~
-
-Returns the text content of a `node`.
-
 							  *ts_utils.is_parent*
 is_parent(dest, source)~
 

--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -1,7 +1,3 @@
-if not pcall(require, "vim.treesitter.languagetree") then
-  error "nvim-treesitter requires a more recent Neovim nightly version!"
-end
-
 local install = require "nvim-treesitter.install"
 local utils = require "nvim-treesitter.utils"
 local ts_utils = require "nvim-treesitter.ts_utils"

--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -4,6 +4,7 @@
 
 local queries = require "nvim-treesitter.query"
 local ts_utils = require "nvim-treesitter.ts_utils"
+local ts_query = vim.treesitter.query
 local api = vim.api
 
 local M = {}
@@ -162,7 +163,7 @@ M.get_definitions_lookup_table = ts_utils.memoize_by_buf_tick(function(bufnr)
       local scopes = M.get_definition_scopes(node_entry.node, bufnr, node_entry.scope)
       -- Always use the highest valid scope
       local scope = scopes[#scopes]
-      local node_text = ts_utils.get_node_text(node_entry.node, bufnr)[1]
+      local node_text = ts_query.get_node_text(node_entry.node, bufnr)[1]
       local id = M.get_definition_id(scope, node_text)
 
       result[id] = node_entry
@@ -210,7 +211,7 @@ end
 
 function M.find_definition(node, bufnr)
   local def_lookup = M.get_definitions_lookup_table(bufnr)
-  local node_text = ts_utils.get_node_text(node, bufnr)[1]
+  local node_text = ts_query.get_node_text(node, bufnr)[1]
 
   for scope in M.iter_scope_tree(node, bufnr) do
     local id = M.get_definition_id(scope, node_text)
@@ -231,7 +232,7 @@ end
 -- @returns a list of nodes
 function M.find_usages(node, scope_node, bufnr)
   local bufnr = bufnr or api.nvim_get_current_buf()
-  local node_text = ts_utils.get_node_text(node, bufnr)[1]
+  local node_text = ts_query.get_node_text(node, bufnr)[1]
 
   if not node_text or #node_text < 1 then
     return {}
@@ -244,7 +245,7 @@ function M.find_usages(node, scope_node, bufnr)
     if
       match.reference
       and match.reference.node
-      and ts_utils.get_node_text(match.reference.node, bufnr)[1] == node_text
+      and ts_query.get_node_text(match.reference.node, bufnr)[1] == node_text
     then
       local def_node, _, kind = M.find_definition(match.reference.node, bufnr)
 

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -2,35 +2,21 @@ local api = vim.api
 
 local parsers = require "nvim-treesitter.parsers"
 local utils = require "nvim-treesitter.utils"
+local ts_query = vim.treesitter.query
 
 local M = {}
 
 --- Gets the actual text content of a node
+-- @deprecated Use vim.treesitter.query.get_node_text
 -- @param node the node to get the text from
 -- @param bufnr the buffer containing the node
 -- @return list of lines of text of the node
 function M.get_node_text(node, bufnr)
-  local bufnr = bufnr or api.nvim_get_current_buf()
-  if not node then
-    return {}
-  end
-
-  -- We have to remember that end_col is end-exclusive
-  local start_row, start_col, end_row, end_col = M.get_node_range(node)
-
-  if start_row ~= end_row then
-    local lines = api.nvim_buf_get_lines(bufnr, start_row, end_row + 1, false)
-    lines[1] = string.sub(lines[1], start_col + 1)
-    -- end_row might be just after the last line. In this case the last line is not truncated.
-    if #lines == end_row - start_row + 1 then
-      lines[#lines] = string.sub(lines[#lines], 1, end_col)
-    end
-    return lines
-  else
-    local line = api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1]
-    -- If line is nil then the line is empty
-    return line and { string.sub(line, start_col + 1, end_col) } or {}
-  end
+  vim.notify_once(
+    "nvim-treesitter.ts_utils.get_node_text is deprecated: use vim.treesitter.query.get_node_text",
+    vim.log.levels.WARN
+  )
+  vim.treesitter.query.get_node_text(node, bufnr)
 end
 
 --- Determines whether a node is the parent of another
@@ -326,8 +312,8 @@ function M.swap_nodes(node_or_range1, node_or_range2, bufnr, cursor_to_second)
   local range1 = M.node_to_lsp_range(node_or_range1)
   local range2 = M.node_to_lsp_range(node_or_range2)
 
-  local text1 = M.get_node_text(node_or_range1)
-  local text2 = M.get_node_text(node_or_range2)
+  local text1 = ts_query.get_node_text(node_or_range1)
+  local text2 = ts_query.get_node_text(node_or_range2)
 
   local edit1 = { range = range1, newText = table.concat(text2, "\n") }
   local edit2 = { range = range2, newText = table.concat(text1, "\n") }


### PR DESCRIPTION
Could also just silently do `M.get_node_text = vim.treesitter.query.get_node_text`. Then, downstream users don't have to switch for each function that gets moved from ts_utils to core