### PR TITLE
 Add support for custom parser install locations #2959 

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,38 @@ This will respect your `foldminlines` and `foldnestmax` settings.
 
 # Advanced setup
 
+## Changing the parser install directory
+
+If you want to install the parsers to a custom directory you can specify this
+directory with `parser_install_dir` option in that is passed to `setup`.
+`nvim-treesitter` will then install the parser files into this directory.
+
+This directory must be writeable and must be explicitly added to the
+`runtimepath`. For example:
+
+``` lua
+  require'nvim-treesitter.configs'.setup {
+    parser_install_dir = "/some/path/to/store/parsers",
+
+    ...
+
+  }
+  vim.opt.runtimepath:append("/some/path/to/store/parsers")
+```
+
+If this option is not included in the setup options, or is explicitly set to
+`nil` then the default install directories will be used. If this value is set
+the default directories will be ignored. 
+
+Bear in mind that any parser installed into a parser folder on the runtime path
+will still be considered installed. (For example if
+"~/.local/share/nvim/site/parser/c.so" exists then the "c" parser will be
+considered installed, even though it is not in `parser_install_dir`)
+
+The default paths are:
+1. first the package folder. Where `nvim-treesitter` is installed.
+2. second the site directory. This is the "site" subdirectory of `stdpath("data")`.
+
 ## Adding parsers
 
 If you have a parser that is not on the list of supported languages (either as a repository on Github or in a local directory), you can add it manually for use by `nvim-treesitter` as follows:

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -42,7 +42,8 @@ To enable supported features, put this in your `init.lua` file:
     -- A directory to install the parsers into.
     -- If this is excluded or nil parsers are installed
     -- to either the package dir, or the "site" dir.
-    parser_install_dir = "/some/path/to/store/parsers
+    -- If a custom path is used (not nil) it must be added to the runtimepath.
+    parser_install_dir = "/some/path/to/store/parsers",
 
     -- A list of parser names, or "all"
     ensure_installed = { "c", "lua", "rust" },
@@ -67,6 +68,7 @@ To enable supported features, put this in your `init.lua` file:
       additional_vim_regex_highlighting = false,
     },
   }
+  vim.opt.runtimepath:append("/some/path/to/store/parsers")
 <
 
 See |nvim-treesitter-modules| for a list of all available modules and its options.

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -39,6 +39,11 @@ To enable supported features, put this in your `init.lua` file:
 
 >
   require'nvim-treesitter.configs'.setup {
+    -- A directory to install the parsers into.
+    -- If this is excluded or nil parsers are installed
+    -- to either the package dir, or the "site" dir.
+    parser_install_dir = "/some/path/to/store/parsers
+
     -- A list of parser names, or "all"
     ensure_installed = { "c", "lua", "rust" },
 

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -544,10 +544,11 @@ function M.get_parser_install_dir(folder_name)
 
   if config.parser_install_dir then
     local parser_dir = utils.join_path(config.parser_install_dir, folder_name)
-    return utils.create_or_resue_writable_dir(parser_dir, 
-            utils.join_space("Could not create parser dir '",dir,"': "), 
-            utils.join_space("Parser dir '",dir,"' should be read/write.")
-        )
+    return utils.create_or_resue_writable_dir(
+      parser_dir,
+      utils.join_space("Could not create parser dir '", parser_dir, "': "),
+      utils.join_space("Parser dir '", parser_dir, "' should be read/write.")
+    )
   end
 
   local package_path = utils.get_package_path()
@@ -561,7 +562,11 @@ function M.get_parser_install_dir(folder_name)
   local site_dir = utils.get_site_dir()
   local parser_dir = utils.join_path(site_dir, folder_name)
 
-  return utils.create_or_resue_writable_dir(parser_dir, nil, utils.join_space("Invalid rights,", package_path, "or", parser_dir, "should be read/write")))
+  return utils.create_or_resue_writable_dir(
+    parser_dir,
+    nil,
+    utils.join_space("Invalid rights,", package_path, "or", parser_dir, "should be read/write")
+  )
 end
 
 function M.get_parser_info_dir(parser_install_dir)

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -15,7 +15,7 @@ local config = {
   ensure_installed = {},
   ignore_install = {},
   update_strategy = "lockfile",
-  parser_install_dir = nil
+  parser_install_dir = nil,
 }
 -- List of modules that need to be setup on initialization.
 local queued_modules_defs = {}
