### PR TITLE
docs: clarify @storageclass in CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @type.definition       ; type definitions (e.g. `typedef` in C)
 @type.qualifier        ; type qualifiers (e.g. `const`)
 
-@storageclass          ; visibility/life-time modifiers
+@storageclass          ; life-time modifiers that affect storage in memory
 @attribute             ; attribute annotations (e.g. Python decorators)
 @field                 ; object and struct fields
 @property              ; similar to `@field`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ effect on highlighting. We will work on improving highlighting in the near futur
 @type.definition       ; type definitions (e.g. `typedef` in C)
 @type.qualifier        ; type qualifiers (e.g. `const`)
 
-@storageclass          ; life-time modifiers that affect storage in memory
+@storageclass          ; modifiers that affect storage in memory or life-time
 @attribute             ; attribute annotations (e.g. Python decorators)
 @field                 ; object and struct fields
 @property              ; similar to `@field`


### PR DESCRIPTION
This is just a tiny change that was in reference to
https://github.com/nvim-treesitter/nvim-treesitter/pull/4153#discussion_r1070276800.
The basis is that `@storageclass` should only be used unless it's
actually affecting storage in memory. There are further conversations
about this in the following places:

- https://github.com/nvim-treesitter/nvim-treesitter/pull/3648#issuecomment-1279923861
- https://github.com/nvim-treesitter/nvim-treesitter/pull/3648#issuecomment-1291624844
