### PR TITLE
Chore: remove prefix from parser "location" property

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -242,7 +242,11 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
   if from_local_path then
     compile_location = repo.url
   else
-    local repo_location = string.gsub(repo.location or project_name, "/", path_sep)
+    local repo_location = project_name
+    if repo.location then
+      repo_location = repo_location .. "/" .. repo.location
+    end
+    repo_location = repo_location:gsub("/", path_sep)
     compile_location = utils.join_path(cache_folder, repo_location)
   end
   local parser_lib_name = utils.join_path(install_folder, lang) .. ".so"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -398,7 +398,7 @@ list.ocaml = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ocaml",
     files = { "src/parser.c", "src/scanner.cc" },
-    location = "tree-sitter-ocaml/ocaml",
+    location = "ocaml",
   },
   maintainers = { "@undu" },
 }
@@ -407,7 +407,7 @@ list.ocaml_interface = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ocaml",
     files = { "src/parser.c", "src/scanner.cc" },
-    location = "tree-sitter-ocaml_interface/interface",
+    location = "interface",
   },
   maintainers = { "@undu" },
   filetype = "ocamlinterface",
@@ -463,7 +463,7 @@ list.typescript = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-typescript",
     files = { "src/parser.c", "src/scanner.c" },
-    location = "tree-sitter-typescript/typescript",
+    location = "typescript",
     generate_requires_npm = true,
   },
   maintainers = { "@steelsojka" },
@@ -473,7 +473,7 @@ list.tsx = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-typescript",
     files = { "src/parser.c", "src/scanner.c" },
-    location = "tree-sitter-tsx/tsx",
+    location = "tsx",
     generate_requires_npm = true,
   },
   filetype = "typescriptreact",
@@ -1083,7 +1083,7 @@ list.v = {
   install_info = {
     url = "https://github.com/vlang/vls",
     files = { "src/parser.c", "src/scanner.c" },
-    location = "tree-sitter-v/tree_sitter_v",
+    location = "tree_sitter_v",
     generate_requires_npm = false,
     requires_generate_from_grammar = false,
   },


### PR DESCRIPTION
This was very confusing when using the location property as it
always had to start with "tree-sitter-<lang>" for no real reason (just
because our installer would rename the download to that name).