### PR TITLE
Update highlights.scm for Python

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -227,6 +227,8 @@
   "is"
   "not"
   "or"
+  "is not"
+  "not in"
 
   "del"
 ] @keyword.operator


### PR DESCRIPTION
Added new keywords "is not" and "not in" to support common python coding conventions.

Before change:
"not in" and "is not" are not recognized by Treesitter 
![is_not_unparsed](https://user-images.githubusercontent.com/69449791/222625983-a9cbb1bf-f500-4f9b-b217-967d93717fc7.png)

![not_in_unparsed](https://user-images.githubusercontent.com/69449791/222626003-4d8e23fc-4f6e-46de-99d5-5a1438d0168f.png)

After change: 

![is_not_parsed](https://user-images.githubusercontent.com/69449791/222626198-79f6dd0a-2295-47aa-b051-594bd8e49d7e.png)

![not_in_parsed](https://user-images.githubusercontent.com/69449791/222626207-3be3cf36-bb6f-4de0-b875-ebfe4428728f.png)

