### PR TITLE
highlights(php): improve highlight for attributes

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -103,6 +103,9 @@
 (namespace_definition
   name: (namespace_name) @namespace)
 
+; Attributes
+(attribute_list) @attribute
+
 ; Conditions ( ? : )
 (conditional_expression) @conditional
 ; Basic tokens
@@ -222,6 +225,7 @@
  "]"
  "{"
  "}"
+ "#["
  ] @punctuation.bracket
 
 [


### PR DESCRIPTION
Improve PHP highlight for attributes.


# Screenshots

Before:

![image](https://user-images.githubusercontent.com/54318333/168282233-38f80e9c-c8a3-4bd9-a233-e7f54daa808d.png)

After:

![image](https://user-images.githubusercontent.com/54318333/168282260-c392da37-be92-4f1d-9f6d-e6a7e7d5c6cb.png)

Colorscheme: [gruvbox](https://github.com/morhetz/gruvbox)
Sample code: [treesitter-php](https://github.com/tree-sitter/tree-sitter-php/blob/6be89d517d550a47b067b23d0f89a364091b41ca/test/corpus/declarations.txt#L321-L358)