### PR TITLE
highlights(comment) Use @text.todo as default tag highlight

### DIFF
--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -7,7 +7,7 @@
 
 ":" @punctuation.delimiter
 
-(tag (name) @text.note (user)? @constant)
+(tag (name) @text.todo (user)? @constant)
 
 ((tag ((name) @text.note))
  (#any-of? @text.note "NOTE"))


### PR DESCRIPTION
None of the other highlight names in the query file are linked to a default highlight. By using `@text.todo` as the base highlight, we can ensure that all comment tags will fall back to be highlighted as the standard `Todo` highlight, which is more likely to be defined in color schemes than `@text.note`.

Color schemes can still define `@text.note`, `@text.warning` and `@text.danger` for more fine-grained highlighting of specific tag names.