### PR TITLE
test: Add test name to summary output

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -10,7 +10,7 @@ run() {
 
 if [[ $2 = '--summary' ]]; then
     ## really simple results summary by filtering plenary busted output
-    run tests/$1  2> /dev/null | grep -E '^\S*(Success|Fail(ed)?|Errors?)\s*:'
+    run tests/$1  2> /dev/null | grep -E '^\S*(Testing|Success|Failed|Errors)\s*:'
 else
     run tests/$1
 fi


### PR DESCRIPTION
Add the test name to summary output. Also clean up regex.

Before:
```
Success: 	1
Failed : 	0
Errors : 	0
Success: 	1
Failed : 	0
Errors : 	0
...
```

After:
```
Testing: 	/Users/shraymonks/Projects/nvim-treesitter/tests/indent/graphql_spec.lua
Success: 	1
Failed : 	0
Errors : 	0
Testing: 	/Users/shraymonks/Projects/nvim-treesitter/tests/indent/wgsl_spec.lua
Success: 	1
Failed : 	0
Errors : 	0
...
```