### PR TITLE
Update to Ruby Indents for Square Brackets

### DIFF
--- a/queries/ruby/indents.scm
+++ b/queries/ruby/indents.scm
@@ -29,16 +29,15 @@
 ] @indent_end
 
 [
+  "end"
   ")"
   "}"
-  "["
   "]"
   (when)
   (elsif)
   (else)
   (rescue)
   (ensure)
-  "end"
 ] @branch
 
 (comment) @ignore

--- a/tests/indent/ruby/indent-square-brackets.rb
+++ b/tests/indent/ruby/indent-square-brackets.rb
@@ -1,0 +1,5 @@
+def indent_brackets
+  [
+    []
+  ]
+end

--- a/tests/indent/ruby/indent-square-brackets.rb
+++ b/tests/indent/ruby/indent-square-brackets.rb
@@ -1,4 +1,4 @@
-def indent_brackets
+def indent_square_brackets
   [
     []
   ]


### PR DESCRIPTION
I don't think the opening bracket should be included in `@branch`. I also moved `'end'` so it would be in the same order as in the previous group. That might be over the top.