### PR TITLE
Reformat "parserinfo" as table with related plugins column

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [zig](https://github.com/maxxnino/tree-sitter-zig) (maintained by @maxxnino)
 <!--parserinfo-->
 
+For related information on the supported languages, including related plugins, see [this wiki page](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Supported-Languages-Information).
 
 # Available modules
 


### PR DESCRIPTION
This modifies the automatically generated "parserinfo" section of the README to display the supported languages as a table with an additional "related plugins" column.

The result can be seen on the branch, where I've also added related plugins for "org".
https://github.com/TerseTears/nvim-treesitter/tree/readme#supported-languages

Let me know what you think and if any fixes are required or if I should add other related plugins.