### PR TITLE
Add support for tree-sitter-ini

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -18,6 +18,7 @@ local filetype_to_parsername = {
   cs = "c_sharp",
   tape = "vhs",
   dosini = "ini",
+  confini = "ini",
 }
 
 ---@class InstallInfo

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -17,6 +17,7 @@ local filetype_to_parsername = {
   rmd = "markdown",
   cs = "c_sharp",
   tape = "vhs",
+  dosini = "ini",
 }
 
 ---@class InstallInfo
@@ -1402,6 +1403,15 @@ list.ebnf = {
     branch = "main",
   },
   maintainers = { "@RubixDev" },
+  experimental = true,
+}
+
+list.ini = {
+  install_info = {
+    url = "https://github.com/justinmk/tree-sitter-ini",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@theHamsta" },
   experimental = true,
 }
 

--- a/queries/ini/folds.scm
+++ b/queries/ini/folds.scm
@@ -1,0 +1,1 @@
+(section) @fold

--- a/queries/ini/highlights.scm
+++ b/queries/ini/highlights.scm
@@ -1,0 +1,16 @@
+(section_name
+  (text) @type) ; consistency with toml
+(comment) @comment
+
+[
+ "["
+ "]"
+] @punctuation.bracket
+
+[
+ "="
+] @operator
+
+(setting (setting_name) @property)
+(setting_value) @text ; grammar does not support subtypes
+(ERROR (setting_name) @text)


### PR DESCRIPTION
Works with classic one-line key-value pairs. Not with Python-style inis with multiline values (highlighting is still ok with used queries)

Addresses https://github.com/nvim-treesitter/nvim-treesitter/issues/2282#issuecomment-1398856301

@dsully
