### PR TITLE
fix: use correct command separators for powershell

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -279,7 +279,7 @@ end
 
 function M.make_directory_change_for_command(dir, command)
   if fn.has "win32" == 1 then
-    return string.format("pushd %s & %s & popd", cmdpath(dir), command)
+    return string.format([[cmd /C "pushd %s & %s & popd"]], dir, command)
   else
     return string.format("cd %s;\n %s", dir, command)
   end


### PR DESCRIPTION
`Windows powershell` and `Powershell` use different command separators (";") than `cmd.exe` ("&"). Before the fix, the plugin would simply not compile the treesitter parsers at all when running `nvim` from any powershell.

As there are also powershell users outside of Windows, one might want to think about implementing an extra case for those guys.