### PR TITLE
feat: add starlark

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [solidity](https://github.com/YongJieYongJie/tree-sitter-solidity) (maintained by @YongJieYongJie)
 - [x] [sparql](https://github.com/BonaBeavis/tree-sitter-sparql) (maintained by @BonaBeavis)
 - [x] [sql](https://github.com/derekstride/tree-sitter-sql) (maintained by @derekstride)
+- [x] [starlark](https://github.com/amaanq/tree-sitter-starlark) (maintained by @amaanq)
 - [x] [supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) (maintained by @madskjeldgaard)
 - [x] [surface](https://github.com/connorlay/tree-sitter-surface) (maintained by @connorlay)
 - [x] [svelte](https://github.com/Himujjal/tree-sitter-svelte) (maintained by @elianiva)

--- a/lockfile.json
+++ b/lockfile.json
@@ -392,6 +392,9 @@
   "sql": {
     "revision": "0d7a121b2a08fb37109f7be1cc6654443cad661f"
   },
+  "starlark": {
+    "revision": "2e94347f71147c268a4c5c0ce188be8baf2fce5a"
+  },
   "supercollider": {
     "revision": "90c6d9f777d2b8c4ce497c48b5f270a44bcf3ea0"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1235,6 +1235,15 @@ list.sql = {
   maintainers = { "@derekstride" },
 }
 
+list.starlark = {
+  install_info = {
+    url = "https://github.com/amaanq/tree-sitter-starlark",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  filetype = "bzl",
+  maintainers = { "@amaanq" },
+}
+
 list.supercollider = {
   install_info = {
     url = "https://github.com/madskjeldgaard/tree-sitter-supercollider",

--- a/queries/starlark/folds.scm
+++ b/queries/starlark/folds.scm
@@ -1,0 +1,22 @@
+[
+  (function_definition)
+
+  (for_statement)
+  (if_statement)
+  (while_statement)
+  (with_statement)
+  (match_statement)
+
+  (parameters)
+  (argument_list)
+
+  (parenthesized_expression)
+  (list_comprehension)
+  (dictionary_comprehension)
+
+  (tuple)
+  (list)
+  (dictionary)
+
+  (string)
+] @fold

--- a/queries/starlark/highlights.scm
+++ b/queries/starlark/highlights.scm
@@ -1,0 +1,285 @@
+;; From tree-sitter-python licensed under MIT License
+; Copyright (c) 2016 Max Brunsfeld
+
+; Variables
+(identifier) @variable
+
+; Reset highlighting in f-string interpolations
+(interpolation) @none
+
+;; Identifier naming conventions
+((identifier) @type
+ (#lua-match? @type "^[A-Z].*[a-z]"))
+((identifier) @constant
+ (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
+
+((identifier) @constant.builtin
+ (#lua-match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
+
+((identifier) @constant.builtin
+ (#any-of? @constant.builtin
+           ;; https://docs.python.org/3/library/constants.html
+           "NotImplemented"
+           "Ellipsis"
+           "quit"
+           "exit"
+           "copyright"
+           "credits"
+           "license"))
+
+((attribute
+    attribute: (identifier) @field)
+ (#match? @field "^([A-Z])@!.*$"))
+
+((identifier) @type.builtin
+ (#any-of? @type.builtin
+              ;; https://docs.python.org/3/library/exceptions.html
+              "ArithmeticError" "BufferError" "LookupError" "AssertionError" "AttributeError"
+              "EOFError" "FloatingPointError" "ModuleNotFoundError" "IndexError" "KeyError"
+              "KeyboardInterrupt" "MemoryError" "NameError" "NotImplementedError" "OSError" "OverflowError" "RecursionError"
+              "ReferenceError" "RuntimeError" "StopIteration" "StopAsyncIteration" "SyntaxError" "IndentationError" "TabError"
+              "SystemError" "SystemExit" "TypeError" "UnboundLocalError" "UnicodeError" "UnicodeEncodeError" "UnicodeDecodeError"
+              "UnicodeTranslateError" "ValueError" "ZeroDivisionError" "EnvironmentError" "IOError" "WindowsError"
+              "BlockingIOError" "ChildProcessError" "ConnectionError" "BrokenPipeError" "ConnectionAbortedError"
+              "ConnectionRefusedError" "ConnectionResetError" "FileExistsError" "FileNotFoundError" "InterruptedError"
+              "IsADirectoryError" "NotADirectoryError" "PermissionError" "ProcessLookupError" "TimeoutError" "Warning"
+              "UserWarning" "DeprecationWarning" "PendingDeprecationWarning" "SyntaxWarning" "RuntimeWarning"
+              "FutureWarning" "UnicodeWarning" "BytesWarning" "ResourceWarning"
+              ;; https://docs.python.org/3/library/stdtypes.html
+              "bool" "int" "float" "complex" "list" "tuple" "range" "str"
+              "bytes" "bytearray" "memoryview" "set" "frozenset" "dict" "type"))
+
+((assignment
+  left: (identifier) @type.definition
+  (type (identifier) @_annotation))
+ (#eq? @_annotation "TypeAlias"))
+
+((assignment
+  left: (identifier) @type.definition
+  right: (call
+    function: (identifier) @_func))
+ (#any-of? @_func "TypeVar" "NewType"))
+
+;; Decorators
+((decorator "@" @attribute)
+ (#set! "priority" 101))
+
+(decorator
+  (identifier) @attribute)
+(decorator
+  (attribute
+    attribute: (identifier) @attribute))
+(decorator
+  (call (identifier) @attribute))
+(decorator
+  (call (attribute
+          attribute: (identifier) @attribute)))
+
+((decorator
+  (identifier) @attribute.builtin)
+ (#any-of? @attribute.builtin "classmethod" "property"))
+
+;; Builtin functions
+((call
+  function: (identifier) @function.builtin)
+ (#any-of? @function.builtin
+          "abs" "all" "any" "ascii" "bin" "bool" "breakpoint" "bytearray" "bytes" "callable" "chr" "classmethod"
+          "compile" "complex" "delattr" "dict" "dir" "divmod" "enumerate" "eval" "exec" "fail" "filter" "float" "format"
+          "frozenset" "getattr" "globals" "hasattr" "hash" "help" "hex" "id" "input" "int" "isinstance" "issubclass"
+          "iter" "len" "list" "locals" "map" "max" "memoryview" "min" "next" "object" "oct" "open" "ord" "pow"
+          "print" "property" "range" "repr" "reversed" "round" "set" "setattr" "slice" "sorted" "staticmethod" "str"
+          "struct" "sum" "super" "tuple" "type" "vars" "zip" "__import__"))
+
+;; Function definitions
+(function_definition
+  name: (identifier) @function)
+
+(type (identifier) @type)
+(type
+  (subscript
+    (identifier) @type)) ; type subscript: Tuple[int]
+
+((call
+  function: (identifier) @_isinstance
+  arguments: (argument_list
+    (_)
+    (identifier) @type))
+ (#eq? @_isinstance "isinstance"))
+
+;; Normal parameters
+(parameters
+  (identifier) @parameter)
+;; Lambda parameters
+(lambda_parameters
+  (identifier) @parameter)
+(lambda_parameters
+  (tuple_pattern
+    (identifier) @parameter))
+; Default parameters
+(keyword_argument
+  name: (identifier) @parameter)
+; Naming parameters on call-site
+(default_parameter
+  name: (identifier) @parameter)
+(typed_parameter
+  (identifier) @parameter)
+(typed_default_parameter
+  (identifier) @parameter)
+; Variadic parameters *args, **kwargs
+(parameters
+  (list_splat_pattern ; *args
+    (identifier) @parameter))
+(parameters
+  (dictionary_splat_pattern ; **kwargs
+    (identifier) @parameter))
+
+
+;; Literals
+(none) @constant.builtin
+[(true) (false)] @boolean
+((identifier) @variable.builtin
+ (#eq? @variable.builtin "self"))
+((identifier) @variable.builtin
+ (#eq? @variable.builtin "cls"))
+
+(integer) @number
+(float) @float
+
+(comment) @comment @spell
+
+((module . (comment) @preproc)
+  (#match? @preproc "^#!/"))
+
+(string) @string
+[
+  (escape_sequence)
+  "{{"
+  "}}"
+] @string.escape
+
+; doc-strings
+(expression_statement (string) @spell)
+
+; Tokens
+
+[
+  "-"
+  "-="
+  ":="
+  "!="
+  "*"
+  "**"
+  "**="
+  "*="
+  "/"
+  "//"
+  "//="
+  "/="
+  "&"
+  "&="
+  "%"
+  "%="
+  "^"
+  "^="
+  "+"
+  "+="
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "<>"
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "@"
+  "@="
+  "|"
+  "|="
+  "~"
+  "->"
+] @operator
+
+; Keywords
+[
+  "and"
+  "in"
+  "not"
+  "or"
+
+  "del"
+] @keyword.operator
+
+[
+  "def"
+  "lambda"
+] @keyword.function
+
+[
+  "assert"
+  "async"
+  "await"
+  "exec"
+  "nonlocal"
+  "pass"
+  "print"
+  "with"
+  "as"
+] @keyword
+
+[
+  "return"
+] @keyword.return
+
+((call
+  function: (identifier) @include
+  arguments: (argument_list
+	(string) @conceal))
+  (#eq? @include "load"))
+
+["if" "elif" "else" "match" "case"] @conditional
+
+["for" "while" "break" "continue"] @repeat
+
+["(" ")" "[" "]" "{" "}"] @punctuation.bracket
+
+(interpolation
+  "{" @punctuation.special
+  "}" @punctuation.special)
+
+["," "." ":" ";" (ellipsis)] @punctuation.delimiter
+
+;; Error
+(ERROR) @error
+
+;; Starlark-specific
+
+;; Struct definitions
+((call
+  function: (identifier) @_func
+  arguments: (argument_list
+    (keyword_argument
+	  name: (identifier) @field)))
+  (#eq? @_func "struct"))
+
+;; Function calls
+
+(call
+  function: (identifier) @function.call)
+
+(call
+  function: (attribute
+              attribute: (identifier) @method.call))
+
+((call
+   function: (identifier) @constructor)
+ (#lua-match? @constructor "^[A-Z]"))
+
+((call
+  function: (attribute
+              attribute: (identifier) @constructor))
+ (#lua-match? @constructor "^[A-Z]"))
+
+

--- a/queries/starlark/indents.scm
+++ b/queries/starlark/indents.scm
@@ -1,0 +1,47 @@
+[
+  (list)
+  (dictionary)
+  (set)
+
+  (for_statement)
+  (if_statement)
+  (while_statement)
+  (with_statement)
+
+  (parenthesized_expression)
+  (dictionary_comprehension)
+  (list_comprehension)
+  (set_comprehension)
+
+  (tuple_pattern)
+  (list_pattern)
+  (binary_operator)
+
+  (lambda)
+  (function_definition)
+] @indent
+
+(if_statement
+  condition: (parenthesized_expression) @aligned_indent
+  (#set! "delimiter" "()")
+)
+((ERROR "(" . (_)) @aligned_indent
+ (#set! "delimiter" "()"))
+((argument_list) @aligned_indent
+ (#set! "delimiter" "()"))
+((argument_list) @aligned_indent
+ (#set! "delimiter" "()"))
+((parameters) @aligned_indent
+ (#set! "delimiter" "()"))
+((tuple) @aligned_indent
+ (#set! "delimiter" "()"))
+
+[
+  ")"
+  "]"
+  "}"
+  (elif_clause)
+  (else_clause)
+] @branch
+
+(string) @auto

--- a/queries/starlark/injections.scm
+++ b/queries/starlark/injections.scm
@@ -1,0 +1,1 @@
+; inherits python

--- a/queries/starlark/locals.scm
+++ b/queries/starlark/locals.scm
@@ -1,0 +1,91 @@
+;;; Program structure
+(module) @scope
+
+; Function with parameters, defines parameters
+(parameters
+  (identifier) @definition.parameter)
+
+(default_parameter
+  (identifier) @definition.parameter)
+
+(typed_parameter
+  (identifier) @definition.parameter)
+
+(typed_default_parameter
+  (identifier) @definition.parameter)
+
+; *args parameter
+(parameters
+  (list_splat_pattern
+    (identifier) @definition.parameter))
+
+; **kwargs parameter
+(parameters
+  (dictionary_splat_pattern
+    (identifier) @definition.parameter))
+
+; Function defines function and scope
+((function_definition
+  name: (identifier) @definition.function) @scope
+ (#set! definition.function.scope "parent"))
+
+;;; Loops
+; not a scope!
+(for_statement
+  left: (pattern_list
+          (identifier) @definition.var))
+(for_statement
+  left: (tuple_pattern
+          (identifier) @definition.var))
+(for_statement
+  left: (identifier) @definition.var)
+
+; for in list comprehension
+(for_in_clause
+  left: (identifier) @definition.var)
+(for_in_clause
+  left: (tuple_pattern
+          (identifier) @definition.var))
+(for_in_clause
+  left: (pattern_list
+          (identifier) @definition.var))
+
+(dictionary_comprehension) @scope
+(list_comprehension) @scope
+(set_comprehension) @scope
+
+;;; Assignments
+
+(assignment
+ left: (identifier) @definition.var)
+
+(assignment
+ left: (pattern_list
+   (identifier) @definition.var))
+(assignment
+ left: (tuple_pattern
+   (identifier) @definition.var))
+
+(assignment
+ left: (attribute
+   (identifier)
+   (identifier) @definition.field))
+
+; Walrus operator  x := 1
+(named_expression
+  (identifier) @definition.var)
+
+(as_pattern 
+  alias: (as_pattern_target) @definition.var)
+
+;;; REFERENCES
+(identifier) @reference
+
+;; Starlark-specific
+
+; Loads
+((call
+  function: (identifier) @_fn
+  arguments: (argument_list
+    (string) @definition.import))
+  (#eq? @_fn "load"))


### PR DESCRIPTION
cc: @folliehiyuki since he first requested it in #2282

This PR adds support for Starlark: https://github.com/bazelbuild/starlark
Grammar: https://github.com/amaanq/tree-sitter-starlark

It is mainly derived from Python with some minor differences. The two differences I'd like looked over by a maintainer are:

- Imports being replaced by a load() call, where individual strings are a module and as such I'd like to have `@conceal` work for the strings in there, but I could not get that to work and my testing would have the actual "load" keyword concealed.
- Classes being replaced by a struct call, e.g. `a = struct(x=123, y=False, z="string")`, so x/y/z are fields. Only issue is when matching I identified the struct in struct() as `@_func` to capture it later, but it seems like this capture is still visible outside of simply matching. No idea how to remove that.

Thanks,
Amaan