### PR TITLE
ci: bump release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   luarocks-upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+      - uses: nvim-neorocks/luarocks-tag-release@v2.2.0
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:


### PR DESCRIPTION
new version adds 'make' support and should fix the release job