### PR TITLE
highlights(latex): only highlight command name, not whole command

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -1,7 +1,7 @@
 ;; General syntax
 (ERROR) @error
 
-(generic_command) @function
+(command_name) @function
 (caption
   command: _ @function)
 
@@ -129,7 +129,6 @@
 (author_declaration
   command: _ @namespace
   authors: (curly_group_author_list
-             ((command_name)? @function)
              ((author)+ @text.title)))
 
 (chapter


### PR DESCRIPTION
Previously, it would highlight the whole command including arguments which can be annoying since some commands include whole paragraphs.