### PR TITLE
fix(go): apply indents in a communication case in a select statement

### DIFF
--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -6,6 +6,7 @@
   (func_literal)
   (literal_value)
   (expression_case)
+  (communication_case)
   (default_case)
   (block)
   (call_expression)

--- a/tests/indent/go/select.go
+++ b/tests/indent/go/select.go
@@ -1,0 +1,16 @@
+// issue #4248
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func test(ch byte) {
+	ctx := context.TODO()
+	select {
+	case <-ctx.Done():
+		fmt.Println("indentation")
+	default:
+	}
+}


### PR DESCRIPTION
Closes #4248 

Thanks