### PR TITLE
highlights(elm): zero args constructor pattern matching

### DIFF
--- a/queries/elm/highlights.scm
+++ b/queries/elm/highlights.scm
@@ -166,6 +166,8 @@
 
 (type_declaration
   (union_variant (upper_case_identifier) @constructor))
+(nullary_constructor_argument_pattern
+  (upper_case_qid (upper_case_identifier) @constructor))
 (union_pattern
   (upper_case_qid (upper_case_identifier) @constructor))
 (value_expr


### PR DESCRIPTION
I missed this in my previous MR.
Found it by browsing through large Elm codebases.

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/4299733/210181608-b172d2e4-4ae5-4e83-a0dd-00d70fb2d63a.png) | ![image](https://user-images.githubusercontent.com/4299733/210181618-bc35411f-ebea-4bf5-b020-3fcd84890cc4.png) |