### PR TITLE
feat: markdown table highlights and inline

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -19,6 +19,14 @@
   (fenced_code_block)
 ] @text.literal
 
+(pipe_table_header (pipe_table_cell) @text.title)
+[
+ (pipe_table_row)
+ (pipe_table_delimiter_row)
+ (pipe_table_header)
+] "|" @punctuation.special
+(pipe_table_delimiter_cell) @punctuation.special
+
 [
   (fenced_code_block_delimiter)
 ] @punctuation.delimiter

--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -9,4 +9,7 @@
 ((minus_metadata) @yaml (#offset! @yaml 1 0 -1 0))
 ((plus_metadata) @toml (#offset! @toml 1 0 -1 0))
 
-((inline) @markdown_inline (#exclude_children! @markdown_inline))
+([
+  (inline)
+  (pipe_table_cell)
+ ] @markdown_inline (#exclude_children! @markdown_inline))


### PR DESCRIPTION
This PR adds extra markdown support:
- [x] table pipe characters are mapped to `@punctuation.special`
- [x] table headers are mapped to `@text.title`
- [x] table cells will be parsed by `markdown_inline`

![image](https://user-images.githubusercontent.com/292349/198827735-03635519-1f99-48af-ad57-01b6368b9a37.png)

The only thing I'm not sure of, is that the `markdown_inline` for table cells with `conceallevel=3` would now mess existing table formatting without conceal.
![image](https://user-images.githubusercontent.com/292349/198827776-7da30530-fe74-4b40-92e8-09a71fe20bcf.png)
