### PR TITLE
docs: add descriptions to incremental_selection keymaps

### DIFF
--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -120,6 +120,13 @@ function M.node_decremental()
   ts_utils.update_selection(buf, node)
 end
 
+local FUNCTION_DESCRIPTIONS = {
+  init_selection = "Start selecting nodes with nvim-treesitter",
+  node_incremental = "Increment selection to named node",
+  scope_incremental = "Increment selection to surrounding scope",
+  node_decremental = "Shrink selection to previous named node",
+}
+
 function M.attach(bufnr)
   local config = configs.get_module "incremental_selection"
   for funcname, mapping in pairs(config.keymaps) do
@@ -129,8 +136,12 @@ function M.attach(bufnr)
     else
       mode = "x"
     end
-    local cmd = string.format(":lua require'nvim-treesitter.incremental_selection'.%s()<CR>", funcname)
-    api.nvim_buf_set_keymap(bufnr, mode, mapping, cmd, { silent = true, noremap = true })
+    vim.keymap.set(
+      mode,
+      mapping,
+      M[funcname],
+      { buffer = bufnr, silent = true, noremap = true, desc = FUNCTION_DESCRIPTIONS[funcname] }
+    )
   end
 end
 
@@ -138,9 +149,9 @@ function M.detach(bufnr)
   local config = configs.get_module "incremental_selection"
   for f, mapping in pairs(config.keymaps) do
     if f == "init_selection" then
-      api.nvim_buf_del_keymap(bufnr, "n", mapping)
+      vim.keymap.del("n", mapping, { buffer = bufnr })
     else
-      api.nvim_buf_del_keymap(bufnr, "x", mapping)
+      vim.keymap.del("x", mapping, { buffer = bufnr })
     end
   end
 end


### PR DESCRIPTION
Thought that after https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/233 we could annotate more keymappings. This are the only keymappings in nvim-treesitter.

TODO:
- playground
- refactor