### PR TITLE
feat(diff): add diff parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,9 @@ Mainly for markup languages.
 @text.note             ; info notes
 @text.warning          ; warning notes
 @text.danger           ; danger/error notes
+
+@text.diff.add         ; added text (for diff files)
+@text.diff.delete      ; deleted text (for diff files)
 ```
 
 #### Tags

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [d](https://github.com/CyberShadow/tree-sitter-d) (experimental, maintained by @nawordar)
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @Akin909)
 - [x] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree) (maintained by @jedrzejboczar)
+- [x] [diff](https://github.com/the-mikedavis/tree-sitter-diff) (maintained by @gbprod)
 - [x] [dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) (maintained by @camdencheek)
 - [x] [dot](https://github.com/rydesun/tree-sitter-dot) (maintained by @rydesun)
 - [x] [eex](https://github.com/connorlay/tree-sitter-eex) (maintained by @connorlay)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1238,6 +1238,16 @@ list.twig = {
   filetype = "twig",
 }
 
+list.diff = {
+  install_info = {
+    url = "https://github.com/the-mikedavis/tree-sitter-diff",
+    branch = "main",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@gbprod" },
+  filetype = "gitdiff",
+}
+
 local M = {
   list = list,
   filetype_to_parsername = filetype_to_parsername,

--- a/queries/diff/highlights.scm
+++ b/queries/diff/highlights.scm
@@ -1,0 +1,6 @@
+[(addition) (new_file)] @text.diff.add
+[(deletion) (old_file)] @text.diff.delete
+
+(commit) @constant
+(location) @attribute
+(command) @function


### PR DESCRIPTION
This commit introduce diff parser.

I'm not sure but I introduce new highlights (`@diff.add` and `@diff.delete`) as I can't find any highlight matching to this usage.

Parser comes from https://github.com/the-mikedavis/tree-sitter-diff

Thanks for your awesome work !