### PR TITLE
RFC: Reducing false positives for comment highlights

### DIFF
--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -1,36 +1,37 @@
 (_) @spell
 
-[
- "("
- ")"
-] @punctuation.bracket
-
-":" @punctuation.delimiter
-
-(tag
+((tag
   (name) @text.todo
-  (user)? @constant)
-
-((tag ((name) @text.todo))
- (#eq? @text.todo "TODO"))
+  ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
+  ":" @punctuation.delimiter)
+  (#eq? @text.todo "TODO"))
 
 ("text" @text.todo
  (#eq? @text.todo "TODO"))
 
-((tag ((name) @text.note))
- (#any-of? @text.note "NOTE" "XXX"))
+((tag
+  (name) @text.note
+  ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
+  ":" @punctuation.delimiter)
+  (#any-of? @text.note "NOTE" "XXX"))
 
 ("text" @text.note
  (#any-of? @text.note "NOTE" "XXX"))
 
-((tag ((name) @text.warning))
- (#any-of? @text.warning "HACK" "WARNING"))
+((tag
+  (name) @text.warning
+  ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
+  ":" @punctuation.delimiter)
+  (#any-of? @text.warning "HACK" "WARNING"))
 
 ("text" @text.warning
  (#any-of? @text.warning "HACK" "WARNING"))
 
-((tag ((name) @text.danger))
- (#any-of? @text.danger "FIXME" "BUG"))
+((tag
+  (name) @text.danger
+  ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
+  ":" @punctuation.delimiter)
+  (#any-of? @text.danger "FIXME" "BUG"))
 
 ("text" @text.danger
  (#any-of? @text.danger "FIXME" "BUG"))


### PR DESCRIPTION
There are a couple cases where the comment highlights will match things that aren't really a tag.
For example, in Rust, when commenting a block that deals with generics (generics are declared as `T: Type`),
this may be distracting.

So, instead of highlighting all tags, we can restrict to highlighting the explicit keywords.

I'm also thinking that I could change the parser itself to match just a set of keywords, and if users want more keywords, add them to the parser or expose a compile-time option to provide a set of keywords.

Suggestions are welcome!

Ref https://github.com/stsewd/tree-sitter-comment/issues/14