### PR TITLE
feat(cmake): add escape to highlight

### DIFF
--- a/queries/cmake/highlights.scm
+++ b/queries/cmake/highlights.scm
@@ -123,3 +123,4 @@
   (#match? @function.builtin "\\c^(add_custom_command)$")
 )
 
+(escape_sequence) @string.escape


### PR DESCRIPTION
add escape word like "\n", "\;" to highlight

Log: escape sequence highlight for cmake
