### PR TITLE
fix(nix): reduce injection false positives

### DIFF
--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -15,7 +15,7 @@
     (string_expression (string_fragment) @bash)
     (indented_string_expression (string_fragment) @bash)
   ]
-  (#match? @_path "(^\\w*Phase|(pre|post)\\w*|(.*\\.)?\\w*([sS]cript|[hH]ook)|(.*\\.)?startup)$"))
+  (#match? @_path "(^\\w+(Phase|Hook)|(pre|post)[A-Z]\\w+|script)$"))
   @combined
 
 (apply_expression


### PR DESCRIPTION
I was running into SIGSEGVs on insanely large nix files due to combining too much injections, this fixes the issue for me