### PR TITLE
Add tree-sitter-rec for RecUtils

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1080,6 +1080,16 @@ list.v = {
   maintainers = { "@tami5" },
 }
 
+list.rec = {
+  install_info = {
+    url = "https://github.com/thmsmlr/tree-sitter-rec",
+    files = { "src/parser.c" },
+    branch = "main",
+  },
+  maintainers = { "@thmsmlr" },
+  filetype = "rec",
+}
+
 local M = {
   list = list,
   filetype_to_parsername = filetype_to_parsername,


### PR DESCRIPTION
I recently put together a tree sitter implementation for [RecUtils](https://www.gnu.org/software/recutils/), I figure we could add it here for others to use