### PR TITLE
ci: stop running update-lockfile after every commit

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -3,9 +3,6 @@ name: Update lockfile
 on:
   schedule:
     - cron: '30 6 * * *'
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is wasteful and noisy for unrelated commits, while the intended use
(making sure that new parsers have a lockfile entry) can be covered by
either making sure this is part of the initial PR (ideally) or running
the action manually.
