### PR TITLE
Update syntax highlighting for hcl

### DIFF
--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -93,7 +93,7 @@
 
 ; var.foo, data.bar
 ;
-; first element in get_attr is a keyword or a reference to a keyword
+; first element in get_attr is a variable.builtin or a reference to a variable.builtin
 (expression (variable_expr (identifier) @variable.builtin) (get_attr (identifier) @field))
 
 (ERROR) @error

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -50,7 +50,7 @@
   "in"
 ] @repeat
 
-[ 
+[
   "if"
   "else"
   "endif"
@@ -94,6 +94,6 @@
 ; var.foo, data.bar
 ;
 ; first element in get_attr is a keyword or a reference to a keyword
-(expression (variable_expr (identifier) @keyword) (get_attr (identifier) @field))
+(expression (variable_expr (identifier) @variable.builtin) (get_attr (identifier) @field))
 
 (ERROR) @error

--- a/queries/terraform/highlights.scm
+++ b/queries/terraform/highlights.scm
@@ -4,7 +4,7 @@
 ;
 ;
 ; local/module/data/var/output
-(expression (variable_expr (identifier) @variable.builtin (#any-of? @variable.builtin "data" "var" "local" "module" "output")) (get_attr (identifier) @field))
+(expression (variable_expr (identifier) @type.builtin (#any-of? @type.builtin "data" "var" "local" "module" "output")) (get_attr (identifier) @field))
 
 ; path.root/cwd/module
 (expression (variable_expr (identifier) @type.builtin (#eq? @type.builtin "path")) (get_attr (identifier) @variable.builtin (#any-of? @variable.builtin "root" "cwd" "module")))

--- a/queries/terraform/highlights.scm
+++ b/queries/terraform/highlights.scm
@@ -4,7 +4,7 @@
 ;
 ;
 ; local/module/data/var/output
-(expression (variable_expr (identifier) @type.builtin (#any-of? @type.builtin "data" "var" "local" "module" "output")) (get_attr (identifier) @field))
+(expression (variable_expr (identifier) @variable.builtin (#any-of? @variable.builtin "data" "var" "local" "module" "output")) (get_attr (identifier) @field))
 
 ; path.root/cwd/module
 (expression (variable_expr (identifier) @type.builtin (#eq? @type.builtin "path")) (get_attr (identifier) @variable.builtin (#any-of? @variable.builtin "root" "cwd" "module")))


### PR DESCRIPTION
cc @MichaHoffmann 

First off - appreciate all the work from everyone going into this plugin! I was recently messing around with LunarVim and liked the syntax-highlighting it was providing for terraform. Through the help of my colleague @pappasam - he helped me understand how syntax highlighting works. From there, I was able to determine that LunarVim was shipping an old version of the tree-sitter parsers.

I'm hoping we can bring back this particular change because it's visually much more pleasing. I'm still learning tree-sitter parser syntax so not sure if this is the best approach and also know this is subjective. Screenshots with before/after.

## BEFORE

![image](https://user-images.githubusercontent.com/4175239/214662682-f2302ad4-9ae3-456f-8c50-7ce064b7093a.png)

## AFTER

![image](https://user-images.githubusercontent.com/4175239/214662908-40de787a-11ea-469b-bd3a-7c541f55db0b.png)
