### PR TITLE
readme: runtimepath before setup call

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,13 +415,14 @@ This directory must be writeable and must be explicitly added to the
 `runtimepath`. For example:
 
 ``` lua
+  vim.opt.runtimepath:append("/some/path/to/store/parsers")
+
   require'nvim-treesitter.configs'.setup {
     parser_install_dir = "/some/path/to/store/parsers",
 
     ...
 
   }
-  vim.opt.runtimepath:append("/some/path/to/store/parsers")
 ```
 
 If this option is not included in the setup options, or is explicitly set to


### PR DESCRIPTION
In the README.md, [it is suggested to add `vim.opt.runtimepath:append("/some/path/to/store/parsers")` **after** the call of `require'nvim-treesitter.configs'.setup`](https://github.com/nvim-treesitter/nvim-treesitter#changing-the-parser-install-directory).

However, it seems to me that it only works if it is placed before.

Related issue: https://github.com/nvim-treesitter/nvim-treesitter/issues/3605