### PR TITLE
ci: remove ready_for_review type

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,6 @@ name: Linting and style checking
 on:
   push:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   luacheck:

--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "master"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "master"
 


### PR DESCRIPTION
It's only needed if a job is disabled for drafts. Otherwise it will just
run the same workflow twice.
