### PR TITLE
highlights(cpp): make "::" `@punctuation.delimiter`

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -174,10 +174,9 @@
  ;"xor_eq"
 ] @keyword.operator
 
-[
-  "<=>"
-  "::"
-] @operator
+"<=>" @operator
+
+"::" @punctuation.delimiter
 
 (attribute_declaration) @attribute
 

--- a/tests/query/highlights/cpp/test.cpp
+++ b/tests/query/highlights/cpp/test.cpp
@@ -10,6 +10,7 @@ auto main( int argc, char** argv ) -> int
       //                  ^ operator
 {
     std::cout << "Hello world!" << std::endl;
+    //  ^ punctuation.delimiter
     
     return EXIT_SUCCESS;
     // ^ keyword.return


### PR DESCRIPTION
Fixes #2902

There was someone who suggested that `@operator` would make more sense when this was originally submitted. But I think since this is not an actual C++ operator it makes sense to align with Rust.