### PR TITLE
Refactor Julia highlights

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -186,7 +186,7 @@
     "revision": "0475a5017ad7dc84845d1d33187f2321abcb261d"
   },
   "julia": {
-    "revision": "0572cebf7b8e8ef5990b4d1e7f44f0b36f62922c"
+    "revision": "8fb38abff74652c4faddbf04d2d5bbbc6b4bae25"
   },
   "kotlin": {
     "revision": "a4f71eb9b8c9b19ded3e0e9470be4b1b77c2b569"

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -1,87 +1,25 @@
+;;; Identifiers
+
 (identifier) @variable
 
-(operator) @operator
-(range_expression ":" @operator)
-(pair_expression "=>" @operator)
-
-;; In case you want type highlighting based on Julia naming conventions (this might collide with mathematical notation)
-;((identifier) @type ; exception: mark `A_foo` sort of identifiers as variables
-  ;(match? @type "^[A-Z][^_]"))
+; ;; If you want type highlighting based on Julia naming conventions (this might collide with mathematical notation)
+; ((identifier) @type
+;   (match? @type "^[A-Z][^_]"))  ; exception: Highlight `A_foo` sort of identifiers as variables
 
 (macro_identifier) @function.macro
-(macro_identifier (identifier) @function.macro) ; for any one using the variable highlight
+(macro_identifier
+  (identifier) @function.macro) ; for any one using the variable highlight
+
 (macro_definition
-  name: (identifier) @function.macro
-  ["macro" "end" @keyword])
+  name: (identifier) @function.macro)
+
+(quote_expression ":" (identifier)) @symbol
+
+
+;;; Fields and indexes
 
 (field_expression
-  (identifier)
   (identifier) @field .)
