### PR TITLE
fix(ecma): properly capture constants in const declarations

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -24,10 +24,15 @@
  (#lua-match? @type "^[A-Z]"))
 
 ((identifier) @constant
- (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
+ (#lua-match? @constant "^_*[A-Z][A-Z%d_]*$"))
 
 ((shorthand_property_identifier) @constant
- (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
+ (#lua-match? @constant "^_*[A-Z][A-Z%d_]*$"))
+
+(lexical_declaration
+  "const"
+  . (variable_declarator
+      . name: (identifier) @constant))
 
 ((identifier) @variable.builtin
  (#vim-match? @variable.builtin "^(arguments|module|console|window|document)$"))

--- a/tests/query/highlights/ecma/const.js
+++ b/tests/query/highlights/ecma/const.js
@@ -1,0 +1,13 @@
+_FOO = 4
+// <- @constant
+__A__ = 2
+// <- @constant
+_ = 2
+// <- @variable
+A_B_C = 4
+// <- @constant
+_1 = 1
+// <- @variable
+
+const A = 2
+//    ^ @constant


### PR DESCRIPTION
Fixes #4434

I also changed the const identifier to allow single letter const identifiers as well