### PR TITLE
add type def highlight, add field declaration highlight and remove co…

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -5,7 +5,6 @@
 ; Identifiers
 
 (type_identifier) @type
-(type_spec name: (type_identifier) @type.definition)
 (field_identifier) @property
 (identifier) @variable
 (package_identifier) @namespace

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -5,6 +5,7 @@
 ; Identifiers
 
 (type_identifier) @type
+(type_spec name: (type_identifier) @type.definition)
 (field_identifier) @property
 (identifier) @variable
 (package_identifier) @namespace
@@ -14,9 +15,6 @@
 
 ((identifier) @constant
  (#eq? @constant "_"))
-
-((identifier) @constant
- (#vim-match? @constant "^[A-Z][A-Z\\d_]+$"))
 
 (const_spec
   name: (identifier) @constant)
@@ -201,6 +199,7 @@
 
 (keyed_element
   . (literal_element (identifier) @field))
+(field_declaration name: (field_identifier) @field)
 
 (comment) @comment
 


### PR DESCRIPTION
* add `@type.definition` highlight
* add `field_declaration` to be highlighted as `@field`
* removed constant highlight based on uppercase chars
In golang constants, identifiers are not supposed to be uppercase nor include "_" and the current query will incorrectly highlight any uppercased field (which is quite common in golang because all the abbrev must be uppercased: ID, HTML, URL etc.)

ID field is incorrectly highlighted as a constant (italic):

<img width="285" alt="image" src="https://user-images.githubusercontent.com/941660/178106911-d2df0843-0860-4dfe-91f0-187d2b3c5eb9.png">
