### PR TITLE
highlights(proto): highlight optional

### DIFF
--- a/queries/proto/highlights.scm
+++ b/queries/proto/highlights.scm
@@ -9,6 +9,7 @@
   "message"
   "enum"
   "oneof"
+  "optional"
   "repeated"
   "reserved"
   "to"


### PR DESCRIPTION
`optional` came back with protobuf 3.15 as a valid modifier so highlight it the same way as `repeated`.