### PR TITLE
fix(ci): ubuntu appimage fails

### DIFF
--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -46,7 +46,7 @@ jobs:
 
           - os: ubuntu-latest
             cc: gcc
-            nvim_tag: nightly
+            nvim_tag: stable
 
     name: Parser compilation
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Cannot find the nightly release on github neovim release page anymore.
I suppose we can use stable now.