### PR TITLE
feat: add tree-sitter-gitattributes

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1205,6 +1205,17 @@ list.gitignore = {
   maintainers = { "@theHamsta" },
 }
 
+list.gitattributes = {
+  install_info = {
+    url = "https://github.com/ObserverOfTime/tree-sitter-gitattributes",
+    files = { "src/parser.c" },
+    branch = "master",
+    requires_generate_from_grammar = false,
+  },
+  maintainers = { "@ObserverOfTime" },
+  experimental = true,
+}
+
 local M = {
   list = list,
   filetype_to_parsername = filetype_to_parsername,

--- a/queries/gitattributes/highlights.scm
+++ b/queries/gitattributes/highlights.scm
@@ -1,0 +1,54 @@
+(dir_sep) @punctuation.delimiter
+
+(wildcard) @punctuation.special
+
+(quoted_pattern
+  ("\"" @character.special))
+
+(range_notation) @string.special
+
+(range_notation
+  [ "[" "]" ] @punctuation.bracket)
+
+(range_negation) @operator
+
+(character_class) @constant
+
+(class_range ("-" @operator))
+
+[
+  (ansi_c_escape)
+  (escaped_char)
+] @string.escape
+
+(attribute
+  (attr_name) @parameter)
+
+(attribute
+  (builtin_attr) @variable.builtin)
+
+[
+  (attr_reset)
+  (attr_unset)
+  (attr_set)
+] @operator
+
+(boolean_value) @boolean
+
+(string_value) @string
+
+(macro_tag) @preproc
+
+(macro_def
+  macro_name: (_) @property)
+
+[
+  (pattern_negation)
+  (redundant_escape)
+  (trailing_slash)
+] @error
+
+(ERROR) @error
+
+(comment) @comment
+(comment) @spell

--- a/queries/gitattributes/injections.scm
+++ b/queries/gitattributes/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment


### PR DESCRIPTION
Vim doesn't have a `gitattributes` filetype so it will have to be added by the user.

```lua
-- for example:
vim.filetype.add {
    filename = {
        [".gitattributes"] = "gitattributes",
    },
    pattern = {
        [".*/git/attributes"] = "gitattributes",
        [".*/info/attributes"] = "gitattributes",
    }
}
```

---

I hadn't written a parser before this one, so I marked it as experimental just in case.