### PR TITLE
highlights(typescript): Fix as highlight

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -213,8 +213,12 @@
 [
 "import"
 "from"
-"as"
 ] @include
+
+(export_specifier "as" @include)
+(import_specifier "as" @include)
+(namespace_export "as" @include)
+(namespace_import "as" @include)
 
 [
 "for"

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -17,6 +17,8 @@
 "satisfies"
 ] @keyword
 
+(as_expression "as" @keyword)
+
 ; types
 
 (type_identifier) @type

--- a/tests/query/highlights/typescript/as.ts
+++ b/tests/query/highlights/typescript/as.ts
@@ -1,0 +1,8 @@
+import * as foo from 'foo';
+//       ^ include
+
+export { foo as bar };
+//           ^ include
+
+const n = 5 as number;
+//          ^ keyword


### PR DESCRIPTION
`as` is currently always highlighted as `include`:
https://github.com/nvim-treesitter/nvim-treesitter/blob/1b3f93dcb90e1c282fe9259e5a15f34d504fd5a1/queries/ecma/highlights.scm#L213-L217

Adds a query for highlighting as `keyword` in `as_expression` type assertions.