### PR TITLE
feat: c# required keyword

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -364,6 +364,7 @@
  "readonly"
  "static"
  "volatile"
+ "required"
 ] @storageclass
 
 [


### PR DESCRIPTION
With C# 11 that was recently released the [`required`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/required) keyword was introduced to the language. The keyword is to be used on properties like the example below.

This PR will add it to the keywords list to fix the broked highlighting

```csharp
public class Person
{
    public required string FirstName { get; init; }
    public required string LastName { get; init; }
}
```
