### PR TITLE
ci(macos): update to upstream changes in release

### DIFF
--- a/scripts/ci-install-macos-latest.sh
+++ b/scripts/ci-install-macos-latest.sh
@@ -1,5 +1,5 @@
 curl -L https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-macos.tar.gz | tar -xz
-sudo ln -s $(pwd)/nvim-osx64/bin/nvim /usr/local/bin
+sudo ln -s $(pwd)/nvim-macos/bin/nvim /usr/local/bin
 mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
 ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter/start
 


### PR DESCRIPTION
macOS release archive now uses `nvim-macos` as extracted directory.