### PR TITLE
feat: add capnp

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [bibtex](https://github.com/latex-lsp/tree-sitter-bibtex) (maintained by @theHamsta, @clason)
 - [x] [blueprint](https://gitlab.com/gabmus/tree-sitter-blueprint.git) (experimental, maintained by @gabmus)
 - [x] [c](https://github.com/tree-sitter/tree-sitter-c) (maintained by @vigoux)
+- [x] [capnp](https://github.com/amaanq/tree-sitter-capnp) (experimental, maintained by @amaanq)
 - [x] [c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) (maintained by @Luxed)
 - [x] [clojure](https://github.com/sogaiu/tree-sitter-clojure) (maintained by @sogaiu)
 - [x] [cmake](https://github.com/uyha/tree-sitter-cmake) (maintained by @uyha)

--- a/lockfile.json
+++ b/lockfile.json
@@ -30,7 +30,7 @@
     "revision": "7175a6dd5fc1cee660dce6fe23f6043d75af424a"
   },
   "capnp": {
-    "revision": "dcb93783452fd8dffab65e8a5dd4574ce4ff91df"
+    "revision": "b37a22b06ba28bfd32018fce39c4277c13bdeb77"
   },
   "c_sharp": {
     "revision": "a29bac0681802139710b4d3875540901504d15cb"

--- a/lockfile.json
+++ b/lockfile.json
@@ -29,6 +29,9 @@
   "c": {
     "revision": "7175a6dd5fc1cee660dce6fe23f6043d75af424a"
   },
+  "capnp": {
+    "revision": "dcb93783452fd8dffab65e8a5dd4574ce4ff91df"
+  },
   "c_sharp": {
     "revision": "a29bac0681802139710b4d3875540901504d15cb"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -30,7 +30,7 @@
     "revision": "7175a6dd5fc1cee660dce6fe23f6043d75af424a"
   },
   "capnp": {
-    "revision": "08b3b016bee2749a4531b1c9b45bfa3f2f5ca834"
+    "revision": "fda654c12f29ec70309d9573bc0af16b7124384e"
   },
   "c_sharp": {
     "revision": "a29bac0681802139710b4d3875540901504d15cb"

--- a/lockfile.json
+++ b/lockfile.json
@@ -30,7 +30,7 @@
     "revision": "7175a6dd5fc1cee660dce6fe23f6043d75af424a"
   },
   "capnp": {
-    "revision": "b37a22b06ba28bfd32018fce39c4277c13bdeb77"
+    "revision": "08b3b016bee2749a4531b1c9b45bfa3f2f5ca834"
   },
   "c_sharp": {
     "revision": "a29bac0681802139710b4d3875540901504d15cb"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1195,6 +1195,15 @@ list.astro = {
   maintainers = { "@virchau13" },
 }
 
+list.capnp = {
+  install_info = {
+    url = "https://github.com/amaanq/tree-sitter-capnp",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@amaanq" },
+  experimental = true,
+}
+
 list.wgsl = {
   install_info = {
     url = "https://github.com/szebniok/tree-sitter-wgsl",

--- a/queries/capnp/highlights.scm
+++ b/queries/capnp/highlights.scm
@@ -1,0 +1,118 @@
+; Preproc (?)
+
+(unique_id) @preproc
+
+; Includes
+
+[
+  "import"
+  "$import"
+] @include
+
+(import_path) @string
+
+; Types
+
+(primitive_type) @type.builtin
+
+[
+  "annotation"
+  "enum"
+  "group"
+  "interface"
+  "List"
+  "struct"
+  "union"
+] @type.builtin
+
+; Methods
+
+(method_identifier) @method
+
+; Fields
+
+(field_identifier) @field
+
+; Parameters
+
+(param_identifier) @parameter
+(return_identifier) @parameter
+
+; Variables
+
+(identifier) @variable
+
+; Constants
+
+(const_identifier) @constant
+(enum_member) @constant
+
+; Types
+
+(enum_identifier) @type
+(extend_type) @type
+(field_type) @type
+(generic_identifier) @type
+(type_identifier) @type
+
+; Attributes
+
+(attribute) @attribute
+(annotation_identifier) @attribute
+
+; Operators
+
+[
+ ; @ ! -
+  "="
+] @operator
+
+; Keywords
+
+[
+  "const"
+  "extends"
+  "import"
+  "$import"
+  "namespace"
+  "using"
+] @keyword
+
+; Literals
+
+(string_literal) @string
+
+(data_string) @string.special
+(namespace) @string.special
+
+(number) @number
+
+(float) @float
+
+(boolean) @boolean
+
+; Misc
+
+[
+  "const"
+] @type.qualifier
+
+[
+  "*"
+] @punctuation.special
+
+["{" "}"] @punctuation.bracket
+
+["(" ")"] @punctuation.bracket
+
+["[" "]"] @punctuation.bracket
+
+[
+  ","
+  ";"
+  "->"
+] @punctuation.delimiter
+
+; Comments
+
+(comment) @comment @spell

--- a/queries/capnp/highlights.scm
+++ b/queries/capnp/highlights.scm
@@ -25,6 +25,14 @@
   "union"
 ] @type.builtin
 
+; Typedefs
+
+(type_definition) @type.definition
+
+; Labels (@number, @number!)
+
+(field_version) @label
+
 ; Methods
 
 (method_identifier) @method
@@ -70,7 +78,6 @@
 ; Keywords
 
 [
-  "const"
   "extends"
   "namespace"
   "using"

--- a/queries/capnp/highlights.scm
+++ b/queries/capnp/highlights.scm
@@ -72,8 +72,6 @@
 [
   "const"
   "extends"
-  "import"
-  "$import"
   "namespace"
   "using"
 ] @keyword

--- a/queries/capnp/highlights.scm
+++ b/queries/capnp/highlights.scm
@@ -7,6 +7,7 @@
 [
   "import"
   "$import"
+  "embed"
 ] @include
 
 (import_path) @string


### PR DESCRIPTION
This PR adds a capnp parser+queries

Parser: https://github.com/amaanq/tree-sitter-capnp
Reference: https://capnproto.org/language.html

cc: @marziply since they first brought it up in #2282 

There are some oddities with this language in general that I'd like some advice on as to how to define the queries for. Cap'n Proto fields have a numeric identifier as a type of "version" for that field, e.g. 

```capnp
struct Test {
  voidField    @0  : Void;
  boolField    @1  : Bool;
}
```

So voidField has a version of 0, boolField 1. you can also optionally add a ! to indicate that the number is an inline (immediate) value, as opposed to a reference to a value stored elsewhere in the data structure, for more efficient encoding and decoding of data. 

At first I thought of just using operator, but that wouldn't work and doesn't fit well. I also thought of string.special, but it's not a string at all so that also doesn't fit well. I'm not sure of the use case of `@symbol`, whether if it's just for a special char or if it even applies here. That and the import vs $import are also confusing, I put them both under @include but I wonder if I should just omit $ and instead declare it as `@punctuation.special`.

Thanks!
-Amaan

