### PR TITLE
fixup: adapt to upstream function

### DIFF
--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -211,7 +211,7 @@ end
 
 function M.find_definition(node, bufnr)
   local def_lookup = M.get_definitions_lookup_table(bufnr)
-  local node_text = ts_query.get_node_text(node, bufnr)[1]
+  local node_text = ts_query.get_node_text(node, bufnr)
 
   for scope in M.iter_scope_tree(node, bufnr) do
     local id = M.get_definition_id(scope, node_text)
@@ -232,7 +232,7 @@ end
 -- @returns a list of nodes
 function M.find_usages(node, scope_node, bufnr)
   local bufnr = bufnr or api.nvim_get_current_buf()
-  local node_text = ts_query.get_node_text(node, bufnr)[1]
+  local node_text = ts_query.get_node_text(node, bufnr)
 
   if not node_text or #node_text < 1 then
     return {}
@@ -245,7 +245,7 @@ function M.find_usages(node, scope_node, bufnr)
     if
       match.reference
       and match.reference.node
-      and ts_query.get_node_text(match.reference.node, bufnr)[1] == node_text
+      and ts_query.get_node_text(match.reference.node, bufnr) == node_text
     then
       local def_node, _, kind = M.find_definition(match.reference.node, bufnr)
 

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -347,8 +347,8 @@ function M.swap_nodes(node_or_range1, node_or_range2, bufnr, cursor_to_second)
   local text1 = ts_query.get_node_text(node_or_range1)
   local text2 = ts_query.get_node_text(node_or_range2)
 
-  local edit1 = { range = range1, newText = table.concat(text2, "\n") }
-  local edit2 = { range = range2, newText = table.concat(text1, "\n") }
+  local edit1 = { range = range1, newText = text2 }
+  local edit2 = { range = range2, newText = text1 }
   vim.lsp.util.apply_text_edits({ edit1, edit2 }, bufnr, "utf-8")
 
   if cursor_to_second then


### PR DESCRIPTION
more fixes to adapt to upstream `get_node_text` returning a string rather than a table.