### PR TITLE
injections: add printf format strings

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1272,6 +1272,15 @@ list.twig = {
   filetype = "twig",
 }
 
+list.printf = {
+  install_info = {
+    url = "https://github.com/pstuifzand/tree-sitter-printf",
+    files = { "src/parser.c" },
+    branch = "main",
+    readme_name = "printf format strings",
+  },
+}
+
 list.diff = {
   install_info = {
     url = "https://github.com/the-mikedavis/tree-sitter-diff",

--- a/queries/arduino/injections.scm
+++ b/queries/arduino/injections.scm
@@ -1,3 +1,3 @@
-(preproc_arg) @arduino
+; inherits: c
 
-(comment) @comment
+(preproc_arg) @arduino

--- a/queries/awk/injections.scm
+++ b/queries/awk/injections.scm
@@ -1,2 +1,8 @@
 (comment) @comment
+
 (regex) @regex
+
+(print_statement
+  (exp_list . (string) @printf))
+(printf_statement
+  (exp_list . (string) @printf))

--- a/queries/bash/injections.scm
+++ b/queries/bash/injections.scm
@@ -1,1 +1,23 @@
 (comment) @comment
+
+; printf 'format'
+(command
+  name: (command_name) @_command
+  (#eq? @_command "printf")
+  . argument: [(string) (raw_string)] @printf)
+
+; printf -v var 'format'
+(command
+  name: (command_name) @_command
+  (#eq? @_command "printf")
+  argument: (word) @_arg
+  (#eq? @_arg "-v")
+  . (_) . argument: [(string) (raw_string)] @printf)
+
+; printf -- 'format'
+(command
+  name: (command_name) @_command
+  (#eq? @_command "printf")
+  argument: (word) @_arg
+  (#eq? @_arg "--")
+  . argument: [(string) (raw_string)] @printf)

--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -1,3 +1,19 @@
 (preproc_arg) @c
 
 (comment) @comment
+
+(call_expression
+  function: (identifier) @_function
+  (#any-of? @_function "printf" "scanf" "printf_s" "scanf_s")
+  arguments: (argument_list . (string_literal) @printf))
+
+(call_expression
+  function: (identifier) @_function
+  (#any-of? @_function "fprintf" "fscanf" "fprintf_s" "fscanf_s"
+                       "sprintf" "sscanf" "sscanf_s")
+  arguments: (argument_list (_) . (string_literal) @printf))
+
+(call_expression
+  function: (identifier) @_function
+  (#any-of? @_function "snprintf" "sprintf_s" "snprintf_s")
+  arguments: (argument_list (_) . (_) . (string_literal) @printf))

--- a/queries/cpp/injections.scm
+++ b/queries/cpp/injections.scm
@@ -1,3 +1,3 @@
-(preproc_arg) @cpp
+; inherits: c
 
-(comment) @comment
+(preproc_arg) @cpp

--- a/queries/cuda/injections.scm
+++ b/queries/cuda/injections.scm
@@ -1,3 +1,3 @@
-(preproc_arg) @cuda
+; inherits: c
 
-(comment) @comment
+(preproc_arg) @cuda

--- a/queries/glsl/injections.scm
+++ b/queries/glsl/injections.scm
@@ -1,3 +1,8 @@
+; inherits: c
+
 (preproc_arg) @glsl
 
-(comment) @comment
+(call_expression
+  function: (identifier) @_function
+  (#eq? @_function "debugPrintfEXT")
+  arguments: (argument_list . (string_literal) @printf))

--- a/queries/go/injections.scm
+++ b/queries/go/injections.scm
@@ -1,1 +1,13 @@
 (comment) @comment
+
+(call_expression
+  function: (selector_expression
+              field: (field_identifier) @_method)
+  (#any-of? @_method "Printf" "Sprintf" "Fatalf")
+  arguments: (argument_list . (interpreted_string_literal) @printf))
+
+(call_expression
+  function: (selector_expression
+              field: (field_identifier) @_method)
+  (#eq? @_method "Fprintf")
+  arguments: (argument_list (_) . (interpreted_string_literal) @printf))

--- a/queries/hlsl/injections.scm
+++ b/queries/hlsl/injections.scm
@@ -1,3 +1,3 @@
-(preproc_arg) @hlsl
+; inherits: c
 
-(comment) @comment
+(preproc_arg) @hlsl

--- a/queries/java/injections.scm
+++ b/queries/java/injections.scm
@@ -1,1 +1,6 @@
 [(block_comment) (line_comment)] @comment
+
+(method_invocation
+  name: (identifier) @_method
+  (#any-of? @_method "format" "printf")
+  arguments: (argument_list . [(string_literal) (text_block)] @printf))

--- a/queries/kotlin/injections.scm
+++ b/queries/kotlin/injections.scm
@@ -30,3 +30,13 @@
 		(value_arguments
 			(value_argument
 				[ (line_string_literal) (multi_line_string_literal) ] @regex))))
+
+; "pi = %.2f".format(3.14159)
+(call_expression
+  (navigation_expression
+    [
+      (line_string_literal)
+      (multi_line_string_literal)
+    ] @printf
+    (navigation_suffix (simple_identifier) @_method)
+    (#eq? @_method "format")))

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -19,4 +19,18 @@
 ;; highlight string as query if starts with `;; query`
 ((string ("string_content") @query) (#lua-match? @query "^%s*;+%s?query"))
 
+; string.format("pi = %.2f", 3.14159)
+(function_call
+  (dot_index_expression
+    field: (identifier) @_method
+    (#eq? @_method "format"))
+  arguments: (arguments . (string) @printf))
+
+; ("pi = %.2f"):format(3.14159)
+(function_call
+  (method_index_expression
+    table: (_ (string) @printf)
+    method: (identifier) @_method
+    (#eq? @_method "format")))
+
 (comment) @comment

--- a/queries/printf/highlights.scm
+++ b/queries/printf/highlights.scm
@@ -1,0 +1,1 @@
+(format) @character

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -5,4 +5,8 @@
  (#eq? @_re "re")
  (#lua-match? @regex "^r.*"))
 
+(binary_operator
+  left: (string) @printf
+  operator: "%")
+
 (comment) @comment

--- a/queries/teal/highlights.scm
+++ b/queries/teal/highlights.scm
@@ -108,24 +108,4 @@
       . ">" @punctuation.bracket)))
 [ "(" ")" "[" "]" "{" "}" ] @punctuation.bracket
 
-;; Only highlight format specifiers in calls to string.format
-;; string.format('...')
-;(function_call
-;  called_object: (index
-;    (identifier) @base
-;    key: (identifier) @entry)
-;  arguments: (arguments .
-;    (string (format_specifier) @string.escape))
-;
-;  (#eq? @base "string")
-;  (#eq? @entry "format"))
-
-;; ('...'):format()
-;(function_call
-;  called_object: (method_index
-;    (string (format_specifier) @string.escape)
-;    key: (identifier) @func-name)
-;    (#eq? @func-name "format"))
-
-
 (ERROR) @error

--- a/queries/teal/injections.scm
+++ b/queries/teal/injections.scm
@@ -24,4 +24,19 @@
   (#offset! @c 0 2 0 -2)
 )
 
+; string.format('...')
+(function_call
+  (index
+    (identifier) @_base
+    key: (identifier) @_entry)
+  (arguments . (string) @printf)
+  (#eq? @_base "string")
+  (#eq? @_entry "format"))
+
+; ('...'):format()
+(function_call
+  (method_index (string) @printf
+    key: (identifier) @_func)
+    (#eq? @_func "format"))
+
 (comment) @comment


### PR DESCRIPTION
I used `@character` to differentiate format strings from other special characters.
The user can define `@character.printf` to customise the highlight.

There're probably more languages that can use format strings but these are the ones I'm familiar with.
Note that `{}`-style format strings (Python, Rust, etc.) are not supported by this grammar.

Closes #3546 & closes #2917.