### PR TITLE
chore: update `tree-sitter-http` parser URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [hjson](https://github.com/winston0410/tree-sitter-hjson) (maintained by @winston0410)
 - [x] [hocon](https://github.com/antosha417/tree-sitter-hocon) (maintained by @antosha417)
 - [x] [html](https://github.com/tree-sitter/tree-sitter-html) (maintained by @TravonteD)
-- [x] [http](https://github.com/NTBBloodbath/tree-sitter-http) (maintained by @NTBBloodbath)
+- [x] [http](https://github.com/rest-nvim/tree-sitter-http) (maintained by @NTBBloodbath)
 - [x] [java](https://github.com/tree-sitter/tree-sitter-java) (maintained by @p00f)
 - [x] [javascript](https://github.com/tree-sitter/tree-sitter-javascript) (maintained by @steelsojka)
 - [x] [jsdoc](https://github.com/tree-sitter/tree-sitter-jsdoc) (maintained by @steelsojka)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -973,7 +973,7 @@ list.llvm = {
 
 list.http = {
   install_info = {
-    url = "https://github.com/NTBBloodbath/tree-sitter-http",
+    url = "https://github.com/rest-nvim/tree-sitter-http",
     branch = "main",
     files = { "src/parser.c" },
     generate_requires_npm = true,


### PR DESCRIPTION
Hey, I've moved `tree-sitter-http` parser repository to an organization very recently.
This PR aims to update said parser url, nothing more.
