### PR TITLE
Remove confusing enable = false comment in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ require'nvim-treesitter.configs'.setup {
   -- parser_install_dir = "/some/path/to/store/parsers", -- Remember to run vim.opt.runtimepath:append("/some/path/to/store/parsers")!
 
   highlight = {
-    -- `false` will disable the whole extension
     enable = true,
 
     -- NOTE: these are the names of the parsers and not the filetype. (for example if you want to


### PR DESCRIPTION
Also uses prettier formatting

I've seen many people, including myself, being confused about `highlight { enable = false }` disabling the whole extension. It means it will disable highlighting, but people get it wrong thinking that they can't use textobjects or any other treesitter related stuff.

Reference: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/discussions/379