### PR TITLE
feat(phpdoc): Remove requires_generate_from_grammar

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -777,8 +777,6 @@ list.phpdoc = {
   install_info = {
     url = "https://github.com/claytonrcarter/tree-sitter-phpdoc",
     files = { "src/parser.c", "src/scanner.c" },
-    -- parser.c in the repo still based on TS 0.17 due to other dependencies
-    requires_generate_from_grammar = true,
     generate_requires_npm = true,
   },
   maintainers = { "@mikehaertl" },


### PR DESCRIPTION
The parser is now on latest treesitter version: 

https://github.com/claytonrcarter/tree-sitter-phpdoc/pull/23

So this should no longer be required. It was added as it still used TS 0.17.3 before (See https://github.com/nvim-treesitter/nvim-treesitter/pull/2280#discussion_r786279693)