### PR TITLE
feat: improve java queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -204,7 +204,7 @@
     "revision": "1a0ce072ebf3afac7d5603d9a95bb7c9a6709b44"
   },
   "java": {
-    "revision": "dd597f13eb9bab0c1bccc9aec390e8e6ebf9e0a6"
+    "revision": "3c24aa9365985830421a3a7b6791b415961ea770"
   },
   "javascript": {
     "revision": "266455e22fc54f0add4dd2404ebe307d4d65deae"

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -14,8 +14,10 @@
 (super) @function.builtin
 
 ; Parameters
+
 (formal_parameter
   name: (identifier) @parameter)
+
 (catch_formal_parameter
   name: (identifier) @parameter)
 
@@ -24,59 +26,58 @@
    name: (identifier) @parameter)) ; int... foo
 
 ;; Lambda parameter
+
 (inferred_parameters (identifier) @parameter) ; (x,y) -> ...
+
 (lambda_expression
     parameters: (identifier) @parameter) ; x -> ...
 
-
 ; Annotations
-
 
 (annotation
   name: (identifier) @attribute)
 (marker_annotation
   name: (identifier) @attribute)
 
-
 ; Operators
 
 [
-"@"
-"+"
-":"
-"++"
-"-"
-"--"
-"&"
-"&&"
-"|"
-"||"
-"!"
-"!="
-"=="
-"*"
-"/"
-"%"
-"<"
-"<="
-">"
-">="
-"="
-"-="
-"+="
-"*="
-"/="
-"%="
-"->"
-"^"
-"^="
-"&="
-"|="
-"~"
-">>"
-">>>"
-"<<"
-"::"
+  "@"
+  "+"
+  ":"
+  "++"
+  "-"
+  "--"
+  "&"
+  "&&"
+  "|"
+  "||"
+  "!"
+  "!="
+  "=="
+  "*"
+  "/"
+  "%"
+  "<"
+  "<="
+  ">"
+  ">="
+  "="
+  "-="
+  "+="
+  "*="
+  "/="
+  "%="
+  "->"
+  "^"
+  "^="
+  "&="
+  "|="
+  "~"
+  ">>"
+  ">>>"
+  "<<"
+  "::"
 ] @operator
 
 ; Types
