### PR TITLE
highlights(rust): handle non-builtin attributes

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -123,6 +123,7 @@
 ;; Attribute macros
 (attribute_item (meta_item (identifier) @function.macro))
 (meta_item (scoped_identifier (identifier) @function.macro .))
+(attribute_item (attr_item (identifier) @function.macro))
 
 ;; Derive macros (assume all arguments are types)
 (meta_item


### PR DESCRIPTION
Tree-sitter-rust changed attribute parsing a bit and non-builtin attributes have different identifier.
Added them to highlight as macros.
Not sure if anything else needs to be changed as well

Related issue: https://github.com/tree-sitter/tree-sitter-rust/issues/134