### PR TITLE
Reintroduce Function/Method Call HL Groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,10 +122,12 @@ effect on highlighting. We will work on improving highlighting in the near futur
 ```
 @function
 @function.builtin
+@function.call
 @function.macro
 @parameter
 
 @method
+@method.call
 @field
 @property
 

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -551,7 +551,11 @@ Floating-point number literals.
 
 							       *hl-TSFunction*
 `TSFunction`
-Function calls and definitions.
+Function definitions.
+
+							   *hl-TSFunctionCall*
+`TSFunctionCall`
+Function calls.
 
 							    *hl-TSFuncBuiltin*
 `TSFuncBuiltin`
@@ -591,7 +595,11 @@ GOTO labels: `label:` in C, and `::label::` in Lua.
 
 								 *hl-TSMethod*
 `TSMethod`
-Method calls and definitions.
+Method definitions.
+
+							     *hl-TSMethodCall*
+`TSMethod`
+Method calls.
 
 							      *hl-TSNamespace*
 `TSNamespace`

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -598,7 +598,7 @@ GOTO labels: `label:` in C, and `::label::` in Lua.
 Method definitions.
 
 							     *hl-TSMethodCall*
-`TSMethod`
+`TSMethodCall`
 Method calls.
 
 							      *hl-TSNamespace*

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -41,6 +41,7 @@ hlmap["field"] = "TSField"
 hlmap["float"] = "TSFloat"
 
 hlmap["function"] = "TSFunction"
+hlmap["function.call"] = "TSFunctionCall"
 hlmap["function.builtin"] = "TSFuncBuiltin"
 hlmap["function.macro"] = "TSFuncMacro"
 
@@ -54,6 +55,7 @@ hlmap["keyword.return"] = "TSKeywordReturn"
 hlmap["label"] = "TSLabel"
 
 hlmap["method"] = "TSMethod"
+hlmap["method.call"] = "TSMethodCall"
 
 hlmap["namespace"] = "TSNamespace"
 
@@ -177,11 +179,13 @@ function M.set_default_hlgroups()
     TSFloat = { link = "Float", default = true },
 
     TSFunction = { link = "Function", default = true },
+    TSFunctionCall = { link = "TSFunction", default = true },
     TSFuncBuiltin = { link = "Special", default = true },
     TSFuncMacro = { link = "Macro", default = true },
     TSParameter = { link = "Identifier", default = true },
     TSParameterReference = { link = "TSParameter", default = true },
     TSMethod = { link = "Function", default = true },
+    TSMethodCall = { link = "TSMethod", default = true },
     TSField = { link = "Identifier", default = true },
     TSProperty = { link = "Identifier", default = true },
     TSConstructor = { link = "Special", default = true },

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -97,7 +97,7 @@
 (function_definition
   name: (word) @function)
 
-(command_name (word) @function)
+(command_name (word) @function.call)
 
 ((command_name (word) @function.builtin)
  (#any-of? @function.builtin

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -157,10 +157,10 @@
   (#eq? @_u "#undef"))
 
 (call_expression
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 (call_expression
   function: (field_expression
-    field: (field_identifier) @function))
+    field: (field_identifier) @function.call))
 (function_declarator
   declarator: (identifier) @function)
 (preproc_function_def

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -66,21 +66,21 @@
 
 (call_expression
   function: (qualified_identifier
-              name: (identifier) @function))
+              name: (identifier) @function.call))
 (call_expression
   function: (qualified_identifier
               name: (qualified_identifier
-                      name: (identifier) @function)))
+                      name: (identifier) @function.call)))
 (call_expression
   function:
       (qualified_identifier
         name: (qualified_identifier
               name: (qualified_identifier
-                      name: (identifier) @function))))
+                      name: (identifier) @function.call))))
 
 (call_expression
   function: (field_expression
-              field: (field_identifier) @function))
+              field: (field_identifier) @function.call))
 
 ((call_expression
   function: (identifier) @constructor)

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -84,13 +84,13 @@
 (stab_clause operator: _ @operator)
 
 ; Local Function Calls
-(call target: (identifier) @function)
+(call target: (identifier) @function.call)
 
 ; Remote Function Calls
 (call target: (dot left: [
   (atom) @type
   (_)
-] right: (identifier) @function) (arguments))
+] right: (identifier) @function.call) (arguments))
 
 ; Definition Function Calls
 (call target: ((identifier) @keyword.function (#any-of? @keyword.function

--- a/queries/erlang/highlights.scm
+++ b/queries/erlang/highlights.scm
@@ -59,7 +59,7 @@
 )
 ;;; expr_function_call
 (expr_function_call
-  name: (computed_function_name) @function 
+  name: (computed_function_name) @function.call 
 ) 
 
 (expr_function_call

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -21,11 +21,11 @@
 ; Function calls
 
 (call_expression
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 
 (call_expression
   function: (selector_expression
-    field: (field_identifier) @method))
+    field: (field_identifier) @method.call))
 
 ; Function definitions
 

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -9,7 +9,7 @@
 (method_declaration
   name: (identifier) @method)
 (method_invocation
-  name: (identifier) @method)
+  name: (identifier) @method.call)
 
 (super) @function.builtin
 

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -23,13 +23,13 @@
 (function_definition
   name: (identifier) @function)
 (call_expression
-  (identifier) @function)
+  (identifier) @function.call)
 (call_expression
-  (field_expression (identifier) @method .))
+  (field_expression (identifier) @method.call .))
 (broadcast_call_expression
-  (identifier) @function)
+  (identifier) @function.call)
 (broadcast_call_expression
-  (field_expression (identifier) @method .))
+  (field_expression (identifier) @method.call .))
 (parameter_list
   (identifier) @parameter)
 (parameter_list

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -149,13 +149,13 @@
 
 ; function()
 (call_expression
-	. (simple_identifier) @function)
+	. (simple_identifier) @function.call)
 
 ; object.function() or object.property.function()
 (call_expression
 	(navigation_expression
 		(navigation_suffix
-			(simple_identifier) @function) . ))
+			(simple_identifier) @function.call) . ))
 
 (call_expression
 	. (simple_identifier) @function.builtin

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -161,10 +161,10 @@
 
 (parameters (identifier) @parameter)
 
-(function_call name: (identifier) @function)
+(function_call name: (identifier) @function.call)
 (function_declaration name: (identifier) @function)
 
-(function_call name: (dot_index_expression field: (identifier) @function))
+(function_call name: (dot_index_expression field: (identifier) @function.call))
 (function_declaration name: (dot_index_expression field: (identifier) @function))
 
 (method_index_expression method: (identifier) @method)

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -89,9 +89,9 @@
 (pod_statement) @text
 
 (method_invocation
-  function_name: (identifier) @method)
+  function_name: (identifier) @method.call)
 (call_expression
-  function_name: (identifier) @function)
+  function_name: (identifier) @function.call)
 
 ;; ----------
 

--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -42,16 +42,16 @@
   name: (name) @method)
 
 (function_call_expression
-  function: (qualified_name (name)) @function)
+  function: (qualified_name (name)) @function.call)
 
 (function_call_expression
-  (name) @function)
+  (name) @function.call)
 
 (scoped_call_expression
-  name: (name) @function)
+  name: (name) @function.call)
 
 (member_call_expression
-  name: (name) @method)
+  name: (name) @method.call)
 
 (function_definition
   name: (name) @function)

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -56,11 +56,11 @@
  (#match? @function "^([A-Z])@!.*$"))
 
 (call
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 
 (call
   function: (attribute
-              attribute: (identifier) @method))
+              attribute: (identifier) @method.call))
 
 ((call
    function: (identifier) @constructor)

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -70,7 +70,7 @@
    method: [
             (identifier)
             (constant)
-            ] @function
+            ] @function.call
    )
 
 (program

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -39,22 +39,22 @@
 
 ; Function calls
 (call_expression
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 (call_expression
   function: (scoped_identifier
-              (identifier) @function .))
+              (identifier) @function.call .))
 (call_expression
   function: (field_expression
-    field: (field_identifier) @function))
+    field: (field_identifier) @function.call))
 
 (generic_function
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 (generic_function
   function: (scoped_identifier
-    name: (identifier) @function))
+    name: (identifier) @function.call))
 (generic_function
   function: (field_expression
-    field: (field_identifier) @function))
+    field: (field_identifier) @function.call))
 
 ; Assume other uppercase names are enum constructors
 ((field_identifier) @constant

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -65,18 +65,18 @@
 
 
 (call_expression
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 
 (call_expression
   function: (field_expression
-    field: (identifier) @method))
+    field: (identifier) @method.call))
 
 ((call_expression
    function: (identifier) @constructor)
  (#lua-match? @constructor "^[A-Z]"))
 
 (generic_function
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 
 (
   (identifier) @function.builtin

--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -1,10 +1,10 @@
 (function_call
   (invocation
-    name: (identifier) @function
+    name: (identifier) @function.call
     parameter: [(field)]? @parameter))
 
 (function_call
-  name: (identifier) @function
+  name: (identifier) @function.call
   parameter: [(field)]? @parameter)
 
 (table_expression

--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -54,10 +54,10 @@
 (enum_entry ["case" @keyword])
 
 ; Function calls
-(call_expression (simple_identifier) @function) ; foo()
+(call_expression (simple_identifier) @function.call) ; foo()
 (call_expression ; foo.bar.baz(): highlight the baz()
   (navigation_expression
-    (navigation_suffix (simple_identifier) @function)))
+    (navigation_suffix (simple_identifier) @function.call)))
 ((navigation_expression
    (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
    (#lua-match? @type "^[A-Z]"))

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -41,16 +41,16 @@
 
 ;; Function calls ----------------
 (call_expression
-  function: (identifier) @function)
+  function: (identifier) @function.call)
 
 (((_
-   function: (selector_expression field: (identifier) @function)
+   function: (selector_expression field: (identifier) @function.call)
    arguments: (_) @_args)
   (#not-has-type? @_args arguments_list)))
 
 ((call_expression
   function: (binded_identifier name: (identifier) @function)
-  @function))
+  @function.call))
 
 
 ;; Function definitions ---------

--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -34,7 +34,7 @@
 
 ;; Function related
 (function_declaration name: (_) @function)
-(call_expression function: (identifier) @function)
+(call_expression function: (identifier) @function.call)
 (parameters (identifier) @parameter)
 (default_parameter (identifier) @parameter)
 

--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -51,7 +51,7 @@ parameter: (IDENTIFIER) @parameter
 [
   function_call: (IDENTIFIER)
   function: (IDENTIFIER)
-] @function
+] @function.call
 
 exception: "!" @exception
 

--- a/tests/query/highlights/cpp/static-namespace-functions.cpp
+++ b/tests/query/highlights/cpp/static-namespace-functions.cpp
@@ -3,10 +3,10 @@
 int main()                                                                
 {                                                                         
   B::foo();                                                                 
-  //  ^ @function
+  //  ^ @function.call
   Foo::A::foo();                                                            
-  //       ^ @function
+  //       ^ @function.call
   Foo::a::A::foo();                                                            
-  //          ^ @function
+  //          ^ @function.call
   return 0;                                                                 
 }    


### PR DESCRIPTION
Following the discussion in #3210, this is a draft reintroducing both method and function calls with the `TSMethodCall` and `TSFunctionCall` groups. Note that they both fallback on their respective `TS<Function/Method>` hl-groups. So far these groups are available for the following languages:

- Python
- Julia
- C
- C++
- Go
- Kotlin
- Bash
- Elixir
- Erlang
- Java
- Lua
- Perl
- Php
- Ruby
- Rust
- Scala
- SQL
- Swift
- V
- Vim (vimscript)
- Zig