### PR TITLE
add method spec highlight and block folds

### DIFF
--- a/queries/go/folds.scm
+++ b/queries/go/folds.scm
@@ -9,5 +9,6 @@
  (method_declaration)
  (type_declaration)
  (var_declaration)
+ (block)
 ] @fold
 

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -38,6 +38,9 @@
 (method_declaration
   name: (field_identifier) @method)
 
+(method_spec 
+  name: (field_identifier) @method) 
+
 ; Operators
 
 [


### PR DESCRIPTION
* `method_spec` highlight should be the same as the `method_declaration`
before:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/941660/178103505-978a1966-c12b-483b-b452-e40151aed866.png">
 
after: 
<img width="358" alt="image" src="https://user-images.githubusercontent.com/941660/178103481-e241023e-5006-4440-928b-edfea2554eb5.png">
 
* `block` should be foldable because it is handy with long table-driven tests 