### PR TITLE
fix(ts_utils): fix swap_nodes after get_node_text change

### DIFF
--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -3,7 +3,6 @@ local utils = require "nvim-treesitter.utils"
 local info = require "nvim-treesitter.info"
 local configs = require "nvim-treesitter.configs"
 local parsers = require "nvim-treesitter.parsers"
-local ts_query = vim.treesitter.query
 local ts_utils = require "nvim-treesitter.ts_utils"
 
 -- Registers all query predicates
@@ -20,23 +19,6 @@ end
 
 function M.define_modules(...)
   configs.define_modules(...)
-end
-
-local get_line_for_node = function(node, type_patterns, transform_fn, bufnr)
-  local node_type = node:type()
-  local is_valid = false
-  for _, rgx in ipairs(type_patterns) do
-    if node_type:find(rgx) then
-      is_valid = true
-      break
-    end
-  end
-  if not is_valid then
-    return ""
-  end
-  local line = transform_fn(vim.trim(ts_query.get_node_text(node, bufnr) or ""))
-  -- Escape % to avoid statusline to evaluate content as expression
-  return line:gsub("%%", "%%%%")
 end
 
 -- Trim spaces and opening brackets from end
@@ -67,7 +49,7 @@ function M.statusline(opts)
   local expr = current_node
 
   while expr do
-    local line = get_line_for_node(expr, type_patterns, transform_fn, bufnr)
+    local line = ts_utils._get_line_for_node(expr, type_patterns, transform_fn, bufnr)
     if line ~= "" and not vim.tbl_contains(lines, line) then
       table.insert(lines, 1, line)
     end

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -2,20 +2,10 @@ local api = vim.api
 
 local parsers = require "nvim-treesitter.parsers"
 local utils = require "nvim-treesitter.utils"
-local ts_query = vim.treesitter.query
 
 local M = {}
 
---- Gets the actual text content of a node
--- @deprecated Use vim.treesitter.query.get_node_text
--- @param node the node to get the text from
--- @param bufnr the buffer containing the node
--- @return list of lines of text of the node
-function M.get_node_text(node, bufnr)
-  vim.notify_once(
-    "nvim-treesitter.ts_utils.get_node_text is deprecated: use vim.treesitter.query.get_node_text",
-    vim.log.levels.WARN
-  )
+local function get_node_text(node, bufnr)
   local bufnr = bufnr or api.nvim_get_current_buf()
   if not node then
     return {}
@@ -37,6 +27,37 @@ function M.get_node_text(node, bufnr)
     -- If line is nil then the line is empty
     return line and { string.sub(line, start_col + 1, end_col) } or {}
   end
+end
+
+---@private
+function M._get_line_for_node(node, type_patterns, transform_fn, bufnr)
+  local node_type = node:type()
+  local is_valid = false
+  for _, rgx in ipairs(type_patterns) do
+    if node_type:find(rgx) then
+      is_valid = true
+      break
+    end
+  end
+  if not is_valid then
+    return ""
+  end
+  local line = transform_fn(vim.trim(get_node_text(node, bufnr)[1] or ""))
+  -- Escape % to avoid statusline to evaluate content as expression
+  return line:gsub("%%", "%%%%")
+end
+
+--- Gets the actual text content of a node
+-- @deprecated Use vim.treesitter.query.get_node_text
+-- @param node the node to get the text from
+-- @param bufnr the buffer containing the node
+-- @return list of lines of text of the node
+function M.get_node_text(node, bufnr)
+  vim.notify_once(
+    "nvim-treesitter.ts_utils.get_node_text is deprecated: use vim.treesitter.query.get_node_text",
+    vim.log.levels.WARN
+  )
+  return get_node_text(node, bufnr)
 end
 
 --- Determines whether a node is the parent of another
@@ -344,8 +365,8 @@ function M.swap_nodes(node_or_range1, node_or_range2, bufnr, cursor_to_second)
   local range1 = M.node_to_lsp_range(node_or_range1)
   local range2 = M.node_to_lsp_range(node_or_range2)
 
-  local text1 = ts_query.get_node_text(node_or_range1)
-  local text2 = ts_query.get_node_text(node_or_range2)
+  local text1 = get_node_text(node_or_range1, bufnr)
+  local text2 = get_node_text(node_or_range2, bufnr)
 
   local edit1 = { range = range1, newText = table.concat(text2, "\n") }
   local edit2 = { range = range2, newText = table.concat(text1, "\n") }


### PR DESCRIPTION
After some discussion, it looks like the easiest thing to do for now is
to keep a private copy of get_node_text (just to skip the deprecation
message) and invoke that, until core provides an equivalent function
that can return the node content in a table representing the node
"lines".

Also fixes the statusline.

Fix #2849.