### PR TITLE
indents(go): don't indent on all composite_literal

### DIFF
--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -3,7 +3,6 @@
   (const_declaration)
   (var_declaration)
   (type_declaration)
-  (composite_literal)
   (func_literal)
   (literal_value)
   (expression_case)
@@ -11,6 +10,7 @@
   (block)
   (call_expression)
   (parameter_list)
+  (struct_type)
 ] @indent
 
 [

--- a/tests/indent/go/issue-3288.go
+++ b/tests/indent/go/issue-3288.go
@@ -7,8 +7,16 @@ func correct(word string) {
 	select {
 
 	} // <---
+}
 
-	arr := []struct {
+func test() {
+	cases := []struct {
+		first, second string
+	} {
+		{"Hello", "World"},   
+	}
 
-	} // <---
+	for range cases {
+		println("random stuff")
+	}
 }

--- a/tests/indent/go/issue-3288.go
+++ b/tests/indent/go/issue-3288.go
@@ -1,0 +1,14 @@
+package main
+
+func correct(word string) {
+	switch word {
+
+	} // <---
+	select {
+
+	} // <---
+
+	arr := []struct {
+
+	} // <---
+}


### PR DESCRIPTION
I don't feel to confident about this change. I don't use go and our test coverage is not exhaustive.