### PR TITLE
fix(health): update to upstream changes

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -7,7 +7,7 @@ local shell = require "nvim-treesitter.shell_command_selectors"
 local install = require "nvim-treesitter.install"
 local utils = require "nvim-treesitter.utils"
 
-local health = require "health"
+local health = vim.health or require "health"
 
 local M = {}
 


### PR DESCRIPTION
The `health` module was moved to `vim.health` in https://github.com/neovim/neovim/pull/18720