### PR TITLE
feat(query): include metadata in matches

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -209,7 +209,7 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
   local matches = query:iter_matches(qnode, bufnr, start_row, end_row)
 
   local function iterator()
-    local pattern, match = matches()
+    local pattern, match, metadata = matches()
     if pattern ~= nil then
       local prepared_match = {}
 
@@ -217,8 +217,8 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
       for id, node in pairs(match) do
         local name = query.captures[id] -- name of the capture in the query
         if name ~= nil then
-          local path = split(name .. ".node")
-          insert_to_path(prepared_match, path, node)
+          insert_to_path(prepared_match, split(name .. ".node"), node)
+          insert_to_path(prepared_match, split(name .. ".metadata"), metadata[id])
         end
       end
 


### PR DESCRIPTION
This includes the metadata in matches. This can be useful if for example `#offset!` is used for the query and you can take this into account when iterating over the matches from eg `get_matches`.

A match will now for example take the form:
```lua
{                                                                                   
  lua = {                                                                                      
    metadata = {                                                                               
      range = { 0, 7, 0, 40 }                                                                  
    },                                                                                         
    node = <userdata 1>                                                                        
  }                                                                                            
}
```