### PR TITLE
highlights(haskell): xxx(True/False)yyyy is not a bool

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -139,7 +139,7 @@
 (constructor) @constructor
 
 ; True or False
-((constructor) @_bool (#match? @_bool "(True|False)")) @boolean
+((constructor) @boolean (#any-of? @boolean "True" "False"))
 
 
 ;; ----------------------------------------------------------------------------


### PR DESCRIPTION
The regex was matching `True` / `False`, but also any constructor containing the value as substring, such as `AlwaysTrue`.

The regex was changed to ensure the matched `True` / `False` is the complete name.

Was:

![image](https://user-images.githubusercontent.com/9705357/211312031-7e982477-8b7f-4828-b1c7-e46bdb39c991.png)


Now:

![image](https://user-images.githubusercontent.com/9705357/211311732-22523da5-2af4-4291-ae49-f459ef93f108.png)
