### PR TITLE
Fix scala

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -30,10 +30,10 @@
     "revision": "7175a6dd5fc1cee660dce6fe23f6043d75af424a"
   },
   "c_sharp": {
-    "revision": "1bd772f69b0db577122533514a239b184650adf2"
+    "revision": "f076a8efe30a0b8c249eeb61383f6d914376114c"
   },
   "clojure": {
-    "revision": "8c23e0ec078af461ccad43fffbbfc204aa6bc238"
+    "revision": "50468d3dc38884caa682800343d9a1d0fda46c9b"
   },
   "cmake": {
     "revision": "a32265307aa2d31941056d69e8b6633e61750b2f"
@@ -48,13 +48,13 @@
     "revision": "5e113412aadb78955c27010daa4dbe1d202013cf"
   },
   "cpp": {
-    "revision": "5ead1e26c6ab71919db0f1880c46a278a93bc5ea"
+    "revision": "cf12e881661e4c9a5ca6ae2ed5c6b9dfd44d81dd"
   },
   "css": {
     "revision": "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51"
   },
   "cuda": {
-    "revision": "7f1a79e612160aa02be87f1a24469ae3655fe818"
+    "revision": "3a9731919dfc117b32500286a1c2800b53fda01b"
   },
   "d": {
     "revision": "c2fbf21bd3aa45495fe13247e040ad5815250032"
@@ -105,7 +105,7 @@
     "revision": "c238f4af9a5723a212cf1a4c9b31dd5c1d5270a2"
   },
   "fortran": {
-    "revision": "f0f2f100952a353e64e26b0fa710b4c296d7af13"
+    "revision": "edcb3374f4698aaedf24bc572f6b2f5ef0e89ac7"
   },
   "fusion": {
     "revision": "19db2f47ba4c3a0f6238d4ae0e2abfca16e61dd6"
@@ -120,7 +120,7 @@
     "revision": "577a075d46ea109905c5cb6179809df88da61ce9"
   },
   "gitcommit": {
-    "revision": "74b40770e6299564f0b7ca474105d7d5238d0583"
+    "revision": "0ef7dd07236141a878b4cc2c488375baa5cc9d5d"
   },
   "gitignore": {
     "revision": "f4685bf11ac466dd278449bcfe5fd014e94aa504"
@@ -168,7 +168,7 @@
     "revision": "02fa3b79b3ff9a296066da6277adfc3f26cbc9e0"
   },
   "hlsl": {
-    "revision": "39c822b795bd6533815d100b5e7d1ec7778a1c2a"
+    "revision": "e6c1bff7205e2ee2a79aafecddc6069015a611ac"
   },
   "hocon": {
     "revision": "c390f10519ae69fdb03b3e5764f5592fb6924bcc"
@@ -177,7 +177,7 @@
     "revision": "29f53d8f4f2335e61bf6418ab8958dac3282077a"
   },
   "http": {
-    "revision": "30a9c1789d64429a830802cde5b1760ff1064312"
+    "revision": "2c6c44574031263326cb1e51658bbc0c084326e7"
   },
   "java": {
     "revision": "09d650def6cdf7f479f4b78f595e9ef5b58ce31e"
@@ -285,7 +285,7 @@
     "revision": "924aadaf5dea2a6074d72027b064f939acf32e20"
   },
   "prisma": {
-    "revision": "17a59236ac25413b81b1613ea6ba5d8d52d7cd6c"
+    "revision": "eca2596a355b1a9952b4f80f8f9caed300a272b5"
   },
   "proto": {
     "revision": "42d82fa18f8afe59b5fc0b16c207ee4f84cb185f"
@@ -333,7 +333,7 @@
     "revision": "f7fb205c424b0962de59b26b931fe484e1262b35"
   },
   "scala": {
-    "revision": "314bc06e59b3e0a37f224b1d391fd764757abd70"
+    "revision": "883a60f83e5e79d4fb37873820b5c1a42bcdd69f"
   },
   "scheme": {
     "revision": "16bdcf0495865e17ae5b995257458e31e8b7f450"
@@ -402,7 +402,7 @@
     "revision": "faad9094f4061a43d4e9005439e9e85c6541ebe7"
   },
   "v": {
-    "revision": "e5ec6a42f1af42d4101fb226a98b8db0f4f21c88"
+    "revision": "497563e140bf17d73f28e20b5a65e72740c2dc65"
   },
   "vala": {
     "revision": "8f690bfa639f2b83d1fb938ed3dd98a7ba453e8b"
@@ -420,7 +420,7 @@
     "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06"
   },
   "wgsl": {
-    "revision": "61d2604525d47238ecbce8aa38f10cb81ba68fd3"
+    "revision": "71803b6c1209ce7a045e768dd3850d1dff02fa86"
   },
   "wgsl_bevy": {
     "revision": "c81dc770310795caea5e00996505deba024ec698"

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -187,7 +187,7 @@
 "def" @keyword.function
 
 [
- "=>"
+ ;"=>" ; TODO: => disappeared from parse trees
  "<-"
  "@"
 ] @operator


### PR DESCRIPTION
No, idea why "=>" is no longer in the parse trees. It is still in grammar, but maybe it gets parsed differently https://github.com/tree-sitter/tree-sitter-scala/blob/master/grammar.js#L790 Did find the energy to bisect for the exact reason.