### PR TITLE
SQL highlight queries rely on latest parser AST

### DIFF
--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -1,9 +1,8 @@
-(function_call
-  (invocation
-    name: (identifier) @function.call
-    parameter: [(field)]? @parameter))
+(invocation
+  name: (identifier) @function.call
+  parameter: [(field)]? @parameter)
 
-(function_call
+(count
   name: (identifier) @function.call
   parameter: [(field)]? @parameter)
 


### PR DESCRIPTION
Fix for https://github.com/nvim-treesitter/nvim-treesitter/pull/3270

Fixes for tree-sitter-sql queries for changes due to the latest parser version.