### PR TITLE
fix(installer): ignore globally installed parsers

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -574,7 +574,7 @@ end
 ---plugin first, followed by the "site" dir from "runtimepath". "site" dir will
 ---be created if it doesn't exist. Using only the package dir won't work when
 ---the plugin is installed with Nix, since the "/nix/store" is read-only.
----@param folder_name string
+---@param folder_name string|nil
 ---@return string|nil, string|nil
 function M.get_parser_install_dir(folder_name)
   folder_name = folder_name or "parser"

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -91,10 +91,18 @@ local function get_installed_revision(lang)
   end
 end
 
+---Checks if parser is installed with nvim-treesitter
 ---@param lang string
 ---@return boolean
 local function is_installed(lang)
-  return #api.nvim_get_runtime_file("parser/" .. lang .. ".so", false) > 0
+  local matched_parsers = vim.api.nvim_get_runtime_file("parser/" .. lang .. ".so", true) or {}
+  for _, path in ipairs(matched_parsers) do
+    local install_dir = configs.get_parser_install_dir()
+    if vim.startswith(path, install_dir) then
+      return true
+    end
+  end
+  return false
 end
 
 ---@param lang string


### PR DESCRIPTION
### Problem

`is_installed` is picking up parsers shipped by neovim v0.8 and these parsers have unknown version
and compatability.

_Note: this applies to any parser found in the rtp_

https://github.com/nvim-treesitter/nvim-treesitter/blob/2072692aaa4b6da7c354e66c2caf4b0a8f736858/lua/nvim-treesitter/install.lua#L94-L98

### Solution

only consider a parser installed if ~~its revision is available~~ it's available in the `parsers_install_dir`.

_Edit: the revision file can still remain after uninstalling a parser, so it's not reliable heuristic!_

