### PR TITLE
feat: add "fold_one_line_after" to allow folding without first line

### DIFF
--- a/autoload/nvim_treesitter.vim
+++ b/autoload/nvim_treesitter.vim
@@ -18,6 +18,10 @@ function! nvim_treesitter#available_modules(arglead, cmdline, cursorpos) abort
   return join(luaeval("require'nvim-treesitter.configs'.available_modules()"), "\n")
 endfunction
 
+function! nvim_treesitter#attachable_modules(arglead, cmdline, cursorpos) abort
+  return join(luaeval("require'nvim-treesitter.configs'.attachable_modules()"), "\n")
+endfunction
+
 function! nvim_treesitter#available_query_groups(arglead, cmdline, cursorpos) abort
   return join(luaeval("require'nvim-treesitter.query'.available_query_groups()"), "\n")
 endfunction


### PR DESCRIPTION
This allows to keep the current behavior of Python folding as an opt-in also for other languages.

![grafik](https://user-images.githubusercontent.com/7189118/168471368-213a8cab-698b-472a-a97d-e720eb9e23d6.png)
![grafik](https://user-images.githubusercontent.com/7189118/168471377-c3e75875-21e9-43d5-ab1c-384d76a1a1f0.png)

multi-line function signature (still only keeping the first line with function name)
![grafik](https://user-images.githubusercontent.com/7189118/168471432-ce1a5e76-cca8-4689-923e-82a981981c33.png)
 

Addresses problems with https://github.com/nvim-treesitter/nvim-treesitter/pull/1451

This also changes our code to have "config" only modules. That can not be attached to buffers. This could also be used to expose the options that we have for `install.lua` via our setup call. I'm not sure whether this is the right way. The option could also be placed directly at `fold.lua` but I think it would be easier to document (same as with install.lua) when we would just show the options in the README in the setup call like options for other modules.

This is still kind of a hack, ideally Vim could just have an option to display the folds in a different way
