### PR TITLE
injections(vue): Update injection queries

### DIFF
--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -1,52 +1,80 @@
 (
   (style_element
-    (start_tag) @_no_lang
+    (start_tag) @_no_attribute
     (raw_text) @css)
-  (#not-contains? @_no_lang "lang=")
+  (#match? @_no_attribute "<\\s*style\\s*>")
 ) 
 
 (
   (style_element
     (start_tag
       (attribute
-        (quoted_attribute_value (attribute_value) @_lang)))
+        (attribute_name) @_no_lang))
     (raw_text) @css)
-  (#eq? @_lang "css")
-)
-
-; if start_tag does not specify `lang="..."` then set it to javascript
-(
- (script_element
-    (start_tag) @_no_lang 
-  (raw_text) @javascript)
- (#not-contains? @_no_lang "lang=")
-)
-
-(
-  (script_element
-    (start_tag
-      (attribute
-        (quoted_attribute_value (attribute_value) @_lang)))
-    (raw_text) @javascript)
-  (#eq? @_lang "js")
-)
+  (#not-eq? @_no_lang "lang")
+) 
 
 (
   (style_element
     (start_tag
       (attribute
-        (quoted_attribute_value (attribute_value) @_lang)))
-    (raw_text) @scss)
-  (#any-of? @_lang "scss" "postcss" "less")
+        (attribute_name) @_lang
+        (quoted_attribute_value (attribute_value) @_css)))
+    (raw_text) @css)
+  (#eq? @_lang "lang")
+  (#eq? @_css "css")
+)
+
+; If script tag does not have any extra attributes, set it to javascript
+(
+  (script_element
+    (start_tag) @_no_attribute
+    (raw_text) @javascript)
+  (#match? @_no_attribute "<\\s*script\\s*>")
+) 
+
+; if start_tag does not specify `lang="..."` then set it to javascript
+(
+ (script_element
+    (start_tag
+      (attribute
+        (attribute_name) @_no_lang))
+    (raw_text) @javascript)
+ (#not-eq? @_no_lang "lang")
 )
 
 (
   (script_element
     (start_tag
       (attribute
-        (quoted_attribute_value (attribute_value) @_lang)))
+        (attribute_name) @_lang
+        (quoted_attribute_value (attribute_value) @_js)))
+    (raw_text) @javascript)
+  (#eq? @_lang "lang")
+  (#eq? @_js "js")
+)
+
+; TODO: When nvim-treesitter have postcss and less parser, use @language and @content instead
+(
+  (style_element
+    (start_tag
+      (attribute
+        (attribute_name) @_lang
+        (quoted_attribute_value (attribute_value) @_scss)))
+    (raw_text) @scss)
+  (#eq? @_lang "lang")
+  (#any-of? @_scss "scss" "less" "postcss")
+)
+
+(
+  (script_element
+    (start_tag
+      (attribute
+        (attribute_name) @_lang
+        (quoted_attribute_value (attribute_value) @_ts)))
     (raw_text) @typescript)
-  (#eq? @_lang "ts")
+  (#eq? @_lang "lang")
+  (#eq? @_ts "ts")
 )
 
 ((interpolation

--- a/tests/query/injections/vue/test-vue-injections.vue
+++ b/tests/query/injections/vue/test-vue-injections.vue
@@ -1,0 +1,41 @@
+<template>
+  <span>{{"Some text"}}</span>
+  <!--      ^ javascript 
+-->
+
+  <template lang="pug">
+    ul
+      li(v-for="item in items")
+        a(v-if="item.type == 'link'" :href="item.url") some link title: 
+<!--                                                    ^ pug
+-->
+  </template>
+
+  <template v-if="true"></template>
+<!--              ^ javascript 
+-->
+</template>
+<script>
+const foo = "1"
+//    ^ javascript
+</script>
+<script defer lang="js">
+const foo = "1"
+//    ^ javascript
+</script>
+<script lang="ts">
+const foo = "1"
+//    ^ typescript
+</script>
+<style>
+.bar {
+/* ^ css*/
+}
+</style>
+<style lang="scss">
+.bar {
+  &-baz {
+//  ^ scss
+  }
+}
+</style>


### PR DESCRIPTION
Follow up of #3981 
Update Vue injection queries with more queries to properly capture cases where it has no `lang` attribute

https://user-images.githubusercontent.com/29790821/209374232-63c1fa60-10ea-4a6b-8246-9d17a3df8079.mp4
It will still correctly capture even if we insert multiple spaces and newlines
https://user-images.githubusercontent.com/29790821/209374644-e178b5c5-8b49-407c-b2ec-1b609eacd173.mp4
