### PR TITLE
chore: update usage `vim.split` to new signature

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1377,7 +1377,7 @@ function M.ft_to_lang(ft)
   if result then
     return result
   else
-    ft = vim.split(ft, ".", true)[1]
+    ft = vim.split(ft, ".", { plain = true })[1]
     return filetype_to_parsername[ft] or ft
   end
 end


### PR DESCRIPTION
Old usage was still working because of backward compatibility of nvim code:
```lua
if type(kwargs) == 'boolean' then
  -- Support old signature for backward compatibility
  plain = kwargs
else
```
https://neovim.io/doc/user/lua.html#vim.split()