-
-(function_definition
-  name: (identifier) @function)
-(call_expression
-  (identifier) @function.call)
-(call_expression
-  (field_expression (identifier) @method.call .))
-(broadcast_call_expression
-  (identifier) @function.call)
-(broadcast_call_expression
-  (field_expression (identifier) @method.call .))
-(parameter_list
-  (identifier) @parameter)
-(parameter_list
-  (optional_parameter .
-    (identifier) @parameter))
-(typed_parameter
-  (identifier) @parameter
-  (identifier) @type)
-(type_parameter_list
-  (identifier) @type)
-(typed_parameter
-  (identifier) @parameter
-  (parameterized_identifier) @type)
-(function_expression
-  . (identifier) @parameter)
-(spread_parameter) @parameter
-(spread_parameter
-  (identifier) @parameter)
-(named_argument
-    . (identifier) @parameter)
-(argument_list
-  (typed_expression
-    (identifier) @parameter
-    (identifier) @type))
-(argument_list
-  (typed_expression
-    (identifier) @parameter
-    (parameterized_identifier) @type))
-
-;; Symbol expressions (:my-wanna-be-lisp-keyword)
-(quote_expression
- (identifier)) @symbol
-
-;; Parsing error! foo (::Type) gets parsed as two quote expressions
-(argument_list
-  (quote_expression
-    (quote_expression
-      (identifier) @type)))
-
-(type_argument_list
-  (identifier) @type)
-(parameterized_identifier (_)) @type
-(argument_list
-  (typed_expression . (identifier) @parameter))
-
-(typed_expression
-  (identifier) @type .)
-(typed_expression
-  (parameterized_identifier) @type .)
-
-(abstract_definition
-  name: (identifier) @type)
-(struct_definition
-  name: (identifier) @type)
 
 (subscript_expression
   (_)
@@ -89,7 +27,109 @@
     (identifier) @constant.builtin .)
   (#eq? @constant.builtin "end"))
 
+
+;;; Function names
+
+;; definitions
+
+(function_definition
+  name: (identifier) @function)
+(short_function_definition
+  name: (identifier) @function)
+
+(function_definition
+  name: (scoped_identifier (identifier) @function .))
+(short_function_definition
+  name: (scoped_identifier (identifier) @function .))
+
+;; calls
+
+(call_expression
+  (identifier) @function.call)
+(call_expression
+  (field_expression (identifier) @function.call .))
+
+(broadcast_call_expression
+  (identifier) @function.call)
+(broadcast_call_expression
+  (field_expression (identifier) @function.call .))
+
+
+;;; Parameters
+
+(parameter_list
+  (identifier) @parameter)
+(optional_parameter .
+  (identifier) @parameter)
+(slurp_parameter
+  (identifier) @parameter)
+
+(typed_parameter
+  parameter: (identifier) @parameter
+  type: (_) @type)
+(typed_parameter
+  type: (_) @type)
+
+(function_expression
+  . (identifier) @parameter) ; Single parameter arrow functions
+
+
+;;; Types
+
+;; Definitions
+
+(abstract_definition
+  name: (identifier) @type)
+(primitive_definition
+  name: (identifier) @type)
+(struct_definition
+  name: (identifier) @type)
+
+;; Annotations
+
+(parameterized_identifier (_) @type)
+
+(type_parameter_list
+  (identifier) @type)
+
+(type_argument_list
+  (identifier) @type)
+
+(typed_expression
+  (identifier) @type .)
+
+(function_definition
+  return_type: (identifier) @type)
+(short_function_definition
+  return_type: (identifier) @type)
+
+(where_clause
+  (identifier) @type) ; where clause without braces
+
+
+;;; Keywords
+
+[
+  "abstract"
+  "const"
+  "macro"
+  "primitive"
+  "struct"
+  "type"
+  "mutable"
+  "where"
+] @keyword
+
 "end" @keyword
+
+((identifier) @keyword (#any-of? @keyword "global" "local")) ; Grammar error
+
+(compound_expression
+  ["begin" "end"] @keyword)
+(quote_statement
+  ["quote" "end"] @keyword)
+(let_statement
+  ["let" "end"] @keyword)
 
 (if_statement
   ["if" "end"] @conditional)
@@ -100,60 +140,67 @@
 (ternary_expression
   ["?" ":"] @conditional)
 
-(function_definition ["function" "end"] @keyword.function)
-
-[
-  "abstract"
-  "const"
-  "macro"
-  "primitive"
-  "struct"
-  "type"
-  "mutable"
-] @keyword
-
-"return" @keyword.return
-
-((identifier) @keyword (#any-of? @keyword "global" "local"))
-
-(compound_expression
-  ["begin" "end"] @keyword)
 (try_statement
-  ["try" "end" ] @exception)
+  ["try" "end"] @exception)
 (finally_clause
   "finally" @exception)
 (catch_clause
   "catch" @exception)
-(quote_statement
-  ["quote" "end"] @keyword)
-(let_statement
-  ["let" "end"] @keyword)
+
 (for_statement
   ["for" "end"] @repeat)
 (while_statement
   ["while" "end"] @repeat)
-(break_statement) @repeat
-(continue_statement) @repeat
 (for_clause
   "for" @repeat)
-(do_clause
-  ["do" "end"] @keyword)
-
-"in" @keyword.operator
-
-(export_statement
-  ["export"] @include)
-
-(import_statement
-  ["import" "using"] @include)
+[
+  (break_statement)
+  (continue_statement)
+] @repeat
 
 (module_definition
-  ["module" "end"] @include)
+  ["module" "baremodule" "end"] @include)
+(import_statement
+  ["import" "using"] @include)
+(export_statement
+  "export" @include)
 
-((identifier) @include (#eq? @include "baremodule"))
+(macro_definition
+  ["macro" "end" @keyword])
+
+(function_definition
+  ["function" "end"] @keyword.function)
+(do_clause
+  ["do" "end"] @keyword.function)
+(function_expression
+  "->" @keyword.function)
+(return_statement
+  "return" @keyword.return)
+
+
+;;; Operators & Punctuation
+
+(operator) @operator
+(for_binding ["in" "=" "∈"] @operator)
+(pair_expression "=>" @operator)
+(range_expression ":" @operator)
+
+(slurp_parameter "..." @operator)
+(spread_expression "..." @operator)
+
+"." @operator
+["::" "<:"] @operator
+
+["," ";"] @punctuation.delimiter
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 
 
 ;;; Literals
+
+[
+  (true)
+  (false)
+] @boolean
 
 (integer_literal) @number
 (float_literal) @float
@@ -161,9 +208,6 @@
 ((identifier) @float
   (#any-of? @float "NaN" "NaN16" "NaN32"
                    "Inf" "Inf16" "Inf32"))
-
-((identifier) @boolean
-  (#any-of? @boolean "true" "false"))
 
 ((identifier) @constant.builtin
   (#any-of? @constant.builtin "nothing" "missing"))
@@ -184,8 +228,3 @@
   (block_comment)
 ] @comment
 
-;;; Punctuation
-
-(quote_expression ":" @symbol)
-["::" "." "," "..."] @punctuation.delimiter
-["[" "]" "(" ")" "{" "}"] @punctuation.bracket

--- a/queries/julia/locals.scm
+++ b/queries/julia/locals.scm
@@ -1,59 +1,83 @@
+;;; Variables
+(assignment_expression
+  (identifier) @definition.var)
+(assignment_expression
+  (tuple_expression
+    (identifier) @definition.var))
+(assignment_expression
+  (bare_tuple_expression
+    (identifier) @definition.var))
 
-(import_statement
- (identifier) @definition.import)
+
+;;; let/const bindings
 (variable_declaration
  (identifier) @definition.var)
 (variable_declaration
  (tuple_expression
   (identifier) @definition.var))
-(for_binding
- (identifier) @definition.var)
-(for_binding
- (tuple_expression
-  (identifier) @definition.var))
 
-(assignment_expression
- (tuple_expression
-  (identifier) @definition.var))
-(assignment_expression
- (bare_tuple_expression
-  (identifier) @definition.var))
-(assignment_expression
- (identifier) @definition.var)
+
+;;; For bindings
+(for_binding
+  (identifier) @definition.var)
+(for_binding
+  (tuple_expression
+    (identifier) @definition.var))
+
+
+;;; Types
+
+(struct_definition
+  name: (identifier) @definition.type)
+(abstract_definition
+  name: (identifier) @definition.type)
+(abstract_definition
+  name: (identifier) @definition.type)
 
 (type_parameter_list
   (identifier) @definition.type)
-(type_argument_list
-  (identifier) @definition.type)
-(struct_definition
-  name: (identifier) @definition.type)
+
+;;; Module imports
+
+(import_statement
+  (identifier) @definition.import)
+
+
+;;; Parameters
 
 (parameter_list
- (identifier) @definition.parameter)
+  (identifier) @definition.parameter)
+(optional_parameter .
+  (identifier) @definition.parameter)
+(slurp_parameter
+  (identifier) @definition.parameter)
+
 (typed_parameter
- (identifier) @definition.parameter
- (identifier))
+  parameter: (identifier) @definition.parameter
+  (_))
+
 (function_expression
- . (identifier) @definition.parameter)
-(argument_list
- (typed_expression
-  (identifier) @definition.parameter
-  (identifier)))
-(spread_parameter
- (identifier) @definition.parameter)
+ . (identifier) @definition.parameter) ;; Single parameter arrow function
+
+
+;;; Function/macro definitions
 
 (function_definition
- name: (identifier) @definition.function) @scope
+  name: (identifier) @definition.function) @scope
+(short_function_definition
+  name: (identifier) @definition.function) @scope
 (macro_definition 
- name: (identifier) @definition.macro) @scope
+  name: (identifier) @definition.macro) @scope
 
 (identifier) @reference
 
 [
-  (try_statement)
-  (finally_clause)
-  (quote_statement)
-  (let_statement)
-  (compound_expression)
   (for_statement)
+  (while_statement)
+  (try_statement)
+  (catch_clause)
+  (finally_clause)
+  (let_statement)
+  (quote_statement)
+  (do_clause)
 ] @scope


### PR DESCRIPTION
See https://github.com/tree-sitter/tree-sitter-julia/pull/54

Remove a bunch of patterns with `argument_list`. No longer necessary
with `short_function_definition`.

Other minor changes including:

- Add boolean literals See
  https://github.com/tree-sitter/tree-sitter-julia/pull/44
- Add highlights for `for_binding` and `subtype_clause` operators