### PR TITLE
feat(swift): compile the grammar from the main branch

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -300,7 +300,7 @@
     "revision": "cfa3f0ac82cd680b4efaa090a0f78035ad43a7c6"
   },
   "swift": {
-    "revision": "706bb2147bd7409bab2989466aff566fa0baf3c8"
+    "revision": "ffc574a3f108e3127fac7647563ea72b707af59a"
   },
   "teal": {
     "revision": "fcc5f6f4d194dede4e676834ff28a506e39e17b4"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -433,8 +433,9 @@ list.org = {
 list.swift = {
   install_info = {
     url = "https://github.com/alex-pinkus/tree-sitter-swift",
-    branch = "with-generated-files",
+    branch = "main",
     files = { "src/parser.c", "src/scanner.c" },
+    requires_generate_from_grammar = true,
   },
   maintainers = { "@alex-pinkus" },
 }


### PR DESCRIPTION
See discussion in #2826 and bug report in https://github.com/alex-pinkus/tree-sitter-swift/issues/197. The `with-generated-files` branch uses ABI 13 and therefore doesn't benefit from the ABI 14 speed improvements.