### PR TITLE
injections(ecma): add injection for commented graphql template strings

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -57,12 +57,6 @@
 
 (regex_pattern) @regex
 
-(variable_declarator
-  (comment) @comment
-  (#eq? @comment "/* GraphQL */")
-  (template_string) @graphql)
-
-(export_statement
-  (comment) @comment
-  (#eq? @comment "/* GraphQL */")
+((comment) @_gql_comment
+  (#eq? @_gql_comment "/* GraphQL */")
   (template_string) @graphql)

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -60,3 +60,6 @@
 ((comment) @_gql_comment
   (#eq? @_gql_comment "/* GraphQL */")
   (template_string) @graphql)
+
+(((template_string) @_template_string
+ (#match? @_template_string "^`#graphql")) @graphql)

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -56,3 +56,8 @@
    (#offset! @css 0 1 0 -1)))
 
 (regex_pattern) @regex
+
+(variable_declarator
+  (comment) @gql_comment
+  (#eq? @gql_comment "/* GraphQL */")
+  (template_string) @graphql)

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -61,3 +61,8 @@
   (comment) @gql_comment
   (#eq? @gql_comment "/* GraphQL */")
   (template_string) @graphql)
+
+(export_statement
+  (comment) @gql_comment
+  (#eq? @gql_comment "/* GraphQL */")
+  (template_string) @graphql)

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -58,11 +58,11 @@
 (regex_pattern) @regex
 
 (variable_declarator
-  (comment) @gql_comment
-  (#eq? @gql_comment "/* GraphQL */")
+  (comment) @comment
+  (#eq? @comment "/* GraphQL */")
   (template_string) @graphql)
 
 (export_statement
-  (comment) @gql_comment
-  (#eq? @gql_comment "/* GraphQL */")
+  (comment) @comment
+  (#eq? @comment "/* GraphQL */")
   (template_string) @graphql)


### PR DESCRIPTION
Sometimes we want to highlight graphql strings without using a template literal like `gql`. In vscode, you can tell the editor to highlight the string as graphql by adding a comment like this:

```typescript
const query = /* GraphQL */ 
`
  type Thing {
    name: String!
  }
`;
```

This injection adds that capability.

Credit goes to @lukas-reineke. He gave me this injection snippet on reddit, but I thought it may as well be added to the repo.