### PR TITLE
fix: disable elm parser in markdown to avoid segfault

### DIFF
--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -1,6 +1,7 @@
 (fenced_code_block
   (info_string
     (language) @language)
+  (#not-match? @language "elm")
   (code_fence_content) @content (#exclude_children! @content))
 
 ((html_block) @html)


### PR DESCRIPTION
the Elm parser segfaults when injected in markdown. Disable it for now.
See https://github.com/elm-tooling/tree-sitter-elm/issues/124

@theHamsta @clason i'm not sure how to debug this, i haven't managed to make the elm parser segfault when not injected. 