### PR TITLE
Add postresql-simple sql to haskell injections

### DIFF
--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -66,3 +66,13 @@
   ((quasiquote_body) @json)
 )
 
+
+;; -----------------------------------------------------------------------------
+;; SQL
+
+; postgresql-simple
+(quasiquote
+  (quoter) @_name 
+  (#eq? @_name "sql")
+  ((quasiquote_body) @sql)
+)


### PR DESCRIPTION
This PR adds a haskell injection for [postgresql-simple](https://hackage.haskell.org/package/postgresql-simple) quasiquotes.