### PR TITLE
highlights(haskell): function and variable bindings

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -106,16 +106,19 @@
 
 (variable) @variable
 (pat_wildcard) @variable
+(signature name: (variable) @variable)
 
-(signature name: (variable) @type)
 (function
   name: (variable) @function
   patterns: (patterns))
 (function
   name: (variable) @function
   rhs: (exp_lambda))
+((signature (variable) @function (fun)) . (function (variable)))
 ((signature (variable) @_type (fun)) . (function (variable) @function) (#eq? @function @_type))
+((signature (variable) @function (context (fun))) . (function (variable)))
 ((signature (variable) @_type (context (fun))) . (function (variable) @function) (#eq? @function @_type))
+((signature (variable) @function (forall (context (fun)))) . (function (variable)))
 ((signature (variable) @_type (forall (context (fun)))) . (function (variable) @function) (#eq? @function @_type))
 
 (exp_infix (variable) @operator)  ; consider infix functions as operators


### PR DESCRIPTION
This PR changes signature names to have the same highlights as the bindings (see the example below).
That's because the actual type is after the `::` operator, and it also keeps the highlighting in line with Elm's, which has a similar syntax.


| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/4299733/210879713-bf33e6c6-3f49-4b5b-aa5e-a1f7fc75b0fb.png) | ![image](https://user-images.githubusercontent.com/4299733/210879881-b4d75c84-fcd4-4216-abd2-627214fdebe6.png) |