### PR TITLE
highlights(swift): fix for_statement variable declaration

### DIFF
--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -73,7 +73,7 @@
 ; Statements
 (for_statement ["for" @repeat])
 (for_statement ["in" @repeat])
-(for_statement item: (simple_identifier) @variable)
+(for_statement (pattern) @variable)
 (else) @keyword
 (as_operator) @keyword
 


### PR DESCRIPTION
Incorporates a fix from upstream, caught due to the emacs tree-sitter plugin using an older version of tree-sitter that does stricter validation.﻿
