### PR TITLE
feat(gitcommit): introduce commit highlight

### DIFF
--- a/queries/gitcommit/highlights.scm
+++ b/queries/gitcommit/highlights.scm
@@ -3,6 +3,7 @@
 (title) @text.title
 (text) @text
 (branch) @text.reference
+(commit) @text.reference
 (change) @keyword
 (filepath) @text.uri
 (arrow) @punctuation.delimiter


### PR DESCRIPTION
Since https://github.com/gbprod/tree-sitter-gitcommit/pull/12, we introduced a new node `commit`, this commit add the associated highlight.