### PR TITLE
feat(scss): add known at-rules to keyword list

### DIFF
--- a/queries/scss/highlights.scm
+++ b/queries/scss/highlights.scm
@@ -1,8 +1,14 @@
 ; inherits: css
 
 [
+  "@at-root"
+  "@debug"
+  "@error"
+  "@extend"
+  "@forward"
   "@mixin"
-  "@media"
+  "@use"
+  "@warn"
 ] @keyword
 
 "@function" @keyword.function


### PR DESCRIPTION
also removed `@media` as we are already inheriting it from [`css`](https://github.com/nvim-treesitter/nvim-treesitter/blob/9a257d989a526c413a28c252c4ec9113a7d35a28/queries/css/highlights.scm#L2)

Ref: https://sass-lang.com/documentation/at-rules