### PR TITLE
highlights(c): Lower the priority of @variable

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -1,4 +1,5 @@
-(identifier) @variable
+; Lower priority to prefer @parameter when identifier appears in parameter_declaration.
+((identifier) @variable (#set! "priority" 95))
 
 [
   "const"


### PR DESCRIPTION
Lower the priority of @variable to prefer @parameter
highlight when identifier appears in parameter_declaration.

Fixes #3061