### PR TITLE
feat: add snakemake

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -509,6 +509,9 @@
   "smithy": {
     "revision": "cf8c7eb9faf7c7049839585eac19c94af231e6a0"
   },
+  "snakemake": {
+    "revision": "65a6c3b4671877821082164da0a310851b211953"
+  },
   "solidity": {
     "revision": "168020304759ad5d8b4a88a541a699134e3730c5"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1499,10 +1499,7 @@ list.smali = {
 list.snakemake = {
   install_info = {
     url = "https://github.com/osthomas/tree-sitter-snakemake",
-    branch = "main",
-    location = "tree-sitter-snakemake",
     files = { "src/parser.c", "src/scanner.c" },
-    requires_generate_from_grammar = false,
   },
   maintainer = { "@osthomas" },
   experimental = true,

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1496,6 +1496,18 @@ list.smali = {
   maintainers = { "@amaanq" },
 }
 
+list.snakemake = {
+  install_info = {
+    url = "https://github.com/osthomas/tree-sitter-snakemake",
+    branch = "main",
+    location = "tree-sitter-snakemake",
+    files = { "src/parser.c", "src/scanner.c" },
+    requires_generate_from_grammar = false,
+  },
+  maintainer = { "@osthomas" },
+  experimental = true,
+}
+
 list.smithy = {
   install_info = {
     url = "https://github.com/indoorvivants/tree-sitter-smithy",

--- a/queries/snakemake/folds.scm
+++ b/queries/snakemake/folds.scm
@@ -1,0 +1,6 @@
+; inherits: python
+[
+  (rule_definition)
+  (module_definition)
+  (checkpoint_definition)
+] @fold

--- a/queries/snakemake/highlights.scm
+++ b/queries/snakemake/highlights.scm
@@ -59,6 +59,6 @@
 
 ;; directive labels in block context (eg. within 'run:')
 ((identifier) @label
+  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards")
   (#has-ancestor? @label "directive")
-  (#has-ancestor? @label "block")
-  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards"))
+  (#has-ancestor? @label "block"))

--- a/queries/snakemake/highlights.scm
+++ b/queries/snakemake/highlights.scm
@@ -1,0 +1,64 @@
+; inherits: python
+
+;; Compound directives
+["rule" "checkpoint" "module"] @keyword
+
+;; Top level directives (eg. configfile, include)
+(module (directive name: _ @keyword))
+
+;; Subordinate directives (eg. input, output)
+(_ body: (_ (directive name: _ @label)))
+
+;; rule/module/checkpoint names
+(rule_definition name: (identifier) @type)
+(module_definition name: (identifier) @type)
+(checkpoint_definition name: (identifier) @type)
+
+
+;; Rule imports
+(rule_import
+  "use" @include
+  "rule" @include
+  "from" @include
+  "as"? @include
+  "with"? @include
+)
+
+
+;; Rule inheritance
+(rule_inheritance
+  "use" @keyword
+  "rule" @keyword
+  "with" @keyword
+)
+
+
+;; Wildcard names
+(wildcard (identifier) @variable)
+
+
+;; builtin variables
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin "checkpoints" "config" "gather" "rules" "scatter" "workflow"))
+
+
+;; References to directive labels in wildcard interpolations
+
+;; the #any-of? queries are moved above the #has-ancestor? queries to
+;; short-circuit the potentially expensive tree traversal, if possible
+;; see:
+;; https://github.com/nvim-treesitter/nvim-treesitter/pull/4302#issuecomment-1685789790
+
+;; directive labels in wildcard context
+((wildcard (identifier) @label)
+  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards"))
+((wildcard (attribute object: (identifier) @label))
+  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards"))
+((wildcard (subscript value: (identifier) @label))
+  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards"))
+
+;; directive labels in block context (eg. within 'run:')
+((identifier) @label
+  (#has-ancestor? @label "directive")
+  (#has-ancestor? @label "block")
+  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards"))

--- a/queries/snakemake/injections.scm
+++ b/queries/snakemake/injections.scm
@@ -1,0 +1,3 @@
+; inherits: python
+
+(wildcard (constraint) @regex)

--- a/queries/snakemake/injections.scm
+++ b/queries/snakemake/injections.scm
@@ -1,3 +1,4 @@
 ; inherits: python
 
-(wildcard (constraint) @regex)
+(wildcard (constraint) @injection.content
+  (#set! injection.language "regex"))

--- a/queries/snakemake/locals.scm
+++ b/queries/snakemake/locals.scm
@@ -1,0 +1,1 @@
+; inherits: python


### PR DESCRIPTION
Hi!

Snakemake is a workflow management system based on Python: https://snakemake.readthedocs.io/en/stable/
The grammar can be found here, but it is not complete: https://snakemake.readthedocs.io/en/stable/snakefiles/writing_snakefiles.html#grammar
I took a stab at implementing a parser for it based on the Python parser because I wanted consistent highlighting between Python and snakemake: https://github.com/osthomas/tree-sitter-snakemake

I've been using it for a bit and would be happy to see it included in nvim-treesitter.