### PR TITLE
markdown: fixup for #3736

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -20,11 +20,10 @@
 ] @text.literal
 
 (pipe_table_header (pipe_table_cell) @text.title)
-[
- (pipe_table_row)
- (pipe_table_delimiter_row)
- (pipe_table_header)
-] "|" @punctuation.special
+
+(pipe_table_header "|" @punctuation.special)
+(pipe_table_row "|" @punctuation.special)
+(pipe_table_delimiter_row "|" @punctuation.special)
 (pipe_table_delimiter_cell) @punctuation.special
 
 [


### PR DESCRIPTION
I wan't able to make this work. I think it's not possible right now, because of `\` in `markdown` and `backslash_escape` in `markdown_inline`.

@MDeiml you were right about my other PR though.

This fixes the `|` outside tables.