### PR TITLE
ci: trim final `"]` when parsers get added in update-lockfile.yml

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -45,7 +45,7 @@ jobs:
           git config user.name "GitHub"
           git config user.email "noreply@github.com"
           git add lockfile.json
-          UPDATED_PARSERS=$(echo $(/tmp/jd -set /tmp/old_lockfile.json lockfile.json | grep @ | sed 's/","revision"\]//' |  sed 's/@ \["//') | sed 's/ /, /g')
+          UPDATED_PARSERS=$(/tmp/jd -set /tmp/old_lockfile.json lockfile.json | sed -n '/@/s/","revision"]//;s/"]//;s/@ \["//p' | sed 'N;s/\n/, /')
           echo "UPDATED_PARSERS=$UPDATED_PARSERS" >> $GITHUB_ENV
           git commit -m "Update parsers: $UPDATED_PARSERS" || echo 'No commit necessary!'
           git clean -xf


### PR DESCRIPTION
See https://github.com/nvim-treesitter/nvim-treesitter/pull/4066

The diff will look different when a whole parser gets added:
```
@ ["gleam","revision"]
- "cfcbca3f8f734773878e00d7bfcedea98eb10be2"
+ "3eb2e1783f3bf6f85c16cdd150e2f256b2f6844e"
@ ["nix","revision"]
- "6b71a810c0acd49b980c50fc79092561f7cee307"
+ "1b69cf1fa92366eefbe6863c184e5d2ece5f187d"
@ ["wgsl_bevy"]
+ {"revision":"c81dc770310795caea5e00996505deba024ec698"}
```
