### PR TITLE
Fix godot indents

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -126,7 +126,7 @@
     "revision": "19db2f47ba4c3a0f6238d4ae0e2abfca16e61dd6"
   },
   "gdscript": {
-    "revision": "5d43d78c276570f76773685f08baf9e4ada09639"
+    "revision": "a56a6fcec3fb63ec3324bf9373aae7298861eb30"
   },
   "git_rebase": {
     "revision": "127f5b56c1ad3e8a449a7d6e0c7412ead7f7724c"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -443,7 +443,6 @@ list.gdscript = {
     files = { "src/parser.c", "src/scanner.cc" },
   },
   readme_name = "Godot (gdscript)",
-  maintainers = { "@Shatur" },
 }
 
 list.git_rebase = {

--- a/queries/gdscript/indents.scm
+++ b/queries/gdscript/indents.scm
@@ -10,7 +10,7 @@
   (class_definition)
 ] @indent
 
-((argument_list) @aligned_indent
+((arguments) @aligned_indent
  (#set! "delimiter" "()"))
 ((parameters) @aligned_indent
  (#set! "delimiter" "()"))


### PR DESCRIPTION
`argument_list` to `arguments` as per

https://github.com/PrestonKnopp/tree-sitter-gdscript/commit/9fd1e94854377891af84b3f7780b850a869c3412

Also remove @Shatur from gdscript maintainers