### PR TITLE
fix(fish): "test" command capture name

### DIFF
--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -13,9 +13,9 @@
  (stream_redirect)
 ] @operator
 
-; match operators of test command
+;; match operators of test command
 (command
-  name: (word) @function (#match? @function "^test$")
+  name: (word) @function.builtin (#match? @function.builtin "^test$")
   argument: (word) @operator (#match? @operator "^(!?\\=|-[a-zA-Z]+)$"))
 
 ;; match operators of [ command


### PR DESCRIPTION
I have made a mistake in this PR: https://github.com/nvim-treesitter/nvim-treesitter/pull/3752
(changes were merged in here: https://github.com/nvim-treesitter/nvim-treesitter/pull/3851)

Instead of `@function` the capture name should be `@function.builtin` as it was previously.

Sorry 🙏