### PR TITLE
feat(gitcommit): improve diff injection since last parser update

### DIFF
--- a/queries/gitcommit/injections.scm
+++ b/queries/gitcommit/injections.scm
@@ -1,2 +1,2 @@
-(diff) @diff
+((diff) @diff (#exclude_children! @diff))
 (rebase_command) @git_rebase


### PR DESCRIPTION
Since last update of the parser, syntax tree is modified.

From : 

```scheme
(diff)
(generated_comment (title))
```

To
```scheme
(diff
    (generated_comment (title)))
```