### PR TITLE
fix(fold): don't include whitespace end regions

### DIFF
--- a/lua/nvim-treesitter/fold.lua
+++ b/lua/nvim-treesitter/fold.lua
@@ -39,8 +39,13 @@ local folds_levels = tsutils.memoize_by_buf_tick(function(bufnr)
 
   local min_fold_lines = api.nvim_win_get_option(0, "foldminlines")
 
-  for _, node in ipairs(matches) do
-    local start, _, stop, stop_col = node.node:range()
+  for _, match in ipairs(matches) do
+    local start, stop, stop_col
+    if match.metadata and match.metadata.range then
+      start, _, stop, stop_col = unpack(match.metadata.range)
+    else
+      start, _, stop, stop_col = match.node:range()
+    end
 
     if stop_col == 0 then
       stop = stop - 1

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -209,7 +209,7 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
   local matches = query:iter_matches(qnode, bufnr, start_row, end_row)
 
   local function iterator()
-    local pattern, match = matches()
+    local pattern, match, metadata = matches()
     if pattern ~= nil then
       local prepared_match = {}
 
@@ -219,6 +219,8 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
         if name ~= nil then
           local path = split(name .. ".node")
           insert_to_path(prepared_match, path, node)
+          local metadata_path = split(name .. ".metadata")
+          insert_to_path(prepared_match, metadata_path, metadata[id])
         end
       end
 

--- a/queries/make/folds.scm
+++ b/queries/make/folds.scm
@@ -1,0 +1,7 @@
+(
+  [
+    (conditional)
+    (rule)
+  ] @fold
+  (#trim! @fold)
+)

--- a/queries/markdown/folds.scm
+++ b/queries/markdown/folds.scm
@@ -1,6 +1,9 @@
-[
-  (fenced_code_block)
-  (indented_code_block)
-  (list)
-  (section)
-] @fold
+(
+  [
+    (fenced_code_block)
+    (indented_code_block)
+    (list)
+    (section)
+  ] @fold
+  (#trim! @fold)
+)


### PR DESCRIPTION
Some languages that are difficult to parse via Treesitter mayincorrectly include whitespace lines at the end of regions. This canmake the calculated folds sub-optimal.

To rectify, use a new `trim!` directive for languages with this issue and accountfor it when calculating folds.

Also added folds for Make

---

Here's a demo with Neovim's Makefile:

(left: original, right: fixed with this PR)

![Screenshot 2022-04-21 at 10 48 01](https://user-images.githubusercontent.com/7904185/164429553-874b8d4b-0f33-422b-972a-a94dbaadfa2a.png)

