### PR TITLE
improve PHP variables and $this highlights

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -96,8 +96,8 @@
 
 (const_declaration (const_element (name) @constant))
 
-((name) @variable.builtin
- (#eq? @variable.builtin "this"))
+((variable_name) @variable.builtin
+ (#eq? @variable.builtin "$this"))
 
 ; Namespace
 (namespace_definition
@@ -142,7 +142,6 @@
 ] @keyword.function
 
 [
- "$"
  "abstract"
  "break"
  "class"


### PR DESCRIPTION
This pull request changes the way of highlighting "$" sign and variable name  in PHP. In PHP all variables starts from "$" and I see no good reason why they should have different color as they do for now.

Current highlight
![image](https://user-images.githubusercontent.com/26829020/198611334-04506ff5-e1be-4121-b7dc-eb9185c687cd.png)

After PR
<img width="758" alt="image" src="https://user-images.githubusercontent.com/26829020/198612004-344feea5-8754-4893-9991-4fd1cbbbe51e.png">

Maybe I'm missing something and some reasons exist for having different color?