### PR TITLE
`jq/highlights.scm` should highlight the `elif` keyword

### DIFF
--- a/queries/jq/highlights.scm
+++ b/queries/jq/highlights.scm
@@ -267,6 +267,7 @@
 [
   "if"
   "then"
+  "elif"
   "else"
   "end"
 ] @conditional


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/10882062/216081537-caa977ac-bf41-4820-8ada-15b47cc3fb42.png)


After:

![image](https://user-images.githubusercontent.com/10882062/216081449-b7e4ae5c-607a-4bc4-8d4c-bb444f0421e7.png)
