### PR TITLE
Disable folding at startup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Tree-sitter based folding. *(Technically not a module because it's per windows a
 ```vim
 set foldmethod=expr
 set foldexpr=nvim_treesitter#foldexpr()
+set foldenable=false                     -- Disable folding at startup. 
 ```
 
 This will respect your `foldminlines` and `foldnestmax` settings.


### PR DESCRIPTION
As discussed per issue https://github.com/nvim-treesitter/nvim-treesitter/issues/3642 .

This PR adds a line to README.md for the configuration. It's now possible to enable folding via nvim-treesitter but disable folding everything at startup. 
Tested with vim -d to see if folding during diff editing still works. 