### PR TITLE
highlights(typescript): Add satisfies keyword

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -375,7 +375,7 @@
     "revision": "8bd2056818b21860e3d756b5a58c4f6e05fb744e"
   },
   "tsx": {
-    "revision": "0ab9d99867435a7667c5548a6617a6bf73dbd830"
+    "revision": "0ae382803abce0807e90f498105c713b9233e0b2"
   },
   "turtle": {
     "revision": "085437f5cb117703b7f520dd92161140a684f092"
@@ -384,7 +384,7 @@
     "revision": "035f549ec8c043e734f04341d7ccdc669bb2ba91"
   },
   "typescript": {
-    "revision": "0ab9d99867435a7667c5548a6617a6bf73dbd830"
+    "revision": "0ae382803abce0807e90f498105c713b9233e0b2"
   },
   "v": {
     "revision": "66b92a89ef1e149300df79c0b2a934ad959c8eec"

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -14,6 +14,7 @@
 "type"
 "readonly"
 "override"
+"satisfies"
 ] @keyword
 
 ; types


### PR DESCRIPTION
Support the new [satisfies operator](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#the-satisfies-operator) added in TypeScript 4.9