### PR TITLE
feat: add dhall

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -71,6 +71,9 @@
   "devicetree": {
     "revision": "ea30a05d0f0446a96d8b096ad11828ad4f8ad849"
   },
+  "dhall": {
+    "revision": "affb6ee38d629c9296749767ab832d69bb0d9ea8"
+  },
   "diff": {
     "revision": "f69bde8e56f431863eba2fe4bab23e7d9692855f"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -275,6 +275,14 @@ list.devicetree = {
   maintainers = { "@jedrzejboczar" },
 }
 
+list.dhall = {
+  install_info = {
+    url = "https://github.com/jbellerb/tree-sitter-dhall",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@amaanq" },
+}
+
 list.diff = {
   install_info = {
     url = "https://github.com/the-mikedavis/tree-sitter-diff",

--- a/queries/dhall/folds.scm
+++ b/queries/dhall/folds.scm
@@ -1,0 +1,14 @@
+[
+  (let_binding)
+
+  (application_expression)
+  (lambda_expression)
+
+  (record_type)
+  (union_type)
+
+  (list_literal)
+  (record_literal)
+
+  (block_comment)
+] @fold

--- a/queries/dhall/highlights.scm
+++ b/queries/dhall/highlights.scm
@@ -1,0 +1,171 @@
+;; Text
+
+;; Imports
+
+(missing_import) @include
+
+(local_import) @string.special.path
+
+(http_import) @string @text.uri
+
+[
+  (env_variable)
+  (import_hash)
+] @string.special
+
+[ (import_as_location) (import_as_text) ] @type
+
+;; Types
+
+([
+  (let_binding (label) @type)
+  (union_type_entry (label) @type)
+] (#match? @type "^[A-Z]"))
+
+((primitive_expression
+  (identifier (label) @type)
+  (selector (label) @type)) @variable
+  (#vim-match? @variable "^[A-Z][^.]*$"))
+
+;; Parameters
+
+(lambda_expression label: (label) @parameter)
+
+;; Variables
+
+(label) @variable
+
+(identifier [
+  (label) @variable
+  (de_bruijn_index) @operator
+])
+
+(let_binding label: (label) @variable)
+
+; Fields
+
+(record_literal_entry (label) @field)
+
+(record_type_entry (label) @field)
+
+(selector
+  (selector_dot)
+  (_) @field)
+
+;; Keywords
+
+(env_import) @keyword
+
+[
+  "let"
+  "in"
+  "assert"
+] @keyword
+
+[
+  "using"
+  "as"
+  "with"
+] @keyword.operator
+
+;; Operators
+
+[
+  (type_operator)
+  (assign_operator)
+  (lambda_operator)
+  (arrow_operator)
+  (infix_operator)
+  (completion_operator)
+  (assert_operator)
+  (forall_operator)
+  (empty_record_literal)
+] @operator
+
+;; Builtins
+
+(builtin_function) @function.builtin
+(builtin [
+  "Natural"
+  "Natural/build"
+  "Natural/fold"
+  "Natural/isZero"
+  "Natural/even"
+  "Natural/odd"
+  "Natural/subtract"
+  "Natural/toInteger"
+  "Natural/show"
+  "Integer"
+  "Integer/toDouble"
+  "Integer/show"
+  "Integer/negate"
+  "Integer/clamp"
+  "Double"
+  "Double/show"
+  "List"
+  "List/build"
+  "List/fold"
+  "List/length"
+  "List/head"
+  "List/last"
+  "List/indexed"
+  "List/reverse"
+  "Text"
+  "Text/show"
+  "Text/replace"
+  "Optional"
+  "Date"
+  "Time"
+  "TimeZone"
+  "Type"
+  "Kind"
+  "Sort"
+] @type.builtin)
+
+;; Punctuation
+
+[ "," "|" ] @punctuation.delimiter
+(selector_dot) @punctuation.delimiter
+
+[ "{" "}" ] @punctuation.bracket
+
+[ "[" "]" ] @punctuation.bracket
+
+[ "(" ")" ] @punctuation.bracket
+
+[ "<" ">" ] @punctuation.bracket
+
+;; Conditionals
+
+[
+  "if"
+  "then"
+  "else"
+] @conditional
+
+;; Literals
+
+(text_literal) @string
+(interpolation "}" @string)
+[
+  (double_quote_escaped)
+  (single_quote_escaped)
+] @string.escape
+
+[
+  (integer_literal)
+  (natural_literal)
+] @number
+
+(double_literal) @float
+
+(boolean_literal) @boolean
+
+(builtin "None") @constant.builtin
+
+;; Comments
+
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell

--- a/queries/dhall/injections.scm
+++ b/queries/dhall/injections.scm
@@ -1,0 +1,4 @@
+[
+  (line_comment)
+  (block_comment)
+] @comment


### PR DESCRIPTION
cc: @FollieHiyuki since he first requested it in https://github.com/nvim-treesitter/nvim-treesitter/issues/2282

This PR adds support for Dhall: https://dhall-lang.org/
Grammar: https://github.com/jbellerb/tree-sitter-dhall

I mostly ported helix's queries, Dhall goes wayy over my head (One of the weirdest languages I've seen...). Only part I'm unsure about is the vim-match bit in highlights.scm, original version is [here](https://github.com/helix-editor/helix/blob/6494fc1daf2bb379e6a1f4ec94f3dafd99b3fb34/runtime/queries/dhall/highlights.scm#L32)

Thanks,
Amaan