### PR TITLE
highlights(java): add support for `text_block`s

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -143,7 +143,7 @@
 ] @float
 
 (character_literal) @character
-(string_literal) @string
+[(string_literal) (text_block)] @string
 (null_literal) @constant.builtin
 
 [


### PR DESCRIPTION
Introduced by https://github.com/tree-sitter/tree-sitter-java/pull/109 via https://github.com/nvim-treesitter/nvim-treesitter/pull/2814