### PR TITLE
feat(go): add folds for type switch and switch cases

### DIFF
--- a/queries/go/folds.scm
+++ b/queries/go/folds.scm
@@ -1,6 +1,10 @@
 [
  (const_declaration)
  (expression_switch_statement)
+ (expression_case)
+ (default_case)
+ (type_switch_statement)
+ (type_case)
  (for_statement)
  (func_literal)
  (function_declaration)


### PR DESCRIPTION
Adds folds for type switches, switch cases and default cases, see this snippet:
```go
func test(hello any, world string) {
    switch hello.(type) { // a new fold
    case string: // a new fold
        log.Println("a string")
    default: // a new fold
        log.Println("something else")
    }

    switch world[0:1] { // was already a fold
    case "h": // a new fold
        log.Println("starts with h")
    }
}
```