### PR TITLE
chore(vim): update parser and highlights

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -357,7 +357,7 @@
     "revision": "8f6b1f357d1231c420404b5f7a368a73c25adfa2"
   },
   "vim": {
-    "revision": "066760141be9085368eb00680fbd43b73533d443"
+    "revision": "73c5ddd92097333ded42c75e93e1df059815b4c9"
   },
   "vue": {
     "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06"

--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -91,12 +91,10 @@
   "belowright"
   "topleft"
   "botright"
+  (unknown_command_name)
 ] @keyword
 (map_statement cmd: _ @keyword)
-[ 
-  (command_name)
-  (unknown_command_name)
-]@function.macro
+(command_name) @function.macro
 
 ;; Syntax command
 


### PR DESCRIPTION
Adds support for map_bar.
Correctly highlight unknown builtin commands.
