### PR TITLE
fix(go): reduce indent after },)

### DIFF
--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -18,6 +18,11 @@
   "}"
 ] @branch
 
+[
+ "}"
+ ")"
+] @indent_end
+
 (parameter_list ")" @branch)
 
 (comment) @ignore

--- a/tests/indent/go/issue-2369-newline.go
+++ b/tests/indent/go/issue-2369-newline.go
@@ -1,0 +1,8 @@
+// https://github.com/nvim-treesitter/nvim-treesitter/issues/2369
+package main
+
+import "fmt"
+
+func new_line() {
+	fmt.Println("Hello, World!")
+}

--- a/tests/indent/go_spec.lua
+++ b/tests/indent/go_spec.lua
@@ -18,4 +18,8 @@ describe("indent Go:", function()
   describe("new line:", function()
     run:new_line("issue-2369.go", { on_line = 13, text = "// some comment", indent = 1 })
   end)
+
+  describe("new line after )/}:", function()
+    run:new_line("issue-2369-newline.go", { on_line = 8, text = "// comment", indent = 0 })
+  end)
 end)


### PR DESCRIPTION
This PR relates to #2369 and hopefully fixes it.

This fix is basically a direct implementation of the comment that @theHamsta made in https://github.com/nvim-treesitter/nvim-treesitter/issues/2369#issuecomment-1034229102.

Locally this seems to mean that when indent after a `}` the indent is reset, so for example
```go
func example() {
} <CURSOR>
	-><CURSOR>
```

becomes

```go
func example() {
}<CURSOR>
<CURSOR>
```

I added in the `}` as I was seeing this behaviour there as well as in the example above.