### PR TITLE
Revert "injections(html): update injection queries"

### DIFF
--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -1,9 +1,10 @@
 ; <style>...</style>
 (
   (style_element
-    (start_tag
-      (tag_name) .) 
+    (start_tag) @_no_attribute
     (raw_text) @css)
+  (#match? @_no_attribute "^\\<\\s*style\\s*\\>$")
+  ; unsure why, but without escaping &lt; and &gt; the query breaks
 ) 
 
 ; <style blocking> ...</style>
@@ -32,9 +33,9 @@
 ; <script>...</script>
 (
   (script_element
-    (start_tag
-      (tag_name) .) 
+    (start_tag) @_no_attribute
     (raw_text) @javascript)
+  (#match? @_no_attribute "^\\<\\s*script\\s*\\>$")
 ) 
 
 ; <script defer>...</script>


### PR DESCRIPTION
Reverts nvim-treesitter/nvim-treesitter#4177

- The queries were faulty and the tests was not able to note it
- Update tests to properly check for faulty cases