@@ -99,8 +100,6 @@
   . (identifier) @type)
  (#lua-match? @type "^[A-Z]"))
 
-
-
 ((field_access
   object: (identifier) @type)
   (#lua-match? @type "^[A-Z]"))
@@ -118,10 +117,10 @@
   field: (identifier) @field)
 
 [
-(boolean_type)
-(integral_type)
-(floating_point_type)
-(void_type)
+  (boolean_type)
+  (integral_type)
+  (floating_point_type)
+  (void_type)
 ] @type.builtin
 
 ; Variables
@@ -133,145 +132,150 @@
 
 ; Literals
 
+(string_literal) @string
+
+(escape_sequence) @string.escape
+
+(character_literal) @character
+
 [
-(hex_integer_literal)
-(decimal_integer_literal)
-(octal_integer_literal)
-(binary_integer_literal)
+  (hex_integer_literal)
+  (decimal_integer_literal)
+  (octal_integer_literal)
+  (binary_integer_literal)
 ] @number
 
 [
-(decimal_floating_point_literal)
-(hex_floating_point_literal)
+  (decimal_floating_point_literal)
+  (hex_floating_point_literal)
 ] @float
 
-(character_literal) @character
-[(string_literal) (text_block)] @string
-(null_literal) @constant.builtin
-
 [
-  (line_comment)
-  (block_comment)
-] @comment @spell
-
-[
-(true)
-(false)
+  (true)
+  (false)
 ] @boolean
+
+(null_literal) @constant.builtin
 
 ; Keywords
 
 [
-"assert"
-"break"
-"class"
-"record"
-"continue"
-"default"
-"enum"
-"exports"
-"extends"
-"implements"
-"instanceof"
-"interface"
-"module"
-"opens"
-"package"
-"permits"
-"provides"
-"requires"
-"to"
-"uses"
-"with"
+  "assert"
+  "class"
+  "record"
+  "default"
+  "enum"
+  "extends"
+  "implements"
+  "instanceof"
+  "interface"
+  "permits"
+  "to"
+  "with"
 ] @keyword
 
 (synchronized_statement
   "synchronized" @keyword)
 
 [
-"abstract"
-"final"
-"native"
-"non-sealed"
-"open"
-"private"
-"protected"
-"public"
-"sealed"
-"static"
-"strictfp"
-"transitive"
+  "abstract"
+  "final"
+  "native"
+  "non-sealed"
+  "open"
+  "private"
+  "protected"
+  "public"
+  "sealed"
+  "static"
+  "strictfp"
+  "transitive"
 ] @type.qualifier
 
 (modifiers
   "synchronized" @type.qualifier)
 
 [
-"transient"
-"volatile"
+  "transient"
+  "volatile"
 ] @storageclass
 
 [
-"return"
-"yield"
+  "return"
+  "yield"
 ] @keyword.return
 
 [
- "new"
+  "new"
 ] @keyword.operator
 
 ; Conditionals
 
 [
-"if"
-"else"
-"switch"
-"case"
+  "if"
+  "else"
+  "switch"
+  "case"
 ] @conditional
 
 (ternary_expression ["?" ":"] @conditional.ternary)
 
-;
+; Loops
 
 [
-"for"
-"while"
-"do"
+  "for"
+  "while"
+  "do"
+  "continue"
+  "break"
 ] @repeat
 
 ; Includes
 
-"import" @include
-"package" @include
+[
+  "exports"
+  "import"
+  "module"
+  "opens"
+  "package"
+  "provides"
+  "requires"
+  "uses"
+] @include
 
 ; Punctuation
 
 [
-";"
-"."
-"..."
-","
+  ";"
+  "."
+  "..."
+  ","
 ] @punctuation.delimiter
 
-[
-"["
-"]"
-"{"
-"}"
-"("
-")"
-] @punctuation.bracket
+[ "{" "}" ] @punctuation.bracket
+
+[ "[" "]" ] @punctuation.bracket
+
+[ "(" ")" ] @punctuation.bracket
 
 ; Exceptions
 
 [
-"throw"
-"throws"
-"finally"
-"try"
-"catch"
+  "throw"
+  "throws"
+  "finally"
+  "try"
+  "catch"
 ] @exception
 
 ; Labels
+
 (labeled_statement
   (identifier) @label)
+
+; Comments
+
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell

--- a/queries/java/indents.scm
+++ b/queries/java/indents.scm
@@ -22,9 +22,7 @@
   "]"
 ] @branch
 
-[
-  "}"
-] @indent_end
+"}" @indent_end
 
 (line_comment) @ignore
 

--- a/queries/java/injections.scm
+++ b/queries/java/injections.scm
@@ -1,1 +1,4 @@
-[(block_comment) (line_comment)] @comment
+[
+  (block_comment)
+  (line_comment)
+] @comment

--- a/queries/java/locals.scm
+++ b/queries/java/locals.scm
@@ -1,5 +1,7 @@
-; SCOPES
+;; SCOPES
+
 ; declarations
+
 (program) @scope
 (class_declaration
   body: (_) @scope)
@@ -11,9 +13,11 @@
 (enhanced_for_statement) @scope
 
 ; block
+
 (block) @scope
 
 ; if/else
+
 (if_statement) @scope ; if+else
 (if_statement
   consequence: (_) @scope) ; if body in case there are no braces
@@ -21,10 +25,12 @@
   alternative: (_) @scope) ; else body in case there are no braces
 
 ; try/catch
+
 (try_statement) @scope ; covers try+catch, individual try and catch are covered by (block)
 (catch_clause) @scope ; needed because `Exception` variable
 
 ; loops
+
 (for_statement) @scope ; whole for_statement because loop iterator variable
 (for_statement         ; "for" body in case there are no braces
   body: (_) @scope)
@@ -38,31 +44,35 @@
 (constructor_declaration) @scope
 (method_declaration) @scope
 
+;; DEFINITIONS
 
-; DEFINITIONS
 (package_declaration
   (identifier) @definition.namespace)
+
 (class_declaration
   name: (identifier) @definition.type)
 (record_declaration
   name: (identifier) @definition.type)
+
 (enum_declaration
   name: (identifier) @definition.enum)
+
 (method_declaration
   name: (identifier) @definition.method)
 
 (local_variable_declaration
   declarator: (variable_declarator
                 name: (identifier) @definition.var))
-(formal_parameter
-  name: (identifier) @definition.var)
-(catch_formal_parameter
-  name: (identifier) @definition.var)
-(inferred_parameters (identifier) @definition.var) ; (x,y) -> ...
-(lambda_expression
-    parameters: (identifier) @definition.var) ; x -> ...
 (enhanced_for_statement ; for (var item : items) {
   name: (identifier) @definition.var)
+
+(formal_parameter
+  name: (identifier) @definition.parameter)
+(catch_formal_parameter
+  name: (identifier) @definition.parameter)
+(inferred_parameters (identifier) @definition.parameter) ; (x,y) -> ...
+(lambda_expression
+    parameters: (identifier) @definition.parameter) ; x -> ...
 
 ((scoped_identifier
   (identifier) @definition.import)
@@ -72,6 +82,8 @@
   declarator: (variable_declarator
                 name: (identifier) @definition.field))
 
-; REFERENCES
+;; REFERENCES
+
 (identifier) @reference
+
 (type_identifier) @reference


### PR DESCRIPTION
Closes #3942 

This PR distinguishes escape sequences (finally), moves a couple keywords to where they belong (continue, break to `@repeat`, some others to `@include`), and fixed a few local definitions where parameters were `@definition.var` and not `@definition.parameter`.

Thanks,
Amaan