### PR TITLE
fix(utils): swap_nodes calculates correct char_delta

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -400,12 +400,12 @@ function M.swap_nodes(node_or_range1, node_or_range2, bufnr, cursor_to_second)
     local line_delta = 0
     if
       range1["end"].line < range2.start.line
-      or (range1["end"].line == range2.start.line and range1["end"].character < range2.start.character)
+      or (range1["end"].line == range2.start.line and range1["end"].character <= range2.start.character)
     then
       line_delta = #text2 - #text1
     end
 
-    if range1["end"].line == range2.start.line and range1["end"].character < range2.start.character then
+    if range1["end"].line == range2.start.line and range1["end"].character <= range2.start.character then
       if line_delta ~= 0 then
         --- why?
         --correction_after_line_change =  -range2.start.character

--- a/tests/unit/ts_utils_spec.lua
+++ b/tests/unit/ts_utils_spec.lua
@@ -110,13 +110,14 @@ end)
 describe("swap_nodes", function()
   local function swap(case)
     vim.api.nvim_buf_set_lines(0, 0, -1, false, case.lines)
-    local a = vim.treesitter.get_node_at_pos(0, case.a[1], case.a[2], {})
-    local b = vim.treesitter.get_node_at_pos(0, case.b[1], case.b[2], {})
+    local a = vim.treesitter.get_node_at_pos(0, case.a[1], case.a[2], { lang = case.lang })
+    local b = vim.treesitter.get_node_at_pos(0, case.b[1], case.b[2], { lang = case.lang })
     tsutils.swap_nodes(a, b, 0, true)
   end
 
   it("works on adjacent nodes", function()
     swap {
+      lang = "python",
       lines = { "print(1)" },
       a = { 0, 0 },
       b = { 0, 5 },
@@ -131,6 +132,7 @@ describe("swap_nodes", function()
 
   it("moves cursor correctly with multiline nodes", function()
     swap {
+      lang = "lua",
       lines = { "x = { [[", "]], [[", ".....]]}" },
       a = { 0, 6 },
       b = { 1, 4 },

--- a/tests/unit/ts_utils_spec.lua
+++ b/tests/unit/ts_utils_spec.lua
@@ -125,13 +125,13 @@ describe("swap_nodes", function()
     }
 
     it("swaps text", function() end)
-    assert.equal(vim.api.nvim_buf_get_lines(0, 0, -1, false), { "(1)print" })
+    assert.same(vim.api.nvim_buf_get_lines(0, 0, -1, false), { "(1)print" })
 
     it("moves the cursor", function() end)
-    assert.equal(vim.api.nvim_win_get_cursor(0), { 1, 3 })
+    assert.same(vim.api.nvim_win_get_cursor(0), { 1, 3 })
   end)
 
-  it("moves cursor correctly with multiline nodes", function()
+  it("works with multiline nodes", function()
     swap {
       filetype = "lua",
       lines = { "x = { [[", "]], [[", ".....]]}" },
@@ -140,9 +140,9 @@ describe("swap_nodes", function()
     }
 
     it("swaps text", function() end)
-    assert.equal(vim.api.nvim_buf_get_lines(0, 0, -1, false), { { "x = { [[" }, { ".....]], [[" }, { "]]}" } })
+    assert.same(vim.api.nvim_buf_get_lines(0, 0, -1, false), { "x = { [[", ".....]], [[", "]]}" })
 
     it("moves the cursor", function() end)
-    assert.equal(vim.api.nvim_win_get_cursor(0), { 2, 9 })
+    assert.same(vim.api.nvim_win_get_cursor(0), { 2, 9 })
   end)
 end)

--- a/tests/unit/ts_utils_spec.lua
+++ b/tests/unit/ts_utils_spec.lua
@@ -110,14 +110,15 @@ end)
 describe("swap_nodes", function()
   local function swap(case)
     vim.api.nvim_buf_set_lines(0, 0, -1, false, case.lines)
-    local a = vim.treesitter.get_node_at_pos(0, case.a[1], case.a[2], { lang = case.lang })
-    local b = vim.treesitter.get_node_at_pos(0, case.b[1], case.b[2], { lang = case.lang })
+    vim.opt.filetype = case.filetype
+    local a = vim.treesitter.get_node_at_pos(0, case.a[1], case.a[2], {})
+    local b = vim.treesitter.get_node_at_pos(0, case.b[1], case.b[2], {})
     tsutils.swap_nodes(a, b, 0, true)
   end
 
   it("works on adjacent nodes", function()
     swap {
-      lang = "python",
+      filetype = "python",
       lines = { "print(1)" },
       a = { 0, 0 },
       b = { 0, 5 },
@@ -132,7 +133,7 @@ describe("swap_nodes", function()
 
   it("moves cursor correctly with multiline nodes", function()
     swap {
-      lang = "lua",
+      filetype = "lua",
       lines = { "x = { [[", "]], [[", ".....]]}" },
       a = { 0, 6 },
       b = { 1, 4 },

--- a/tests/unit/ts_utils_spec.lua
+++ b/tests/unit/ts_utils_spec.lua
@@ -108,33 +108,38 @@ describe("update_selection", function()
 end)
 
 describe("swap_nodes", function()
-  local function swap_and_return_cursor(case)
+  local function swap(case)
     vim.api.nvim_buf_set_lines(0, 0, -1, false, case.lines)
-    local a = vim.treesitter.get_node_at_position(0, case.a[1], case.a[2], {})
-    local b = vim.treesitter.get_node_at_position(0, case.b[1], case.b[2], {})
+    local a = vim.treesitter.get_node_at_pos(0, case.a[1], case.a[2], {})
+    local b = vim.treesitter.get_node_at_pos(0, case.b[1], case.b[2], {})
     tsutils.swap_nodes(a, b, 0, true)
-    return vim.api.nvim_win_get_cursor(vim.api.nvim_get_current_win())
   end
 
-  it("moves cursor correctly with adjacent nodes", function()
-    assert.equal(
-      swap_and_return_cursor {
-        lines = { "print(1)" },
-        a = { 0, 0 },
-        b = { 0, 5 },
-      },
-      { 1, 3 }
-    )
+  it("works on adjacent nodes", function()
+    swap {
+      lines = { "print(1)" },
+      a = { 0, 0 },
+      b = { 0, 5 },
+    }
+
+    it("swaps text", function() end)
+    assert.equal(vim.api.nvim_buf_get_lines(0, 0, -1, false), { "(1)print" })
+
+    it("moves the cursor", function() end)
+    assert.equal(vim.api.nvim_win_get_cursor(0), { 1, 3 })
   end)
 
   it("moves cursor correctly with multiline nodes", function()
-    assert.equal(
-      swap_and_return_cursor {
-        lines = { "x = { [[", "]], [[", ".....]]}" },
-        a = { 0, 6 },
-        b = { 1, 4 },
-      },
-      { 2, 9 }
-    )
+    swap {
+      lines = { "x = { [[", "]], [[", ".....]]}" },
+      a = { 0, 6 },
+      b = { 1, 4 },
+    }
+
+    it("swaps text", function() end)
+    assert.equal(vim.api.nvim_buf_get_lines(0, 0, -1, false), { { "x = { [[" }, { ".....]], [[" }, { "]]}" } })
+
+    it("moves the cursor", function() end)
+    assert.equal(vim.api.nvim_win_get_cursor(0), { 2, 9 })
   end)
 end)

--- a/tests/unit/ts_utils_spec.lua
+++ b/tests/unit/ts_utils_spec.lua
@@ -106,3 +106,35 @@ describe("update_selection", function()
     )
   end)
 end)
+
+describe("swap_nodes", function()
+  local function swap_and_return_cursor(case)
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, case.lines)
+    local a = vim.treesitter.get_node_at_position(0, case.a[1], case.a[2], {})
+    local b = vim.treesitter.get_node_at_position(0, case.b[1], case.b[2], {})
+    tsutils.swap_nodes(a, b, 0, true)
+    return vim.api.nvim_win_get_cursor(vim.api.nvim_get_current_win())
+  end
+
+  it("moves cursor correctly with adjacent nodes", function()
+    assert.equal(
+      swap_and_return_cursor {
+        lines = { "print(1)" },
+        a = { 0, 0 },
+        b = { 0, 5 },
+      },
+      { 1, 3 }
+    )
+  end)
+
+  it("moves cursor correctly with multiline nodes", function()
+    assert.equal(
+      swap_and_return_cursor {
+        lines = { "x = { [[", "]], [[", ".....]]}" },
+        a = { 0, 6 },
+        b = { 1, 4 },
+      },
+      { 2, 9 }
+    )
+  end)
+end)


### PR DESCRIPTION
The char_delta is not calculated correctly right now when there are two treesitter nodes being swapped, one directly following the other. This is rare but can happen for example when attempting to swap "print" and "(1)" in "print(1)". In this case an incorrect char_delta is calculated because of a bug in range comparison.