### PR TITLE
fix(health): check required neovim version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more detailed information on setting these up, see ["Advanced setup"](#advan
 
 ## Requirements
 
-- **Neovim 0.8.3 or later** built with **tree-sitter 0.20.3+** (latest [nightly](https://github.com/neovim/neovim#install-from-source) recommended)
+- [Latest](https://github.com/neovim/neovim/releases/tag/stable) Neovim release ([nightly](https://github.com/neovim/neovim#install-from-source) recommended)
 - `tar` and `curl` in your path (or alternatively `git`)
 - A C compiler in your path and libstdc++ installed ([Windows users please read this!](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Windows-support)).
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more detailed information on setting these up, see ["Advanced setup"](#advan
 
 ## Requirements
 
-- **Neovim 0.8.0 or later** built with **tree-sitter 0.20.3+** (latest [nightly](https://github.com/neovim/neovim#install-from-source) recommended)
+- **Neovim 0.8.3 or later** built with **tree-sitter 0.20.3+** (latest [nightly](https://github.com/neovim/neovim#install-from-source) recommended)
 - `tar` and `curl` in your path (or alternatively `git`)
 - A C compiler in your path and libstdc++ installed ([Windows users please read this!](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Windows-support)).
 

--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -16,8 +16,8 @@ local NVIM_TREESITTER_MINIMUM_ABI = 13
 local function install_health()
   health.report_start "Installation"
 
-  if fn.has "nvim-0.8.0" ~= 1 then
-    health.report_error "Nvim-treesitter requires Neovim 0.8.0+"
+  if fn.has "nvim-0.8.3" ~= 1 then
+    health.report_error "Nvim-treesitter requires Neovim 0.8.3+"
   end
 
   if fn.executable "tree-sitter" == 0 then

--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -16,8 +16,8 @@ local NVIM_TREESITTER_MINIMUM_ABI = 13
 local function install_health()
   health.report_start "Installation"
 
-  if fn.has "nvim-0.7" == 0 then
-    health.report_error "Nvim-treesitter requires Neovim 0.7.0+"
+  if fn.has "nvim-0.8.0" ~= 1 then
+    health.report_error "Nvim-treesitter requires Neovim 0.8.0+"
   end
 
   if fn.executable "tree-sitter" == 0 then


### PR DESCRIPTION
Minimim required version has been bumped to 0.8.0+ since https://github.com/nvim-treesitter/nvim-treesitter/pull/3656
