### PR TITLE
highlights(python): add "except*"

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -273,7 +273,7 @@
     "revision": "63e214905970e75f065688b1e8aa90823c3aacdc"
   },
   "python": {
-    "revision": "de221eccf9a221f5b85474a553474a69b4b5784d"
+    "revision": "b14614e2144b8f9ee54deed5a24f3c6f51f9ffa8"
   },
   "ql": {
     "revision": "bd087020f0d8c183080ca615d38de0ec827aeeaf"

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -246,6 +246,7 @@
 [
   "try"
   "except"
+  "except*"
   "raise"
   "finally"
 ] @exception


### PR DESCRIPTION
Added in https://github.com/tree-sitter/tree-sitter-python/pull/176

About the feature https://realpython.com/python311-exception-groups/#exception-groups-and-except-in-python-311