### PR TITLE
fix(test): update tests to Nvim 0.8

### DIFF
--- a/lua/nvim-treesitter/highlight.lua
+++ b/lua/nvim-treesitter/highlight.lua
@@ -10,7 +10,7 @@ local M = {}
 -- Note: Some highlight groups may not be applied upstream, some may be experimental
 -- TODO(clason): deprecated and will be removed for Nvim 0.8
 
-local default_map = {
+M.default_map = {
   ["annotation"] = "TSAnnotation",
 
   ["attribute"] = "TSAttribute",
@@ -132,7 +132,7 @@ end
 
 local function link_all_captures()
   if link_captures then
-    for capture, hlgroup in pairs(default_map) do
+    for capture, hlgroup in pairs(M.default_map) do
       link_captures(capture, hlgroup)
     end
   end

--- a/tests/query/highlights_spec.lua
+++ b/tests/query/highlights_spec.lua
@@ -1,4 +1,4 @@
-require "nvim-treesitter.highlight" -- yes, this is necessary to set the hlmap
+local ts_highlight = require "nvim-treesitter.highlight" -- yes, this is necessary to set the hlmap
 local highlighter = require "vim.treesitter.highlighter"
 local ts_utils = require "nvim-treesitter.ts_utils"
 local parsers = require "nvim-treesitter.parsers"
@@ -70,9 +70,9 @@ local function check_assertions(file)
         assert.is.number(col)
         if hl and ts_utils.is_in_node_range(node, row, col) then
           local c = query._query.captures[capture] -- name of the capture in the query
-          if c ~= nil then
+          if c ~= nil and c ~= "spell" and c ~= "conceal" then
             captures[c] = true
-            local general_hl = query:_get_hl_from_capture(capture)
+            local general_hl = ts_highlight.default_map[c]
             highlights[general_hl] = true
           end
         end


### PR DESCRIPTION
`Tests / Run tests` now runs with Neovim 0.8, which 
1. removed `_get_hl_from_capture`
2. switched to "native" tree-sitter highlight groups
3. added non-highlighting captures `@conceal` and `@spell`.

This is something of a band-aid until the tests are rewritten to use the new upstream highlight groups.