### PR TITLE
fix(html): fix faulty css/js injections

### DIFF
--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -1,22 +1,12 @@
 ; <style>...</style>
-(
-  (style_element
-    (start_tag
-      (tag_name) .) 
-    (raw_text) @css)
-) 
-
 ; <style blocking> ...</style>
 ; Add "lang" to predicate check so that vue/svelte can inherit this
 ; without having this element being captured twice
 (
   (style_element
-    (start_tag
-      (attribute
-        (attribute_name) @_no_set_type))
-    (raw_text) @css)
-  (#not-any-of? @_no_set_type "type" "lang")
-) 
+    (start_tag) @_no_type_lang 
+      (#not-match? @_no_type_lang "\\s(lang|type)\\s*\\=")
+    (raw_text) @css))
 
 (
   (style_element
@@ -30,22 +20,12 @@
 )
 
 ; <script>...</script>
-(
-  (script_element
-    (start_tag
-      (tag_name) .) 
-    (raw_text) @javascript)
-) 
-
 ; <script defer>...</script>
 (
   (script_element
-    (start_tag
-      (attribute
-        (attribute_name) @_no_set_type))
-    (raw_text) @javascript)
-  (#not-any-of? @_no_set_type "type" "lang")
-) 
+    (start_tag) @_no_type_lang 
+      (#not-match? @_no_type_lang "\\s(lang|type)\\s*\\=")
+    (raw_text) @javascript))
 
 (
   (script_element
@@ -55,7 +35,7 @@
         (quoted_attribute_value (attribute_value) @_javascript)))
     (raw_text) @javascript)
   (#eq? @_type "type")
-  (#eq? @_javascript "text/javascript")
+  (#any-of? @_javascript "text/javascript" "module")
 )
 
 ((attribute

--- a/tests/query/injections/html/test-html-injections.html
+++ b/tests/query/injections/html/test-html-injections.html
@@ -19,6 +19,10 @@
     <!--              ^ javascript -->
     <script type="text/javascript"> const x = 1 </script>
     <!--                              ^ javascript -->
+    <script type="module"> import { foo } from "bar" </script>
+    <!--                              ^ javascript -->
+    <script defer type="text/javascript"> const x = 1 </script>
+                                        <!-- ^ javascript -->
     <div style="height: 100%">
 <!--                ^ css      -->
       Test div to test css injections for style attributes

--- a/tests/query/injections/vue/test-vue-injections.vue
+++ b/tests/query/injections/vue/test-vue-injections.vue
@@ -17,6 +17,9 @@
 <script lang="ts"> const foo: number = "1" </script>
 <!--                            ^ typescript -->
 <!--                            ^ !javascript -->
+<script lang="ts" defer>const foo: number = 1 </script>
+<!--                            ^ typescript -->
+<!--                            ^ !javascript -->
 <style> .bar { .foo{ } } </style>
 <!--                ^ css   -->
 <style scoped> .page.page--news { background: rebeccapurple; } </style>
@@ -24,5 +27,8 @@
 <style lang="css"> .bar { justify-content: center; } </style>
 <!--                ^ css  -->
 <style lang="scss"> .bar { &-baz { } } </style>
+<!--                       ^ scss -->
+<!--                       ^ !css -->
+<style scoped lang="scss">body{} </style>
 <!--                       ^ scss -->
 <!--                       ^ !css -->


### PR DESCRIPTION
- This partially reverts the queries added in #4073 
- Add tests for expected behavior

The intention for the queries were: Only if `lang` and `type` is not an attribute, then inject css/js. At the time, I did not understand `any-of?` so they were faulty.

For the reasonings of not noticing this, it was that I didn't code in Vue for the past 2 months (lol)
Revert back to regex-based matching to ensure correct behavior

