### PR TITLE
highlights(sql): change table_expression to table_reference

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -315,7 +315,7 @@
     "revision": "05f949d3c1c15e3261473a244d3ce87777374dec"
   },
   "sql": {
-    "revision": "f83c41287b75f51dab6dd4e86014077c67627725"
+    "revision": "b032eaa5122e70cd4b012e2272eb357e1971ddc7"
   },
   "supercollider": {
     "revision": "90c6d9f777d2b8c4ce497c48b5f270a44bcf3ea0"

--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -9,8 +9,9 @@
 (table_reference
   name: (identifier) @type)
 
-(table_reference
-  name: (identifier) @type
+(relation
+  (table_reference
+    name: (identifier) @type)
   table_alias: (identifier) @variable)
 
 (field
@@ -91,7 +92,6 @@
   (keyword_using)
   (keyword_cascade)
   (keyword_between)
-  (keyword_window)
   (keyword_window)
   (double)
   (keyword_with)

--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -6,10 +6,10 @@
   name: (identifier) @function.call
   parameter: [(field)]? @parameter)
 
-(table_expression
+(table_reference
   name: (identifier) @type)
 
-(table_expression
+(table_reference
   name: (identifier) @type
   table_alias: (identifier) @variable)
 


### PR DESCRIPTION
The node name `table_expression` has been refactored and renamed into `table_reference` in [here](https://github.com/DerekStride/tree-sitter-sql/commit/b032eaa5122e70cd4b012e2272eb357e1971ddc7).
Therefore, the queries for highlighting do not work anymore. They break with the following message:

```
ERROR 2022-09-07T07:56:07.092 2000835 decor_provider_invoke:37: error in provider treesitter/highlighter:line: Error executing lua: /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:172: query: error at position 257
stack traceback:
        [C]: in function '_ts_parse_query'
        /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:172: in function 'get_query'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:122: in function 'new'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:247: in function 'get_query'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:265: in function 'fn'
        ...l/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:194: in function 'for_each_tree'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:255: in function 'on_line_impl'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:303: in function <...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:299>
```

I have changed the query accordingly. However it fails to match on the second query:
```
(table_reference
  name: (identifier) @type
  table_alias: (identifier) @variable)
```

I am still quite fresh in the tree-sitter world. Could you take another look?.