### PR TITLE
fix(haskell): highlight exp_name as function in infix operations

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -116,6 +116,7 @@
 
 (exp_infix (variable) @operator)  ; consider infix functions as operators
 
+(exp_infix (exp_name) @function)
 (exp_apply . (exp_name (variable) @function))
 (exp_apply . (exp_name (qualified_variable (variable) @function)))
 


### PR DESCRIPTION
fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/3056, although i'm not very confident this is the right change