### PR TITLE
highlights(php): highlight more string types and escapes

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -112,10 +112,12 @@
 
 [
  (string)
+ (encapsed_string)
  (heredoc)
+ (nowdoc)
  (shell_command_expression) ; backtick operator: `ls -la`
  ] @string
-(encapsed_string (escape_sequence) @string.escape)
+(escape_sequence) @string.escape
 
 (boolean) @boolean
 (null) @constant.builtin

--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -113,8 +113,8 @@
 [
  (string)
  (encapsed_string)
- (heredoc)
- (nowdoc)
+ (heredoc_body)
+ (nowdoc_body)
  (shell_command_expression) ; backtick operator: `ls -la`
  ] @string
 (escape_sequence) @string.escape


### PR DESCRIPTION
`encapsed_string`s are double-quoted strings. Highlight their non-escaped portions like normal single-quoted `string`s.

`nowdoc`s are non-parsed `heredoc`s. Highlight them like normal single-quoted `string`s.

`escape_sequence`s can appear in `heredoc`s and `shell_command_expression`s, not just `encapsed_string`s. Highlight these too.

Before:
<img width="488"  src="https://user-images.githubusercontent.com/15011974/181170431-e1d7aebf-e72e-49ac-bd52-dd1eadb4c741.png">

After:
<img width="480" src="https://user-images.githubusercontent.com/15011974/181170538-af79da78-4a8c-40f5-938f-bf70197548cd.png">