### PR TITLE
install: allow pure C parsers to be compiled without `-lstdc++`

### DIFF
--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -73,7 +73,7 @@ jobs:
           path: |
             ./parser/
             ~/AppData/Local/nvim/pack/nvim-treesitter/start/nvim-treesitter/parser/
-          key: ${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.nvim_tag }}-parsers-v1-${{ hashFiles('./lockfile.json', './lua/nvim-treesitter/parsers.lua', './lua/nvim-treesitter/install.lua', './lua/nvim-treesitter/shell_selectors.lua') }}
+          key: ${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.nvim_tag }}-parsers-v1-${{ hashFiles('./lockfile.json', './lua/nvim-treesitter/parsers.lua', './lua/nvim-treesitter/install.lua', './lua/nvim-treesitter/shell_command_selectors.lua') }}
 
       - name: Compile parsers
         run: $NVIM --headless -c "lua require'nvim-treesitter.install'.prefer_git=false" -c "TSInstallSync all" -c "q"

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -99,7 +99,8 @@ function M.select_compiler_args(repo, compiler)
     }
     if
       #vim.tbl_filter(function(file)
-        return file:match "%.cc$" or file:match "%cpp$" or file:match "%.cxx$"
+        local ext = vim.fn.fnamemodify(file, ":e")
+        return ext == "cc" or ext == "cpp" or ext == "cxx"
       end, repo.files) > 0
     then
       table.insert(args, "-lstdc++")

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -96,8 +96,14 @@ function M.select_compiler_args(repo, compiler)
       repo.files,
       "-shared",
       "-Os",
-      "-lstdc++",
     }
+    if
+      #vim.tbl_filter(function(file)
+        return file:match "%.cc$" or file:match "%cpp$" or file:match "%.cxx$"
+      end, repo.files) > 0
+    then
+      table.insert(args, "-lstdc++")
+    end
     if fn.has "win32" == 0 then
       table.insert(args, "-fPIC")
     end


### PR DESCRIPTION
E.g. installing C [here](https://github.com/nvim-treesitter/nvim-treesitter/issues/4056) does not require libstdc++.