### PR TITLE
fix(highlight): ensure links are rebuilt on colorscheme change

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -136,6 +136,8 @@ local function link_all_captures()
   end
 end
 
+link_all_captures()
+
 local function should_enable_vim_regex(config, lang)
   local additional_hl = config.additional_vim_regex_highlighting
   local is_table = type(additional_hl) == "table"

--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -130,8 +130,10 @@ elseif not vim.g.skip_ts_default_groups then
   end
 end
 
-for capture, hlgroup in pairs(default_map) do
-  link_captures(capture, hlgroup)
+local function link_all_captures()
+  for capture, hlgroup in pairs(default_map) do
+    link_captures(capture, hlgroup)
+  end
 end
 
 local function should_enable_vim_regex(config, lang)
@@ -177,6 +179,9 @@ function M.set_custom_captures(captures)
 end
 
 function M.set_default_hlgroups()
+  if not ts.highlighter.hl_map then
+    link_all_captures()
+  end
   local highlights = {
     TSNone = { default = true },
     TSPunctDelimiter = { link = "Delimiter", default = true },


### PR DESCRIPTION
This PR fixes an issue where, for users on nvim nightly, the links for the captures are not reset when a user reloads or changes their colorscheme. This was previously done for the default highlight groups, but this logic did not include creating the links now need on 0.8. Not sure if this code is all destined for a fire at some point, but it's useful for people who are doing this in the short term.