### PR TITLE
highlights(php): declare directives and `:`

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -110,9 +110,7 @@
 (conditional_expression) @conditional
 
 ; Directives
-(declare_directive "strict_types" @preproc)
-(declare_directive "ticks" @preproc)
-(declare_directive "encoding" @preproc)
+(declare_directive ["strict_types" "ticks" "encoding"] @preproc)
 
 ; Basic tokens
 

--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -110,7 +110,7 @@
 (conditional_expression) @conditional
 
 ; Directives
-(declare_directive ["strict_types" "ticks" "encoding"] @preproc)
+(declare_directive ["strict_types" "ticks" "encoding"] @parameter)
 
 ; Basic tokens
 

--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -108,6 +108,12 @@
 
 ; Conditions ( ? : )
 (conditional_expression) @conditional
+
+; Directives
+(declare_directive "strict_types" @preproc)
+(declare_directive "ticks" @preproc)
+(declare_directive "encoding" @preproc)
+
 ; Basic tokens
 
 [
@@ -219,6 +225,7 @@
 [
  ","
  ";"
+ ":"
  ] @punctuation.delimiter
 
 [


### PR DESCRIPTION
Is `@preproc` the right capture for this?

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/4299733/213964895-22a2d35b-a1d3-40df-ad08-5eecacfacd25.png) | ![image](https://user-images.githubusercontent.com/4299733/213964825-b77a45d7-c383-4832-89e6-7fd0e70beac9.png) |