### PR TITLE
injections (vue): fix js/css injection conditions

### DIFF
--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -1,4 +1,35 @@
-; inherits: html_tags
+(
+  (style_element
+    (start_tag) @_no_lang
+    (raw_text) @css)
+  (#not-contains? @_no_lang "lang=")
+) 
+
+(
+  (style_element
+    (start_tag
+      (attribute
+        (quoted_attribute_value (attribute_value) @_lang)))
+    (raw_text) @css)
+  (#eq? @_lang "css")
+)
+
+; if start_tag does not specify `lang="..."` then set it to javascript
+(
+ (script_element
+    (start_tag) @_no_lang 
+  (raw_text) @javascript)
+ (#not-contains? @_no_lang "lang=")
+)
+
+(
+  (script_element
+    (start_tag
+      (attribute
+        (quoted_attribute_value (attribute_value) @_lang)))
+    (raw_text) @javascript)
+  (#eq? @_lang "js")
+)
 
 (
   (style_element
@@ -15,7 +46,7 @@
       (attribute
         (quoted_attribute_value (attribute_value) @_lang)))
     (raw_text) @typescript)
-  (#any-of? @_lang "ts" "typescript")
+  (#eq? @_lang "ts")
 )
 
 ((interpolation


### PR DESCRIPTION
My attempt to fix #3980 

Changes:
- Will no longer inherits `html_tags`
- Will only injects javascript if `lang="js"` is specified, or if there is no `lang` attributes
- Remove `typescript` as a validate predicate for typescript injection as there is no mention of `lang="typescript"` being a valid attribute on [vuejs website](https://vuejs.org/)

| Before AST | After AST |
| -- | --|
| ![image](https://user-images.githubusercontent.com/29790821/208475726-651c0b15-6940-42b0-991d-526d4b9f4dec.png) | ![image](https://user-images.githubusercontent.com/29790821/208475585-3eececdb-4be4-4f15-8b8e-2d36f144a264.png) | 

Any helps would be appreciated