### PR TITLE
feat: let filetype qml use the highlight of qmljs

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -96,7 +96,7 @@ list.qmljs = {
     branch = "master",
     files = { "src/parser.c", "src/scanner.c" },
   },
-  filetype = "qmljs",
+  filetype = "qml",
   maintainers = { "@Decodetalkers" },
 }
 


### PR DESCRIPTION
Someone like qml to mark qmljs, so let 'qml'
use qmljs
