### PR TITLE
feat(kotlin): improve highlight queries

### DIFF
--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -48,7 +48,7 @@
 (type_identifier) @type
 
 ; '?' operator, replacement for Java @Nullable
-(nullable_type) @attribute
+(nullable_type) @punctuation.special
 
 (type_alias
 	(type_identifier) @type.definition)

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -408,7 +408,7 @@
 ; NOTE: `interpolated_identifier`s can be highlighted in any way
 (line_string_literal
 	"$" @punctuation.special
-	(interpolated_identifier) @variable)
+	(interpolated_identifier) @none @variable)
 (line_string_literal
 	"${" @punctuation.special
 	(interpolated_expression) @none
@@ -416,7 +416,7 @@
 
 (multi_line_string_literal
     "$" @punctuation.special
-    (interpolated_identifier) @variable)
+    (interpolated_identifier) @none @variable)
 (multi_line_string_literal
 	"${" @punctuation.special
 	(interpolated_expression) @none

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -47,6 +47,9 @@
 
 (type_identifier) @type
 
+; '?' operator, replacement for Java @Nullable
+(nullable_type) @attribute
+
 (type_alias
 	(type_identifier) @type.definition)
 
@@ -405,7 +408,7 @@
 ; NOTE: `interpolated_identifier`s can be highlighted in any way
 (line_string_literal
 	"$" @punctuation.special
-	(interpolated_identifier) @none)
+	(interpolated_identifier) @variable)
 (line_string_literal
 	"${" @punctuation.special
 	(interpolated_expression) @none
@@ -413,7 +416,7 @@
 
 (multi_line_string_literal
     "$" @punctuation.special
-    (interpolated_identifier) @none)
+    (interpolated_identifier) @variable)
 (multi_line_string_literal
 	"${" @punctuation.special
 	(interpolated_expression) @none


### PR DESCRIPTION
it would be nice, if the parser could distinguish arguments and giving arguments by specified name of the parameter. The first one is an argument, but the latter is just the name of the parameter and therefore it should be recognized as a parameter rather than a `value_argument->simple_identifier`