@@ -384,9 +384,8 @@ function M.setup(user_data)
   config.parser_install_dir = user_data.parser_install_dir or nil
   if config.parser_install_dir then
     config.parser_install_dir = vim.fn.expand(config.parser_install_dir, ":p")
-    vim.cmd("set runtimepath+="..config.parser_install_dir)
+    vim.cmd("set runtimepath+=" .. config.parser_install_dir)
   end
-  
 
   local ensure_installed = user_data.ensure_installed or {}
   if #ensure_installed > 0 then
@@ -536,74 +535,71 @@ function M.init()
   end
 end
 
--- If parser_install_dir is not nil is used or created. 
+-- If parser_install_dir is not nil is used or created.
 -- If parser_install_dir is nil try the package dir of the nvim-treesitter
 -- plugin first, followed by the "site" dir from "runtimepath". "site" dir will
 -- be created if it doesn't exist. Using only the package dir won't work when
 -- the plugin is installed with Nix, since the "/nix/store" is read-only.
 function M.get_parser_install_dir(folder_name)
-    folder_name = folder_name or "parser"
+  folder_name = folder_name or "parser"
 
-    if config.parser_install_dir then
-        local parser_dir = utils.join_path(config.parser_install_dir, folder_name)
-
-        -- Try creating and using parser_dir if it doesn't exist
-        if not luv.fs_stat(parser_dir) then
-            local ok, error = pcall(vim.fn.mkdir, parser_dir, "p", "0755")
-            if not ok then
-                return nil, join_space("Couldn't create parser dir", parser_dir, ":", error)
-            end
-
-            return parser_dir
-        end
-
-        -- parser_dir exists, use it if it's read/write
-        if luv.fs_access(parser_dir, "RW") then
-            return parser_dir
-        end
-
-        -- package_path isn't read/write, parser_dir exists but isn't read/write
-        -- either, give up
-        return nil, join_space("Invalid cache rights,", parser_dir, "should be read/write")
-    end
-
-
-
-    local package_path = utils.get_package_path()
-    local package_path_parser_dir = utils.join_path(package_path, folder_name)
-
-    -- If package_path is read/write, use that
-    if luv.fs_access(package_path_parser_dir, "RW") then
-        return package_path_parser_dir
-    end
-
-    local site_dir = utils.get_site_dir()
-    local parser_dir = utils.join_path(site_dir, folder_name)
+  if config.parser_install_dir then
+    local parser_dir = utils.join_path(config.parser_install_dir, folder_name)
 
     -- Try creating and using parser_dir if it doesn't exist
     if not luv.fs_stat(parser_dir) then
-        local ok, error = pcall(vim.fn.mkdir, parser_dir, "p", "0755")
-        if not ok then
-            return nil, join_space("Couldn't create parser dir", parser_dir, ":", error)
-        end
+      local ok, error = pcall(vim.fn.mkdir, parser_dir, "p", "0755")
+      if not ok then
+        return nil, utils.join_space("Couldn't create parser dir", parser_dir, ":", error)
+      end
 
-        return parser_dir
+      return parser_dir
     end
 
     -- parser_dir exists, use it if it's read/write
     if luv.fs_access(parser_dir, "RW") then
-        return parser_dir
+      return parser_dir
     end
 
     -- package_path isn't read/write, parser_dir exists but isn't read/write
     -- either, give up
-    return nil, join_space("Invalid cache rights,", package_path, "or", parser_dir, "should be read/write")
+    return nil, utils.join_space("Invalid cache rights,", parser_dir, "should be read/write")
+  end
+
+  local package_path = utils.get_package_path()
+  local package_path_parser_dir = utils.join_path(package_path, folder_name)
+
+  -- If package_path is read/write, use that
+  if luv.fs_access(package_path_parser_dir, "RW") then
+    return package_path_parser_dir
+  end
+
+  local site_dir = utils.get_site_dir()
+  local parser_dir = utils.join_path(site_dir, folder_name)
+
+  -- Try creating and using parser_dir if it doesn't exist
+  if not luv.fs_stat(parser_dir) then
+    local ok, error = pcall(vim.fn.mkdir, parser_dir, "p", "0755")
+    if not ok then
+      return nil, utils.join_space("Couldn't create parser dir", parser_dir, ":", error)
+    end
+
+    return parser_dir
+  end
+
+  -- parser_dir exists, use it if it's read/write
+  if luv.fs_access(parser_dir, "RW") then
+    return parser_dir
+  end
+
+  -- package_path isn't read/write, parser_dir exists but isn't read/write
+  -- either, give up
+  return nil, utils.join_space("Invalid cache rights,", package_path, "or", parser_dir, "should be read/write")
 end
 
