### PR TITLE
No fallback install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ require'nvim-treesitter.configs'.setup {
   -- List of parsers to ignore installing (for "all")
   ignore_install = { "javascript" },
 
+  ---- If you need to change the installation directory of the parsers (see -> Advanced Setup)
+  -- parser_install_dir = "/some/path/to/store/parsers", -- Remember to run vim.opt.runtimepath:append("/some/path/to/store/parsers")!
+
   highlight = {
     -- `false` will disable the whole extension
     enable = true,

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -1,5 +1,4 @@
 local api = vim.api
-local luv = vim.loop
 
 local queries = require "nvim-treesitter.query"
 local ts_query = require "vim.treesitter.query"
@@ -548,30 +547,22 @@ end
 function M.get_parser_install_dir(folder_name)
   folder_name = folder_name or "parser"
 
+  local install_dir
   if config.parser_install_dir then
-    local parser_dir = utils.join_path(config.parser_install_dir, folder_name)
-    return utils.create_or_reuse_writable_dir(
-      parser_dir,
-      utils.join_space("Could not create parser dir '", parser_dir, "': "),
-      utils.join_space("Parser dir '", parser_dir, "' should be read/write.")
-    )
+    install_dir = config.parser_install_dir
+  else
+    install_dir = utils.get_package_path()
   end
-
-  local package_path = utils.get_package_path()
-  local package_path_parser_dir = utils.join_path(package_path, folder_name)
-
-  -- If package_path is read/write, use that
-  if luv.fs_access(package_path_parser_dir, "RW") then
-    return package_path_parser_dir
-  end
-
-  local site_dir = utils.get_site_dir()
-  local parser_dir = utils.join_path(site_dir, folder_name)
+  local parser_dir = utils.join_path(install_dir, folder_name)
 
   return utils.create_or_reuse_writable_dir(
     parser_dir,
-    nil,
-    utils.join_space("Invalid rights,", package_path, "or", parser_dir, "should be read/write")
+    utils.join_space("Could not create parser dir '", parser_dir, "': "),
+    utils.join_space(
+      "Parser dir '",
+      parser_dir,
+      "' should be read/write (see README on how to configure an alternative install location)"
+    )
   )
 end
 

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -566,7 +566,7 @@ function M.get_parser_install_dir(folder_name)
   )
 end
 
-function M.get_parser_info_dir(parser_install_dir)
+function M.get_parser_info_dir()
   return M.get_parser_install_dir "parser-info"
 end
 

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -401,6 +401,7 @@ function M.setup(user_data)
   end
 
   config.modules.ensure_installed = nil
+  config.ensure_installed = ensure_installed
 
   recurse_modules(function(_, _, new_path)
     local data = utils.get_at_path(config.modules, new_path)
@@ -576,6 +577,10 @@ end
 
 function M.get_ignored_parser_installs()
   return config.ignore_install or {}
+end
+
+function M.get_ensure_installed_parsers()
+  return config.ensure_installed or {}
 end
 
 return M

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -489,6 +489,16 @@ function M.uninstall(...)
         return api.nvim_err_writeln(err)
       end
 
+      if vim.tbl_contains(configs.get_ensure_installed_parsers(), lang) then
+        vim.notify(
+          "Uninstalling "
+            .. lang
+            .. '. But the parser is still configured in "ensure_installed" setting of nvim-treesitter.'
+            .. " Please consider updating your config!",
+          vim.log.levels.ERROR
+        )
+      end
+
       local parser_lib = utils.join_path(install_dir, lang) .. ".so"
       local all_parsers = vim.api.nvim_get_runtime_file("parser/" .. lang .. ".so", true)
       if vim.fn.filereadable(parser_lib) == 1 then


### PR DESCRIPTION
- don't allow to silently fallback to alternative install location
- remove argument of function that wasn't used anywhere (neither in function nor in call sites)
- display warning when parser is still installed after `:TSUninstall`. nvim-treesitter will only uninstall from configured install dir
- warn when uninstalling a parser in ensure_uninstalled

![grafik](https://user-images.githubusercontent.com/7189118/182234458-d0b8fba4-9a11-4de0-9238-655dded4b183.png)

Fixes #2777

Please test before merging! Will also test a few days. I think this is not urgent but helpful for issues in future.