### PR TITLE
Move class keyword from highlighting group

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -202,6 +202,7 @@
 ] @keyword.operator
 
 [
+  "class"
   "def"
   "lambda"
 ] @keyword.function
@@ -210,7 +211,6 @@
   "assert"
   "async"
   "await"
-  "class"
   "exec"
   "global"
   "nonlocal"


### PR DESCRIPTION
Usually the python `class` keyword has the same highlighting color as the other keywords in the function group. It has more sense to move the keyword from one group to the other.