### PR TITLE
feat: add "exist?" predicate

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -119,6 +119,32 @@ query.add_predicate("has-type?", function(match, _pattern, _bufnr, pred)
   return vim.tbl_contains(types, node:type())
 end)
 
+---@param match (TSNode|nil)[]
+---@param _pattern string
+---@param bufnr integer
+---@param pred string[]
+---@return boolean|nil
+query.add_predicate("exist?", function(match, _pattern, bufnr, pred)
+  local node = match[pred[2]]
+  if not node then
+    return true
+  end
+
+  local string_set = pred["string_set"]
+  if not string_set then
+    string_set = {}
+    for i = 3, #pred do
+      string_set[pred[i]] = true
+    end
+    pred["string_set"] = string_set
+  end
+  local node_text = query.get_node_text(node, bufnr)
+  if not pred["exist"] then
+    pred["exist"] = pred["exist"] or string_set[node_text]
+  end
+  return pred["exist"]
+end)
+
 -- Just avoid some annoying warnings for this directive
 query.add_directive("make-range!", function() end)
 

--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -15,7 +15,7 @@
       (attribute
         (attribute_name) @_no_set_type))
     (raw_text) @css)
-  (#not-any-of? @_no_set_type "type" "lang")
+  (#not-exist? @_no_set_type "type" "lang")
 ) 
 
 (
@@ -44,7 +44,7 @@
       (attribute
         (attribute_name) @_no_set_type))
     (raw_text) @javascript)
-  (#not-any-of? @_no_set_type "type" "lang")
+  (#not-exist? @_no_set_type "type" "lang")
 ) 
 
 (
@@ -55,7 +55,7 @@
         (quoted_attribute_value (attribute_value) @_javascript)))
     (raw_text) @javascript)
   (#eq? @_type "type")
-  (#eq? @_javascript "text/javascript")
+  (#any-of? @_javascript "text/javascript" "module")
 )
 
 ((attribute

--- a/tests/query/injections/vue/test-vue-injections.vue
+++ b/tests/query/injections/vue/test-vue-injections.vue
@@ -17,6 +17,9 @@
 <script lang="ts"> const foo: number = "1" </script>
 <!--                            ^ typescript -->
 <!--                            ^ !javascript -->
+<script setup lang="ts"> const foo: number = "1" </script>
+<!--                            ^ typescript -->
+<!--                            ^ !javascript -->
 <style> .bar { .foo{ } } </style>
 <!--                ^ css   -->
 <style scoped> .page.page--news { background: rebeccapurple; } </style>
@@ -24,5 +27,12 @@
 <style lang="css"> .bar { justify-content: center; } </style>
 <!--                ^ css  -->
 <style lang="scss"> .bar { &-baz { } } </style>
+<!--                       ^ scss -->
+<!--                       ^ !css -->
+<style scoped lang="scss">
+.header.isFixed {
+  position: sticky;
+  top: 0;
+  z-index: 10000; box-sizing: border-box; } </style>
 <!--                       ^ scss -->
 <!--                       ^ !css -->


### PR DESCRIPTION
The intention for using `not-any-of?` in #4073 was that it should inject javascript/css *only if* `lang` and `type` attribute were not found, and if it exists, use them to deduct the language

#4419: Failed

With this PR, I added a new predicate `exists?` to implement the desired behavior that should have been in #4073 

TODO: 
- [ ] Figure out why <script defer> failed in Vue files, but not HTML files 