### PR TITLE
fix(eex): map eelixir filetype to the eex parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -354,7 +354,7 @@ list.eex = {
     files = { "src/parser.c" },
     branch = "main",
   },
-  filetype = "eex",
+  filetype = "eelixir",
   maintainers = { "@connorlay" },
 }
 


### PR DESCRIPTION
The filetype for the `eex` is actually called `eelixir`.
