### PR TITLE
ci: publish parsers as prerelease

### DIFF
--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -84,3 +84,16 @@ jobs:
 
       - name: Check query files
         run: $NVIM --headless -c "luafile ./scripts/check-queries.lua" -c "q"
+
+      - name: Compress parsers
+        run: tar czf parsers-${{ matrix.os }}-${{ matrix.cc }}.tar.gz parser
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+           repo_token: "${{ secrets.GITHUB_TOKEN }}"
+           automatic_release_tag: "latest-parsers-${{ matrix.os }}-${{ matrix.cc }}"
+           prerelease: true
+           title: "Parser artifacts (${{ matrix.os }}-${{ matrix.cc }})"
+           files: |
+             parsers-${{ matrix.os }}-${{ matrix.cc }}.tar.gz


### PR DESCRIPTION
This could be the basis for a commend `:TSUpdateBinary`

Comparison between different release mechanism:

- GH packages
        :-1:  requires supported package manager: e.g. npm, ruby gems, vcpkg, container images (how does brew use GH packages? Via Ruby gems? Is it a packages manager supported by GH backend?)
        :+1:  arbitrary versions available
- Create prerelease with individual parsers as release artifacts:
        :-1: :   works for one OS, multiple OSes hit Github API (solvable with custom GH API key?)
        :-1:  only latest available
- Create prerelease with all parsers bundled as artifacts:
        :+1:  works for multiple OSes hit Github API, file size of bundles ~7-~15MB (~100MB uncompressed, pick only those needed for TSUpdateBinary, cl.exe output bigger than by other compilers) -> https://github.com/theHamsta/nvim-treesitter/releases
        :-1:  only latest available

For all :    
 :-1: only have parsers our CI currently compilers. For some configs, we're missing parsers that require npm (at least I think that not all parsers are not always installed except for Ubuntu).

Binaries will be available as `https://github.com/nvim-treesitter/nvim-treesitter/releases/download/latest-parsers-{{ matrix.os }}-{{ matrix.cc }}/parsers-{{ matrix.os }}-{{ matrix.cc }.tar.gz`