### PR TITLE
indents(go): improve `@branch` rules

### DIFF
--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -14,11 +14,12 @@
 ] @indent
 
 [
-  "case"
   "}"
 ] @branch
 
 (const_declaration ")" @branch)
+(import_spec_list ")" @branch)
+(var_declaration ")" @branch)
 
 [
  "}"

--- a/tests/indent/go/multiple-vars.go
+++ b/tests/indent/go/multiple-vars.go
@@ -1,0 +1,19 @@
+package main
+
+var (
+	thing    = 1
+	thingTwo = 2
+) // <-- This paren should be at 0 instead of indented
+
+var (
+	thing    = 1
+	thingTwo = 2
+)
+
+func main() {
+	// It should be
+	var (
+		thing    = 1
+		thingTwo = 2
+	)
+}

--- a/tests/indent/go/switch.go
+++ b/tests/indent/go/switch.go
@@ -1,0 +1,14 @@
+// issue #2166
+package main
+
+import (
+	"fmt"
+)
+
+func test(ch byte) {
+	fmt.Println("hey!")
+	switch ch {
+	case 'l':
+		return
+	}
+}


### PR DESCRIPTION
- Don't branch at `case`
- Let `import_spec_list`/`var_declaration` behave like
  `const_declaration`

Fixes #2166

@geefuoco can you test please!