### PR TITLE
refactor(c): Refactor indent queries

### DIFF
--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -1,28 +1,92 @@
 [
-  (compound_statement)
-  (preproc_arg)
+  (compound_statement) 
   (field_declaration_list)
   (case_statement)
   (enumerator_list)
-  (struct_specifier)
   (compound_literal_expression)
   (initializer_list)
-  (while_statement)
-  (for_statement)
-  (switch_statement)
+  (init_declarator)
   (expression_statement)
 ] @indent
-(if_statement condition: (_) @indent)
-((if_statement
-  consequence: (_) @_consequence
+
+(
+ if_statement
+  condition: (_) @indent
+)
+(
+  (if_statement
+    consequence: (_ ";" @indent_end) @_consequence
+  ) @indent
   (#not-has-type? @_consequence compound_statement)
-  ) @indent)
-(init_declarator) @indent
+) 
+
+;; if-else case,
+;; with else that is not if/compound statement
+(
+  (if_statement
+    consequence: (_ ";" @indent_end) @_consequence
+    "else" @branch
+    alternative: (_) @_alternative 
+  )@indent
+  (#not-has-type? @_consequence compound_statement)
+  (#not-has-type? @_alternative compound_statement)
+)
+
+;; if-elseif-else case
+(
+  if_statement
+  consequence: (_) @_consequence
+  alternative: 
+    (if_statement "else" @branch)
+  (#not-has-type? @_consequence compound_statement)
+)
+
+;; if- else case
+;; The alternative should be one of the cases below 
+;; because the alternative is a nested tree inside the original if
+;; dedent to offset the indent it should have gotten
+;; Does not support multi chained bare ifs 
+(
+  (if_statement
+    consequence: (_ ";" @indent_end) @_consequence
+    "else" @branch
+    alternative: 
+      [
+        (compound_statement) @dedent
+        (if_statement 
+          consequence: (_) @_consequence (#not-has-type? @_consequence compound_statement)
+        ) @dedent
+        (if_statement consequence: (compound_statement) @dedent)
+      ] 
+  )@indent
+  (#not-has-type? @_consequence compound_statement)
+)
+
+(
+  ERROR
+    "for" "(" @indent ";" ";" ")" @indent_end)
+(
+  (for_statement
+    body: (_) @_body
+  ) @indent
+  (#not-has-type? @_body compound_statement)
+)
+
+(
+  while_statement
+    condition: (_) @indent
+)
+(
+  (while_statement
+    body: (_) @_body
+  ) @indent
+  (#not-has-type? @_body compound_statement)
+)
+
 
 (compound_statement "}" @indent_end)
 
 [
-  "else"
   ")"
   "}"
   (statement_identifier)

--- a/tests/indent/c/if_else.c
+++ b/tests/indent/c/if_else.c
@@ -1,0 +1,60 @@
+int foo(int x){
+    if (x > 10)
+        return 10;
+
+    if (x > 10)
+        return 10;
+    else
+        return 10;
+
+    if (x > 20)
+        return 20;
+    else if (x > 15)
+        return 15;
+    else
+        return 10;
+}
+
+int bar(int x){
+    if (x > 20)
+        return 10;
+    else {
+        return 10;
+    }
+
+    if (x > 20)
+        return 10;
+    else if (x > 10) {
+        return 10;
+    }
+}
+
+int baz(int x){
+    if (x > 20)
+        return x;
+    else if(x > 10) {
+        if(x > 10) {
+            if(x > 10)
+                return 10;
+            if(x > 5) {
+                return 5;
+            }
+        }
+    }
+
+    if (x > 20)
+        if (x > 19)
+            if(x > 18)
+                return x;
+
+    if (x > 20)
+        return x;
+    else if (x > 19) {
+        if (x > 18)
+            return x;
+        else
+            x++;
+    }
+    else
+        return x;
+}

--- a/tests/indent/c/issue-4079.c
+++ b/tests/indent/c/issue-4079.c
@@ -1,0 +1,7 @@
+int main(){
+    for(;;)
+}
+
+int foo(){
+    while(1)
+}

--- a/tests/indent/c/issue-4117.c
+++ b/tests/indent/c/issue-4117.c
@@ -1,0 +1,6 @@
+int main(){
+    if(1){
+    } 
+    else {
+    }
+}

--- a/tests/indent/c/no_braces.c
+++ b/tests/indent/c/no_braces.c
@@ -10,3 +10,4 @@ int foo(int x) {
     for (int i = 0; i < 3; ++i)
         x--;
 }
+

--- a/tests/indent/c_spec.lua
+++ b/tests/indent/c_spec.lua
@@ -38,9 +38,35 @@ describe("indent C:", function()
     runner:new_line("ternary.c", { on_line = 4, text = ": (x == 0) : 0", indent = 8 })
     runner:new_line("issue-1568.c", { on_line = 4, text = "x++;", indent = 8 })
     runner:new_line("issue-2086.c", { on_line = 3, text = "}", indent = 0 })
+    runner:new_line("issue-4079.c", { on_line = 2, text = "return;", indent = 8 })
+    runner:new_line("issue-4079.c", { on_line = 2, text = "{", indent = 4 })
+    runner:new_line("issue-4079.c", { on_line = 6, text = "{", indent = 4 })
     -- the line after inserted one will be left with wrong indent but we only care about the inserted one
-    runner:new_line("no_braces.c", { on_line = 4, text = "x++;", indent = 8 })
-    runner:new_line("no_braces.c", { on_line = 7, text = "x++;", indent = 8 })
-    runner:new_line("no_braces.c", { on_line = 10, text = "x++;", indent = 8 })
+    for _, line in ipairs { 2, 4, 7, 10 } do
+      runner:new_line("no_braces.c", { on_line = line, text = "x++;", indent = 8 })
+    end
+    for _, line in ipairs { 2, 5, 7, 10, 12, 14, 20, 22, 25, 27, 28, 33 } do
+      runner:new_line("if_else.c", { on_line = line, text = "x++;", indent = 8 })
+    end
+    for _, line in ipairs { 3, 6, 8, 13, 15, 20, 23 } do
+      runner:new_line("if_else.c", { on_line = line, text = "else", indent = 4 })
+    end
+    for _, info in ipairs {
+      { 36, 12 },
+      { 37, 16 },
+      { 38, 12 },
+      { 39, 16 },
+      { 41, 12 },
+      { 42, 8 },
+      { 45, 8 },
+      { 46, 12 },
+      { 47, 16 },
+      { 48, 4 },
+      { 52, 8 },
+      { 53, 12 },
+      { 54, 12 },
+    } do
+      runner:new_line("if_else.c", { on_line = info[1], text = "x++;", indent = info[2] })
+    end
   end)
 end)

--- a/tests/indent/c_spec.lua
+++ b/tests/indent/c_spec.lua
@@ -41,6 +41,7 @@ describe("indent C:", function()
     runner:new_line("issue-4079.c", { on_line = 2, text = "return;", indent = 8 })
     runner:new_line("issue-4079.c", { on_line = 2, text = "{", indent = 4 })
     runner:new_line("issue-4079.c", { on_line = 6, text = "{", indent = 4 })
+    runner:new_line("issue-4117.c", { on_line = 3, text = "else", indent = 4 })
     -- the line after inserted one will be left with wrong indent but we only care about the inserted one
     for _, line in ipairs { 2, 4, 7, 10 } do
       runner:new_line("no_braces.c", { on_line = line, text = "x++;", indent = 8 })
@@ -67,6 +68,10 @@ describe("indent C:", function()
       { 54, 12 },
     } do
       runner:new_line("if_else.c", { on_line = info[1], text = "x++;", indent = info[2] })
+    end
+    -- dedent braces on new line
+    for _, line in ipairs { 10, 12, 14 } do
+      runner:new_line("if_else.c", { on_line = line, text = "{}", indent = 4 })
     end
   end)
 end)


### PR DESCRIPTION
Resolves #4079
Resolves #4117
Behavior changes:
- Before:
  - An if statement without code blocks, following by another if statement/ code blocks will be indented twice
  - If the chain continues, then it is indented multiple times (equal to the amount of bare if statements that appears in the chain of if-else above it)
- Now:
  - A bare if statement, followed by a bare if statement, then the second bare if statement will not be indented any extra
I have yet to cover for the situations below
- else immediately followed by a for/while/switch statement (indent twice)
  - This case I don't know how to handle, as there may be two styles for this (for/while in the same/different line to else)

<details>
<summary>Supported if styles</summary>   

```   
if 
  ret
else if
  ret
else
  ret

if
{
  ret
}
else if
{
  ret
}

if {
  ret
} else if {
  ret
} else {
  ret
}

if {
  ret
}
else if {
  ret
}
else {
  ret
}
```
</details>