### PR TITLE
map quarto ft to markdown parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -15,6 +15,7 @@ local filetype_to_parsername = {
   OpenFOAM = "foam",
   pandoc = "markdown",
   rmd = "markdown",
+  quarto = "markdown",
   cs = "c_sharp",
   tape = "vhs",
   dosini = "ini",


### PR DESCRIPTION
Adds the [quarto](https://quarto.org/) filetype to use the markdown parser. When the filetype was very new we had just changed the filetype from quarto to markdown, but now it is time to make use of it :) 