### PR TITLE
highlights(c): highlight member-access as operator

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -63,6 +63,7 @@
   ">>"
 
   "->"
+  "."
 
   "<"
   "<="
@@ -94,7 +95,7 @@
  (false)
 ] @boolean
 
-[ "." ";" ":" "," ] @punctuation.delimiter
+[ ";" ":" "," ] @punctuation.delimiter
 
 "..." @punctuation.special
 


### PR DESCRIPTION
![2022-06-30-145853_826x219_scrot](https://user-images.githubusercontent.com/25590950/176711511-c89884ce-25c7-4f7d-8265-48b1ed39313f.png)

Here's how a C standard draft refers to `.` in various places. I've
replaced the irrelevant parts with (...):

https://www.iso-9899.info/n1570.html#6.6p9
>(...) member-access . and -> operators (...)

https://www.iso-9899.info/n1570.html#6.4.6p1
>punctuator: one of (...) . (...)

https://www.iso-9899.info/n1570.html#6.4.6p2
>A punctuator (...) may specify an operation to be performed (...)
>in which case it is known as an operator (...)