### PR TITLE
highlights(rust): panic!() and assert!() as @exception

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -273,3 +273,8 @@
 (inner_attribute_item ["!" "#"] @punctuation.special)
 (macro_invocation "!" @function.macro)
 (empty_type "!" @type.builtin)
+
+(macro_invocation macro: (identifier) @_ident @exception "!" @exception
+ (#eq? @_ident "panic"))
+(macro_invocation macro: (identifier) @_ident @exception "!" @exception
+ (#contains? @_ident "assert"))


### PR DESCRIPTION
This is what rust.vim used to do with the rustPanic and rustAssert highlight groups. If I'm remembering right, this is slightly better as it also catches `debug_assert!()`.

Edit: for clarity `println!` still highlights as `@function.macro`.

<img width="345" alt="Screen Shot 2022-10-18 at 1 30 46 pm" src="https://user-images.githubusercontent.com/378760/196417910-7bd51fb3-663a-48cc-a400-064198aae6e9.png">
