### PR TITLE
indents(ecma): Fix switch default indent

### DIFF
--- a/queries/ecma/folds.scm
+++ b/queries/ecma/folds.scm
@@ -11,6 +11,7 @@
   (with_statement)
   (switch_statement)
   (switch_case)
+  (switch_default)
   (import_statement)
   (if_statement)
   (try_statement)

--- a/queries/ecma/indents.scm
+++ b/queries/ecma/indents.scm
@@ -12,6 +12,7 @@
   (return_statement)
   (statement_block)
   (switch_case)
+  (switch_default)
   (switch_statement)
   (template_substitution)
   (ternary_expression)

--- a/tests/indent/ecma/switch.js
+++ b/tests/indent/ecma/switch.js
@@ -1,0 +1,8 @@
+switch (variable) {
+  case 'case1':
+    foo();
+    break;
+
+  default:
+    bar();
+}


### PR DESCRIPTION
Add `@indent` and `@fold` for `switch_default`.