### PR TITLE
fix(html): fix incorrect indents for elements/texts after end tag

### DIFF
--- a/queries/html_tags/indents.scm
+++ b/queries/html_tags/indents.scm
@@ -1,9 +1,32 @@
 [
-  (element)
+  (
+    (element
+      (start_tag 
+        (tag_name) @_not_special)
+    )
+    (#not-any-of? @_not_special "meta" "link")
+  )
+  (element (self_closing_tag))
 ] @indent
 
+; These tags are usually written one-lined and doesnt use self-closing tags so special-cased them 
+; but add indent to the tag to make sure attributes inside them are still indented if written multi-lined
+(
+  (start_tag 
+     (tag_name) @_special)
+  (#any-of? @_special "meta" "link")
+) @indent
+
+
+; These are the nodes that will be captured when we do `normal o`
+; But last element has already been ended, so capturing this
+; to mark end of last element
+(element (end_tag [">"] @indent_end))
+(element (self_closing_tag "/>" @indent_end))
+
+; Script/style elements aren't indented, so only branch the end tag of other elements
+(element (end_tag) @branch)
 [
-  (end_tag)
   ">"
   "/>"
 ] @branch

--- a/tests/indent/html/issue-3986.html
+++ b/tests/indent/html/issue-3986.html
@@ -1,0 +1,4 @@
+<div>
+  <div>
+  </div>
+</div>

--- a/tests/indent/html/script_style.html
+++ b/tests/indent/html/script_style.html
@@ -1,0 +1,12 @@
+<head>
+  <style>
+  a {
+    stroke-linecap: round;
+  }
+  </style>
+</head>
+<body>
+  <script>
+  const foo = "bar"
+  </script>
+</body>

--- a/tests/indent/html/self_closing_tag.html
+++ b/tests/indent/html/self_closing_tag.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title></title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="css/style.css" rel="stylesheet">
+  </head>
+  <body>
+    <br/>
+    <button 
+      id = "123"
+  </body>
+</html>

--- a/tests/indent/html/start_tag.html
+++ b/tests/indent/html/start_tag.html
@@ -1,0 +1,8 @@
+<meta charset="UTF-8">
+
+<html lang="en">
+  <head>
+    <meta 
+      charset="UTF-8"
+  </head>
+</html>

--- a/tests/indent/html_spec.lua
+++ b/tests/indent/html_spec.lua
@@ -1,0 +1,28 @@
+local Runner = require("tests.indent.common").Runner
+local runner = Runner:new(it, "tests/indent/html", {
+  tabstop = 2,
+  shiftwidth = 2,
+  expandtab = true,
+})
+
+describe("indent HTML:", function()
+  describe("whole file:", function()
+    runner:whole_file "."
+  end)
+
+  describe("new line:", function()
+    runner:new_line("start_tag.html", { on_line = 1, text = "anything", indent = 0 })
+    runner:new_line("start_tag.html", { on_line = 4, text = "anything", indent = 4 })
+    runner:new_line("start_tag.html", { on_line = 6, text = "charset = utf-8", indent = 6 })
+    runner:new_line("start_tag.html", { on_line = 6, text = ">", indent = 4 })
+    runner:new_line("start_tag.html", { on_line = 6, text = "/>", indent = 4 })
+    runner:new_line("issue-3986.html", { on_line = 3, text = "indent once", indent = 2 })
+    runner:new_line("self_closing_tag.html", { on_line = 10, text = "Something", indent = 4 })
+    runner:new_line("self_closing_tag.html", { on_line = 12, text = "disabled", indent = 6 })
+    runner:new_line("self_closing_tag.html", { on_line = 12, text = "/>", indent = 4 })
+    runner:new_line("script_style.html", { on_line = 5, text = "body", indent = 2 })
+    runner:new_line("script_style.html", { on_line = 6, text = "<div></div>", indent = 2 })
+    runner:new_line("script_style.html", { on_line = 9, text = "const x = 1", indent = 2 })
+    runner:new_line("script_style.html", { on_line = 11, text = "Text", indent = 2 })
+  end)
+end)


### PR DESCRIPTION
- HTML was only indenting child elements of element captures, but dedents all end tags (including script/style elements)
Change it so it now only dedents end tag of non-script/style elements
- Indent for elements was specified, but no ending mark for indents means directly following text/element will be incorrectly indented
  - It will still indent correctly if you add one space after the ending tag (not nice)
  - So adding `indent_end` to properly mark end of an element
Before:
```html
<body>
  <script>
</script>
  <div>
  </div>
    | cursor will be here if you click enter on the line above
</body>
```
After: 
```html
<body>
  <script>
  </script>
  <div>
  </div>
  | cursor will be here if you click enter on the live above
</body>
```