### PR TITLE
Add support for menhir (OCaml parser generator)

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -227,6 +227,9 @@
   "ocamllex": {
     "revision": "ac1d5957e719d49bd6acd27439b79843e4daf8ed"
   },
+  "menhir": {
+    "revision": "db7953acb0d5551f207373c81fa07a57d7b085cb"
+  },
   "org": {
     "revision": "698bb1a34331e68f83fc24bdd1b6f97016bb30de"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -471,6 +471,15 @@ list.ocamllex = {
   maintainers = { "@undu" },
 }
 
+list.menhir = {
+  install_info = {
+    url = "https://github.com/Kerl13/tree-sitter-menhir",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  maintainers = { "@Kerl13" },
+  filetype = "menhir",
+}
+
 list.org = {
   install_info = {
     url = "https://github.com/milisims/tree-sitter-org",

--- a/queries/menhir/highlights.scm
+++ b/queries/menhir/highlights.scm
@@ -1,0 +1,29 @@
+["%parameter" "%token" "%type" "%start" "%attribute" "%left" "%right" "%nonassoc" "%public" "%inline" "%prec"] @keyword
+["%on_error_reduce"] @exception
+
+["let"] @keyword.function
+
+[(equality_symbol) ":" "|" ";" ","] @punctuation.delimiter
+
+["=" "~" "_"] @operator
+(modifier) @operator
+
+["<" ">" "{" "}" "%{" "%}" "%%"] @punctuation.special
+
+["(" ")"] @punctuation.bracket
+
+(old_rule [(symbol)] @function)
+(new_rule [(lid)] @function)
+
+(precedence [(symbol)] @parameter)
+
+(funcall) @function.call
+
+; Not very accurant but does a decent job
+(uid) @constant
+
+(ocaml_type) @type
+(ocaml) @none
+
+[(comment) (line_comment) (ocaml_comment)] @comment
+(ERROR) @error

--- a/queries/menhir/injections.scm
+++ b/queries/menhir/injections.scm
@@ -1,0 +1,1 @@
+(ocaml) @ocaml


### PR DESCRIPTION
Hi!

This patch adds support for [menhir](http://gallium.inria.fr/~fpottier/menhir/) files (menhir is a parser generator for [OCaml](https://ocaml.org/)). The parser has been used a little outside of nvim already, and is reasonably tested. I hope it can be a nice addition to nvim-treesitter :slightly_smiling_face: 

Let me know if I did something wrong in the PR, I'll be happy to fix it

cheers!
