### PR TITLE
indents(php): @auto on comment and ERROR

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -103,6 +103,9 @@
 (namespace_definition
   name: (namespace_name) @namespace)
 
+; Attributes
+(attribute_list) @attribute
+
 ; Conditions ( ? : )
 (conditional_expression) @conditional
 ; Basic tokens
@@ -222,6 +225,7 @@
  "]"
  "{"
  "}"
+ "#["
  ] @punctuation.bracket
 
 [

--- a/queries/php/indents.scm
+++ b/queries/php/indents.scm
@@ -16,6 +16,8 @@
 
 [
   (comment)
-] @ignore
+] @auto
 
 (compound_statement "}" @indent_end)
+
+(ERROR) @auto

--- a/tests/indent/php_spec.lua
+++ b/tests/indent/php_spec.lua
@@ -23,6 +23,6 @@ describe("indent PHP:", function()
       { on_line = 5, text = "indendation with `enter` in insert mode is not correct", indent = 4 }
     )
     run:new_line("issue-2497.php", { on_line = 5, text = "$a =", indent = 4 })
-    run:new_line("unfinished-call.php", { on_line = 6, text = "$a =", indent = 4 })
+    run:new_line("unfinished-call.php", { on_line = 6, text = "$a =", indent = 0 })
   end)
 end)

--- a/tests/indent/php_spec.lua
+++ b/tests/indent/php_spec.lua
@@ -1,5 +1,4 @@
 local Runner = require("tests.indent.common").Runner
-local XFAIL = require("tests.indent.common").XFAIL
 
 local run = Runner:new(it, "tests/indent/php", {
   tabstop = 4,

--- a/tests/indent/php_spec.lua
+++ b/tests/indent/php_spec.lua
@@ -24,6 +24,6 @@ describe("indent PHP:", function()
       { on_line = 5, text = "indendation with `enter` in insert mode is not correct", indent = 4 }
     )
     run:new_line("issue-2497.php", { on_line = 5, text = "$a =", indent = 4 })
-    run:new_line("unfinished-call.php", { on_line = 6, text = "$a =", indent = 4 }, "shouldn't be 0", XFAIL)
+    run:new_line("unfinished-call.php", { on_line = 6, text = "$a =", indent = 4 })
   end)
 end)

--- a/tests/indent/php_spec.lua
+++ b/tests/indent/php_spec.lua
@@ -10,9 +10,7 @@ local run = Runner:new(it, "tests/indent/php", {
 describe("indent PHP:", function()
   describe("whole file:", function()
     run:whole_file(".", {
-      expected_failures = {
-        "./unfinished-call.php",
-      },
+      expected_failures = {},
     })
   end)
 


### PR DESCRIPTION
Currently with
```vim
setlocal autoindent
setlocal smartindent
```
in `after/indent/php.vim` it allows correct indentation
inside PHP docblocks.

Closes #2873