### PR TITLE
highlights(rust): use `@namespace` for `[(crate) (self) (super)]`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p ~/.local/share/nvim/site/pack/plenary.nvim/start
           cd ~/.local/share/nvim/site/pack/plenary.nvim/start
           git clone https://github.com/nvim-lua/plenary.nvim
-          curl -L https://github.com/theHamsta/highlight-assertions/releases/download/v0.1.5/highlight-assertions_v0.1.5_x86_64-unknown-linux-gnu.tar.gz | tar -xz
+          curl -L https://github.com/theHamsta/highlight-assertions/releases/download/v0.1.6/highlight-assertions_v0.1.6_x86_64-unknown-linux-gnu.tar.gz | tar -xz
           cp highlight-assertions /usr/local/bin
 
       - name: Install and prepare Neovim

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -209,10 +209,10 @@
 (type_cast_expression "as" @keyword.operator)
 (qualified_type "as" @keyword.operator)
 
-(use_list (self) @keyword)
-(scoped_use_list (self) @keyword)
-(scoped_identifier [(crate) (super) (self)] @keyword)
-(visibility_modifier [(crate) (super) (self)] @keyword)
+(use_list (self) @namespace)
+(scoped_use_list (self) @namespace)
+(scoped_identifier [(crate) (super) (self)] @namespace)
+(visibility_modifier [(crate) (super) (self)] @namespace)
 
 [
   "else"

--- a/tests/query/highlights/rust/super-crate-imports.rs
+++ b/tests/query/highlights/rust/super-crate-imports.rs
@@ -1,0 +1,12 @@
+use crate::a;
+//  ^ namespace
+//  ^ !keyword
+use crate::{b, c};
+//  ^ namespace
+//  ^ !keyword
+use super::a;
+//  ^ namespace
+//  ^ !keyword
+use super::{b, c};
+//  ^ namespace
+//  ^ !keyword

--- a/tests/query/highlights_spec.lua
+++ b/tests/query/highlights_spec.lua
@@ -76,21 +76,39 @@ local function check_assertions(file)
         end
       end
     end, true)
-    assert.True(
-      captures[assertion.expected_capture_name] or highlights[assertion.expected_capture_name],
-      "Error in at "
-        .. file
-        .. ":"
-        .. (row + 1)
-        .. ":"
-        .. (col + 1)
-        .. ': expected "'
-        .. assertion.expected_capture_name
-        .. '", captures: '
-        .. vim.inspect(vim.tbl_keys(captures))
-        .. '", highlights: '
-        .. vim.inspect(vim.tbl_keys(highlights))
-    )
+    if assertion.expected_capture_name:match "^!" then
+      assert.Falsy(
+        captures[assertion.expected_capture_name:sub(2)] or highlights[assertion.expected_capture_name:sub(2)],
+        "Error in at "
+          .. file
+          .. ":"
+          .. (row + 1)
+          .. ":"
+          .. (col + 1)
+          .. ': expected "'
+          .. assertion.expected_capture_name
+          .. '", captures: '
+          .. vim.inspect(vim.tbl_keys(captures))
+          .. '", highlights: '
+          .. vim.inspect(vim.tbl_keys(highlights))
+      )
+    else
+      assert.True(
+        captures[assertion.expected_capture_name] or highlights[assertion.expected_capture_name],
+        "Error in at "
+          .. file
+          .. ":"
+          .. (row + 1)
+          .. ":"
+          .. (col + 1)
+          .. ': expected "'
+          .. assertion.expected_capture_name
+          .. '", captures: '
+          .. vim.inspect(vim.tbl_keys(captures))
+          .. '", highlights: '
+          .. vim.inspect(vim.tbl_keys(highlights))
+      )
+    end
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/3992

Add negative assertions to verify, that there is no dual-highlight as before.