### PR TITLE
fix(nix): update parser and queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -198,7 +198,7 @@
     "revision": "0a95cfdc0745b6ae82f60d3a339b37f19b7b9267"
   },
   "nix": {
-    "revision": "6d6aaa50793b8265b6a8b6628577a0083d3b923d"
+    "revision": "6b71a810c0acd49b980c50fc79092561f7cee307"
   },
   "norg": {
     "revision": "17d61df817c1e0a9cdef8d915d4e4c556b7cf68c"

--- a/queries/nix/folds.scm
+++ b/queries/nix/folds.scm
@@ -1,11 +1,11 @@
 ; Nix doesn't really have blocks, so just guess what people might want folds for
 [
-  (if)
-  (with)
-  (let)
-  (function)
-  (attrset)
-  (rec_attrset)
-  (list)
-  (indented_string)
+  (if_expression)
+  (with_expression)
+  (let_expression)
+  (function_expression)
+  (attrset_expression)
+  (rec_attrset_expression)
+  (list_expression)
+  (indented_string_expression)
 ] @fold

--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -22,10 +22,10 @@
 (comment) @comment
 
 ; strings
-[ (string) (indented_string) ] @string
+[ (string_expression) (indented_string_expression) ] @string
 
 ; paths and URLs
-[ (path) (spath) (uri) ] @string.special
+[ (path_expression) (spath_expression) (uri_expression) ] @string.special
 
 ; escape sequences
 (escape_sequence) @string.escape
@@ -55,16 +55,18 @@
 (ellipses) @punctuation.special
 
 ; `:` in `x: y`, used to separate function argument from body (see above)
-(function ":" @punctuation.special)
+(function_expression ":" @punctuation.special)
 
 ; basic identifiers
-(identifier) @variable
+(variable_expression) @variable
 
 ; builtin functions
 ((identifier) @_i (#match? @_i "^(builtins|baseNameOf|dirOf|fetchTarball|map|removeAttrs|toString)$")) @variable.builtin
 
 ; display entire builtins path as builtin (ex. `builtins.filter` is highlighted as one long builtin)
-(select ((identifier) @_i (#eq? @_i "builtins")) (attrpath (attr_identifier) @variable.builtin)) @variable.builtin
+(select_expression
+  expression: ((variable_expression) @_i (#eq? @_i "builtins"))
+  attrpath: (attrpath attr: (identifier) @variable.builtin)) @variable.builtin
 
 ; import
 ((identifier) @_i (#eq? @_i "import")) @include
@@ -82,39 +84,23 @@
 (interpolation "${" @punctuation.special (_) "}" @punctuation.special) @none
 
 ; fields (the `.` in `a.b = c;` isn't included)
-(attrset (bind . (attrpath (attr_identifier) @field)))
-(rec_attrset (bind . (attrpath (attr_identifier) @field)))
+(attrset_expression (binding_set (binding . (attrpath (identifier) @field))))
+(rec_attrset_expression (binding_set (binding . (attrpath (identifier) @field))))
 
 ; unary operators
-(unary "-" @operator)
-(unary "!" @operator)
+(unary_expression operator: _ @operator)
 
 ; binary operators
-(binary "?" @operator)
-(binary "++" @operator)
-(binary "*" @operator)
-(binary "/" @operator)
-(binary "+" @operator)
-(binary "-" @operator)
-(binary "//" @operator)
-(binary "<" @operator)
-(binary "<=" @operator)
-(binary ">" @operator)
-(binary ">=" @operator)
-(binary "==" @operator)
-(binary "!=" @operator)
-(binary "&&" @operator)
-(binary "||" @operator)
-(binary "->" @operator)
+(binary_expression operator: _ @operator)
 
 ; integers, also highlight a unary -
 [
-  (unary "-" (integer))
-  (integer)
+  (unary_expression "-" (integer_expression))
+  (integer_expression)
 ] @number
 
 ; floats, also highlight a unary -
 [
-  (unary "-" (float))
-  (float)
+  (unary_expression "-" (float_expression))
+  (float_expression)
 ] @float

--- a/queries/nix/locals.scm
+++ b/queries/nix/locals.scm
@@ -1,15 +1,15 @@
 ; let bindings
-(let (bind . (attrpath) @definition.var)) @scope
+(let_expression (binding_set (binding . (attrpath) @definition.var))) @scope
 
 ; rec attrsets
-(rec_attrset (bind . (attrpath) @definition.field)) @scope
+(rec_attrset_expression (binding_set (binding . (attrpath) @definition.field))) @scope
 
 ; functions and parameters
-(function . [
+(function_expression . [
     (identifier) @definition.parameter
     (formals (formal . (identifier) @definition.parameter))
 ]) @scope
 ((formals) "@" (identifier) @definition.parameter) ; I couldn't get this to work properly inside the (function)
 
-; some identifiers can't be references, but @reference doesn't seem to have an inverse like @none
-(identifier) @reference
+(variable_expression (identifier) @reference)
+(inherited_attrs attr: (identifier) @reference)


### PR DESCRIPTION
Updates the nix queries to the latest changes upstream.

Upstream added a `variable_expression` which allows us to to specify the references/variables more (changed in `highlights.scm` and `locals.scm`). I also changed the binary and unary operators to be less specific in `highlights.scm`, as is done upstream's queries (which removes some code).

Pinging @leo60228 as maintainer