### PR TITLE
Add org parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [ocaml](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
 - [x] [ocaml_interface](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
 - [x] [ocamllex](https://github.com/atom-ocaml/tree-sitter-ocamllex) (maintained by @undu)
+- [ ] [org](https://github.com/milisims/tree-sitter-org)
 - [x] [pascal](https://github.com/Isopod/tree-sitter-pascal.git) (maintained by @isopod)
 - [x] [perl](https://github.com/ganezdragon/tree-sitter-perl) (maintained by @ganezdragon)
 - [x] [php](https://github.com/tree-sitter/tree-sitter-php) (maintained by @tk-shirasaka)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -413,6 +413,14 @@ list.ocamllex = {
   maintainers = { "@undu" },
 }
 
+list.org = {
+  install_info = {
+    url = "https://github.com/milisims/tree-sitter-org",
+    branch = "main",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+}
+
 list.swift = {
   install_info = {
     url = "https://github.com/alex-pinkus/tree-sitter-swift",


### PR DESCRIPTION
This simply adds the [tree-sitter-org](https://github.com/milisims/tree-sitter-org) parser to the list of parsers. Highlights, folds, etc. are handled by the separate [orgmode](https://github.com/nvim-orgmode/orgmode) plugin for now it seems. Regardless, this fixes the issue of having to separately add the parser to `nvim-treesitter` for the purposes of simply accessing treesitter information. 