### PR TITLE
fix: Use ColorScheme event to define highlights

### DIFF
--- a/plugin/nvim-treesitter.lua
+++ b/plugin/nvim-treesitter.lua
@@ -116,6 +116,13 @@ local highlights = {
   TSTagAttribute = { link = "TSProperty", default = true },
 }
 
-for k, v in pairs(highlights) do
-  api.nvim_set_hl(0, k, v)
-end
+api.nvim_create_autocmd("ColorScheme", {
+  pattern = "*",
+  group = augroup,
+  callback = function()
+    for k, v in pairs(highlights) do
+      api.nvim_set_hl(0, k, v)
+    end
+  end,
+  desc = "Define default highlights",
+})


### PR DESCRIPTION
Before this, highlights were cleared when colorscheme was changed to one which is not support nvim-treesitter. This will fix the problem.