### PR TITLE
highlights: create subscoping for ternary operator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,7 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @keyword.return   ; keywords like `return` and `yield`
 
 @conditional      ; keywords related to conditionals (e.g. `if` / `else`)
+@conditional.ternary ; Ternary operator: condition ? 1 : 2
 @repeat           ; keywords related to loops (e.g. `for` / `while`)
 @debug            ; keywords related to debugging
 @label            ; GOTO and other labels (e.g. `label:` in C)

--- a/queries/awk/highlights.scm
+++ b/queries/awk/highlights.scm
@@ -115,7 +115,7 @@
 (ternary_exp [
   "?"
   ":"
-] @operator)
+] @conditional.ternary)
 
 (update_exp [
   "++"

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -102,7 +102,7 @@
  (false)
 ] @boolean
 
-(conditional_expression [ "?" ":" ] @conditional)
+(conditional_expression [ "?" ":" ] @conditional.ternary)
 
 (string_literal) @string
 (system_lib_string) @string

--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -185,7 +185,7 @@
 ] @operator
 
 (binary_expression "/" @operator)
-(ternary_expression ["?" ":"] @conditional)
+(ternary_expression ["?" ":"] @conditional.ternary)
 (unary_expression ["!" "~" "-" "+"] @operator)
 (unary_expression ["delete" "void" "typeof"] @keyword.operator)
 

--- a/queries/fusion/highlights.scm
+++ b/queries/fusion/highlights.scm
@@ -115,3 +115,6 @@
  "."
  "?"
 ] @punctuation.delimiter
+
+(eel_ternary_expression
+  ["?" ":"] @conditional.ternary)

--- a/queries/hack/highlights.scm
+++ b/queries/hack/highlights.scm
@@ -273,7 +273,7 @@
   "\\" @punctuation.delimiter)
 
 (ternary_expression
-  ["?" ":"] @conditional)
+  ["?" ":"] @conditional.ternary)
 
 [
   "if"

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -226,7 +226,7 @@
 "case"
 ] @conditional
 
-(ternary_expression ["?" ":"] @conditional)
+(ternary_expression ["?" ":"] @conditional.ternary)
 
 ;
 

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -134,7 +134,7 @@
 (else_clause
   ["else"] @conditional)
 (ternary_expression
-  ["?" ":"] @conditional)
+  ["?" ":"] @conditional.ternary)
 
 (try_statement
   ["try" "end"] @exception)

--- a/queries/meson/highlights.scm
+++ b/queries/meson/highlights.scm
@@ -39,7 +39,8 @@
   ">="
 ] @operator
 
-"?" @conditional.ternary
+(ternaryoperator
+  ["?" ":"] @conditional.ternary)
 
 [
   "if"

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -13,6 +13,10 @@
 
 ; Keywords that mark conditional statements
 [ "if" "elsif" "unless" "else" ] @conditional
+(ternary_expression
+  ["?" ":"] @conditional.ternary)
+(ternary_expression_in_hash
+  ["?" ":"] @conditional.ternary)
 
 ; Keywords that mark repeating loops
 [ "while" "until" "for" "foreach" ] @repeat
@@ -142,8 +146,6 @@
 (to_reference)
 (type_glob)
 (hash_access_variable)
-(ternary_expression)
-(ternary_expression_in_hash)
 ] @operator
 
 [

--- a/queries/slint/highlights.scm
+++ b/queries/slint/highlights.scm
@@ -143,4 +143,4 @@
  "=>"
  ] @operator
 
-(ternary_expression [":" "?"] @conditional)
+(ternary_expression [":" "?"] @conditional.ternary)

--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -271,7 +271,7 @@
   ":"
 ] @punctuation.delimiter
 
-(ternary_expression ["?" ":"] @conditional)
+(ternary_expression ["?" ":"] @conditional.ternary)
 
 ; Options
 ((set_value) @number

--- a/tests/query/highlights/fusion/expressions.fusion
+++ b/tests/query/highlights/fusion/expressions.fusion
@@ -76,7 +76,7 @@ logic = ${!foo && !(bar || baz) and not 'string'}
 //                              ^operator
 
 ternary = ${ check ? true : false}
-//                 ^punctuation.delimiter
-//                        ^punctuation.delimiter
+//                 ^@conditional.ternary
+//                        ^@conditional.ternary
 
 


### PR DESCRIPTION
After https://github.com/nvim-treesitter/nvim-treesitter/issues/470, we decided to use `@conditional` for ternary operator instead of operator despite `@conditional` is documented for keywords only. A sub-scoping can make it easier for people to highlight this operator group differently while keeping the `@conditional` highlight. It also makes the documentation clearer for people adding new languages with ternary operator as they will find the categorization in CONTRIBUTING.md

Also unify the usage of `@conditional...` across languages.