### PR TITLE
Fix bevy: comment -> {line,block}_comment

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -423,7 +423,7 @@
     "revision": "40259f3c77ea856841a4e0c4c807705f3e4a2b65"
   },
   "wgsl_bevy": {
-    "revision": "24757275fa01e813ebfdb6acab85862ced9405d7"
+    "revision": "7cd38d6895060b023353e04f7af099ec64add5d1"
   },
   "yaml": {
     "revision": "0e36bed171768908f331ff7dff9d956bae016efb"

--- a/lockfile.json
+++ b/lockfile.json
@@ -333,7 +333,7 @@
     "revision": "f7fb205c424b0962de59b26b931fe484e1262b35"
   },
   "scala": {
-    "revision": "c4c7d2e454014659be7383a582bd84456688bb1c"
+    "revision": "ac853f11d66dd24f0aa0105f9d72b65703fc6e25"
   },
   "scheme": {
     "revision": "16bdcf0495865e17ae5b995257458e31e8b7f450"
@@ -420,7 +420,7 @@
     "revision": "91fe2754796cd8fba5f229505a23fa08f3546c06"
   },
   "wgsl": {
-    "revision": "4c03f73822c72130c63c385a112e44ad5a69f3e9"
+    "revision": "40259f3c77ea856841a4e0c4c807705f3e4a2b65"
   },
   "wgsl_bevy": {
     "revision": "24757275fa01e813ebfdb6acab85862ced9405d7"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1177,7 +1177,7 @@ list.astro = {
 list.wgsl = {
   install_info = {
     url = "https://github.com/szebniok/tree-sitter-wgsl",
-    files = { "src/parser.c" },
+    files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@szebniok" },
   filetype = "wgsl",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1186,7 +1186,7 @@ list.wgsl = {
 list.wgsl_bevy = {
   install_info = {
     url = "https://github.com/theHamsta/tree-sitter-wgsl-bevy",
-    files = { "src/parser.c" },
+    files = { "src/parser.c", "src/scanner.c" },
     generate_requires_npm = true,
   },
   maintainers = { "@theHamsta" },

--- a/queries/wgsl/highlights.scm
+++ b/queries/wgsl/highlights.scm
@@ -101,6 +101,6 @@
 (attribute
     (identifier) @attribute)
 
-(comment) @comment
+[(line_comment) (block_comment)] @comment
 
 (ERROR) @error

--- a/queries/wgsl/indents.scm
+++ b/queries/wgsl/indents.scm
@@ -16,4 +16,4 @@
   "}"
 ] @branch
 
-(comment) @auto
+[(line_comment) (block_comment)] @auto


### PR DESCRIPTION
https://github.com/szebniok/tree-sitter-wgsl/pull/7/files#diff-bbcf6c785b007d9655b443abc204cc3cc32aa03cea190cb865fe44252dc6f1df added support for block comments. This requires to add a parser and to replace `comment` in the queries.