### PR TITLE
injections(jsx): highlight `<style jsx>` as css

### DIFF
--- a/queries/jsx/injections.scm
+++ b/queries/jsx/injections.scm
@@ -1,0 +1,8 @@
+; Styled Jsx <style jsx>
+(jsx_element
+  (jsx_opening_element
+    (identifier) @_name (#eq? @_name "style")
+    (jsx_attribute) @_attr (#eq? @_attr "jsx"))
+  (jsx_expression (template_string) @css
+    (#offset! @css 0 1 0 -1))
+)

--- a/queries/tsx/injections.scm
+++ b/queries/tsx/injections.scm
@@ -1,1 +1,1 @@
-; inherits: ecma
+; inherits: ecma,jsx


### PR DESCRIPTION
~Although this is only valid for jsx/tsx, I am putting this in `ecma` so both can inherit the injections.~ https://github.com/nvim-treesitter/nvim-treesitter/pull/3358#issuecomment-1225340609

Created `jsx/injections.scm` with the injection query which is (and should be) then inherited by `javascript` and `tsx` injections.

For some reason, `javascript` was already importing the `jsx` injections, thus no changes required.

---

Before and After

![image](https://user-images.githubusercontent.com/24727447/186354028-34d8a427-b909-4048-9373-40d2f90b73eb.png)
