### PR TITLE
goto_node select last character when in operator-pending mode

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -439,6 +439,14 @@ function M.goto_node(node, goto_end, avoid_set_jump)
   else
     position = { range[3], range[4] }
   end
+
+  -- Enter visual mode if we are in operator pending mode
+  -- If we don't do this, it will miss the last character.
+  local mode = vim.api.nvim_get_mode()
+  if mode.mode == "no" then
+    vim.cmd "normal! v"
+  end
+
   -- Position is 1, 0 indexed.
   api.nvim_win_set_cursor(0, { position[1], position[2] - 1 })
 end


### PR DESCRIPTION
When the `goto_node` is used in operator-pending mode, it will miss the last character. So the result of  
`v]Md` is different from `d]M`.

It's a similar issue to https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/381 and it's not only limited to the built-in movements. This PR fixes the node movements.

The solution is to enter visual mode just like in `update_selection`. It will make operator-pending mode consistent with visual mode behaviour, including the last character.

I will add tests in the `nvim-treesitter-textobjects`.