### PR TITLE
feat(swift): sync highlight queries with upstream

### DIFF
--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -34,15 +34,15 @@
   "struct"
   "class"
   "actor"
-  "nonisolated"
   "enum"
   "protocol"
   "extension"
   "indirect"
-  "some"
+  "nonisolated"
   "override"
   "convenience"
   "required"
+  "some"
 ] @keyword
 
 [
@@ -123,6 +123,9 @@
 (real_literal) @float
 (boolean_literal) @boolean
 "nil" @variable.builtin
+
+; Regex literals
+(regex_literal) @string.regex
 
 ; Operators
 (custom_operator) @operator


### PR DESCRIPTION
Upstream highlight queries have added support for Swift regex literals. This change brings that support to nvim-treesitter.

Also includes some minor reordering of modifiers for logical consistency (no impact on highlighting behavior).
