### PR TITLE
Revert "chore: deprecate ts_utils.get_node_text"

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -16,7 +16,27 @@ function M.get_node_text(node, bufnr)
     "nvim-treesitter.ts_utils.get_node_text is deprecated: use vim.treesitter.query.get_node_text",
     vim.log.levels.WARN
   )
-  vim.treesitter.query.get_node_text(node, bufnr)
+  local bufnr = bufnr or api.nvim_get_current_buf()
+  if not node then
+    return {}
+  end
+
+  -- We have to remember that end_col is end-exclusive
+  local start_row, start_col, end_row, end_col = M.get_node_range(node)
+
+  if start_row ~= end_row then
+    local lines = api.nvim_buf_get_lines(bufnr, start_row, end_row + 1, false)
+    lines[1] = string.sub(lines[1], start_col + 1)
+    -- end_row might be just after the last line. In this case the last line is not truncated.
+    if #lines == end_row - start_row + 1 then
+      lines[#lines] = string.sub(lines[#lines], 1, end_col)
+    end
+    return lines
+  else
+    local line = api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1]
+    -- If line is nil then the line is empty
+    return line and { string.sub(line, start_col + 1, end_col) } or {}
+  end
 end
 
 --- Determines whether a node is the parent of another


### PR DESCRIPTION
This reverts commit c3848e713a8272e524a7eabe9eb0897cf2d6932e.

The wrapper needs extra work, so revert to unbreak all the things.