### PR TITLE
fix(julia): remove highlight query for constants

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -7,8 +7,6 @@
 ;; In case you want type highlighting based on Julia naming conventions (this might collide with mathematical notation)
 ;((identifier) @type ; exception: mark `A_foo` sort of identifiers as variables
   ;(match? @type "^[A-Z][^_]"))
-((identifier) @constant
-  (#match? @constant "^[A-Z][A-Z_]{2}[A-Z_]*$"))
 
 (macro_identifier) @function.macro
 (macro_identifier (identifier) @function.macro) ; for any one using the variable highlight


### PR DESCRIPTION
This patch removes the highlight query for constant identifiers based on capitalization. This led to inconsistent highlighting since e.g. `AA` would be a regular identifier, but `AAA` a constant. It is indeed true that some constants are uppercase only identifiers, but there are also constants which doesn't follow this pattern. Since there are no rules about this it seems better to not try to guess.