### PR TITLE
fix(configs): ensure_installed can be a string

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -11,7 +11,7 @@ local M = {}
 ---@class TSConfig
 ---@field modules {[string]:TSModule}
 ---@field sync_install boolean
----@field ensure_installed string[]
+---@field ensure_installed string[]|string
 ---@field ignore_install string[]
 ---@field auto_install boolean
 ---@field update_strategy string


### PR DESCRIPTION
I always get a warning when editing my dotfiles, as I have `ensure_installed = "all"`.
Let's fix it 😊 

Thanks for all your work guys!