### PR TITLE
feat(solidity): use maintained parser and update highlights accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [slint](https://github.com/jrmoulton/tree-sitter-slint) (experimental, maintained by @jrmoulton)
 - [x] [smali](https://git.sr.ht/~yotam/tree-sitter-smali) (maintained by @amaanq)
 - [x] [smithy](https://github.com/indoorvivants/tree-sitter-smithy) (maintained by @amaanq, @keynmol)
-- [x] [solidity](https://github.com/YongJieYongJie/tree-sitter-solidity) (maintained by @YongJieYongJie)
+- [x] [solidity](https://github.com/JoranHonig/tree-sitter-solidity) (maintained by @amaanq)
 - [x] [sparql](https://github.com/BonaBeavis/tree-sitter-sparql) (maintained by @BonaBeavis)
 - [x] [sql](https://github.com/derekstride/tree-sitter-sql) (maintained by @derekstride)
 - [x] [starlark](https://github.com/amaanq/tree-sitter-starlark) (maintained by @amaanq)

--- a/lockfile.json
+++ b/lockfile.json
@@ -390,7 +390,7 @@
     "revision": "cf8c7eb9faf7c7049839585eac19c94af231e6a0"
   },
   "solidity": {
-    "revision": "52ed0880c0126df2f2c7693f215fe6f38e4a2e0a"
+    "revision": "168020304759ad5d8b4a88a541a699134e3730c5"
   },
   "sparql": {
     "revision": "05f949d3c1c15e3261473a244d3ce87777374dec"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1235,11 +1235,11 @@ list.smithy = {
 
 list.solidity = {
   install_info = {
-    url = "https://github.com/YongJieYongJie/tree-sitter-solidity",
-    branch = "with-generated-c-code",
+    url = "https://github.com/JoranHonig/tree-sitter-solidity",
+    branch = "master",
     files = { "src/parser.c" },
   },
-  maintainers = { "@YongJieYongJie" },
+  maintainers = { "@amaanq" },
 }
 
 list.sparql = {

--- a/queries/solidity/highlights.scm
+++ b/queries/solidity/highlights.scm
@@ -1,73 +1,75 @@
-(comment) @comment
-;; Handles natspec comments
-((comment) @preproc
- (#match? @preproc "^/// .*"))
-
 ; Pragma
-(pragma_directive) @attribute
 
+[
+  "pragma" 
+  "solidity"
+] @preproc
+
+(solidity_pragma_token
+  "||" @symbol)
+(solidity_pragma_token
+  "-" @symbol)
+
+(solidity_version_comparison_operator) @operator
 
 ; Literals
+
 [
  (string)
- (hex_string_literal)
- (unicode_string_literal)
  (yul_string_literal)
 ] @string
+
+(hex_string_literal
+  "hex" @symbol
+  (_) @string)
+
+(unicode_string_literal
+  "unicode" @symbol
+  (_) @string)
+
 [
  (number_literal)
  (yul_decimal_number)
  (yul_hex_number)
 ] @number
-[
- (true)
- (false)
-] @constant.builtin
 
+(yul_boolean) @boolean
 
 ; Type
 (type_name (identifier) @type)
-(type_name "mapping" @type)
-(primitive_type) @type
+(type_name "mapping" @function.builtin)
+
+[
+  (primitive_type)
+  (number_unit)
+] @type.builtin
+
 (contract_declaration name: (identifier) @type)
-(struct_declaration struct_name: (identifier) @type)
+(struct_declaration name: (identifier) @type)
 (struct_member name: (identifier) @field)
-(enum_declaration enum_type_name: (identifier) @type)
+(enum_declaration name: (identifier) @type)
 (emit_statement . (identifier) @type)
 ; Handles ContractA, ContractB in function foo() override(ContractA, contractB) {}
-(override_specifier (identifier) @type)
-; Ensures that delimiters in mapping( ... => .. ) are not colored like types
-(type_name
-  "(" @punctuation.bracket
-  "=>" @punctuation.delimiter
-  ")" @punctuation.bracket)
-
+(override_specifier (user_defined_type) @type)
 
 ; Functions and parameters
 
 (function_definition
-  function_name:  (identifier) @function)
+  name:  (identifier) @function)
 (modifier_definition
   name:  (identifier) @function)
 (yul_evm_builtin) @function.builtin
 
 ; Use constructor coloring for special functions
 (constructor_definition "constructor" @constructor)
-(fallback_receive_definition "receive" @constructor)
-(fallback_receive_definition "fallback" @constructor)
 
 (modifier_invocation (identifier) @function)
 
 ; Handles expressions like structVariable.g();
-(call_expression . (member_expression (property_identifier) @method.call))
+(call_expression . (member_expression (identifier) @method.call))
 
 ; Handles expressions like g();
 (call_expression . (identifier) @function.call)
-(function_definition
- function_name: (identifier) @function)
-
-; Handles the field in struct literals like MyStruct({MyField: MyVar * 2})
-(call_expression (identifier) @field . ":")
 
 ; Function parameters
 (event_paramater name: (identifier) @parameter)
@@ -81,100 +83,123 @@
 
 (meta_type_expression "type" @keyword)
 
-(member_expression (property_identifier) @field)
-(property_identifier) @field
-(struct_expression ((identifier) @field . ":"))
+(member_expression property: (identifier) @field)
+(call_struct_argument name: (identifier) @field)
+(struct_field_assignment name: (identifier) @field)
 (enum_value) @constant
 
 
 ; Keywords
 [
- "contract"
- "interface"
- "library"
- "is"
- "struct"
- "enum"
- "event"
- "assembly"
- "emit"
- "modifier"
- "var"
- (virtual)
- (override_specifier)
+  "contract"
+  "interface"
+  "library"
+  "is"
+  "struct"
+  "enum"
+  "event"
+  "assembly"
+  "emit"
+  "override"
+  "modifier"
+  "var"
+  "let"
+  "emit"
+  "fallback"
+  "receive"
+  (virtual)
 ] @keyword
 
+; FIXME: update grammar
+; (block_statement "unchecked" @keyword)
+
+(event_paramater "indexed" @keyword)
+
 [
- "public"
- "internal"
- "private"
- "external"
- "pure"
- "view"
- "payable"
+  "public"
+  "internal"
+  "private"
+  "external"
+  "pure"
+  "view"
+  "payable"
+  (immutable)
 ] @type.qualifier
 
 [
- "memory"
- "storage"
- "calldata"
- (constant)
+  "memory"
+  "storage"
+  "calldata"
+  "constant"
 ] @storageclass
 
 [
- "for"
- "while"
- "do"
+  "for"
+  "while"
+  "do"
+  "break"
+  "continue"
 ] @repeat
 
 [
- "break"
- "continue"
- "if"
- "else"
- "switch"
- "case"
- "default"
+  "if"
+  "else"
+  "switch"
+  "case"
+  "default"
 ] @conditional
 
+(ternary_expression
+  "?" @conditional.ternary
+  ":" @conditional.ternary)
+
 [
- "try"
- "catch"
+  "try"
+  "catch"
+  "revert"
 ] @exception
 
 [
- "return"
- "returns"
- (yul_leave)
+  "return"
+  "returns"
+  (yul_leave)
 ] @keyword.return
 
 "function" @keyword.function
 
-"pragma" @preproc
-
-["import" "using"] @include
+[
+  "import" 
+  "using"
+] @include
 (import_directive "as" @include)
 (import_directive "from" @include)
-
-(event_paramater "indexed" @keyword)
+(import_directive "*" @character.special)
 
 ; Punctuation
 
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
+[ "{" "}" ] @punctuation.bracket
 
+[ "[" "]" ] @punctuation.bracket
+
+[ "(" ")" ] @punctuation.bracket
 
 [
   "."
   ","
+  ; FIXME: update grammar
+  ; (semicolon)
+  "->"
+  "=>"
 ] @punctuation.delimiter
 
+(call_struct_argument
+  ":" @punctuation.delimiter)
+(slice_access
+  ":" @punctuation.delimiter)
+(struct_field_assignment
+  ":" @punctuation.delimiter)
+(yul_label 
+  ":" @punctuation.delimiter)
 
 ; Operators
 
@@ -206,12 +231,27 @@
   "+"
   "++"
   "--"
+  ":="
 ] @operator
+
+(yul_assignment
+  ":" @operator
+  "=" @operator)
 
 [
   "delete"
   "new"
 ] @keyword.operator
 
-(identifier) @variable
-(yul_identifier) @variable
+[
+  (identifier)
+  (yul_identifier)
+] @variable
+
+; Comments
+
+(comment) @comment @spell
+
+; Errors
+
+(ERROR) @error

--- a/tests/query/highlights/solidity/test.sol
+++ b/tests/query/highlights/solidity/test.sol
@@ -4,13 +4,13 @@
 // ^ comment
 pragma solidity >=0.7.0 <0.9.0;
 // ^ preproc
-//     ^ attribute
+//     ^ preproc
 
 import * as something from "anotherFile";
 // ^     ^            ^ include
 
 /// @title Voting with delegation.
-//  ^ preproc
+// <- comment
 contract Ballot {
 // ^keyword
 //       ^ type
@@ -20,7 +20,7 @@ contract Ballot {
     struct Voter {
 //         ^ type
         uint weight; // weight is accumulated by delegation
-//      ^ type
+//      ^ type.builtin
 //           ^ field
         bool voted;  // if true, that person already voted
         address delegate; // person delegated to
@@ -34,7 +34,7 @@ contract Ballot {
     }
 
     address public chairperson;
-//  ^ type
+//  ^ type.builtin
 
     // This declares a state variable that
     // stores a `Voter` struct for each possible address.


### PR DESCRIPTION
Closes #3421 (cc: @shuklaayush)

This PR uses the maintained parser (of which the current nvim-treesitter parser is a fork of, and now somewhat dead), and updates the highlights accordingly