### PR TITLE
statusline: pass node to transform_fn and allow dupes

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -451,7 +451,8 @@ Default options (lua syntax):
     indicator_size = 100,
     type_patterns = {'class', 'function', 'method'},
     transform_fn = function(line, _node) return line:gsub('%s*[%[%(%{]*%s*$', '') end,
-    separator = ' -> '
+    separator = ' -> ',
+    dedupe = true
   }
 <
 - `indicator_size` - How long should the string be. If longer, it is cut from
@@ -461,6 +462,7 @@ Default options (lua syntax):
   default removes opening brackets and spaces from end. Takes two arguments:
   the text of the line in question, and the corresponding treesitter node.
 - `separator` - Separator between nodes.
+- `dedupe` - Whether or not to remove duplicate components.
 
 						  *nvim_treesitter#foldexpr()*
 nvim_treesitter#foldexpr()~

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -452,7 +452,7 @@ Default options (lua syntax):
     type_patterns = {'class', 'function', 'method'},
     transform_fn = function(line, _node) return line:gsub('%s*[%[%(%{]*%s*$', '') end,
     separator = ' -> ',
-    dedupe = true
+    allow_duplicates = false
   }
 <
 - `indicator_size` - How long should the string be. If longer, it is cut from
@@ -462,7 +462,7 @@ Default options (lua syntax):
   default removes opening brackets and spaces from end. Takes two arguments:
   the text of the line in question, and the corresponding treesitter node.
 - `separator` - Separator between nodes.
-- `dedupe` - Whether or not to remove duplicate components.
+- `allow_duplicates` - Whether or not to remove duplicate components.
 
 						  *nvim_treesitter#foldexpr()*
 nvim_treesitter#foldexpr()~

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -450,7 +450,7 @@ Default options (lua syntax):
   {
     indicator_size = 100,
     type_patterns = {'class', 'function', 'method'},
-    transform_fn = function(line) return line:gsub('%s*[%[%(%{]*%s*$', '') end,
+    transform_fn = function(line, _node) return line:gsub('%s*[%[%(%{]*%s*$', '') end,
     separator = ' -> '
   }
 <
@@ -458,7 +458,8 @@ Default options (lua syntax):
   the beginning.
 - `type_patterns` - Which node type patterns to match.
 - `transform_fn` - Function used to transform the single item in line. By
-  default removes opening brackets and spaces from end.
+  default removes opening brackets and spaces from end. Takes two arguments:
+  the text of the line in question, and the corresponding treesitter node.
 - `separator` - Separator between nodes.
 
 						  *nvim_treesitter#foldexpr()*

--- a/lua/nvim-treesitter/statusline.lua
+++ b/lua/nvim-treesitter/statusline.lua
@@ -21,6 +21,10 @@ function M.statusline(opts)
   local type_patterns = options.type_patterns or { "class", "function", "method" }
   local transform_fn = options.transform_fn or transform_line
   local separator = options.separator or " -> "
+  local dedupe = options.dedupe
+  if dedupe == nil then
+    dedupe = true
+  end
 
   local current_node = ts_utils.get_node_at_cursor()
   if not current_node then
@@ -32,8 +36,10 @@ function M.statusline(opts)
 
   while expr do
     local line = ts_utils._get_line_for_node(expr, type_patterns, transform_fn, bufnr)
-    if line ~= "" and not vim.tbl_contains(lines, line) then
-      table.insert(lines, 1, line)
+    if line ~= "" then
+      if not dedupe or not vim.tbl_contains(lines, line) then
+        table.insert(lines, 1, line)
+      end
     end
     expr = expr:parent()
   end

--- a/lua/nvim-treesitter/statusline.lua
+++ b/lua/nvim-treesitter/statusline.lua
@@ -21,10 +21,7 @@ function M.statusline(opts)
   local type_patterns = options.type_patterns or { "class", "function", "method" }
   local transform_fn = options.transform_fn or transform_line
   local separator = options.separator or " -> "
-  local dedupe = options.dedupe
-  if dedupe == nil then
-    dedupe = true
-  end
+  local allow_duplicates = options.allow_duplicates or false
 
   local current_node = ts_utils.get_node_at_cursor()
   if not current_node then
@@ -37,7 +34,7 @@ function M.statusline(opts)
   while expr do
     local line = ts_utils._get_line_for_node(expr, type_patterns, transform_fn, bufnr)
     if line ~= "" then
-      if not dedupe or not vim.tbl_contains(lines, line) then
+      if allow_duplicates or not vim.tbl_contains(lines, line) then
         table.insert(lines, 1, line)
       end
     end

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -45,7 +45,7 @@ function M._get_line_for_node(node, type_patterns, transform_fn, bufnr)
   if not is_valid then
     return ""
   end
-  local line = transform_fn(vim.trim(get_node_text(node, bufnr)[1] or ""))
+  local line = transform_fn(vim.trim(get_node_text(node, bufnr)[1] or ""), node)
   -- Escape % to avoid statusline to evaluate content as expression
   return line:gsub("%%", "%%%%")
 end


### PR DESCRIPTION
In the spirit of full disclosure, this is mostly about supporting a single use case that I came up with, but I think it's fairly reasonable. And unless my understanding of lua is wrong, shouldn't affect anyone's existing code.

The first change is editing `ts_utils._get_line_for_node` to also pass the treesitter node as an argument to the `transform_fn` that `statusline` uses to format the components of its output.

The second is adding another option to `statusline` to allow duplicate items. Honestly I don't know why it's deduping at all, that seems wrong, but in the interest of backwards-compatibility I just added an option. 

---

If you're interested, my specific use case is configuring a statusline call that will give me a sort of "path" query in a `yaml` file. I'm sure it could be adapted for other formats, but yaml's the one I care about at the moment. In larger documents, I often get lost and want to confirm I'm at the level I think I am.

Here's what I've got at the moment.
```lua
local nt = function(node)
  return vim.trim(require('vim.treesitter.query').get_node_text(node, 0))
end

local transform_line = function(_, node)
  local typ = node:type()
  if typ == "block_mapping_pair" then
    return string.format(".%s", nt(node:named_child(0)))
  elseif typ == "block_sequence_item" then
    local id = node:id()
    local parent = node:parent()
    local i = 0
    for cn in parent:iter_children() do
      if cn:id() == id then
        return string.format("[%d]", i)
      end
      i = i + 1
    end
  end
end

local function yaml_statusline()
  local sl = require('nvim-treesitter.statusline').statusline({
    separator = "",
    type_patterns = { "block_mapping_pair", "block_sequence_item" },
    transform_fn = transform_line,
    allow_duplicates = true,
  })
  if vim.startswith(sl, ".") then
    print(sl:sub(2, 123))
  else
    print(sl)
  end
end
```

With a yaml document like:
```yaml
top:
  - "thing"
  - key:
      key: "here"
```

Putting the cursor on "here" and calling `yaml_statusline` gives me `top[1].key.key`.

If you are aware of a plugin that already does this, please spare my delicate feelings and don't mention it. XD