### PR TITLE
go folds.scm composit_literal

### DIFF
--- a/queries/go/folds.scm
+++ b/queries/go/folds.scm
@@ -9,6 +9,8 @@
  (method_declaration)
  (type_declaration)
  (var_declaration)
+ (composite_literal)
+ (literal_element)
  (block)
 ] @fold
 


### PR DESCRIPTION
<img width="285" alt="image" src="https://user-images.githubusercontent.com/1681295/182806758-722008d8-5609-45c1-9ea1-28f1326753c1.png">
Fold to: (I used a modified version of fold.lua that keep last `}`
<img width="285" alt="image" src="https://user-images.githubusercontent.com/1681295/182806818-60db065c-060d-4e4a-9b20-648b14295f4e.png">
