### PR TITLE
Remove update_selection side-effects

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -288,7 +288,8 @@ function M.update_selection(buf, node, selection_mode)
   -- "gv": Start Visual mode with the same area as the previous area and the same mode.
   -- Hence, area will be what we defined in "<" and ">" marks. We only feed `selection_mode` if it is
   -- different than previous `visualmode`, otherwise it will stop visual mode.
-  api.nvim_feedkeys("gv" .. selection_mode, "x", false)
+  -- bang=true is provided to avoid gv side-effects
+  api.nvim_cmd({ cmd = "normal", bang = true, args = { "gv" .. selection_mode } }, {})
 end
 
 -- Byte length of node range


### PR DESCRIPTION
With [4bcd3a3](https://github.com/nvim-treesitter/nvim-treesitter/commit/4bcd3a3cc31b9628a48ff126938262292b1ed988) some issues have come up since `feedkeys` is being used to pass `gv`. 

With the current implementation if gv is remapped, e.g. `map gv <NOP>` then `update_selection` wouldn't work properly. That's why I suggest passing instead `:normal! gv` , as it would limit side-effects.