### PR TITLE
feat(php): improve indents for match and switch

### DIFF
--- a/queries/php/indents.scm
+++ b/queries/php/indents.scm
@@ -7,6 +7,9 @@
   (arguments)
   (formal_parameters)
   (enum_declaration_list)
+  (switch_block)
+  (match_block)
+  (case_statement)
   "["
 ] @indent
 


### PR DESCRIPTION
Indent for `match` and `switch` are broken, this will allows to provide this default indents:

```php
<?php

match($e) {
    true => "ok",
    false => "ko",
}

switch($e) {
    case true:
        echo 'ok';
        break;
    case false:
        echo 'ko';
        break;
}
```