-function M.get_parser_info_dir( parser_install_dir)
-    return M.get_parser_install_dir("parser-info")
+function M.get_parser_info_dir(parser_install_dir)
+  return M.get_parser_install_dir "parser-info"
 end
-
 
 function M.get_update_strategy()
   return config.update_strategy

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -382,6 +382,11 @@ function M.setup(user_data)
   config.modules = vim.tbl_deep_extend("force", config.modules, user_data)
   config.ignore_install = user_data.ignore_install or {}
   config.parser_install_dir = user_data.parser_install_dir or nil
+  if config.parser_install_dir then
+    config.parser_install_dir = vim.fn.expand(config.parser_install_dir, ":p")
+    vim.cmd("set runtimepath+="..config.parser_install_dir)
+  end
+  
 
   local ensure_installed = user_data.ensure_installed or {}
   if #ensure_installed > 0 then

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -544,7 +544,10 @@ function M.get_parser_install_dir(folder_name)
 
   if config.parser_install_dir then
     local parser_dir = utils.join_path(config.parser_install_dir, folder_name)
-    return utils.create_or_resue_writable_dir(parser_dir)
+    return utils.create_or_resue_writable_dir(parser_dir, 
+            utils.join_space("Could not create parser dir '",dir,"': "), 
+            utils.join_space("Parser dir '",dir,"' should be read/write.")
+        )
   end
 
   local package_path = utils.get_package_path()
@@ -558,12 +561,7 @@ function M.get_parser_install_dir(folder_name)
   local site_dir = utils.get_site_dir()
   local parser_dir = utils.join_path(site_dir, folder_name)
 
-  parser_dir = utils.create_or_resue_writable_dir(parser_dir)
-  if parser_dir then
-    return parser_dir
-  else
-    return nil, utils.join_space("Invalid cache rights,", package_path, "or", parser_dir, "should be read/write")
-  end
+  return utils.create_or_resue_writable_dir(parser_dir, nil, utils.join_space("Invalid rights,", package_path, "or", parser_dir, "should be read/write")))
 end
 
 function M.get_parser_info_dir(parser_install_dir)

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -80,7 +80,7 @@ local function get_revision(lang)
 end
 
 local function get_installed_revision(lang)
-  local lang_file = utils.join_path(utils.get_parser_info_dir(), lang .. ".revision")
+  local lang_file = utils.join_path(configs.get_parser_info_dir(), lang .. ".revision")
   if vim.fn.filereadable(lang_file) == 1 then
     return vim.fn.readfile(lang_file)[1]
   end
