### PR TITLE
highlights(c): extern in linkage specification

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -138,6 +138,9 @@
 
 (type_qualifier) @type.qualifier
 
+(linkage_specification
+  "extern" @storageclass)
+
 (type_definition
   declarator: (type_identifier) @type.definition)
 


### PR DESCRIPTION
Using `@storageclass` so it's consistent with `extern` as `storage_class_specifier`.