### PR TITLE
feat: improve Thrift queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -417,7 +417,7 @@
     "revision": "0ff887f2a60a147452d52db060de6b42f42f1441"
   },
   "thrift": {
-    "revision": "634a73fd2c80e169f302917ba665c07ec0b6ff7b"
+    "revision": "c5a94547f01eb51b26446f9b94ee8644fa791223"
   },
   "tiger": {
     "revision": "a233ebe360a73a92c50978e5c4e9e471bc59ff42"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1324,6 +1324,7 @@ list.thrift = {
   install_info = {
     url = "https://github.com/duskmoon314/tree-sitter-thrift",
     files = { "src/parser.c" },
+    branch = "main",
   },
   maintainers = { "@amaanq", "@duskmoon314" },
 }

--- a/queries/thrift/folds.scm
+++ b/queries/thrift/folds.scm
@@ -1,11 +1,12 @@
 [
   (annotation)
   (enum)
+  (exception)
+  (function)
   (senum)
   (service)
   (struct)
   (union)
 
-  (function_parameters)
-  (exception_parameters)
+  (comment)
 ] @fold

--- a/queries/thrift/highlights.scm
+++ b/queries/thrift/highlights.scm
@@ -4,15 +4,15 @@
 
 ; Includes
 
-  "include"
 [
+  "include"
   "cpp_include"
 ] @include
 
 (include_path) @string
 (package_path) @string
 
-; Types
+; Builtins
 
 (primitive) @type.builtin
 
@@ -182,7 +182,6 @@
 [
   ";"
   ","
-  (list_separator)
 ] @punctuation.delimiter
 
 ; Errors

--- a/queries/thrift/indents.scm
+++ b/queries/thrift/indents.scm
@@ -1,0 +1,20 @@
+(definition) @indent
+
+; (function (function_identifier) @aligned_indent)
+
+((function_parameters (function_parameter)) @aligned_indent
+  (#set! "delimiter" "()"))
+
+((exception_parameters (exception_parameter)) @aligned_indent
+  (#set! "delimiter" "()"))
+
+"}" @indent_end
+
+[ "{" "}" ] @branch
+
+[ "(" ")" ] @branch
+
+[
+ (ERROR)
+ (comment)
+] @auto

--- a/queries/thrift/injections.scm
+++ b/queries/thrift/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment

--- a/queries/thrift/locals.scm
+++ b/queries/thrift/locals.scm
@@ -1,0 +1,32 @@
+(document) @scope
+(definition) @scope
+
+[
+  (identifier)
+  (field_type)
+  (custom_type)
+] @reference
+(const_value (const_identifier) @reference)
+
+(annotation_identifier) @definition
+
+(const (const_identifier) @definition.constant)
+(enum_member) @definition.constant
+
+(enum_identifier) @definition.enum
+
+(field_identifier) @definition.field
+
+(function_identifier) @definition.function
+
+(namespace_definition) @definition.namespace
+
+[
+  (param_identifier)
+  (exception_param_identifier)
+] @definition.parameter
+
+[
+  (type_identifier)
+  (exception_identifier)
+] @definition.type


### PR DESCRIPTION
This PR improves Thrift queries.

* Set branch to main (if it's not master you should do this right?)
* Added indents, injections, and locals, improved folds

One semi-issue I had was getting the indent to go to the function identifier level after parameters if there's an exception (in thrift, a comma signifies the end of a function definition in a service so this would happen in the absence of a comma, note the screenshot has the comma after the exception parameters signifying the function end)

![image](https://user-images.githubusercontent.com/29718261/217056597-b5163f65-01a9-4a04-a0cb-2d19b2b2f227.png)

Screenshot shows my cursor position after hitting enter after a parameters list. It should ideally be aligned where throws is (under the function name), but I could not figure that out. If anyone reviewing this has a solution for that, that'd be a great addition to the indents.

Thanks!