### PR TITLE
highlights(cpp): add alternative operator names

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -158,20 +158,17 @@
  "new"
  "delete"
 
- ;; these keywords are not supported by the parser
- ;"eq"
- ;"not_eq"
- ;
- ;"compl"
- ;"and"
- ;"or"
- ;
- ;"bitand"
- ;"bitand_eq"
- ;"bitor"
- ;"bitor_eq"
- ;"xor"
- ;"xor_eq"
+ "xor"
+ "bitand"
+ "bitor"
+ "compl"
+ "not"
+ "xor_eq"
+ "and_eq"
+ "or_eq"
+ "not_eq"
+ "and"
+ "or"
 ] @keyword.operator
 
 "<=>" @operator


### PR DESCRIPTION
These keywords are now supported by the parser.
See: https://github.com/tree-sitter/tree-sitter-cpp/pull/179