### PR TITLE
fix: uninstall function in the install.lua

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -580,6 +580,9 @@ function M.get_ignored_parser_installs()
 end
 
 function M.get_ensure_installed_parsers()
+  if type(config.ensure_installed) == "string" then
+    return { config.ensure_installed }
+  end
   return config.ensure_installed or {}
 end
 

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -478,9 +478,7 @@ function M.uninstall(...)
   if vim.tbl_contains({ "all" }, ...) then
     reset_progress_counter()
     local installed = info.installed_parsers()
-    for _, langitem in pairs(installed) do
-      M.uninstall(langitem)
-    end
+    M.uninstall(installed)
   elseif ... then
     local languages = vim.tbl_flatten { ... }
     for _, lang in ipairs(languages) do


### PR DESCRIPTION
The get_ensure_installed_parsers function return a table for the option "all" because uninstall accepts a table
This PR fix an error when trying to delete all parsers.
```
E5108: Error executing lua vim/shared.lua:0: t: expected table, got string
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'tbl_contains'
        ...cker/opt/nvim-treesitter/lua/nvim-treesitter/install.lua:492: in function 'uninstall'
        ...cker/opt/nvim-treesitter/lua/nvim-treesitter/install.lua:482: in function 'run'
        [string ":lua"]:1: in main chunk
```