### PR TITLE
improve highlights and injections for Nix

### DIFF
--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -49,13 +49,18 @@
 
 ; `?` in `{ x ? y }:`, used to set defaults for named function arguments
 ; I'm not really sure what group this should go in, but it should probably have highlighting, so I'm putting it in @punctuation.special
-(formal "?" @punctuation.special)
+(formal
+  name: (identifier) @parameter
+  "?"? @punctuation.special)
 
 ; `...` in `{ ... }`, used to ignore unknown named function arguments (see above)
 (ellipses) @punctuation.special
 
+; universal is the parameter of the function expression
 ; `:` in `x: y`, used to separate function argument from body (see above)
-(function_expression ":" @punctuation.special)
+(function_expression
+  universal: (identifier) @parameter
+  ":" @punctuation.special)
 
 ; basic identifiers
 (variable_expression) @variable

--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -1,1 +1,90 @@
 (comment) @comment
+
+(binding
+  attrpath: (attrpath (identifier) @_path)
+  expression: [
+    (string_expression (string_fragment) @bash)
+    (indented_string_expression (string_fragment) @bash)
+  ]
+  (#match? @_path "(^\\w*Phase|(pre|post)\\w*|(.*\\.)?\\w*([sS]cript|[hH]ook)|(.*\\.)?startup)$"))
+
+(apply_expression
+  function: (_) @_func
+  argument: (_ (_)* (_ (_)* (binding
+    attrpath: (attrpath (identifier) @_path)
+    expression: [
+      (string_expression (string_fragment) @bash)
+      (indented_string_expression (string_fragment) @bash)
+    ])))
+  (#match? @_func "(^|\\.)writeShellApplication$")
+  (#match? @_path "^text$"))
+
+(apply_expression
+  (apply_expression
+    function: (apply_expression function: (_) @_func)
+    argument: [
+      (string_expression (string_fragment) @bash)
+      (indented_string_expression (string_fragment) @bash)
+    ])
+  (#match? @_func "(^|\\.)runCommand(((No)?CC)?(Local)?)?$"))
+
+((apply_expression
+  function: (apply_expression function: (_) @_func)
+  argument: [
+    (string_expression (string_fragment) @bash)
+    (indented_string_expression (string_fragment) @bash)
+  ])
+  (#match? @_func "(^|\\.)write(Bash|Dash|ShellScript)(Bin)?$"))
+
+((apply_expression
+  function: (apply_expression function: (_) @_func)
+  argument: [
+    (string_expression (string_fragment) @fish)
+    (indented_string_expression (string_fragment) @fish)
+  ])
+  (#match? @_func "(^|\\.)writeFish(Bin)?$"))
+
+((apply_expression
+  function: (apply_expression
+    function: (apply_expression function: (_) @_func))
+  argument: [
+    (string_expression (string_fragment) @haskell)
+    (indented_string_expression (string_fragment) @haskell)
+  ])
+  (#match? @_func "(^|\\.)writeHaskell(Bin)?$"))
+
+((apply_expression
+  function: (apply_expression
+    function: (apply_expression function: (_) @_func))
+  argument: [
+    (string_expression (string_fragment) @javascript)
+    (indented_string_expression (string_fragment) @javascript)
+  ])
+  (#match? @_func "(^|\\.)writeJS(Bin)?$"))
+
+((apply_expression
+  function: (apply_expression
+    function: (apply_expression function: (_) @_func))
+  argument: [
+    (string_expression (string_fragment) @perl)
+    (indented_string_expression (string_fragment) @perl)
+  ])
+  (#match? @_func "(^|\\.)writePerl(Bin)?$"))
+
+((apply_expression
+  function: (apply_expression
+    function: (apply_expression function: (_) @_func))
+  argument: [
+    (string_expression (string_fragment) @python)
+    (indented_string_expression (string_fragment) @python)
+  ])
+  (#match? @_func "(^|\\.)write(PyPy|Python)[23](Bin)?$"))
+
+((apply_expression
+  function: (apply_expression
+    function: (apply_expression function: (_) @_func))
+  argument: [
+    (string_expression (string_fragment) @rust)
+    (indented_string_expression (string_fragment) @rust)
+  ])
+  (#match? @_func "(^|\\.)writeRust(Bin)?$"))

--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -1,5 +1,13 @@
 (comment) @comment
 
+(apply_expression
+  function: (_) @_func
+  argument: [
+    (string_expression (string_fragment) @regex)
+    (indented_string_expression (string_fragment) @regex)
+  ]
+  (#match? @_func "(^|\\.)match$"))
+
 (binding
   attrpath: (attrpath (identifier) @_path)
   expression: [


### PR DESCRIPTION
- highlight parameters
- add injections for code blocks (phases, runCommand*, writers) based on https://github.com/cstrahan/tree-sitter-nix/pull/31 by @nrdxp
- add injections for `builtins.match` (regex)