### PR TITLE
chore: print OS version on health report

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -94,6 +94,8 @@ local function install_health()
       )
     end
   end
+
+  health.report_start("OS Info:\n" .. vim.inspect(vim.loop.os_uname()))
 end
 
 local function query_status(lang, query_group)


### PR DESCRIPTION
Often we get issue report without knowing which version of Windows or Linux or MacOS they are running.

E.g.
```
nvim-treesitter: require("nvim-treesitter.health").check()

Installation ~
- OK `tree-sitter` found 0.20.7 (870fb8772f3e47b5aef4c7000a78d61f3aa2b005) (parser generator, only needed for :TSInstallFromGrammar)
- OK `node` found v17.9.1 (only needed for :TSInstallFromGrammar)
- OK `git` executable found.
- OK `/usr/lib/ccache/clang-16` executable found. Selected from { "/usr/lib/ccache/clang-16", "cc", "gcc", "clang", "cl", "zig" }
  Version: Ubuntu clang version 16.0.0 (++20221123042319+910204cfbdf3-1~exp1~20221123042440.568)
- OK Neovim was compiled with tree-sitter runtime ABI version 14 (required >=13). Parsers must be compatible with runtime ABI.

OS Info:
{
  machine = "x86_64",
  release = "5.15.0-47-generic",
  sysname = "Linux",
  version = "#51-Ubuntu SMP Thu Aug 11 07:51:15 UTC 2022"
} ~
```