### PR TITLE
highlights(java): add "non-sealed" keyword

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -185,6 +185,7 @@
 "public"
 "requires"
 "sealed"
+"non-sealed"
 "static"
 "strictfp"
 "synchronized"


### PR DESCRIPTION
After #3336, I saw that there is also `"non-sealed"`