### PR TITLE
highlights(c): highlight field_designator as `@property`

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -120,6 +120,7 @@
      (field_identifier) @property)) @_parent
  (#not-has-parent? @_parent template_method function_declarator call_expression))
 
+(field_designator) @property
 (((field_identifier) @property)
  (#has-ancestor? @property field_declaration)
  (#not-has-ancestor? @property function_declarator))


### PR DESCRIPTION
Highlight C (or C++20) style designated initializers as `@property`

In theory we have `@field` but this is not used in C yet (neither for all the other `field_...` nodes). Probably, we should just throw together `field/property` into one category. The default highlight for both is the same `@TSProperty` says same as `TSField`