### PR TITLE
chore: show in TSInstallInfo when parser is still loaded

### DIFF
--- a/lua/nvim-treesitter/info.lua
+++ b/lua/nvim-treesitter/info.lua
@@ -14,11 +14,13 @@ local function install_info()
 
   local parser_list = parsers.available_parsers()
   table.sort(parser_list)
-  for _, ft in pairs(parser_list) do
-    local is_installed = #api.nvim_get_runtime_file("parser/" .. ft .. ".so", false) > 0
-    api.nvim_out_write(ft .. string.rep(" ", max_len - #ft + 1))
+  for _, lang in pairs(parser_list) do
+    local is_installed = #api.nvim_get_runtime_file("parser/" .. lang .. ".so", false) > 0
+    api.nvim_out_write(lang .. string.rep(" ", max_len - #lang + 1))
     if is_installed then
       api.nvim_out_write "[✓] installed\n"
+    elseif pcall(vim.treesitter.inspect_lang, lang) then
+      api.nvim_out_write "[✗] not installed (but still loaded. Restart Neovim!)\n"
     else
       api.nvim_out_write "[✗] not installed\n"
     end


### PR DESCRIPTION
should we be more precise in `:TSInstallInfo` when parser is still active after uninstallation?