### PR TITLE
parsers: add wgsl_bevy

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1173,6 +1173,15 @@ list.wgsl = {
   filetype = "wgsl",
 }
 
+list.wgsl_bevy = {
+  install_info = {
+    url = "https://github.com/theHamsta/tree-sitter-wgsl-bevy",
+    files = { "src/parser.c" },
+    generate_requires_npm = true,
+  },
+  maintainers = { "@theHamsta" },
+}
+
 list.m68k = {
   install_info = {
     url = "https://github.com/grahambates/tree-sitter-m68k",

--- a/queries/wgsl_bevy/folds.scm
+++ b/queries/wgsl_bevy/folds.scm
@@ -1,0 +1,5 @@
+; inherits wgsl
+
+[
+ (preproc_ifdef)
+] @fold

--- a/queries/wgsl_bevy/highlights.scm
+++ b/queries/wgsl_bevy/highlights.scm
@@ -1,0 +1,25 @@
+; inherits wgsl
+
+[
+ "#import"
+ "#define_import_path"
+] @include
+"::" @punctuation.delimiter
+
+(import_path (identifier) @namespace (identifier))
+
+(struct_declaration
+    (preproc_ifdef (struct_member (variable_identifier_declaration (identifier) @field))))
+(struct_declaration
+    (preproc_ifdef
+      (preproc_else (struct_member (variable_identifier_declaration (identifier) @field)))))
+
+(preproc_ifdef
+  name: (identifier) @constant.macro)
+
+[
+ "#ifdef"
+ "#ifndef"
+ "#endif"
+ "#else"
+] @preproc

--- a/queries/wgsl_bevy/indents.scm
+++ b/queries/wgsl_bevy/indents.scm
@@ -1,0 +1,7 @@
+; inherits wgsl
+[
+  "#ifdef"
+  "#ifndef"
+  "#else"
+  "#endif"
+] @zero_indent


### PR DESCRIPTION
This adds an extension (https://github.com/theHamsta/tree-sitter-wgsl-bevy) of tree-sitter-wgsl that understands [Bevy's](https://bevyengine.org/) preprocessor directives.