### PR TITLE
highlights(sql): missing keyword & marginalia

### DIFF
--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -10,8 +10,6 @@
   name: (identifier) @type)
 
 (relation
-  (table_reference
-    name: (identifier) @type)
   table_alias: (identifier) @variable)
 
 (field
@@ -20,6 +18,7 @@
 
 (literal) @string
 (comment) @comment
+(marginalia) @comment
 
 ((literal) @number
  (lua-match? @number "^%d+$"))
@@ -143,6 +142,7 @@
   (keyword_geography)
   (keyword_box2d)
   (keyword_box3d)
+  (keyword_only)
 ] @keyword
 
 [


### PR DESCRIPTION
This PR builds on https://github.com/nvim-treesitter/nvim-treesitter/pull/3445 and adds the rest of the changes that were present in https://github.com/nvim-treesitter/nvim-treesitter/pull/3458.

* I've added a new highlights for the `marginalia` & `keyword_only` nodes.
* I've cleaned up the query for matching `table_alias`.
  * The previous query matches `table_reference` nodes so there isn't a need to repeat it.