### PR TITLE
feat(swift): update parser and queries to 0.3.0

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -297,7 +297,7 @@
     "revision": "cfa3f0ac82cd680b4efaa090a0f78035ad43a7c6"
   },
   "swift": {
-    "revision": "9607603b9bd7a174b06567367ae3949c7a19f011"
+    "revision": "706bb2147bd7409bab2989466aff566fa0baf3c8"
   },
   "teal": {
     "revision": "fcc5f6f4d194dede4e676834ff28a506e39e17b4"

--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -21,7 +21,7 @@
 (function_declaration (simple_identifier) @method)
 (function_declaration ["init" @constructor])
 (throws) @keyword
-(async) @keyword
+"async" @keyword
 (where_keyword) @keyword
 (parameter external_name: (simple_identifier) @parameter)
 (parameter name: (simple_identifier) @parameter)
@@ -39,8 +39,8 @@
   "indirect"
 ] @keyword
 
-(class_body (property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property))))
-(protocol_property_declaration (value_binding_pattern (non_binding_pattern (simple_identifier) @property)))
+(class_body (property_declaration (pattern (simple_identifier) @property)))
+(protocol_property_declaration (pattern (simple_identifier) @property))
 
 (import_declaration ["import" @include])
 
@@ -68,7 +68,6 @@
 ["while" "repeat" "continue" "break"] @repeat
 
 ["let" "var"] @keyword
-(non_binding_pattern (simple_identifier) @variable)
 
 (guard_statement ["guard" @conditional])
 (if_statement ["if" @conditional])

--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -3,7 +3,6 @@
 
 ; Identifiers
 (attribute) @variable
-(simple_identifier) @variable
 (type_identifier) @type
 (self_expression) @variable.builtin
 
@@ -28,6 +27,7 @@
 (type_parameter (type_identifier) @parameter)
 (inheritance_constraint (identifier (simple_identifier) @parameter))
 (equality_constraint (identifier (simple_identifier) @parameter))
+(pattern bound_identifier: (simple_identifier)) @variable
 
 [
   "typealias"
@@ -37,6 +37,13 @@
   "protocol"
   "extension"
   "indirect"
+  "some"
+] @keyword
+
+[
+  (getter_specifier)
+  (setter_specifier)
+  (modify_specifier)
 ] @keyword
 
 (class_body (property_declaration (pattern (simple_identifier) @property)))


### PR DESCRIPTION
I see that our queries are almost-but-not-completely the same as the upstream ones. Is the divergence intentional, or should/can I just pull in the latest upstream version?

@alex-pinkus @theHamsta 