### PR TITLE
injections(html): update injection queries

### DIFF
--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -1,10 +1,9 @@
 ; <style>...</style>
 (
   (style_element
-    (start_tag) @_no_attribute
+    (start_tag
+      (tag_name) .) 
     (raw_text) @css)
-  (#match? @_no_attribute "^\\<\\s*style\\s*\\>$")
-  ; unsure why, but without escaping &lt; and &gt; the query breaks
 ) 
 
 ; <style blocking> ...</style>
@@ -33,9 +32,9 @@
 ; <script>...</script>
 (
   (script_element
-    (start_tag) @_no_attribute
+    (start_tag
+      (tag_name) .) 
     (raw_text) @javascript)
-  (#match? @_no_attribute "^\\<\\s*script\\s*\\>$")
 ) 
 
 ; <script defer>...</script>


### PR DESCRIPTION
Use built in anchor node instead of predicate for checking no attribute style/script tags