### PR TITLE
folds(yaml): Fold at the entire node, not at the body.

### DIFF
--- a/queries/yaml/folds.scm
+++ b/queries/yaml/folds.scm
@@ -1,3 +1,4 @@
 [
-  (block_node)
+  (block_mapping_pair)
+  (block_sequence_item)
 ] @fold


### PR DESCRIPTION
The current yaml folds are based on #887 and #928, but I don't think this is a good folding syntax.


Example and Tests
-----------------

Let's take a look at the example which is a slight extension of #887's one:

```
days:
  Monday:
    - test: example
      day: 1
  Tuesday:
    - test: example
      day: 2
  Wednesday:
    - test: example
      day: 3
    - test: example
      day: 3
  Thursday:
    - test: example
      day: 4
  Friday:
    - test: example
      day: 5
```

### Current behavior:

(at foldlevel=0)
```
days:  ⋯    ( 17 lines)
```

(at foldlevel=1)
```
days:
  Monday:  ⋯    ( 16 lines)
```

Oops! you can fold the "body" of the `days` node (`block_mapping_pair`). See [this comment from #887](https://github.com/nvim-treesitter/nvim-treesitter/issues/887#issuecomment-874207744) as well.

(at foldlevel=2)
```
days:
  Monday:
    - test: example  ⋯    ( 2 lines)
  Tuesday:
    - test: example  ⋯    ( 2 lines)
  Wednesday:
    - test: example  ⋯    ( 4 lines)
  Thursday:
    - test: example  ⋯    ( 2 lines)
  Friday:
    - test: example  ⋯    ( 2 lines)
```

Again, this is because only the "body" can be folded. But wouldn't we want to see `Monday: ...`, `Tuesday: ...`, etc. only? Folding a list of two items on `Wednesday` into a single line is also confusing.


### Changed behavior:

(at foldlevel=1)
```
days:
  Monday:  ⋯    ( 3 lines)
  Tuesday:  ⋯    ( 3 lines)
  Wednesday:  ⋯    ( 5 lines)
  Thursday:  ⋯    ( 3 lines)
  Friday:  ⋯    ( 3 lines)
```

<img width="600" alt="The corrected behavior." src="https://user-images.githubusercontent.com/1009873/190843707-1ab7aad3-6d69-44cc-95bd-d356cf25d370.png">


(at foldlevel=2)
```
days:
  Monday:
    - test: example  ⋯    ( 2 lines)
  Tuesday:
    - test: example  ⋯    ( 2 lines)
  Wednesday:
    - test: example  ⋯    ( 2 lines)
    - test: example  ⋯    ( 2 lines)
  Thursday:
    - test: example  ⋯    ( 2 lines)
  Friday:
    - test: example  ⋯    ( 2 lines)
```

Note folding of "list of items" on the `Wednesday` node (`block_sequence_item`)

I think this is a more semantically meaningful fold, and also meets @gegoune's request in the original message of #887 (separate folds for some "mapping" nodes).

/cc @gegoune @stsewd @vigoux