### PR TITLE
highlights(rust): namespace/type confusion; highlight `for<'a>` and bracketed types better

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -268,6 +268,8 @@
 (closure_parameters "|"    @punctuation.bracket)
 (type_arguments  ["<" ">"] @punctuation.bracket)
 (type_parameters ["<" ">"] @punctuation.bracket)
+(bracketed_type ["<" ">"] @punctuation.bracket)
+(for_lifetimes ["<" ">"] @punctuation.bracket)
 
 ["," "." ":" "::" ";"] @punctuation.delimiter
 

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -72,6 +72,9 @@
 (scoped_type_identifier
   path: (identifier) @namespace)
 (scoped_type_identifier
+  path: (identifier) @type
+  (#lua-match? @type "^[A-Z]"))
+(scoped_type_identifier
  (scoped_identifier
   name: (identifier) @namespace))
 ((scoped_identifier

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -204,7 +204,8 @@
 
 (use_list (self) @keyword)
 (scoped_use_list (self) @keyword)
-(scoped_identifier (self) @keyword)
+(scoped_identifier [(crate) (super) (self)] @keyword)
+(visibility_modifier [(crate) (super) (self)] @keyword)
 
 [
   "else"

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -219,8 +219,7 @@
   "while"
 ] @repeat
 
-(impl_item
-  "for" @keyword)
+"for" @keyword
 (for_expression
   "for" @repeat)
 


### PR DESCRIPTION
#### 1. `@namespace` -> `@type` fix

```rust
trait Trait { type Assoc; }
fn thing<T: Trait>(arg: T::Assoc) {}
```

Previously, T in `T::Assoc` was highlighted as `@namespace`. Now it's `@type`.

#### 2. `for_lifetimes` highlights

Highlights the for as a keyword, and the angle brackets as brackets.

```rust
type T = &'static dyn for<'a> Fn(&'a str) -> i32;
```

#### 3. `<T as Trait>` brackets (`bracketed_type`)

Highlights the angle brackets as brackets.

```rust
type A = <B as Trait>::Assoc;
<B as Trait>::method(5);
```

#### Before:

<img width="571" alt="Screen Shot 2022-10-18 at 12 17 55 pm" src="https://user-images.githubusercontent.com/378760/196403891-44376d62-222e-4564-a5c2-90cccc0b04a8.png">

#### After:

<img width="579" alt="Screen Shot 2022-10-18 at 12 17 05 pm" src="https://user-images.githubusercontent.com/378760/196403915-a259a38e-b304-43d8-ba5a-1b86f6e06d5e.png">
