### PR TITLE
Fix nickel: switch -> match

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -30,7 +30,7 @@
     "revision": "7175a6dd5fc1cee660dce6fe23f6043d75af424a"
   },
   "c_sharp": {
-    "revision": "829ecfe94b417bb4c1ed1fe7a5c5378486d3b873"
+    "revision": "50b8184db72d7c27d72e82154b975e406bcfe068"
   },
   "clojure": {
     "revision": "50468d3dc38884caa682800343d9a1d0fda46c9b"
@@ -246,7 +246,7 @@
     "revision": "6c5f7ef944f9c6ae8a0fc28b9071a4b493652238"
   },
   "nickel": {
-    "revision": "9d83db400b6c11260b9106f131f93ddda8131933"
+    "revision": "7867780e52ebeda0daa4a55acb870100e070d274"
   },
   "ninja": {
     "revision": "0a95cfdc0745b6ae82f60d3a339b37f19b7b9267"
@@ -354,7 +354,7 @@
     "revision": "05f949d3c1c15e3261473a244d3ce87777374dec"
   },
   "sql": {
-    "revision": "8635357363f8b01931ce6abbe0c937aa73e47bf8"
+    "revision": "c9e2453821fafafe79c6911e49f3ce5fe7c60542"
   },
   "supercollider": {
     "revision": "90c6d9f777d2b8c4ce497c48b5f270a44bcf3ea0"

--- a/queries/nickel/highlights.scm
+++ b/queries/nickel/highlights.scm
@@ -14,7 +14,7 @@
 "import" @include
 
 [ "if" "then" "else" ] @conditional
-"switch" @conditional
+"match" @conditional
 
 (types) @type
 "Array" @type.builtin


### PR DESCRIPTION
Follow upstream change in https://github.com/nickel-lang/tree-sitter-nickel/pull/13/files#diff-d485a982e458ef8da2cc203585065b7542665cb80b78d230b1e8f77ea25825d4 that also modified highlights.scm
