### PR TITLE
Add method to definitions in ECMA locals

### DIFF
--- a/queries/ecma/locals.scm
+++ b/queries/ecma/locals.scm
@@ -26,6 +26,10 @@
   ((identifier) @definition.var)
    (#set! definition.var.scope parent))
 
+(method_definition
+  ((property_identifier) @definition.var)
+   (#set! definition.var.scope parent))
+
 ; References
 ;------------
 

--- a/queries/ecma/locals.scm
+++ b/queries/ecma/locals.scm
@@ -23,11 +23,11 @@
   (identifier) @definition.import)
 
 (function_declaration
-  ((identifier) @definition.var)
+  ((identifier) @definition.function)
    (#set! definition.var.scope parent))
 
 (method_definition
-  ((property_identifier) @definition.var)
+  ((property_identifier) @definition.function)
    (#set! definition.var.scope parent))
 
 ; References


### PR DESCRIPTION
In Telescope, function declarations were being exposed in the selector,
but not method definitions which are also a form of function
declaration.