### PR TITLE
Haskell injection: support inline json

### DIFF
--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -56,3 +56,13 @@
  (#eq? @_name "hsx")
  ((quasiquote_body) @html)
 )
+
+;; -----------------------------------------------------------------------------
+;; Inline JSON from aeson
+
+(quasiquote
+  (quoter) @_name
+  (#eq? @_quoter "aesonQQ")
+  ((quasiquote_body) @json)
+)
+

--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -62,7 +62,7 @@
 
 (quasiquote
   (quoter) @_name
-  (#eq? @_quoter "aesonQQ")
+  (#eq? @_name "aesonQQ")
   ((quasiquote_body) @json)
 )
 


### PR DESCRIPTION
Support for inline json using the quasiquoter `aesonQQ`: https://github.com/sol/aeson-qq#readme