### PR TITLE
Injections(vue): Fix vue injection regressions

### DIFF
--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -3,6 +3,7 @@
     (start_tag) @_no_attribute
     (raw_text) @css)
   (#match? @_no_attribute "^\\<\\s*style\\s*\\>$")
+  ; unsure why, but without escaping &lt; and &gt; the query breaks
 ) 
 
 (

--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -2,7 +2,7 @@
   (style_element
     (start_tag) @_no_attribute
     (raw_text) @css)
-  (#match? @_no_attribute "<\\s*style\\s*>")
+  (#match? @_no_attribute "^\\<\\s*style\\s*\\>$")
 ) 
 
 (
@@ -30,7 +30,7 @@
   (script_element
     (start_tag) @_no_attribute
     (raw_text) @javascript)
-  (#match? @_no_attribute "<\\s*script\\s*>")
+  (#match? @_no_attribute "^\\<\\s*script\\s*\\>$")
 ) 
 
 ; if start_tag does not specify `lang="..."` then set it to javascript

--- a/tests/query/injections/vue/test-vue-injections.vue
+++ b/tests/query/injections/vue/test-vue-injections.vue
@@ -1,17 +1,17 @@
 <template>
-  <span>{{"Some text"}}</span>
+  <span>{{"Text inside interpolation"}}</span>
   <!--      ^ javascript 
 -->
 
   <template lang="pug">
     ul
       li(v-for="item in items")
-        a(v-if="item.type == 'link'" :href="item.url") some link title: 
+        a(v-if="item.type == 'link'" :href="item.url") some link title in pug: 
 <!--                                                    ^ pug
 -->
   </template>
 
-  <template v-if="true"></template>
+  <template v-if="'text inside directives'"></template>
 <!--              ^ javascript 
 -->
 </template>
@@ -19,23 +19,50 @@
 const foo = "1"
 //    ^ javascript
 </script>
-<script defer lang="js">
+<script defer>
+const foo = "1"
+//    ^ javascript
+</script>
+<script lang="js">
 const foo = "1"
 //    ^ javascript
 </script>
 <script lang="ts">
-const foo = "1"
-//    ^ typescript
+const foo: number = "1"
+//          ^ typescript
 </script>
 <style>
 .bar {
-/* ^ css*/
+/* ^ css  
+*/
+}
+</style>
+<style scoped>
+.page.page--news {
+  padding: calc(var(--header-height)) 1rem 0 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  min-height: calc(var(--vh, 1vh) * 100 - var(--header-height));
+  background: rebeccapurple;
+/*              ^ css 
+*/
+}
+</style>
+<style lang="css">
+.bar {
+  justify-content: center;
+/*         ^ css
+*/
 }
 </style>
 <style lang="scss">
 .bar {
   &-baz {
+    &.page{
 //  ^ scss
+    }
   }
 }
 </style>


### PR DESCRIPTION
Change L5 and L33 to denote start of node's text so that `match?` can work properly (the `<` and `>` was recognized as something else, unsure what)
So explicity escape it to guarantees it won't be read as something else

CC @theHamsta again today, sorry for the regression :bow: 

