### PR TITLE
fix(ocaml): change query order for Variables

### DIFF
--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -18,6 +18,13 @@
 
 [(constructor_name) (tag)] @constructor
 
+; Variables
+;----------
+
+[(value_name) (type_variable)] @variable
+
+(value_pattern) @parameter
+
 ; Functions
 ;----------
 
@@ -34,13 +41,6 @@
 (external (value_name) @function)
 
 (method_name) @method
-
-; Variables
-;----------
-
-[(value_name) (type_variable)] @variable
-
-(value_pattern) @parameter
 
 ; Application
 ;------------


### PR DESCRIPTION
By moving the Variables query higher it gives the @variable capture group a lower precedence when highlighting.
This makes it possible to distinguish between @function and @variable.

Fixes tree-sitter/tree-sitter-ocaml#61.