### PR TITLE
highlights: use @preproc where appropriate

### DIFF
--- a/queries/agda/highlights.scm
+++ b/queries/agda/highlights.scm
@@ -33,7 +33,7 @@
 
 ;; Pragmas and comments
 
-(pragma) @constant.macro
+(pragma) @preproc
 
 (comment) @comment
 

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -129,3 +129,6 @@
   value: (word) @parameter)
 
 (regex) @string.regex
+
+((program . (comment) @preproc)
+  (#match? @preproc "^#!/"))

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -43,7 +43,7 @@
   "#elif"
   "#endif"
   (preproc_directive)
-] @keyword
+] @preproc
 
 "#include" @include
 

--- a/queries/cmake/highlights.scm
+++ b/queries/cmake/highlights.scm
@@ -124,3 +124,6 @@
 )
 
 (escape_sequence) @string.escape
+
+((source_file . (line_comment) @preproc)
+  (#match? @preproc "^#!/"))

--- a/queries/dot/highlights.scm
+++ b/queries/dot/highlights.scm
@@ -46,10 +46,9 @@
     (identifier) @constant)
 )
 
-[
-(comment)
-(preproc)
-] @comment
+(comment) @comment
+
+(preproc) @preproc
 
 (comment) @spell
 

--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -112,10 +112,9 @@
   (undefined)
 ] @constant.builtin
 
-[
-  (comment)
-  (hash_bang_line)
-] @comment
+(comment) @comment
+
+(hash_bang_line) @preproc
 
 (comment) @spell
 

--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -155,6 +155,9 @@
 ((word) @boolean
 (#any-of? @boolean "true" "false"))
 
+((program . (comment) @preproc)
+  (#match? @preproc "^#!/"))
+
 ;; Error
 
 (ERROR) @error

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -207,10 +207,9 @@
 
 ;;; Literals
 
-[
-	(comment)
-	(shebang_line)
-] @comment
+(comment) @comment
+
+(shebang_line) @preproc
 
 (comment) @spell
 

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -15,6 +15,9 @@
  (comment_environment)
 ] @comment
 
+((line_comment) @preproc
+  (#lua-match? @preproc "^%% !TeX"))
+
 [
  (brack_group)
  (brack_group_argc)

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -182,7 +182,7 @@
 
 (comment) @comment @spell
 
-(hash_bang_line) @comment
+(hash_bang_line) @preproc
 
 (number) @number
 

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -85,6 +85,9 @@
 (comments) @comment
 (comments) @spell
 
+((source_file . (comments) @preproc)
+  (#match? @preproc "^#!/"))
+
 ; POD should be handled specially with its own embedded subtype but for now
 ;   we'll just have to do this.
 (pod_statement) @text

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -141,6 +141,10 @@
 (float) @float
 
 (comment) @comment @spell
+
+((module . (comment) @preproc)
+  (#match? @preproc "^#!/"))
+
 (string) @string
 [
   (escape_sequence)

--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -29,3 +29,6 @@
 
 ((program . (comment) @include)
  (#match? @include "^;\ +inherits\ *:"))
+
+((program . (comment) @preproc)
+ (#match? @preproc "^; +extends"))

--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -12,6 +12,9 @@
 
 (comment) @comment
 
+((program . (comment) @preproc)
+  (#match? @preproc "^#!/"))
+
 (identifier) @variable
 
 (formal_parameters (identifier) @parameter)

--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -11,8 +11,13 @@
 (anchor_name) @type
 (alias_name) @type
 (tag) @type
-(yaml_directive) @keyword
 (ERROR) @error
+
+[
+  (yaml_directive)
+  (tag_directive)
+  (reserved_directive)
+] @preproc
 
 (block_mapping_pair
   key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @field))


### PR DESCRIPTION
Use the `@preproc` capture to highlight certain preprocessor directives and shebangs.
It could also be used to highlight (some or all) at-rules in CSS if that's desirable. 
There are definitely more languages which could use it that I'm not familiar with.