### PR TITLE
feat: add jsonnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [jsdoc](https://github.com/tree-sitter/tree-sitter-jsdoc) (maintained by @steelsojka)
 - [x] [json](https://github.com/tree-sitter/tree-sitter-json) (maintained by @steelsojka)
 - [x] [json5](https://github.com/Joakker/tree-sitter-json5) (maintained by @Joakker)
+- [x] [Jsonnet](https://github.com/sourcegraph/tree-sitter-jsonnet) (maintained by @nawordar)
 - [x] [JSON with comments](https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git) (maintained by @WhyNotHugo)
 - [x] [julia](https://github.com/tree-sitter/tree-sitter-julia) (maintained by @mroavi, @theHamsta)
 - [x] [kotlin](https://github.com/fwcd/tree-sitter-kotlin) (maintained by @SalBakraa)

--- a/lockfile.json
+++ b/lockfile.json
@@ -173,6 +173,9 @@
   "jsonc": {
     "revision": "02b01653c8a1c198ae7287d566efa86a135b30d5"
   },
+  "jsonnet": {
+    "revision": "0475a5017ad7dc84845d1d33187f2321abcb261d"
+  },
   "julia": {
     "revision": "0572cebf7b8e8ef5990b4d1e7f44f0b36f62922c"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -370,6 +370,14 @@ list.json = {
   maintainers = { "@steelsojka" },
 }
 
+list.jsonnet = {
+  install_info = {
+    url = "https://github.com/sourcegraph/tree-sitter-jsonnet",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@nawordar" },
+}
+
 list.css = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-css",

--- a/queries/jsonnet/highlights.scm
+++ b/queries/jsonnet/highlights.scm
@@ -1,0 +1,76 @@
+[
+  (true)
+  (false)
+] @boolean
+
+(comment) @comment
+(id) @variable
+(import) @include
+(null) @constant.builtin
+(number) @number
+(string) @string
+
+(fieldname (id) @label)
+
+[
+  "["
+  "]"
+  "{"
+  "}"
+  "("
+  ")"
+] @punctuation.bracket
+
+[
+  "."
+  ","
+  ";"
+  ":"
+  "::"
+  ":::"
+] @punctuation.delimiter
+
+(expr
+  operator: (_) @operator)
+[
+  "+"
+  "="
+] @operator
+
+"in" @keyword.operator
+
+[
+ (local)
+ "assert"
+] @keyword
+
+[
+  "else"
+  "if"
+  "then"
+] @conditional
+
+[
+  (dollar)
+  (self)
+] @variable.builtin
+((id) @variable.builtin
+ (#eq? @variable.builtin "std"))
+
+; Function declaration
+(bind
+  function: (id) @function
+  params: (params
+            (param
+              identifier: (id) @parameter)))
+
+; Function call
+(expr
+  (expr (id) @function.call)
+  "("
+  (args
+    (named_argument
+      (id) @parameter))?
+  ")")
+
+(ERROR) @error


### PR DESCRIPTION
Neovim does not have a built in Jsonnet file type detection, so it only works with google/vim-jsonnet extension or with ftdetect file added (https://github.com/google/vim-jsonnet/blob/master/ftdetect/jsonnet.vim). Is it fine, or maybe that ftdetect file should be added to Neovim first? I'm not sure if they would even accept a PR that would only add file type detection without other features. 