### PR TITLE
chore: sync latest Scala parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -333,7 +333,7 @@
     "revision": "f7fb205c424b0962de59b26b931fe484e1262b35"
   },
   "scala": {
-    "revision": "fce8f8c3f6210a3eaf7ca210a1c0ebacc974ddda"
+    "revision": "8079aede955f95148b874819087c5741ac8b3689"
   },
   "scheme": {
     "revision": "67b90a365bebf4406af4e5a546d6336de787e135"


### PR DESCRIPTION
I just missed the cron to generate this by like an hour, so I'm just
manually shooting this in. This should help in the crashes reported in
https://github.com/nvim-treesitter/nvim-treesitter/issues/4170 since it
includes https://github.com/tree-sitter/tree-sitter-scala/pull/160.
