### PR TITLE
Expand locals to include properties and methods

### DIFF
--- a/queries/javascript/locals.scm
+++ b/queries/javascript/locals.scm
@@ -1,5 +1,20 @@
 ; inherits: ecma,jsx
 
+; Both properties are matched here.
+;
+;   class Foo {
+;     this.#bar = "baz";
+;     this.quuz = "qux";
+;   }
+(field_definition 
+  property: [(property_identifier) (private_property_identifier)] @definition.var)
+
+; this.foo = "bar"
+(assignment_expression
+  left: (member_expression
+    object: (this)
+    property: (property_identifier) @definition.var))
+
 (formal_parameters
   (identifier) @definition.parameter)
 
@@ -31,3 +46,18 @@
 (formal_parameters
   (rest_pattern
     (identifier) @definition.parameter))
+
+; Both methods are matched here.
+;
+;   class Foo {
+;     #bar(x) { x }
+;     baz(y) { y }
+;   }
+(method_definition
+  ([(property_identifier) (private_property_identifier)] @definition.function)
+   (#set! definition.var.scope parent))
+
+; this.foo()
+(member_expression
+  object: (this)
+  property: (property_identifier) @reference)


### PR DESCRIPTION
The previous locals were lacking a few locals related to JS classes. This expands the locals to include properties defined on classes (e.g. `this.foo = "bar"` or `static #targets`) as both vars & references, as well as private methods on classes (e.g. `#bar(x) { x }` and `#bar(y)`).