### PR TITLE
feat(arduino): separate from cpp

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2,7 +2,6 @@ local api = vim.api
 local ts = vim.treesitter
 
 local filetype_to_parsername = {
-  arduino = "cpp",
   javascriptreact = "javascript",
   ecma = "javascript",
   jsx = "javascript",
@@ -1298,6 +1297,14 @@ list.awk = {
     url = "https://github.com/Beaglefoot/tree-sitter-awk",
     files = { "src/parser.c", "src/scanner.c" },
   },
+}
+
+list.arduino = {
+  install_info = {
+    url = "https://github.com/ObserverOfTime/tree-sitter-arduino",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  maintainers = { "@ObserverOfTime" },
 }
 
 local M = {

--- a/queries/arduino/folds.scm
+++ b/queries/arduino/folds.scm
@@ -1,0 +1,1 @@
+; inherits: cpp

--- a/queries/arduino/highlights.scm
+++ b/queries/arduino/highlights.scm
@@ -1,0 +1,111 @@
+; inherits: cpp
+
+((identifier) @function.builtin
+ (#any-of? @function.builtin
+           ; Digital I/O
+           "digitalRead"
+           "digitalWrite"
+           "pinMode"
+           ; Analog I/O
+           "analogRead"
+           "analogReference"
+           "analogWrite"
+           ; Zero, Due & MKR Family
+           "analogReadResolution"
+           "analogWriteResolution"
+           ; Advanced I/O
+           "noTone"
+           "pulseIn"
+           "pulseInLong"
+           "shiftIn"
+           "shiftOut"
+           "tone"
+           ; Time
+           "delay"
+           "delayMicroseconds"
+           "micros"
+           "millis"
+           ; Math
+           "abs"
+           "constrain"
+           "map"
+           "max"
+           "min"
+           "pow"
+           "sq"
+           "sqrt"
+           ; Trigonometry
+           "cos"
+           "sin"
+           "tan"
+           ; Characters
+           "isAlpha"
+           "isAlphaNumeric"
+           "isAscii"
+           "isControl"
+           "isDigit"
+           "isGraph"
+           "isHexadecimalDigit"
+           "isLowerCase"
+           "isPrintable"
+           "isPunct"
+           "isSpace"
+           "isUpperCase"
+           "isWhitespace"
+           ; Random Numbers
+           "random"
+           "randomSeed"
+           ; Bits and Bytes
+           "bit"
+           "bitClear"
+           "bitRead"
+           "bitSet"
+           "bitWrite"
+           "highByte"
+           "lowByte"
+           ; External Interrupts
+           "attachInterrupt"
+           "detachInterrupt"
+           ; Interrupts
+           "interrupts"
+           "noInterrupts"
+           ))
+
+((identifier) @type.builtin
+ (#any-of? @type.builtin
+           "Serial"
+           "SPI"
+           "Stream"
+           "Wire"
+           "Keyboard"
+           "Mouse"
+           "String"
+           ))
+
+((identifier) @constant.builtin
+ (#any-of? @constant.builtin
+           "HIGH"
+           "LOW"
+           "INPUT"
+           "OUTPUT"
+           "INPUT_PULLUP"
+           "LED_BUILTIN"
+           ))
+
+(function_definition
+  (function_declarator
+    declarator: (identifier) @function.builtin)
+  (#any-of? @function.builtin "loop" "setup"))
+
+(call_expression
+  function: (primitive_type) @function.builtin)
+
+(call_expression
+  function: (identifier) @constructor
+  (#any-of? @constructor "SPISettings" "String"))
+
+(declaration
+  (type_identifier) @type.builtin
+  (function_declarator
+    declarator: (identifier) @constructor)
+  (#eq? @type.builtin "SPISettings"))

--- a/queries/arduino/indents.scm
+++ b/queries/arduino/indents.scm
@@ -1,0 +1,1 @@
+; inherits: cpp

--- a/queries/arduino/injections.scm
+++ b/queries/arduino/injections.scm
@@ -1,0 +1,3 @@
+(preproc_arg) @arduino
+
+(comment) @comment

--- a/queries/arduino/locals.scm
+++ b/queries/arduino/locals.scm
@@ -1,0 +1,1 @@
+; inherits: cpp


### PR DESCRIPTION
This handles the (few) extensions and (many) built-ins defined by Arduino.

Almost all extensions are already highlighted via the C queries.
The only exception is `PROGMEM` which depends on #3693 (839c89a).

See: https://www.arduino.cc/reference/en/
