### PR TITLE
fix(indent): set only one autocmd for binding indentexpr

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -195,10 +195,6 @@ local indent_funcs = {}
 function M.attach(bufnr)
   indent_funcs[bufnr] = vim.bo.indentexpr
   vim.bo.indentexpr = "nvim_treesitter#indent()"
-  vim.api.nvim_create_autocmd("Filetype", {
-    pattern = vim.bo.filetype,
-    command = "setlocal indentexpr=nvim_treesitter#indent()",
-  })
 end
 
 function M.detach(bufnr)


### PR DESCRIPTION
Seems like the configs module already setup the filetype autocmd to attach, so this autocmd is not needed at all.
fixes #3172