### PR TITLE
highlights(scheme): some fix

### DIFF
--- a/queries/scheme/highlights.scm
+++ b/queries/scheme/highlights.scm
@@ -43,7 +43,7 @@
  .
  (list
    (symbol) @variable)
- (#eq? @_f "lambda"))
+ (#any-of? @_f "lambda" "λ"))
 
 (list
  .
@@ -65,7 +65,7 @@
 
 ((symbol) @keyword
  (#any-of? @keyword
-  "define" "lambda" "begin" "do" "define-syntax"
+  "define" "lambda" "λ" "begin" "do" "define-syntax"
   "and" "or"
   "if" "cond" "case" "when" "unless" "else" "=>"
   "let" "let*" "let-syntax" "let-values" "let*-values" "letrec" "letrec*" "letrec-syntax"

--- a/queries/scheme/highlights.scm
+++ b/queries/scheme/highlights.scm
@@ -6,7 +6,8 @@
 (character) @character
 (boolean) @boolean
 (string) @string
-(comment) @comment
+[(comment)
+ (block_comment)] @comment
 
 ;; highlight for datum comment
 ;; copied from ../clojure/highlights.scm


### PR DESCRIPTION
This PR fix block comments in Scheme and highlights `λ` correctly.