### PR TITLE
fix(zig): Do not indent on newline after block

### DIFF
--- a/queries/zig/indents.scm
+++ b/queries/zig/indents.scm
@@ -5,6 +5,8 @@
   (InitList)
 ] @indent
 
+(Block "}" @indent_end)
+
 [
   "("
   ")"

--- a/tests/indent/zig/pr-3269.zig
+++ b/tests/indent/zig/pr-3269.zig
@@ -1,0 +1,10 @@
+// https://github.com/nvim-treesitter/nvim-treesitter/pull/3269
+const std = @import("std");
+
+pub fn main() anyerror!void {
+    std.log.info("All your codebase are belong to us.", .{});
+}
+
+test "basic test" {
+    try std.testing.expectEqual(10, 3 + 7);
+}

--- a/tests/indent/zig_spec.lua
+++ b/tests/indent/zig_spec.lua
@@ -1,0 +1,22 @@
+local Runner = require("tests.indent.common").Runner
+--local XFAIL = require("tests.indent.common").XFAIL
+
+local run = Runner:new(it, "tests/indent/zig", {
+  tabstop = 4,
+  shiftwidth = 4,
+  softtabstop = 4,
+  expandtab = false,
+})
+
+describe("indent Zig:", function()
+  describe("whole file:", function()
+    run:whole_file(".", {
+      expected_failures = {},
+    })
+  end)
+
+  describe("new lines:", function()
+    run:new_line("pr-3269.zig", { on_line = 5, text = "return;", indent = 4 })
+    run:new_line("pr-3269.zig", { on_line = 6, text = "", indent = 0 })
+  end)
+end)

--- a/tests/indent/zig_spec.lua
+++ b/tests/indent/zig_spec.lua
@@ -5,7 +5,7 @@ local run = Runner:new(it, "tests/indent/zig", {
   tabstop = 4,
   shiftwidth = 4,
   softtabstop = 4,
-  expandtab = false,
+  expandtab = true,
 })
 
 describe("indent Zig:", function()


### PR DESCRIPTION
An additional indentaion on newline is appended.

This PR fixes a bug that an additional indentaion on newline is appended.



Current Behaviour is 
```
}<cursor>

to

}
<indent><cursor>
```

But expected behaviour should be below
```
}<cursor>

to

}
<cursor>
```


