### PR TITLE
Partially revert json highlight updates

### DIFF
--- a/queries/json/highlights.scm
+++ b/queries/json/highlights.scm
@@ -7,9 +7,8 @@
 
 (number) @number
 
-(pair
-  key: (string) @label
-  value: (string) @string)
+(pair key: (string) @label)
+(pair value: (string) @string)
 
 (array (string) @string)
 


### PR DESCRIPTION
This PR partially reverts da6dc21 as currently it breaks highlighting if the value of a pair is not a string (can also be boolean, number, array and object)

@ObserverOfTime is it ok to revert this?