### PR TITLE
fix: is_installed correctly detects installed parsers

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -96,9 +96,14 @@ end
 ---@return boolean
 local function is_installed(lang)
   local matched_parsers = vim.api.nvim_get_runtime_file("parser/" .. lang .. ".so", true) or {}
+  local install_dir = configs.get_parser_install_dir()
+  if not install_dir then
+    return false
+  end
+  install_dir = vim.fn.fnamemodify(install_dir, ":p")
   for _, path in ipairs(matched_parsers) do
-    local install_dir = configs.get_parser_install_dir()
-    if vim.startswith(path, install_dir) then
+    local abspath = vim.fn.fnamemodify(path, ":p")
+    if vim.startswith(abspath, install_dir) then
       return true
     end
   end


### PR DESCRIPTION
`is_installed` sometimes returns false for parsers that are already installed. This can happen when the detected install_dir is an absolute path and the runtime `.so` files are relative paths, or vice-versa.

I've changed the logic to always convert the paths to absolute paths before doing the prefix comparison. I've also added a guard for the case where the install_dir is nil.