### PR TITLE
highlights(ecma): remove `switch` from `@keyword`

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -239,7 +239,6 @@
 "let"
 "set"
 "static"
-"switch"
 "target"
 "typeof"
 "var"


### PR DESCRIPTION
 `switch` must be removed from `@keyword` because it's already highlighted as `@conditional`
 
 ---
 
> In your screen shot it looks like `switch` is not highlighted as `@conditional`. Maybe that could be adapted as well...

It's `@keyword` and `@conditional` at same time.
![image](https://user-images.githubusercontent.com/68790724/201118059-26907052-c3ad-4385-ac41-8be18dcda9c1.png)

I can create another PR to remove it from keywords

_Originally posted by @Trard in https://github.com/nvim-treesitter/nvim-treesitter/issues/3778#issuecomment-1310383801_

 ---