### PR TITLE
highlights(lua): highlight only `self` as `self`

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -129,7 +129,7 @@
 (identifier) @variable
 
 ((identifier) @variable.builtin
- (#match? @variable.builtin "^self$"))
+ (#eq? @variable.builtin "self"))
 
 ;; Constants
 

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -129,7 +129,7 @@
 (identifier) @variable
 
 ((identifier) @variable.builtin
- (#match? @variable.builtin "self"))
+ (#match? @variable.builtin "^self$"))
 
 ;; Constants
 


### PR DESCRIPTION
Before, all identifiers containing the substring "self" were highlighted as the builtin `self`. Now, only the identifier `self` is highlighted as `self`.