### PR TITLE
refactor(scala): update the Scala highlight queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -333,7 +333,7 @@
     "revision": "f7fb205c424b0962de59b26b931fe484e1262b35"
   },
   "scala": {
-    "revision": "fd05f09043051c82fba695aa95cee9c534fbc533"
+    "revision": "47767fca8f422d7f22819f5dd2511ecaa290e7be"
   },
   "scheme": {
     "revision": "16bdcf0495865e17ae5b995257458e31e8b7f450"

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -1,28 +1,9 @@
 ; CREDITS @stumash (stuart.mashaal@gmail.com)
 
-;; variables
-
-(identifier) @variable
-
-((identifier) @variable.builtin
- (#lua-match? @variable.builtin "^this$"))
-
-(interpolation) @none
-
-; Assume other uppercase names constants.
-; NOTE: In order to distinguish constants we highlight
-; all the identifiers that are uppercased. But this solution
-; is not suitable for all occurrences e.g. it will highlight
-; an uppercased method as a constant if used with no params.
-; Introducing highlighting for those specific cases, is probably
-; best way to resolve the issue.
-((identifier) @constant (#lua-match? @constant "^[A-Z]"))
-
-;; types
-
-(type_identifier) @type
-
 (class_definition
+  name: (identifier) @type)
+
+(enum_definition
   name: (identifier) @type)
 
 (object_definition
@@ -30,26 +11,52 @@
 
 (trait_definition
   name: (identifier) @type)
+
+(full_enum_case
+  name: (identifier) @type)
+
+(simple_enum_case
+  name: (identifier) @type)
+
+;; variables
+
+(class_parameter 
+  name: (identifier) @parameter)
+
+
+(interpolation) @none
+
+;; types
 
 (type_definition
   name: (type_identifier) @type.definition)
 
+(type_identifier) @type
+
+
+;; val/var definitions/declarations
+
+(val_definition
+  pattern: (identifier) @variable)
+
+(var_definition
+  pattern: (identifier) @variable)
+
+(val_declaration
+  name: (identifier) @variable)
+
+(var_declaration
+  name: (identifier) @variable)
+
 ; method definition
 
-(class_definition
-  body: (template_body
-    (function_definition
-      name: (identifier) @method)))
-(object_definition
-  body: (template_body
-    (function_definition
-      name: (identifier) @method)))
-(trait_definition
-  body: (template_body
-    (function_definition
-      name: (identifier) @method)))
+(function_declaration
+      name: (identifier) @method)
 
-; imports
+(function_definition
+      name: (identifier) @method)
+
+; imports/exports
 
 (import_declaration
   path: (identifier) @namespace)
@@ -59,13 +66,24 @@
   path: (identifier) @type) (#lua-match? @type "^[A-Z]"))
 ((stable_identifier (identifier) @type) (#lua-match? @type "^[A-Z]"))
 
-((import_selectors (identifier) @type) (#lua-match? @type "^[A-Z]"))
+(export_declaration
+  path: (identifier) @namespace)
+((stable_identifier (identifier) @namespace))
+
+((export_declaration
+  path: (identifier) @type) (#lua-match? @type "^[A-Z]"))
+((stable_identifier (identifier) @type) (#lua-match? @type "^[A-Z]"))
+
+((namespace_selectors (identifier) @type) (#lua-match? @type "^[A-Z]"))
 
 ; method invocation
 
 
 (call_expression
   function: (identifier) @function.call)
+
+(call_expression
+  function: (operator_identifier) @function.call)
 
 (call_expression
   function: (field_expression
@@ -78,11 +96,6 @@
 (generic_function
   function: (identifier) @function.call)
 
-(
-  (identifier) @function.builtin
-  (#lua-match? @function.builtin "^super$")
-)
-
 ; function definitions
 
 (function_definition
@@ -92,7 +105,6 @@
   name: (identifier) @parameter)
 
 ; expressions
-
 
 (field_expression field: (identifier) @property)
 (field_expression value: (identifier) @type
@@ -110,20 +122,27 @@
 (floating_point_literal) @float
 
 [
-(symbol_literal)
-(string)
-(character_literal)
-(interpolated_string_expression)
+  (symbol_literal)
+  (string)
+  (character_literal)
+  (interpolated_string_expression)
 ] @string
 
 (interpolation "$" @punctuation.special)
 
 ;; keywords
 
+(opaque_modifier) @type.qualifier
+(infix_modifier) @keyword
+(transparent_modifier) @type.qualifier
+(open_modifier) @type.qualifier
+
 [
   "case"
   "class"
+  "enum"
   "extends"
+  "derives"
   "finally"
 ;; `forSome` existential types not implemented yet
 ;; `macro` not implemented yet
@@ -135,17 +154,24 @@
   "val"
   "var"
   "with"
+  "given"
+  "using"
+  "end"
+  "implicit"
+  "extension"
+  "with"
 ] @keyword
 
 [
   "abstract"
   "final"
-  "implicit"
   "lazy"
+  "sealed"
   "private"
   "protected"
-  "sealed"
 ] @type.qualifier
+
+(inline_modifier) @storageclass
 
 (null_literal) @constant.builtin
 
@@ -161,6 +187,7 @@
   "else"
   "if"
   "match"
+  "then"
 ] @conditional
 
 [
@@ -192,7 +219,7 @@
  "@"
 ] @operator
 
-"import" @include
+["import" "export"] @include
 
 [
   "try"
@@ -208,3 +235,14 @@
 
 (case_block
   (case_clause ("case") @conditional))
+
+(operator_identifier) @operator
+
+((identifier) @constant (#lua-match? @constant "^[A-Z]"))
+((identifier) @variable.builtin
+ (#lua-match? @variable.builtin "^this$"))
+
+(
+  (identifier) @function.builtin
+  (#lua-match? @function.builtin "^super$")
+)


### PR DESCRIPTION
There has been a lot of changes recently to the Scala grammar and we've been merging in a handful of things before syncing the actual generated parser. We are currently at a stage where we're going to sync everything, but there are some breaking changes that are included in https://github.com/tree-sitter/tree-sitter-scala/pull/135, so when that commit gets synced here stuff will break. We've taken the queries that existed here and have been building off of them in the actual upstream repo. This will hopefully make the transition smooth and updates the queries to ensure that there is no breakage. It's recommended to wait until that pr is merged, synced here, and then merge this in around the same time.

Co-authored-by: eugene yokota <eed3si9n@gmail.com>
Co-authored-by: Anton Sviridov <keynmol@gmail.com>

CC @stevanmilic since you did all the initial work on these.