### PR TITLE
highlights(ecma): Update queries for literals

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -97,22 +97,35 @@
 ; Literals
 ;---------
 
-(this) @variable.builtin
-(super) @variable.builtin
-
-(true) @boolean
-(false) @boolean
-(null) @constant.builtin
 [
-(comment)
-(hash_bang_line)
+  (this)
+  (super)
+] @variable.builtin
+
+[
+  (true)
+  (false)
+] @boolean
+
+[
+  (null) 
+  (undefined)
+] @constant.builtin
+
+[
+  (comment)
+  (hash_bang_line)
 ] @comment
+
 (string) @string
-(regex) @punctuation.delimiter
-(regex_pattern) @string.regex
 (template_string) @string
 (escape_sequence) @string.escape
+(regex_pattern) @string.regex
+(regex "/" @punctuation.bracket) ; Regex delimiters
+
 (number) @number
+((identifier) @number
+  (#any-of? @number "NaN" "Infinity"))
 
 ; Punctuation
 ;------------


### PR DESCRIPTION
- Add queries for value properties:
    - undefined
    - NaN
    - Infinity
- Highlight regex delimiters as brackets instead of punctuation
- Format queries for literals

These changes were suggested by [u/based5 on reddit](https://www.reddit.com/r/neovim/comments/ws23tm/why_no_treesitter_highlight_for_undefined_in/). I don't know their github username, but credit to them.