### PR TITLE
highlights(typescript): add `module` keyword

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -11,6 +11,7 @@
   "namespace"
   "override"
   "satisfies"
+  "module"
 ] @keyword
 
 (as_expression "as" @keyword)


### PR DESCRIPTION
Add highlights for the `module` keyword that is used inside declaration files (`.d.ts`).