### PR TITLE
fix(elixir): properly apply `@function` captures

### DIFF
--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -111,9 +111,10 @@
   "defp"
   "defprotocol"
   "defstruct"
-)) (arguments [
-  (identifier) @function
-  (binary_operator left: (identifier) @function operator: "when")])?)
+  ))
+  (arguments [
+    (call (identifier) @function)
+    (binary_operator left: (call target: (identifier) @function) operator: "when")])?)
 
 ; Kernel Keywords & Special Forms
 (call target: ((identifier) @keyword (#any-of? @keyword


### PR DESCRIPTION
When viewing the previous rule in the `TSPlayground` the `@function` captures were not actually matching. This led all functions to get the `@function.call` group applied to them. This change makes it so that the capture now works and where functions are defined will get the `@function` group.