### PR TITLE
highlights(elm): fix boolean literals

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -723,6 +723,7 @@ list.elm = {
     url = "https://github.com/elm-tooling/tree-sitter-elm",
     files = { "src/parser.c", "src/scanner.cc" },
   },
+  maintainers = { "@zweimach" },
 }
 
 list.yaml = {

--- a/queries/elm/highlights.scm
+++ b/queries/elm/highlights.scm
@@ -181,7 +181,7 @@
   (number_literal) @number)
 
 (upper_case_qid
-  ((upper_case_identifier) @_bool (#match? @_bool "(True|False)")) @boolean)
+  ((upper_case_identifier) @boolean (#any-of? @boolean "True" "False")))
 
 [
   (open_quote)


### PR DESCRIPTION
This fixes a query similar to #4130 with @ObserverOfTime's suggested query.

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/4299733/212498416-a304a2e8-1731-49eb-86b9-3426b3de4da8.png) | ![image](https://user-images.githubusercontent.com/4299733/212498365-99580767-c6d7-4da7-9a2d-68a9e7e95e37.png) |