### PR TITLE
highlights(markdown): conceal links

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -88,3 +88,25 @@
 (inline_link 
   "["  @conceal
   (#set! conceal ""))
+
+;; Conceal @text.uri preceding '('
+([
+  (link_label)
+  (link_text)
+  (image_description)
+] ["("] @conceal
+(#set! conceal ""))
+
+;; Conceal @text.uri text
+([
+  (link_destination)
+  (uri_autolink)
+] @conceal
+(#set! conceal ""))
+
+;; Conceal @text.uri proceding '('
+([
+  (link_destination)
+  (uri_autolink)
+] [")"] @conceal
+(#set! conceal ""))

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -81,32 +81,36 @@
 ] @conceal
 (#set! conceal ""))
 
-(inline_link 
-  ["]"] @conceal
-  (#set! conceal " "))
 
+;; Inline_link Conceal
+; Conceal preceeding "[" character for inline links
 (inline_link 
   "["  @conceal
   (#set! conceal ""))
 
-;; Conceal @text.uri preceding '('
-([
-  (link_label)
-  (link_text)
-  (image_description)
-] ["("] @conceal
-(#set! conceal ""))
-
-;; Conceal @text.uri text
-([
-  (link_destination)
-  (uri_autolink)
+; Conceal inline links
+(inline_link
+  [
+    "]"
+    "("
+   (link_destination)
+    ")"
 ] @conceal
 (#set! conceal ""))
 
-;; Conceal @text.uri proceding '('
-([
-  (link_destination)
-  (uri_autolink)
-] [")"] @conceal
-(#set! conceal ""))
+
+;; Image Conceal
+; Conceal preceeding "!" and "[" characters for image links
+(image
+  ["!" "["]  @conceal
+  (#set! conceal ""))
+
+; Conceal image links
+(image
+  [
+    "]"
+    "("
+   (link_destination)
+    ")"
+] @conceal
+  (#set! conceal ""))

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -82,15 +82,10 @@
 (#set! conceal ""))
 
 
-;; Inline_link Conceal
-; Conceal preceeding "[" character for inline links
-(inline_link 
-  "["  @conceal
-  (#set! conceal ""))
-
 ; Conceal inline links
 (inline_link
   [
+    "["
     "]"
     "("
    (link_destination)
@@ -99,15 +94,11 @@
 (#set! conceal ""))
 
 
-;; Image Conceal
-; Conceal preceeding "!" and "[" characters for image links
-(image
-  ["!" "["]  @conceal
-  (#set! conceal ""))
-
 ; Conceal image links
 (image
   [
+    "!"
+    "["
     "]"
     "("
    (link_destination)


### PR DESCRIPTION
Before:
![markdown_before](https://user-images.githubusercontent.com/54177704/172873714-33b064de-8404-4939-a22b-a9840c8535a1.png)


After:
![markdown_after](https://user-images.githubusercontent.com/54177704/172873746-488743c8-a4e1-4979-8eef-7c3f8b2139a6.png)



I'm still getting antiquated with the query/scheme syntax used by tree-sitter so if there is a better way to write these queries please let me know! 