### PR TITLE
feat: add tree-sitter-sxhkdrc

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1178,7 +1178,7 @@ list.tiger = {
 
 list.sxhkdrc = {
   install_info = {
-    url = "~/sectors/treesitter/tree-sitter-sxhkdrc",
+    url = "https://github.com/RaafatTurki/tree-sitter-sxhkdrc",
     files = {"src/parser.c"},
     branch = "master",
     generate_requires_npm = false,

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1179,13 +1179,13 @@ list.tiger = {
 list.sxhkdrc = {
   install_info = {
     url = "https://github.com/RaafatTurki/tree-sitter-sxhkdrc",
-    files = {"src/parser.c"},
+    files = { "src/parser.c" },
     branch = "master",
     generate_requires_npm = false,
     requires_generate_from_grammar = false,
     filetype = "sxhkdrc",
-    maintainers = { "@RaafatTurki" },
-  }
+  },
+  maintainers = { "@RaafatTurki" },
 }
 
 list.gitignore = {

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1176,6 +1176,18 @@ list.tiger = {
   maintainers = { "@ambroisie" },
 }
 
+list.sxhkdrc = {
+  install_info = {
+    url = "~/sectors/treesitter/tree-sitter-sxhkdrc",
+    files = {"src/parser.c"},
+    branch = "master",
+    generate_requires_npm = false,
+    requires_generate_from_grammar = false,
+    filetype = "sxhkdrc",
+    maintainers = { "@RaafatTurki" },
+  }
+}
+
 list.gitignore = {
   install_info = {
     url = "https://github.com/shunsambongi/tree-sitter-gitignore",

--- a/queries/sxhkdrc/folds.scm
+++ b/queries/sxhkdrc/folds.scm
@@ -1,0 +1,3 @@
+[
+ (binding)
+] @fold

--- a/queries/sxhkdrc/highlights.scm
+++ b/queries/sxhkdrc/highlights.scm
@@ -1,0 +1,10 @@
+(modifier) @keyword
+(operator) @operator
+(attribute) @type
+(command_sync_prefix) @type
+(punctuation) @punctuation.bracket
+(delimiter) @punctuation.delimiter
+(keysym) @variable
+(comment) @comment
+(range) @number
+"\\\n" @punctuation.special

--- a/queries/sxhkdrc/injections.scm
+++ b/queries/sxhkdrc/injections.scm
@@ -1,0 +1,3 @@
+(command) @bash
+
+(comment) @comment

--- a/queries/sxhkdrc/injections.scm
+++ b/queries/sxhkdrc/injections.scm
@@ -1,3 +1,1 @@
-(command) @bash
-
 (comment) @comment


### PR DESCRIPTION
This adds my recently created [sxhkdrc grammar](https://github.com/RaafatTurki/tree-sitter-sxhkdrc) which is the configuration format for the [simple x hotkey daemon](https://github.com/baskerville/sxhkd)

I've also added highlighting queries to make it useful from the get go:
![image](https://user-images.githubusercontent.com/16624558/187569265-72b9fc9b-631d-4481-a4d6-08f48e352135.png)

At 1st I've had my highlight queries within the grammar repo itself and `tree-sitter highlight` worked using it but nvim wouldn't use it (`checkhealth nvim-treesitter` says my grammar has no highlighting support), Only after moving my queries into this plugin did nvim start highlighting things. I'm relatively new to the nvim-treesitter scene, Is there a way to relocate my queries back into my repo and have nvim-treesitter use them (that way I can update the queries without PRing here) or is that a no no?

*before*
![image](https://user-images.githubusercontent.com/16624558/187570310-9951e8ac-3e54-4172-8877-1cf069a28d5b.png)
*after*
![image](https://user-images.githubusercontent.com/16624558/187570372-6e46b7ed-9215-4986-bb81-a7fb3058bf8b.png)

Making those queries was a bit unusual as this isn't a programming/markup language so let me know if I'm linking a query against a really odd highlight group.

Also currently I must set the local `filetype` with something like `au BufEnter sxhkdrc,*.sxhkdrc set ft=sxhkdrc` as nvim doesn't really recognize the `sxhkdrc` filetype, how do other parsers overcome such issue?

I plan on adding folding support and unit tests in the future
LMK what you think!