@@ -329,7 +329,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
     shell.select_mv_cmd("parser.so", parser_lib_name, compile_location),
     {
       cmd = function()
-        vim.fn.writefile({ revision or "" }, utils.join_path(utils.get_parser_info_dir(), lang .. ".revision"))
+        vim.fn.writefile({ revision or "" }, utils.join_path(configs.get_parser_info_dir(), lang .. ".revision"))
       end,
     },
     { -- auto-attach modules after installation
@@ -392,7 +392,7 @@ local function install(options)
       return api.nvim_err_writeln(err)
     end
 
-    local install_folder, err = utils.get_parser_install_dir()
+    local install_folder, err = configs.get_parser_install_dir()
     if err then
       return api.nvim_err_writeln(err)
     end
@@ -473,7 +473,7 @@ function M.uninstall(...)
   elseif ... then
     local languages = vim.tbl_flatten { ... }
     for _, lang in ipairs(languages) do
-      local install_dir, err = utils.get_parser_install_dir()
+      local install_dir, err = configs.get_parser_install_dir()
       if err then
         return api.nvim_err_writeln(err)
       end

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -243,9 +243,9 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
     compile_location = repo.url
   else
     local repo_location = string.gsub(repo.location or project_name, "/", path_sep)
-    compile_location = cache_folder .. path_sep .. repo_location
+    compile_location = utils.join_path(cache_folder, repo_location)
   end
-  local parser_lib_name = install_folder .. path_sep .. lang .. ".so"
+  local parser_lib_name = utils.join_path(install_folder, lang) .. ".so"
 
   generate_from_grammar = repo.requires_generate_from_grammar or generate_from_grammar
 
@@ -459,11 +459,6 @@ function M.update(options)
 end
 
 function M.uninstall(...)
-  local path_sep = "/"
-  if fn.has "win32" == 1 then
-    path_sep = "\\"
-  end
-
   if vim.tbl_contains({ "all" }, ...) then
     reset_progress_counter()
     local installed = info.installed_parsers()
@@ -478,7 +473,7 @@ function M.uninstall(...)
         return api.nvim_err_writeln(err)
       end
 
-      local parser_lib = install_dir .. path_sep .. lang .. ".so"
+      local parser_lib = utils.join_path(install_dir, lang) .. ".so"
 
       local command_list = {
         shell.select_rm_file_cmd(parser_lib, "Uninstalling parser for " .. lang),

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -187,7 +187,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
       M.select_install_rm_cmd(cache_folder, project_name .. "-tmp"),
       {
         cmd = "curl",
-        info = "Downloading...",
+        info = "Downloading "..project_name.."...",
         err = "Error during download, please verify your internet connection",
         opts = {
           args = {
@@ -204,7 +204,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
       M.select_mkdir_cmd(project_name .. "-tmp", cache_folder, "Creating temporary directory"),
       {
         cmd = "tar",
-        info = "Extracting...",
+        info = "Extracting "..project_name.."...",
         err = "Error during tarball extraction.",
         opts = {
           args = {
@@ -231,7 +231,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
     return {
       {
         cmd = "git",
-        info = "Downloading...",
+        info = "Downloading "..project_name.."...",
         err = clone_error,
         opts = {
           args = {

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -187,7 +187,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
       M.select_install_rm_cmd(cache_folder, project_name .. "-tmp"),
       {
         cmd = "curl",
-        info = "Downloading "..project_name.."...",
+        info = "Downloading " .. project_name .. "...",
         err = "Error during download, please verify your internet connection",
         opts = {
           args = {
@@ -204,7 +204,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
       M.select_mkdir_cmd(project_name .. "-tmp", cache_folder, "Creating temporary directory"),
       {
         cmd = "tar",
-        info = "Extracting "..project_name.."...",
+        info = "Extracting " .. project_name .. "...",
         err = "Error during tarball extraction.",
         opts = {
           args = {
@@ -231,7 +231,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
     return {
       {
         cmd = "git",
-        info = "Downloading "..project_name.."...",
+        info = "Downloading " .. project_name .. "...",
         err = clone_error,
         opts = {
           args = {

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -86,14 +86,14 @@ function M.setup_commands(mod, commands)
   end
 end
 
-function M.create_or_resue_writable_dir(dir,create_err, unreadable_err )
-    create_err = create_err or M.join_space("Could not create dir '",dir,"': ")
-    readable_err = readable_err or M.join_space("Invalid rights, '", dir,"' should be read/write")
+function M.create_or_resue_writable_dir(dir, create_err, writeable_err)
+  create_err = create_err or M.join_space("Could not create dir '", dir, "': ")
+  writeable_err = writeable_err or M.join_space("Invalid rights, '", dir, "' should be read/write")
   -- Try creating and using parser_dir if it doesn't exist
   if not luv.fs_stat(dir) then
     local ok, error = pcall(vim.fn.mkdir, dir, "p", "0755")
     if not ok then
-      return nil, M.join_space(create_err, create_error)
+      return nil, M.join_space(create_err, error)
     end
 
     return dir
@@ -105,7 +105,7 @@ function M.create_or_resue_writable_dir(dir,create_err, unreadable_err )
   end
 
   -- parser_dir exists but isn't read/write, give up
-  return nil, M.join_space(readable_err,dir,"'")
+  return nil, M.join_space(writeable_err, dir, "'")
 end
 
 function M.get_package_path()

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -109,7 +109,7 @@ end
 -- runtimepath
 function M.get_site_dir()
     local path_sep = M.get_path_sep()
-    return M.join_path(fn.stdpath "data", path_sep, "site")
+    return M.join_path(fn.stdpath "data", "site")
 end
 
 -- Gets a property at path

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -86,12 +86,14 @@ function M.setup_commands(mod, commands)
   end
 end
 
-function M.create_or_resue_writable_dir(dir)
+function M.create_or_resue_writable_dir(dir,create_err, unreadable_err )
+    create_err = create_err or M.join_space("Could not create dir '",dir,"': ")
+    readable_err = readable_err or M.join_space("Invalid rights, '", dir,"' should be read/write")
   -- Try creating and using parser_dir if it doesn't exist
   if not luv.fs_stat(dir) then
     local ok, error = pcall(vim.fn.mkdir, dir, "p", "0755")
     if not ok then
-      return nil, M.join_space("Couldn't create parser dir", dir, ":", error)
+      return nil, M.join_space(create_err, create_error)
     end
 
     return dir
@@ -103,7 +105,7 @@ function M.create_or_resue_writable_dir(dir)
   end
 
   -- parser_dir exists but isn't read/write, give up
-  return nil, M.join_space("Invalid cache rights,", dir, "should be read/write")
+  return nil, M.join_space(readable_err,dir,"'")
 end
 
 function M.get_package_path()

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -6,8 +6,8 @@ local M = {}
 
 -- Wrapper around vim.notify with common options set.
 function M.notify(msg, log_level, opts)
-  local default_opts = { title = "nvim-treesitter" }
-  vim.notify(msg, log_level, vim.tbl_extend("force", default_opts, opts or {}))
+    local default_opts = { title = "nvim-treesitter" }
+    vim.notify(msg, log_level, vim.tbl_extend("force", default_opts, opts or {}))
 end
 
 --- Define user defined vim command which calls nvim-treesitter module function
@@ -46,27 +46,27 @@ end
 ---      lua require'nvim-treesitter.custom_mod'.commands.custom_command['run<bang>'](<f-args>)
 ---  </pre>
 function M.setup_commands(mod, commands)
-  for command_name, def in pairs(commands) do
-    local f_args = def.f_args or "<f-args>"
-    local call_fn = string.format(
-      "lua require'nvim-treesitter.%s'.commands.%s['run<bang>'](%s)",
-      mod,
-      command_name,
-      f_args
-    )
-    local parts = vim.tbl_flatten {
-      "command!",
-      "-bar",
-      def.args,
-      command_name,
-      call_fn,
-    }
-    api.nvim_command(table.concat(parts, " "))
-  end
+    for command_name, def in pairs(commands) do
+        local f_args = def.f_args or "<f-args>"
+        local call_fn = string.format(
+            "lua require'nvim-treesitter.%s'.commands.%s['run<bang>'](%s)",
+            mod,
+            command_name,
+            f_args
+        )
+        local parts = vim.tbl_flatten {
+            "command!",
+            "-bar",
+            def.args,
+            command_name,
+            call_fn,
+        }
+        api.nvim_command(table.concat(parts, " "))
+    end
 end
 
 function M.get_path_sep()
-  return fn.has "win32" == 1 and "\\" or "/"
+    return fn.has "win32" == 1 and "\\" or "/"
 end
 
 -- Returns a function that joins the given arguments with separator. Arguments
@@ -76,9 +76,9 @@ print(M.generate_join(" ")("foo", "bar"))
 --]]
 -- prints "foo bar"
 function M.generate_join(separator)
-  return function(...)
-    return table.concat({ ... }, separator)
-  end
+    return function(...)
+        return table.concat({ ... }, separator)
+    end
 end
 
 M.join_path = M.generate_join(M.get_path_sep())
@@ -86,72 +86,30 @@ M.join_path = M.generate_join(M.get_path_sep())
 local join_space = M.generate_join " "
 
 function M.get_package_path()
-  -- Path to this source file, removing the leading '@'
-  local source = string.sub(debug.getinfo(1, "S").source, 2)
+    -- Path to this source file, removing the leading '@'
+    local source = string.sub(debug.getinfo(1, "S").source, 2)
 
-  -- Path to the package root
-  return fn.fnamemodify(source, ":p:h:h:h")
+    -- Path to the package root
+    return fn.fnamemodify(source, ":p:h:h:h")
 end
 
 function M.get_cache_dir()
-  local cache_dir = fn.stdpath "data"
+    local cache_dir = fn.stdpath "data"
 
-  if luv.fs_access(cache_dir, "RW") then
-    return cache_dir
-  elseif luv.fs_access("/tmp", "RW") then
-    return "/tmp"
-  end
+    if luv.fs_access(cache_dir, "RW") then
+        return cache_dir
+    elseif luv.fs_access("/tmp", "RW") then
+        return "/tmp"
+    end
 
-  return nil, join_space("Invalid cache rights,", fn.stdpath "data", "or /tmp should be read/write")
+    return nil, join_space("Invalid cache rights,", fn.stdpath "data", "or /tmp should be read/write")
 end
 
 -- Returns $XDG_DATA_HOME/nvim/site, but could use any directory that is in
 -- runtimepath
 function M.get_site_dir()
-  local path_sep = M.get_path_sep()
-  return M.join_path(fn.stdpath "data", path_sep, "site")
-end
-
--- Try the package dir of the nvim-treesitter plugin first, followed by the
--- "site" dir from "runtimepath". "site" dir will be created if it doesn't
--- exist. Using only the package dir won't work when the plugin is installed
--- with Nix, since the "/nix/store" is read-only.
-function M.get_parser_install_dir(folder_name)
-  folder_name = folder_name or "parser"
-  local package_path = M.get_package_path()
-  local package_path_parser_dir = M.join_path(package_path, folder_name)
-
-  -- If package_path is read/write, use that
-  if luv.fs_access(package_path_parser_dir, "RW") then
-    return package_path_parser_dir
-  end
-
-  local site_dir = M.get_site_dir()
-  local path_sep = M.get_path_sep()
-  local parser_dir = M.join_path(site_dir, path_sep, folder_name)
-
-  -- Try creating and using parser_dir if it doesn't exist
-  if not luv.fs_stat(parser_dir) then
-    local ok, error = pcall(vim.fn.mkdir, parser_dir, "p", "0755")
-    if not ok then
-      return nil, join_space("Couldn't create parser dir", parser_dir, ":", error)
-    end
-
-    return parser_dir
-  end
-
-  -- parser_dir exists, use it if it's read/write
-  if luv.fs_access(parser_dir, "RW") then
-    return parser_dir
-  end
-
-  -- package_path isn't read/write, parser_dir exists but isn't read/write
-  -- either, give up
-  return nil, join_space("Invalid cache rights,", package_path, "or", parser_dir, "should be read/write")
-end
-
-function M.get_parser_info_dir()
-  return M.get_parser_install_dir "parser-info"
+    local path_sep = M.get_path_sep()
+    return M.join_path(fn.stdpath "data", path_sep, "site")
 end
 
 -- Gets a property at path
@@ -159,46 +117,46 @@ end
 -- @param path the '.' separated path
 -- @returns the value at path or nil
 function M.get_at_path(tbl, path)
-  if path == "" then
-    return tbl
-  end
-  local segments = vim.split(path, ".", true)
-  local result = tbl
-
-  for _, segment in ipairs(segments) do
-    if type(result) == "table" then
-      result = result[segment]
+    if path == "" then
+        return tbl
     end
-  end
+    local segments = vim.split(path, ".", true)
+    local result = tbl
 
-  return result
+    for _, segment in ipairs(segments) do
+        if type(result) == "table" then
+            result = result[segment]
+        end
+    end
+
+    return result
 end
 
 function M.set_jump()
-  vim.cmd "normal! m'"
+    vim.cmd "normal! m'"
 end
 
 function M.index_of(tbl, obj)
-  for i, o in ipairs(tbl) do
-    if o == obj then
-      return i
+    for i, o in ipairs(tbl) do
+        if o == obj then
+            return i
+        end
     end
-  end
 end
 
 -- Filters a list based on the given predicate
 -- @param tbl The list to filter
 -- @param predicate The predicate to filter with
 function M.filter(tbl, predicate)
-  local result = {}
+    local result = {}
 
-  for i, v in ipairs(tbl) do
-    if predicate(v, i) then
-      table.insert(result, v)
+    for i, v in ipairs(tbl) do
+        if predicate(v, i) then
+            table.insert(result, v)
+        end
     end
-  end
 
-  return result
+    return result
 end
 
 -- Returns a list of all values from the first list
@@ -206,32 +164,32 @@ end
 -- @params tbl1 The first table
 -- @params tbl2 The second table
 function M.difference(tbl1, tbl2)
-  return M.filter(tbl1, function(v)
-    return not vim.tbl_contains(tbl2, v)
-  end)
+    return M.filter(tbl1, function(v)
+        return not vim.tbl_contains(tbl2, v)
+    end)
 end
 
 function M.identity(a)
-  return a
+    return a
 end
 
 function M.constant(a)
-  return function()
-    return a
-  end
+    return function()
+        return a
+    end
 end
 
 function M.to_func(a)
-  return type(a) == "function" and a or M.constant(a)
+    return type(a) == "function" and a or M.constant(a)
 end
 
 function M.ts_cli_version()
-  if fn.executable "tree-sitter" == 1 then
-    local handle = io.popen "tree-sitter  -V"
-    local result = handle:read "*a"
-    handle:close()
-    return vim.split(result, "\n")[1]:match "[^tree%psitter ].*"
-  end
+    if fn.executable "tree-sitter" == 1 then
+        local handle = io.popen "tree-sitter  -V"
+        local result = handle:read "*a"
+        handle:close()
+        return vim.split(result, "\n")[1]:match "[^tree%psitter ].*"
+    end
 end
 
 return M

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -6,8 +6,8 @@ local M = {}
 
 -- Wrapper around vim.notify with common options set.
 function M.notify(msg, log_level, opts)
-    local default_opts = { title = "nvim-treesitter" }
-    vim.notify(msg, log_level, vim.tbl_extend("force", default_opts, opts or {}))
+  local default_opts = { title = "nvim-treesitter" }
+  vim.notify(msg, log_level, vim.tbl_extend("force", default_opts, opts or {}))
 end
 
 --- Define user defined vim command which calls nvim-treesitter module function
@@ -46,27 +46,27 @@ end
 ---      lua require'nvim-treesitter.custom_mod'.commands.custom_command['run<bang>'](<f-args>)
 ---  </pre>
 function M.setup_commands(mod, commands)
-    for command_name, def in pairs(commands) do
-        local f_args = def.f_args or "<f-args>"
-        local call_fn = string.format(
-            "lua require'nvim-treesitter.%s'.commands.%s['run<bang>'](%s)",
-            mod,
-            command_name,
-            f_args
-        )
-        local parts = vim.tbl_flatten {
-            "command!",
-            "-bar",
-            def.args,
-            command_name,
-            call_fn,
-        }
-        api.nvim_command(table.concat(parts, " "))
-    end
+  for command_name, def in pairs(commands) do
+    local f_args = def.f_args or "<f-args>"
+    local call_fn = string.format(
+      "lua require'nvim-treesitter.%s'.commands.%s['run<bang>'](%s)",
+      mod,
+      command_name,
+      f_args
+    )
+    local parts = vim.tbl_flatten {
+      "command!",
+      "-bar",
+      def.args,
+      command_name,
+      call_fn,
+    }
+    api.nvim_command(table.concat(parts, " "))
+  end
 end
 
 function M.get_path_sep()
-    return fn.has "win32" == 1 and "\\" or "/"
+  return fn.has "win32" == 1 and "\\" or "/"
 end
 
 -- Returns a function that joins the given arguments with separator. Arguments
@@ -76,40 +76,39 @@ print(M.generate_join(" ")("foo", "bar"))
 --]]
 -- prints "foo bar"
 function M.generate_join(separator)
-    return function(...)
-        return table.concat({ ... }, separator)
-    end
+  return function(...)
+    return table.concat({ ... }, separator)
+  end
 end
 
 M.join_path = M.generate_join(M.get_path_sep())
 
-local join_space = M.generate_join " "
+M.join_space = M.generate_join " "
 
 function M.get_package_path()
-    -- Path to this source file, removing the leading '@'
-    local source = string.sub(debug.getinfo(1, "S").source, 2)
+  -- Path to this source file, removing the leading '@'
+  local source = string.sub(debug.getinfo(1, "S").source, 2)
 
-    -- Path to the package root
-    return fn.fnamemodify(source, ":p:h:h:h")
+  -- Path to the package root
+  return fn.fnamemodify(source, ":p:h:h:h")
 end
 
 function M.get_cache_dir()
-    local cache_dir = fn.stdpath "data"
+  local cache_dir = fn.stdpath "data"
 
-    if luv.fs_access(cache_dir, "RW") then
-        return cache_dir
-    elseif luv.fs_access("/tmp", "RW") then
-        return "/tmp"
-    end
+  if luv.fs_access(cache_dir, "RW") then
+    return cache_dir
+  elseif luv.fs_access("/tmp", "RW") then
+    return "/tmp"
+  end
 
-    return nil, join_space("Invalid cache rights,", fn.stdpath "data", "or /tmp should be read/write")
+  return nil, M.join_space("Invalid cache rights,", fn.stdpath "data", "or /tmp should be read/write")
 end
 
 -- Returns $XDG_DATA_HOME/nvim/site, but could use any directory that is in
 -- runtimepath
 function M.get_site_dir()
-    local path_sep = M.get_path_sep()
-    return M.join_path(fn.stdpath "data", "site")
+  return M.join_path(fn.stdpath "data", "site")
 end
 
 -- Gets a property at path
@@ -117,46 +116,46 @@ end
 -- @param path the '.' separated path
 -- @returns the value at path or nil
 function M.get_at_path(tbl, path)
-    if path == "" then
-        return tbl
-    end
-    local segments = vim.split(path, ".", true)
-    local result = tbl
+  if path == "" then
+    return tbl
+  end
+  local segments = vim.split(path, ".", true)
+  local result = tbl
 
-    for _, segment in ipairs(segments) do
-        if type(result) == "table" then
-            result = result[segment]
-        end
+  for _, segment in ipairs(segments) do
+    if type(result) == "table" then
+      result = result[segment]
     end
+  end
 
-    return result
+  return result
 end
 
 function M.set_jump()
-    vim.cmd "normal! m'"
+  vim.cmd "normal! m'"
 end
 
 function M.index_of(tbl, obj)
-    for i, o in ipairs(tbl) do
-        if o == obj then
-            return i
-        end
+  for i, o in ipairs(tbl) do
+    if o == obj then
+      return i
     end
+  end
 end
 
 -- Filters a list based on the given predicate
 -- @param tbl The list to filter
 -- @param predicate The predicate to filter with
 function M.filter(tbl, predicate)
-    local result = {}
+  local result = {}
 
-    for i, v in ipairs(tbl) do
-        if predicate(v, i) then
-            table.insert(result, v)
-        end
+  for i, v in ipairs(tbl) do
+    if predicate(v, i) then
+      table.insert(result, v)
     end
+  end
 
-    return result
+  return result
 end
 
 -- Returns a list of all values from the first list
@@ -164,32 +163,32 @@ end
 -- @params tbl1 The first table
 -- @params tbl2 The second table
 function M.difference(tbl1, tbl2)
-    return M.filter(tbl1, function(v)
-        return not vim.tbl_contains(tbl2, v)
-    end)
+  return M.filter(tbl1, function(v)
+    return not vim.tbl_contains(tbl2, v)
+  end)
 end
 
 function M.identity(a)
-    return a
+  return a
 end
 
 function M.constant(a)
-    return function()
-        return a
-    end
+  return function()
+    return a
+  end
 end
 
 function M.to_func(a)
-    return type(a) == "function" and a or M.constant(a)
+  return type(a) == "function" and a or M.constant(a)
 end
 
 function M.ts_cli_version()
-    if fn.executable "tree-sitter" == 1 then
-        local handle = io.popen "tree-sitter  -V"
-        local result = handle:read "*a"
-        handle:close()
-        return vim.split(result, "\n")[1]:match "[^tree%psitter ].*"
-    end
+  if fn.executable "tree-sitter" == 1 then
+    local handle = io.popen "tree-sitter  -V"
+    local result = handle:read "*a"
+    handle:close()
+    return vim.split(result, "\n")[1]:match "[^tree%psitter ].*"
+  end
 end
 
 return M

--- a/tests/query/injection_spec.lua
+++ b/tests/query/injection_spec.lua
@@ -1,6 +1,6 @@
 require "nvim-treesitter.highlight" -- yes, this is necessary to set the hlmap
 local highlighter = require "vim.treesitter.highlighter"
-local utils = require "nvim-treesitter.utils"
+local configs = require "nvim-treesitter.configs"
 local ts_utils = require "nvim-treesitter.ts_utils"
 local parsers = require "nvim-treesitter.parsers"
 
@@ -16,7 +16,7 @@ local function check_assertions(file)
   )
   local assertions = vim.fn.json_decode(
     vim.fn.system(
-      "highlight-assertions -p '" .. utils.get_parser_install_dir() .. "/" .. lang .. ".so'" .. " -s '" .. file .. "'"
+      "highlight-assertions -p '" .. configs.get_parser_install_dir() .. "/" .. lang .. ".so'" .. " -s '" .. file .. "'"
     )
   )
   local parser = parsers.get_parser(buf, lang)


### PR DESCRIPTION
 Moves get_parser_install_dir into configs out of utils and adds a config option to satisfy  [#2959 ](https://github.com/nvim-treesitter/nvim-treesitter/issues/2959)

Previously `get_parser_install_dir` and `get_parser_info_dir` were both in
utils. This is because they only took into the package dir and the site
dir.
Now there is a configuration option, `parser_install_dir` that takes
precedence over the package and site directories. This is parsed in with
``` lua
configs.setup(
{
    parser_install_dir = "some/path",
})
```

As such the `get_parser_install_dir` needs to take this option in. One
was is to leave it in usils and parse it in:
```lua
utils.get_parser_install_dir("parser", configs.get_parser_install_dir_option())
```
But that will always require access to configs, or will work
inconsistently. So it was easier to move the whole setting into configs:
```lua
configs.get_parser_install_dir("parser")
```