### PR TITLE
test: remove bundled parsers in CI

### DIFF
--- a/queries/help/highlights.scm
+++ b/queries/help/highlights.scm
@@ -2,6 +2,8 @@
 (h2) @text.title
 (h3) @text.title
 (column_heading) @text.title
+(column_heading
+   "~" @conceal (#set! conceal ""))
 (tag
    "*" @conceal (#set! conceal "")
    text: (_) @label)
@@ -9,8 +11,15 @@
    "|" @conceal (#set! conceal "")
    text: (_) @text.reference)
 (optionlink
-   text: (_) @text.literal)
+   text: (_) @text.reference)
 (codespan
    "`" @conceal (#set! conceal "")
-   text: (_) @string)
+   text: (_) @text.literal)
+(codeblock) @text.literal
+(codeblock
+   ">" @conceal (#set! conceal ""))
+(block
+   "<" @conceal (#set! conceal ""))
 (argument) @parameter
+(keycode) @string.special
+(url) @text.uri

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -131,6 +131,11 @@
 ((identifier) @variable.builtin
  (#eq? @variable.builtin "self"))
 
+(variable_list
+   attribute: (attribute
+     (["<" ">"] @punctuation.bracket
+      (identifier) @attribute)))
+
 ;; Constants
 
 ((identifier) @constant

--- a/scripts/ci-install-macos-latest.sh
+++ b/scripts/ci-install-macos-latest.sh
@@ -1,5 +1,6 @@
 curl -L https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-macos.tar.gz | tar -xz
 sudo ln -s $(pwd)/nvim-macos/bin/nvim /usr/local/bin
+rm -rf $(pwd)/nvim-macos/lib/nvim/parser
 mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
 ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter/start
 

--- a/scripts/ci-install-ubuntu-latest.sh
+++ b/scripts/ci-install-ubuntu-latest.sh
@@ -1,10 +1,9 @@
 wget -O - https://github.com/tree-sitter/tree-sitter/releases/download/${TREE_SITTER_CLI_TAG}/tree-sitter-linux-x64.gz | gunzip -c > tree-sitter
 sudo cp ./tree-sitter /usr/bin/tree-sitter
 sudo chmod uog+rwx /usr/bin/tree-sitter
-wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim.appimage
-chmod u+x nvim.appimage
+wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux64.tar.gz
+tar -zxf nvim-linux64.tar.gz
+sudo ln -s $(pwd)/nvim-linux64/bin/nvim /usr/local/bin
+rm -rf $(pwd)/nvim-linux64/lib/nvim/parser
 mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
 ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter/start
-sudo cp ./nvim.appimage /usr/bin/nvim
-sudo chmod uog+rwx /usr/bin/nvim
-


### PR DESCRIPTION
Remove bundled parsers in CI to make sure we test queries against the parser version specified in the lockfile.

Also bump `help` and `lua` queries (which were blocked by this issue) while I'm at it.