### PR TITLE
Switch to a better Meson grammar

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -82,7 +82,7 @@ list.agda = {
 
 list.meson = {
   install_info = {
-    url = "https://github.com/Decodetalkers/tree-sitter-meson",
+    url = "https://github.com/staysail/tree-sitter-meson",
     branch = "master",
     files = { "src/parser.c" },
   },


### PR DESCRIPTION
https://github.com/staysail/tree-sitter-meson is a more accurate and complete Meson grammar than the current one, by the admission of [the creator of the current one](https://github.com/Decodetalkers/tree-sitter-meson/issues/4#issuecomment-1301503254).