### PR TITLE
feat(prql): update queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -339,7 +339,7 @@
     "revision": "42d82fa18f8afe59b5fc0b16c207ee4f84cb185f"
   },
   "prql": {
-    "revision": "3f27cac466f030ee7d985d91eba5470e01dd21ea"
+    "revision": "5f6c4e4a90633b19e2077c1d37248989789d64be"
   },
   "pug": {
     "revision": "884e225b5ecca5d885ae627275f16ef648acd42e"

--- a/queries/prql/highlights.scm
+++ b/queries/prql/highlights.scm
@@ -22,7 +22,7 @@
 ] @keyword
 
 [
- (literal)
+ (literal_string)
  (f_string)
  (s_string)
 ] @string
@@ -84,6 +84,15 @@ alias: (identifier) @field
   (keyword_sum)
   (keyword_stddev)
   (keyword_count)
+  (keyword_lag)
+  (keyword_lead)
+  (keyword_first)
+  (keyword_last)
+  (keyword_rank)
+  (keyword_row_number)
+  (keyword_round)
+  (keyword_all)
+  (keyword_map)
 ] @function
 
 [


### PR DESCRIPTION
`literal_string` is now a public node, thus `@string` matches now directly instead on `literal`

* added multiple builtin functions