### PR TITLE
highlights(c/cpp): move attributes to C (again)

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -188,6 +188,7 @@
   "_unaligned"
   "__unaligned"
   "__declspec"
+  (attribute_declaration)
 ] @attribute
 
 (ERROR) @error

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -178,6 +178,4 @@
 
 "::" @punctuation.delimiter
 
-(attribute_declaration) @attribute
-
 (literal_suffix) @operator


### PR DESCRIPTION
Let's hope that this time the C tests pass, also for the built-in C
parser.

This will also bring attributes to GLSL.