### PR TITLE
fix(phpdoc): highlight optional type as @type

### DIFF
--- a/queries/phpdoc/highlights.scm
+++ b/queries/phpdoc/highlights.scm
@@ -22,6 +22,7 @@
     (array_type)
     (primitive_type)
     (named_type)
+    (optional_type)
   ] @type)
 (tag
   (description (text) @text))


### PR DESCRIPTION
`optional_type` is not considered as `@type` in phpdoc.

Before:
![2022-11-29-112851_282x29_scrot](https://user-images.githubusercontent.com/3751019/204505423-fb861a3d-b78c-4fb8-9267-3681c1cf3060.png)

After:
![2022-11-29-112837_277x31_scrot](https://user-images.githubusercontent.com/3751019/204505413-a65301b3-be8f-4934-891b-1752e029ad4f.png)
