### PR TITLE
Ruby: Add `undef` and `redo` keywords to highlights.scm

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -14,9 +14,11 @@
  "ensure"
  "module"
  "next"
+ "redo"
  "rescue"
  "retry"
  "then"
+ "undef"
  ] @keyword
 
 [


### PR DESCRIPTION
Adds `undef` and `redo` keywords.

https://docs.ruby-lang.org/en/2.4.0/syntax/miscellaneous_rdoc.html#label-undef
https://docs.ruby-lang.org/en/2.4.0/syntax/control_expressions_rdoc.html#label-redo+Statement