### PR TITLE
add set-substring-trim! for dynamic nix language injections with comments

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -154,6 +154,10 @@ query.add_directive("exclude_children!", function(match, _pattern, _bufnr, pred,
   metadata.content = ranges
 end)
 
+query.add_directive("set-substring-trim!", function(match, _, bufnr, pred, metadata)
+  metadata[pred[2]] = vim.trim(query.get_node_text(match[pred[3]], bufnr):sub(pred[4], pred[5]))
+end)
+
 -- Trim blank lines from end of the region
 -- Arguments are the captures to trim.
 query.add_directive("trim!", function(match, _, bufnr, pred, metadata)

--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -1,5 +1,15 @@
 (comment) @comment
 
+(
+  (comment) @_lang
+  [
+    (string_expression (string_fragment) @content)
+    (indented_string_expression (string_fragment) @content)
+  ]
+  (#match? @_lang "^/\\*[[:space:]]*\\w+[[:space:]]*\\*/$")
+  (#set-substring-trim! "language" @_lang 3 -3)
+)
+
 (apply_expression
   function: (_) @_func
   argument: [


### PR DESCRIPTION
follow up to https://github.com/nvim-treesitter/nvim-treesitter/pull/3842 and https://github.com/nvim-treesitter/nvim-treesitter/pull/3890, made this a separate pr since it adds a new directive

I couldn't find a good way to do this without adding a directive, so that's what I did