### PR TITLE
feat: vimscript injections for string args

### DIFF
--- a/queries/vim/injections.scm
+++ b/queries/vim/injections.scm
@@ -25,3 +25,18 @@
     "charconvert" "ccv"))
 
 (comment) @comment
+
+(call_expression
+  function: (identifier) @_func
+  (_)
+  (string_literal) @vim
+  (#any-of @_func "map" "filter")
+  (#offset! @vim 0 1 0 -1)
+)
+
+(call_expression
+  function: (identifier) @_func
+  (string_literal) @vim
+  (#eq? @_func "call")
+  (#offset! @vim 0 1 0 -1)
+)


### PR DESCRIPTION
This doesn't yet work properly as these kinds of injections require a `call ` prefix on the node text to parse as desired.

It might be better to hard code these injections into the parser itself.