### PR TITLE
injections(python): inject rst in docstrings

### DIFF
--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -7,5 +7,14 @@
   (#lua-match? @_string "^r.*")
   (#set! injection.language "regex"))
 
+((expression_statement
+   (string (string_content) @injection.content))
+ (#set! injection.language "rst"))
+
+((comment) @injection.content
+ (#lua-match? @injection.content "^#: ")
+ (#offset! @injection.content 0 3 0 0)
+ (#set! injection.language "rst"))
+
 ((comment) @injection.content
  (#set! injection.language "comment"))


### PR DESCRIPTION
Includes an injection for the special comments supported by [Sphinx](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autofunction).

> For module data members and class attributes, documentation can either be put into a comment with special formatting (using a `#:` to start the comment instead of just `#`), or in a docstring after the definition.

---

Ideally, we would have a special parser that extends `rst` but this is good enough for now.
Here's how it looks on the different docstring styles (with the gruvbox theme):

**Sphinx** (decent)

![image](https://user-images.githubusercontent.com/24971970/213907752-c8ae4645-d4b9-4cb1-b7be-a186cd3c53a7.png)

**Google** (acceptable)

![image](https://user-images.githubusercontent.com/24971970/213907761-0239681f-7785-4c6c-be37-4e4232376212.png)

**NumPy** (deficient)

![image](https://user-images.githubusercontent.com/24971970/213907782-03471efb-7033-447a-887f-b047156a0ce9.png)

*Not sure why the `PEP 484` reference isn't even highlighted in this case.*