### PR TITLE
feat: added highlights for markdown checkboxes

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -49,6 +49,10 @@
   (thematic_break)
 ] @punctuation.special
 
+
+(task_list_marker_unchecked) @text.todo.unchecked
+(task_list_marker_checked) @text.todo.checked
+
 [
   (block_continuation)
   (block_quote_marker)


### PR DESCRIPTION
See example below. Before they did not have highlights.

![image](https://user-images.githubusercontent.com/292349/205343677-aab69fe1-0ff6-4df6-9cb2-d1f0a4da4688.png)
