### PR TITLE
fix(latex): highlights for math_environment

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -112,16 +112,16 @@
 
 (math_environment
   (begin
-   command: _ @text.math
-   name: (curly_group_text (text) @text.math)))
+   command: _ @text.environment
+   name: (curly_group_text (text) @text.environment.name)))
 
 (math_environment
   (text) @text.math)
 
 (math_environment
   (end
-   command: _ @text.math
-   name: (curly_group_text (text) @text.math)))
+   command: _ @text.environment
+   name: (curly_group_text (text) @text.environment.name)))
 
 ;; Sectioning
 (title_declaration


### PR DESCRIPTION
`math_environment` delimiter is not `math`