### PR TITLE
Update Julia highlights

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -204,7 +204,7 @@
     "revision": "505f5bd90053ae895aa3d6f2bac8071dd9abd8b2"
   },
   "julia": {
-    "revision": "f254ff9c52e994f629a60821662917d2c6c0e8eb"
+    "revision": "1cd300bda52e680872053cd55a228c1809cb0c3a"
   },
   "kotlin": {
     "revision": "b953dbdd05257fcb2b64bc4d9c1578fac12e3c28"

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -13,7 +13,7 @@
 (macro_definition
   name: (identifier) @function.macro)
 
-(quote_expression ":" (identifier)) @symbol
+(quote_expression ":" [(identifier) (operator)]) @symbol
 
 (field_expression
   (identifier) @field .)
@@ -71,18 +71,21 @@
 ;; Definitions
 
 (abstract_definition
-  name: (identifier) @type.definition)
+  name: (identifier) @type.definition) @keyword
 (primitive_definition
-  name: (identifier) @type.definition)
+  name: (identifier) @type.definition) @keyword
 (struct_definition
   name: (identifier) @type)
-(subtype_clause [
-  (identifier) @type
-  (field_expression (identifier) @type .)])
+(type_clause
+  ["<:" ">:"] @operator
+  [(identifier) @type
+    (field_expression (identifier) @type .)])
 
 ;; Annotations
 
-(parametrized_type_expression (_) @type)
+(parametrized_type_expression
+  (_) @type
+  (curly_expression (_) @type))
 
 (type_parameter_list
   (identifier) @type)
@@ -96,7 +99,9 @@
   return_type: (identifier) @type)
 
 (where_clause
-  (identifier) @type) ; where clause without braces
+  (identifier) @type)
+(where_clause
+  (curly_expression (_) @type))
 
 
 ;;; Keywords
@@ -106,8 +111,6 @@
   "local"
   "macro"
   "struct"
-  "type"
-  "where"
 ] @keyword
 
 "end" @keyword
@@ -166,24 +169,30 @@
   "return" @keyword.return)
 
 [
-  "abstract"
   "const"
   "mutable"
-  "primitive"
 ] @type.qualifier
 
 
 ;;; Operators & Punctuation
 
 (operator) @operator
-(for_binding ["in" "=" "∈"] @operator)
-(range_expression ":" @operator)
 
+(adjoint_expression "'" @operator)
+(range_expression ":" @operator)
 (slurp_parameter "..." @operator)
 (splat_expression "..." @operator)
 
-"." @operator
-["::" "<:"] @operator
+((operator) @keyword.operator
+  (#any-of? @keyword.operator "in" "isa"))
+
+(for_binding "in" @keyword.operator)
+(for_binding ["=" "∈"] @operator)
+
+(where_clause "where" @keyword.operator)
+(where_expression "where" @keyword.operator)
+
+["." "::"] @operator
 
 ["," ";"] @punctuation.delimiter
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket


### PR DESCRIPTION
- Update patterns for type definitions:
  The grammar was updated to parse `abstract type` and `primitive type` as a single token.
- Update `@symbol` capture to highlight quoted operators as symbols.
- Add pattern to highlight adjoint operator.
- Update patterns and captures for:
  - "keyword" operators (`in`, `isa`, and `where`)
  - type operators (`<:`, `>:`)
  - Parametrized types.

---

- See https://github.com/tree-sitter/tree-sitter-julia/pull/87
- There's also a few changes that I forgot to add to https://github.com/nvim-treesitter/nvim-treesitter/pull/4016