### PR TITLE
fix: keep python `cls` variable highlighting consistent in classmethods

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -134,6 +134,8 @@
 [(true) (false)] @boolean
 ((identifier) @variable.builtin
  (#eq? @variable.builtin "self"))
+((identifier) @variable.builtin
+ (#eq? @variable.builtin "cls"))
 
 (integer) @number
 (float) @float
@@ -287,16 +289,6 @@
     (function_definition
       name: (identifier) @constructor)))
  (#any-of? @constructor "__new__" "__init__"))
-
-; First parameter of a classmethod is cls.
-((class_definition
-  body: (block
-          (decorated_definition
-            (decorator (identifier) @_decorator)
-            definition: (function_definition
-              parameters: (parameters . (identifier) @variable.builtin)))))
- (#eq? @variable.builtin "cls")
- (#eq? @_decorator "classmethod"))
 
 ;; Error
 (ERROR) @error


### PR DESCRIPTION

This change makes the highlighting behavior of `cls` variables consistent with the highlighting of `self`. The motivation for this change can be summed up in this screenshot.

<img src="https://i2.lensdump.com/i/tKEZf5.png"/>

I believe the highlighting for `self` is the better way to go. The single color makes it easy to follow the through the method. The mismatched colors for `cls` does not provide the same convenience when scanning code.

In Python both `self` and `cls` are only privileged names by convention. There is nothing actually special or "builtin" about those names in the language. Treating them differently does not make sense to me.

I have been using this alternate query setup in my personal dotfiles for a while and thought I would offer it upstream. If you disagree feel free to close. Cheers and thanks for the great project!
