### PR TITLE
docs: add example of how to use function to disable a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ require'nvim-treesitter.configs'.setup {
     -- the name of the parser)
     -- list of language that will be disabled
     disable = { "c", "rust" },
+    -- Or use a function for more flexibility, e.g. to disable slow treesitter highlight for large files
+    disable = function(lang, buf)
+        local max_filesize = 100 * 1024 -- 100 KB
+        local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
+        if ok and stats and stats.size > max_filesize then
+            return true
+        end
+    end,
 
     -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
     -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).


### PR DESCRIPTION
I found out that `disable` can be a function be looking through the source code, but it may be helpful to include this in the readme. 

In the readme I added an example of what I actually used this for - disabling highlight on large files. This is a nice workaround for https://github.com/nvim-treesitter/nvim-treesitter/issues/2996,  https://github.com/nvim-treesitter/nvim-treesitter/issues/2860, https://github.com/nvim-treesitter/nvim-treesitter/issues/1292, etc. This solution is also quite performant as from my tests `fs_stat` takes <100 us. 