### PR TITLE
fix(highlight): ensure link captures function exists

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -131,8 +131,10 @@ elseif not vim.g.skip_ts_default_groups then
 end
 
 local function link_all_captures()
-  for capture, hlgroup in pairs(default_map) do
-    link_captures(capture, hlgroup)
+  if link_captures then
+    for capture, hlgroup in pairs(default_map) do
+      link_captures(capture, hlgroup)
+    end
   end
 end
 


### PR DESCRIPTION
Before attempting to call it. The function in question only exists if someone has a pre 0.8 version of neovim or if they are explicitly choosing to use treesitter highlight groups. If a user tries to opt out, this function won't exist. I accidentally introduced this bug in #3409 

fixes #3465