### PR TITLE
docs: minimal supported tree-sitter version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more detailed information on setting these up, see ["Advanced setup"](#advan
 
 ## Requirements
 
-- **Neovim 0.7.0 or later** (latest [nightly](https://github.com/neovim/neovim#install-from-source) recommended)
+- **Neovim 0.7.0 or later** built with **tree-sitter 0.20.3+** (latest [nightly](https://github.com/neovim/neovim#install-from-source) recommended)
 - `tar` and `curl` in your path (or alternatively `git`)
 - A C compiler in your path and libstdc++ installed ([Windows users please read this!](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Windows-support)).
 


### PR DESCRIPTION
Some parsers are built with ABI 14, which was introduced in tree-sitter 0.20.3.