### PR TITLE
@nospell for environment names, citations and commands

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -242,6 +242,8 @@
 (displayed_equation) @nospell
 (key_value_pair) @nospell
 (generic_environment
-  begin: (begin) @nospell
-  end: (end) @nospell)
+  begin: _ @nospell
+  end: _ @nospell)
+(citation
+  keys: _ @nospell)
 (command_name) @nospell

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -237,10 +237,11 @@
   command: _ @include
   paths: (curly_group_path_list) @string)
 
-(
-    (text) @spell
-    (#not-has-parent? @spell
-        inline_formula
-        displayed_equation
-    )
-)
+(text) @spell
+(inline_formula) @nospell
+(displayed_equation) @nospell
+(key_value_pair) @nospell
+(generic_environment
+  begin: (begin) @nospell
+  end: (end) @nospell)
+(command_name) @nospell


### PR DESCRIPTION
See [this issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/3511).

The names of environments in latex are in English, regardless of what language the document you are writing is in. If you turn on spell checking for a different language this means that e.g. the document in `\begin{document}` will be marked as a typo. This pull request removes spell checking from `\begin` and `\end`, as well as command names, citations and key-value pairs in arguments, which can also be assumed to be in English regardless of the document language.

There are still a lot of things that remain incorrectly spell checked after this patch, like how arguments to commands are sometimes text that should be spell checked (e.g. `\emph`) and sometimes not (e.g. `\setbeamertemplate`). Properly addressing this could potentially involve a parser that is aware of more commands, but will probably also involve going through different commands in latex and individually marking their arguments as `@spell`/`@nospell`. Maybe one could look at the vim latex syntax file for inspiration.

That said, this patch fixes a couple of the most common cases of things incorrectly marked as spell and makes spell checking latex documents in languages other than English significantly less annoying.
