### PR TITLE
fix(bash): Rename ansii_c_string to ansi_c_string.

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "947e93089e60c66e681eba22283f4037841451e7"
   },
   "bash": {
-    "revision": "275effdfc0edce774acf7d481f9ea195c6c403cd"
+    "revision": "385a8e4d383f6c045965d1de9c514932319dea4b"
   },
   "beancount": {
     "revision": "4cbd1f09cd07c1f1fabf867c2cf354f9da53cc4c"

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -43,7 +43,7 @@
 [
  (string)
  (raw_string)
- (ansii_c_string)
+ (ansi_c_string)
  (heredoc_body)
 ] @string @spell
 


### PR DESCRIPTION
This patch renamed `ansii_c_string` to `ansi_c_string` to match the upstream change.

See https://github.com/tree-sitter/tree-sitter-bash/pull/121.