### PR TITLE
feat: add Ada

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 
 <!--This section of the README is automatically updated by a CI job-->
 <!--parserinfo-->
+- [x] [ada](https://github.com/briot/tree-sitter-ada) (maintained by @briot)
 - [x] [agda](https://github.com/AusCyberman/tree-sitter-agda) (maintained by @Decodetalkers)
 - [x] [arduino](https://github.com/ObserverOfTime/tree-sitter-arduino) (maintained by @ObserverOfTime)
 - [x] [astro](https://github.com/virchau13/tree-sitter-astro) (maintained by @virchau13)

--- a/lockfile.json
+++ b/lockfile.json
@@ -1,4 +1,7 @@
 {
+  "ada": {
+    "revision": "0210164cce71a6b6010ab24fb4fe77693469db14"
+  },
   "agda": {
     "revision": "80ea622cf952a0059e168e5c92a798b2f1925652"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -60,6 +60,16 @@ local list = setmetatable({}, {
   end,
 })
 
+list.ada = {
+  install_info = {
+    url = "https://github.com/briot/tree-sitter-ada",
+    branch = "master",
+    files = { "src/parser.c" },
+  },
+  filetype = "ada",
+  maintainers = { "@briot" },
+}
+
 list.agda = {
   install_info = {
     url = "https://github.com/AusCyberman/tree-sitter-agda",

--- a/queries/ada/folds.scm
+++ b/queries/ada/folds.scm
@@ -1,0 +1,13 @@
+;; Support for folding in Ada
+;;    za     toggles folding a package, subprogram, if statement or loop
+
+[
+   (package_specification)
+   (package_body)
+   (subprogram_body)
+   (block_statement)
+   (if_statement)
+   (loop_statement)
+   (gnatprep_declarative_if_statement)
+   (gnatprep_if_statement)
+] @fold

--- a/queries/ada/highlights.scm
+++ b/queries/ada/highlights.scm
@@ -1,0 +1,179 @@
+;; highlight queries.
+;; See the syntax at https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries
+;; See also https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#parser-configurations
+;; for a list of recommended @ tags, though not all of them have matching
+;; highlights in neovim.
+
+[
+   "abort"
+   "abs"
+   "abstract"
+   "accept"
+   "access"
+   "all"
+   "array"
+   "at"
+   "begin"
+   "declare"
+   "delay"
+   "delta"
+   "digits"
+   "do"
+   "end"
+   "entry"
+   "exit"
+   "generic"
+   "interface"
+   "is"
+   "limited"
+   "null"
+   "of"
+   "others"
+   "out"
+   "pragma"
+   "private"
+   "range"
+   "synchronized"
+   "tagged"
+   "task"
+   "terminate"
+   "until"
+   "when"
+] @keyword
+[
+   "aliased"
+   "constant"
+   "renames"
+] @storageclass
+[
+   "mod"
+   "new"
+   "protected"
+   "record"
+   "subtype"
+   "type"
+] @keyword.type
+[
+   "with"
+   "use"
+] @include
+[
+   "body"
+   "function"
+   "overriding"
+   "procedure"
+   "package"
+   "separate"
+] @keyword.function
+[
+   "and"
+   "in"
+   "not"
+   "or"
+   "xor"
+] @keyword.operator
+[
+   "while"
+   "loop"
+   "for"
+   "parallel"
+   "reverse"
+   "some"
+] @repeat
+[
+   "return"
+] @keyword.return
+[
+   "case"
+   "if"
+   "else"
+   "then"
+   "elsif"
+   "select"
+] @conditional
+[
+   "exception"
+   "raise"
+]  @exception
+(comment)         @comment
+(comment)         @spell       ;; spell-check comments
+(string_literal)  @string
+(string_literal)  @spell       ;; spell-check strings
+(character_literal) @string
+(numeric_literal) @number
+
+;; Highlight the name of subprograms
+(procedure_specification name: (_) @function)
+(function_specification name: (_) @function)
+(package_specification name: (_) @function)
+(package_body name: (_) @function)
+(generic_instantiation name: (_) @function)
+
+;; Some keywords should take different categories depending on the context
+(use_clause "use"  @include "type" @include)
+(with_clause "private" @include)
+(with_clause "limited" @include)
+(use_clause (_) @namespace)
+(with_clause (_) @namespace)
+
+(loop_statement "end" @keyword.repeat)
+(if_statement "end" @conditional)
+(loop_parameter_specification "in" @keyword.repeat)
+(loop_parameter_specification "in" @keyword.repeat)
+(iterator_specification ["in" "of"] @keyword.repeat)
+(range_attribute_designator "range" @keyword.repeat)
+
+(raise_statement "with" @exception)
+
+(gnatprep_declarative_if_statement)  @preproc
+(gnatprep_if_statement)              @preproc
+(gnatprep_identifier)                @preproc
+
+(subprogram_declaration "is" @keyword.function "abstract"  @keyword.function)
+(aspect_specification "with" @keyword.function)
+
+(full_type_declaration "is" @keyword.type)
+(subtype_declaration "is" @keyword.type)
+(record_definition "end" @keyword.type)
+(full_type_declaration (_ "access" @keyword.type))
+(array_type_definition "array" @keyword.type "of" @keyword.type)
+(access_to_object_definition "access" @keyword.type)
+(access_to_object_definition "access" @keyword.type
+   [
+      (general_access_modifier "constant" @keyword.type)
+      (general_access_modifier "all" @keyword.type)
+   ]
+)
+(range_constraint "range" @keyword.type)
+(signed_integer_type_definition "range" @keyword.type)
+(index_subtype_definition "range" @keyword.type)
+(record_type_definition "abstract" @keyword.type)
+(record_type_definition "tagged" @keyword.type)
+(record_type_definition "limited" @keyword.type)
+(record_type_definition (record_definition "null" @keyword.type))
+(private_type_declaration "is" @keyword.type "private" @keyword.type)
+(private_type_declaration "tagged" @keyword.type)
+(private_type_declaration "limited" @keyword.type)
+(task_type_declaration "task" @keyword.type "is" @keyword.type)
+
+;; Gray the body of expression functions
+(expression_function_declaration
+   (function_specification)
+   "is"
+   (_) @attribute
+)
+(subprogram_declaration (aspect_specification) @attribute)
+
+;; Highlight full subprogram specifications
+;(subprogram_body
+;    [
+;       (procedure_specification)
+;       (function_specification)
+;    ] @function.spec
+;)
+
+;; Highlight errors in red. This is not very useful in practice, as text will
+;; be highlighted as user types, and the error could be elsewhere in the code.
+;; This also requires defining    :hi @error guifg=Red    for instance.
+(ERROR) @error
+

--- a/queries/ada/locals.scm
+++ b/queries/ada/locals.scm
@@ -1,0 +1,33 @@
+;;  Better highlighting by referencing to the definition, for variable
+;;  references. However, this is not yet supported by neovim
+;;  See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#local-variables
+
+(compilation) @scope
+(package_specification) @scope
+(package_body) @scope
+(subprogram_declaration) @scope
+(subprogram_body) @scope
+(block_statement) @scope
+
+(with_clause (identifier) @definition.import)
+(procedure_specification name: (_) @definition.function)
+(function_specification name: (_) @definition.function)
+(package_specification name: (_) @definition.var)
+(package_body name: (_) @definition.var)
+(generic_instantiation . name: (_) @definition.var)
+(component_declaration . (identifier) @definition.var)
+(exception_declaration . (identifier) @definition.var)
+(formal_object_declaration . (identifier) @definition.var)
+(object_declaration . (identifier) @definition.var)
+(parameter_specification . (identifier) @definition.var)
+(full_type_declaration . (identifier) @definition.type)
+(private_type_declaration . (identifier) @definition.type)
+(private_extension_declaration . (identifier) @definition.type)
+(incomplete_type_declaration . (identifier) @definition.type)
+(protected_type_declaration . (identifier) @definition.type)
+(formal_complete_type_declaration . (identifier) @definition.type)
+(formal_incomplete_type_declaration . (identifier) @definition.type)
+(task_type_declaration . (identifier) @definition.type)
+(subtype_declaration . (identifier) @definition.type)
+
+(identifier) @reference


### PR DESCRIPTION
The grammar was built from the official Ada grammar available in the ISO standard, and from an existing similar grammar used for the Emacs ada-mode.
The resulting grammar is able to parse all source files in the GNAT runtime (the kind of "official" compiler for Ada), as well as the 3 million+ lines of code at my company), without ERROR, though of course I could not check all resulting trees.
The testsuite is reasonably complete at this stage.