### PR TITLE
Conceal reference and shortcut links in markdown

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -48,11 +48,10 @@
     "["
     "]"
     "("
-   (link_destination)
+    (link_destination)
     ")"
-] @conceal
-(#set! conceal ""))
-
+  ] @conceal
+  (#set! conceal ""))
 
 ; Conceal image links
 (image
@@ -61,7 +60,32 @@
     "["
     "]"
     "("
-   (link_destination)
+    (link_destination)
     ")"
-] @conceal
+  ] @conceal
+  (#set! conceal ""))
+
+; Conceal full reference links
+(full_reference_link
+  [
+    "["
+    "]"
+    (link_label)
+  ] @conceal
+  (#set! conceal ""))
+
+; Conceal collapsed reference links
+(collapsed_reference_link
+  [
+    "["
+    "]"
+  ] @conceal
+  (#set! conceal ""))
+
+; Conceal shortcut links
+(shortcut_link
+  [
+    "["
+    "]"
+  ] @conceal
   (#set! conceal ""))


### PR DESCRIPTION
This change conceals `full_reference_link`, `collapsed_reference_link`,
and `shortcut_link` similarly to how the `markdown_inline` query file
already conceals `inline_link` and `image`.

## Test markdown contents

```markdown
Some text before the link [full reference link text][link label] and now some
text after the link onto a new line.

Some text before the link [collapsed reference link text][] and now some text
after the link onto a new line.

Some text before the link [shortcut link text] and now some text after the link
onto a new line.
```

## Test markdown concealed screenshot

![image](https://user-images.githubusercontent.com/2928612/183823041-49541e8a-1c56-4285-991b-fcade8710815.png)

Closes #3267