### PR TITLE
add golang type definition highlight

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -5,6 +5,7 @@
 ; Identifiers
 
 (type_identifier) @type
+(type_spec name: (type_identifier) @type.definition)
 (field_identifier) @property
 (identifier) @variable
 (package_identifier) @namespace


### PR DESCRIPTION
Continuing the discussion started at https://github.com/nvim-treesitter/nvim-treesitter/pull/3152
regarding `@type.definition` highlight if we should it or not.