### PR TITLE
injections: add more regex injections

### DIFF
--- a/queries/bash/injections.scm
+++ b/queries/bash/injections.scm
@@ -1,1 +1,3 @@
 (comment) @comment
+
+(regex) @regex

--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -6,3 +6,8 @@
   (line_comment)
   (block_comment)
 ] @comment
+
+((prefixed_string_literal
+   prefix: (identifier) @_prefix) @regex
+ (#eq? @_prefix "r")
+ (#offset! @regex 0 2 0 -1))

--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -1,6 +1,6 @@
-; TODO: re-add when markdown is added.
-; ((triple_string) @markdown
-;   (#offset! @markdown 0 3 0 -3))
+((string_literal) @markdown
+ (#match? @markdown "^\"\"\"")
+ (#offset! @markdown 0 3 0 -3))
 
 [
   (line_comment)

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -166,7 +166,8 @@
 ] @string
 
 [
-(regex_pattern_qr) 
+(pattern_matcher)
+(regex_pattern_qr)
 (patter_matcher_m)
 (substitution_pattern_s)
 ] @string.regex

--- a/queries/perl/injections.scm
+++ b/queries/perl/injections.scm
@@ -1,0 +1,1 @@
+(comments) @comment

--- a/queries/ruby/injections.scm
+++ b/queries/ruby/injections.scm
@@ -5,3 +5,5 @@
  (heredoc_end) @language
  (#set! "language" @language)
  (#downcase! "language"))
+
+(regex (string_content) @regex)


### PR DESCRIPTION
I added a missing node to the `string.regex` highlights for Perl but didn't add the injections because the patterns might include expressions which should be interpolated and highlighted by the grammar (though they currently aren't).