### PR TITLE
fix(installer): don't update parsers that are not installed

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -115,7 +115,7 @@ end
 ---@return table
 local function outdated_parsers()
   return vim.tbl_filter(function(lang)
-    return needs_update(lang)
+    return is_installed(lang) and needs_update(lang)
   end, info.installed_parsers())
 end
 


### PR DESCRIPTION
When installing nvim-treesitter without any config and then
running `TSUpdate`, the global parsers will be installed.

This PR fixes that