### PR TITLE
Help: update highlights

### DIFF
--- a/queries/help/highlights.scm
+++ b/queries/help/highlights.scm
@@ -8,7 +8,8 @@
    name: (_) @text.literal)
 (hotlink
    "|" @conceal (#set! conceal "")
-   destination: (_) @text.uri)
+   destination: (_) @text.reference)
 (backtick
    "`" @conceal (#set! conceal "")
    content: (_) @string)
+(argument) @parameter


### PR DESCRIPTION
- A hotlink on vimdoc is `|foo|`.
  Which is a reference to part of a document,
  not a URI.
- (argument) wasn't being highlighted,
  wasn't sure about the best hl group for this,
  but `@parameter` seems like the obvious one?