### PR TITLE
highlights(haskell): Fix highlighting of partially applied infix functions

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -116,6 +116,8 @@
 ((signature (forall (context (fun)))) . (function (variable) @function))
 
 (exp_infix (variable) @operator)  ; consider infix functions as operators
+(exp_section_right (variable) @operator) ; partially applied infix functions (sections) also get highlighted as operators
+(exp_section_left (variable) @operator)
 
 (exp_infix (exp_name) @function.call (#set! "priority" 101))
 (exp_apply . (exp_name (variable) @function.call))


### PR DESCRIPTION
__Highlighting partially applied infix functions (right and left sections) as operators.__

The expected highlight would be:

```haskell
vowels :: [Char] -> [Char]
vowels = filter (`elem` "aeiou")

divisors :: Int -> [Int]
divisors n = filter ((== 0) . (n `mod`)) [1..n]
```

But currently we get:
![image](https://user-images.githubusercontent.com/61030164/204794697-8040d7f2-5694-439a-be80-27da39bc669f.png)

This change fixes that:
![image](https://user-images.githubusercontent.com/61030164/204794980-df3cce2e-6cd5-48b0-bd4c-19aa4c4df4de.png)

