### PR TITLE
Update Julia highlights and injections

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -201,7 +201,7 @@
     "revision": "44c0d58dfb523b7f1066ef4013cc543afc696960"
   },
   "julia": {
-    "revision": "91ba1c3c9b50f388d4b67518c04bc9a003ed3475"
+    "revision": "36b099e9ea577f64ba53323115028dadd2991d2c"
   },
   "kotlin": {
     "revision": "b953dbdd05257fcb2b64bc4d9c1578fac12e3c28"

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -15,17 +15,9 @@
 
 (quote_expression ":" (identifier)) @symbol
 
-
-;;; Fields and indexes
-
 (field_expression
   (identifier) @field .)
 
-(index_expression
-  (_)
-  (range_expression
-    (identifier) @constant.builtin .)
-  (#eq? @constant.builtin "end"))
 
 
 ;;; Function names
@@ -79,13 +71,14 @@
 ;; Definitions
 
 (abstract_definition
-  name: (identifier) @type.definition
-  (subtype_clause (identifier) @type))
+  name: (identifier) @type.definition)
 (primitive_definition
-  name: (identifier) @type.definition
-  (subtype_clause (identifier) @type))
+  name: (identifier) @type.definition)
 (struct_definition
   name: (identifier) @type)
+(subtype_clause [
+  (identifier) @type
+  (field_expression (identifier) @type .)])
 
 ;; Annotations
 
@@ -109,6 +102,8 @@
 ;;; Keywords
 
 [
+  "global"
+  "local"
   "macro"
   "struct"
   "type"
@@ -116,9 +111,6 @@
 ] @keyword
 
 "end" @keyword
-
-((identifier) @keyword
- (#any-of? @keyword "global" "local")) ; Grammar error
 
 (compound_statement
   ["begin" "end"] @keyword)
@@ -185,11 +177,10 @@
 
 (operator) @operator
 (for_binding ["in" "=" "∈"] @operator)
-(pair_expression "=>" @operator)
 (range_expression ":" @operator)
 
 (slurp_parameter "..." @operator)
-(spread_expression "..." @operator)
+(splat_expression "..." @operator)
 
 "." @operator
 ["::" "<:"] @operator

--- a/queries/julia/indents.scm
+++ b/queries/julia/indents.scm
@@ -3,24 +3,25 @@
   (macro_definition)
   (function_definition)
 
+  (compound_statement)
   (if_statement)
   (try_statement)
   (for_statement)
   (while_statement)
   (let_statement)
   (quote_statement)
-
   (do_clause)
-  (compound_statement)
 
   (assignment)
+  (for_binding)
 
   (binary_expression)
   (call_expression)
 
-  (array_expression)
   (tuple_expression)
+  (comprehension_expression)
   (matrix_expression)
+  (vector_expression)
 ] @indent
 
 [

--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -1,4 +1,13 @@
+;; Inject markdown in docstrings 
 ((string_literal) @markdown
+  . [
+    (module_definition)
+    (abstract_definition)
+    (struct_definition)
+    (function_definition)
+    (assignment)
+    (const_declaration)
+  ]
  (#match? @markdown "^\"\"\"")
  (#offset! @markdown 0 3 0 -3))
 


### PR DESCRIPTION
See https://github.com/tree-sitter/tree-sitter-julia/pull/83

- Add global and local as keywords. See https://github.com/tree-sitter/tree-sitter-julia/pull/78
- Fix a small mistake with subtypes in type definitions
- Restrict markdown injections to docstrings