### PR TITLE
refactor(scala): update scala highlights for uppercase identifiers

### DIFF
--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -241,7 +241,7 @@
 
 (operator_identifier) @operator
 
-((identifier) @constant (#lua-match? @constant "^[A-Z]"))
+((identifier) @type (#lua-match? @type "^[A-Z]"))
 ((identifier) @variable.builtin
  (#lua-match? @variable.builtin "^this$"))
 


### PR DESCRIPTION
This is a small change that comes from the discussion we had in
https://github.com/tree-sitter/tree-sitter-scala/discussions/168#discussioncomment-4718624.
The idea here is that we're sort of making an assumption on what an
uppercase identifier is in Scala and more times than not, it's actually
a `@type`. So this changes the `@constant` capture to a `@type` one. You
can find the full context in the linked discussion.
