### PR TITLE
fix(ecma injections): jsdoc match /** */ only

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -1,4 +1,6 @@
-(comment) @jsdoc
+(((comment) @_jsdoc_comment
+  (#match? @_jsdoc_comment "^/\\*\\*[^\\*].*\\*/")) @jsdoc)
+
 (comment) @comment
 
 (call_expression


### PR DESCRIPTION
From [Use JSDoc: Getting Started](https://jsdoc.app/about-getting-started.html):

> Each comment must start with a `/**` sequence in order to be recognized by the
> JSDoc parser. Comments beginning with `/*`, `/***`, or more than 3 stars will
> be ignored. This is a feature to allow you to suppress parsing of comment blocks.
