### PR TITLE
feat: add RON

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [regex](https://github.com/tree-sitter/tree-sitter-regex) (maintained by @theHamsta)
 - [x] [rego](https://github.com/FallenAngel97/tree-sitter-rego) (maintained by @FallenAngel97)
 - [x] [rnoweb](https://github.com/bamonroe/tree-sitter-rnoweb) (maintained by @bamonroe)
+- [x] [ron](https://github.com/amaanq/tree-sitter-ron) (maintained by @amaanq)
 - [x] [rst](https://github.com/stsewd/tree-sitter-rst) (maintained by @stsewd)
 - [x] [ruby](https://github.com/tree-sitter/tree-sitter-ruby) (maintained by @TravonteD)
 - [x] [rust](https://github.com/tree-sitter/tree-sitter-rust) (maintained by @vigoux)

--- a/lockfile.json
+++ b/lockfile.json
@@ -347,6 +347,9 @@
   "rnoweb": {
     "revision": "502c1126dc6777f09af5bef16e72a42f75bd081e"
   },
+  "ron": {
+    "revision": "81e528eeb35518b8ef6f2761e91c0b10c76b4183"
+  },
   "rst": {
     "revision": "25e6328872ac3a764ba8b926aea12719741103f1"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -416,7 +416,6 @@ list.func = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-func",
     files = { "src/parser.c" },
-    branch = "master",
   },
   maintainers = { "@amaanq" },
 }
@@ -738,7 +737,6 @@ list.julia = {
 list.kdl = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-kdl",
-    branch = "master",
     files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@amaanq" },
@@ -1109,6 +1107,14 @@ list.rnoweb = {
   },
   filetype = "rnoweb",
   maintainers = { "@bamonroe" },
+}
+
+list.ron = {
+  install_info = {
+    url = "https://github.com/amaanq/tree-sitter-ron",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@amaanq" },
 }
 
 list.rst = {

--- a/queries/ron/folds.scm
+++ b/queries/ron/folds.scm
@@ -1,0 +1,7 @@
+[
+  (array)
+  (map)
+  (tuple)
+  (struct)
+  (block_comment)
+] @fold

--- a/queries/ron/highlights.scm
+++ b/queries/ron/highlights.scm
@@ -1,0 +1,53 @@
+; Structs
+;------------
+
+(enum_variant) @constant
+(struct_entry (identifier) @property)
+(struct_entry (enum_variant (identifier) @constant))
+(struct_name (identifier)) @type
+
+(unit_struct) @type.builtin
+
+
+; Literals
+;------------
+
+(string) @string
+(boolean) @boolean
+(integer) @number
+(float) @float
+(char) @character
+
+
+; Comments
+;------------
+
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell
+
+
+; Punctuation
+;------------
+
+["{" "}"] @punctuation.bracket
+
+["(" ")"] @punctuation.bracket
+
+["[" "]"] @punctuation.bracket
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
+  "-"
+] @operator
+
+; Special
+;------------
+
+(escape_sequence) @string.escape
+(ERROR) @error

--- a/queries/ron/indents.scm
+++ b/queries/ron/indents.scm
@@ -1,0 +1,12 @@
+[
+  (array)
+  (map)
+  (tuple)
+  (struct)
+] @indent
+
+[ "{" "}" ] @branch
+
+[ "(" ")" ] @branch
+
+[ "[" "]" ] @branch

--- a/queries/ron/injections.scm
+++ b/queries/ron/injections.scm
@@ -1,0 +1,4 @@
+[
+  (line_comment)
+  (block_comment)
+] @comment

--- a/queries/ron/locals.scm
+++ b/queries/ron/locals.scm
@@ -1,0 +1,12 @@
+(source_file) @scope
+(source_file (array) @scope)
+(source_file (map) @scope)
+(source_file (struct) @scope)
+(source_file (tuple) @scope)
+
+(identifier) @reference
+
+(struct_entry (identifier) @definition.field)
+(struct_entry (identifier) @definition.enum (enum_variant))
+
+(struct (struct_name) @definition.type)


### PR DESCRIPTION
This PR adds support for RON (Rusty Object Notation) https://github.com/ron-rs/ron

cc: @xrelkd as they first requested it in #2282

This is my first time adding queries that aren't highlights, so I'd really like a maintainer to have a look over folds, indents, and injections just for a sanity check.

I also noticed a lot of parsers have an injection for comments where it's just `@comment`, it'd be nice if someone could explain the reason/why behind that :)

Lastly, I removed redundant branch = "master" from my parsers, I also noticed quite a few parsers have this and have a redundant filetype field as well (which is meant for when the parser name doesn't equal the filetype name right?). If it's alright, I'll fix up other filetype/branch redundancies as well.