### PR TITLE
fix: avoid installing parsers multiple times when using auto_install

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -430,8 +430,8 @@ function M.setup_auto_install()
     pattern = { "*" },
     callback = function()
       local lang = parsers.get_buf_lang()
-      if parsers.get_parser_configs()[lang] and not parsers.has_parser(lang) then
-        install { ask_reinstall = true } { lang }
+      if parsers.get_parser_configs()[lang] and not is_installed(lang) then
+        install() { lang }
       end
     end,
   })


### PR DESCRIPTION
This fixes the following issue I came across when using `auto_install = true`.
To reproduce:
1. `:TSUninstall bash`
2. `:e ~/test.sh` (parser will be installed)
3. `:e ~/test.sh` (user will be prompted whether parser should be installed again which is unexpected)

Also this includes a small refactor, because specifying `ask_reinstall` is not necessary.