### PR TITLE
build: add a rockspec

### DIFF
--- a/contrib/nvim-treesitter-scm-1.rockspec
+++ b/contrib/nvim-treesitter-scm-1.rockspec
@@ -1,0 +1,32 @@
+local MODREV, SPECREV = "scm", "-1"
+rockspec_format = "3.0"
+package = "nvim-treesitter"
+version = MODREV .. SPECREV
+
+description = {
+	summary = "Nvim Treesitter configurations and abstraction layer",
+	labels = { "neovim"},
+	homepage = "https://github.com/nvim-treesitter/nvim-treesitter",
+	license = "Apache-2.0",
+}
+
+dependencies = {
+	"lua >= 5.1, < 5.4",
+}
+
+source = {
+	url = "http://github.com/nvim-treesitter/nvim-treesitter/archive/v" .. MODREV .. ".zip",
+}
+
+if MODREV == 'scm' then
+  source = {
+    url = 'git://github.com/nvim-treesitter/nvim-treesitter',
+  }
+end
+
+build = {
+   type = "builtin",
+   copy_directories = {
+	 'plugin'
+   }
+}


### PR DESCRIPTION
so that users can install the plugin via luarocks but even better: 
so that other plugins can reference this one and add it as a dependency.

