### PR TITLE
highlights(ocaml): highlight units as such

### DIFF
--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -71,7 +71,8 @@
 ; Constants
 ;----------
 
-(unit) @constant.builtin
+; Don't let normal parens take priority over this
+((unit) @constant.builtin (#set! "priority" 105))
 
 (boolean) @boolean
 


### PR DESCRIPTION
Units were shadowed by the punctuation highlights in all situations.
Restrict the context where parentheses are highlighted as punctuation so
() can be highlighted as constants.

Before:
![before](https://user-images.githubusercontent.com/578125/165961943-d30a7c01-ccc4-46e5-b0d9-3b99ff1b5b3c.png)

After
![after](https://user-images.githubusercontent.com/578125/165961954-1b59c4b3-cff8-4b58-933b-557e620d1010.png)
: