### PR TITLE
highlights(haskell): lambda and function with type signature

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -111,9 +111,12 @@
 (function
   name: (variable) @function
   patterns: (patterns))
-((signature (fun)) . (function (variable) @function))
-((signature (context (fun))) . (function (variable) @function))
-((signature (forall (context (fun)))) . (function (variable) @function))
+(function
+  name: (variable) @function
+  rhs: (exp_lambda))
+((signature (variable) @_type (fun)) . (function (variable) @function) (#eq? @function @_type))
+((signature (variable) @_type (context (fun))) . (function (variable) @function) (#eq? @function @_type))
+((signature (variable) @_type (forall (context (fun)))) . (function (variable) @function) (#eq? @function @_type))
 
 (exp_infix (variable) @operator)  ; consider infix functions as operators
 


### PR DESCRIPTION
Add highlights for lambda bindings (`lambdaOne` below) and prevents capturing bindings as functions if signatures have different names (the last three bindings in the example below).  
  
| Before                                                                                                         | After                                                                                                          |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/4299733/210000298-25a8eacd-800b-40cc-bbec-e61d901b6691.png) | ![image](https://user-images.githubusercontent.com/4299733/209999754-b8be6201-c523-4d7c-814b-0ffad885f3a6.png) |
