### PR TITLE
highlights(ecma): distinguish between "default" in export and switch

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -207,7 +207,6 @@
 "else"
 "switch"
 "case"
-"default"
 ] @conditional
 
 [
@@ -267,3 +266,8 @@
  "catch"
  "finally"
 ] @exception
+
+(export_statement
+  "default" @keyword)
+(switch_default
+  "default" @conditional)


### PR DESCRIPTION
`default` keyword is used in [switch statements](https://262.ecma-international.org/12.0/#prod-DefaultClause) and [export declarations](https://262.ecma-international.org/12.0/#prod-ExportDeclaration).

In switch statements it must be highlighted as `@conditional`.
In export declarations it must be highlighted as `@keyword`.