### PR TITLE
highlights(haskell): special sigils and operators

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -60,8 +60,12 @@
   (type_operator)
   (tycon_arrow)
   (qualified_module)  ; grabs the `.` (dot), ex: import System.IO
+  (qualified_type)
+  (qualified_variable)
   (all_names)
   (wildcard)
+  "."
+  ".."
   "="
   "|"
   "::"
@@ -134,6 +138,7 @@
 ;; Types
 
 (type) @type
+(type_star) @type
 (type_variable) @type
 
 (constructor) @constructor


### PR DESCRIPTION
This PR adds highlights for several things:
1. Range operator (`..`)
2. Dot in qualified types and variables (`M.Map` & `M.lookup`)
3. Dot at the end of `forall` statements.
4. `*` in kind signatures (`* -> *`).

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/4299733/212496637-e60d053d-c1d1-4752-8505-198f8b7671f6.png) | ![image](https://user-images.githubusercontent.com/4299733/212496599-cc218f47-242c-4eca-84de-54e38e6e00fa.png) |