### PR TITLE
fix(astro): make the script element use typescript instead of javascript

### DIFF
--- a/queries/astro/injections.scm
+++ b/queries/astro/injections.scm
@@ -5,3 +5,6 @@
 
 ((interpolation
     (raw_text) @tsx))
+
+((script_element
+    (raw_text) @typescript))


### PR DESCRIPTION
The Astro parser should use the typescript parser for the `<script>` element instead of the javascript parser as defined by `; inherits: html`. This overrides it.

Note: Is this the correct way to do things? Does this completely override the HTML `javascript` injection or will this break at some point?