### PR TITLE
Add query to highlight comment marker `NOTE`

### DIFF
--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -7,11 +7,17 @@
 
 (tag (name) @text.note (user)? @constant)
 
+((tag ((name) @text.note))
+ (#any-of? @text.note "NOTE"))
+
+("text" @text.note
+ (#any-of? @text.note "NOTE"))
+
 ((tag ((name) @text.warning))
- (#any-of? @text.warning "TODO" "HACK" "WARNING" "NOTE"))
+ (#any-of? @text.warning "TODO" "HACK" "WARNING"))
 
 ("text" @text.warning
- (#any-of? @text.warning "TODO" "HACK" "WARNING" "NOTE"))
+ (#any-of? @text.warning "TODO" "HACK" "WARNING"))
 
 ((tag ((name) @text.danger))
  (#any-of? @text.danger "FIXME" "XXX" "BUG"))

--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -8,10 +8,10 @@
 (tag (name) @text.note (user)? @constant)
 
 ((tag ((name) @text.warning))
- (#any-of? @text.warning "TODO" "HACK" "WARNING"))
+ (#any-of? @text.warning "TODO" "HACK" "WARNING" "NOTE"))
 
 ("text" @text.warning
- (#any-of? @text.warning "TODO" "HACK" "WARNING"))
+ (#any-of? @text.warning "TODO" "HACK" "WARNING" "NOTE"))
 
 ((tag ((name) @text.danger))
  (#any-of? @text.danger "FIXME" "XXX" "BUG"))


### PR DESCRIPTION
This is a common comment marker, and nvim-tree sitter would provide more
value to developers by highlighting this by default! Please see #3536
for further motivation and discussion.

Fixes #3536
