### PR TITLE
highlights(markdown): conceal check boxes

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -88,3 +88,6 @@
 (inline_link 
   "["  @conceal
   (#set! conceal ""))
+
+((shortcut_link) @conceal (#set! conceal "") (eq? @conceal "[ ]"))
+((shortcut_link) @conceal (#set! conceal "☒") (eq? @conceal "[x]"))


### PR DESCRIPTION
Demo for @megalithic (https://github.com/nvim-treesitter/nvim-treesitter/issues/2663#issuecomment-1101757822)

not sure whether one would only count `- [ ]` as checkbox or every `[ ]`. There is also ☑ which is sometimes rendered in the same style and sometimes as a green tick.

Non-ascii conceals should be somehow guarded as mentioned in #2825 