### PR TITLE
parsers: use html parser for django template language

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -8,6 +8,7 @@ local filetype_to_parsername = {
   jsx = "javascript",
   PKGBUILD = "bash",
   html_tags = "html",
+  htmldjango = "html",
   ["typescript.tsx"] = "tsx",
   terraform = "hcl",
   ["html.handlebars"] = "glimmer",


### PR DESCRIPTION
Temporarily enable HTML parser for `htmldjango` filetype as suggested in https://github.com/nvim-treesitter/nvim-treesitter/issues/3330 until there's a proper parser for [Django Template Language](https://docs.djangoproject.com/en/dev/ref/templates/language/).