### PR TITLE
fix(highlight): respect g:skip_ts_default_groups on ColorScheme autocmd

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -183,7 +183,7 @@ function M.set_custom_captures(captures)
 end
 
 function M.set_default_hlgroups()
-  if not ts.highlighter.hl_map then
+  if not ts.highlighter.hl_map and not vim.g.skip_ts_default_groups then
     link_all_captures()
   end
   local highlights = {


### PR DESCRIPTION
From my understanding you need to enable `skip_ts_default_groups` in order to set [custom colorscheme](https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/groups/integrations/treesitter.lua)

Without it after `:colorscheme catppuccin` the highlight captures will link to the deprecated TS* highlights

I can simply merge the old TS* highlight groups but that's rather ugly

![image](https://user-images.githubusercontent.com/56817415/190219467-f36c98f4-6d05-4c48-bf7f-0eceda3225df.png)

![image](https://user-images.githubusercontent.com/56817415/190219896-48cb4c0c-cef9-4edf-8b75-1a6c7fac0566.png)

