### PR TITLE
v: inject regex

### DIFF
--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -1,39 +1,39 @@
 (_) @spell
 
 ((tag
-  (name) @text.todo
+  (name) @text.todo @nospell
   ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
   ":" @punctuation.delimiter)
   (#eq? @text.todo "TODO"))
 
-("text" @text.todo
+("text" @text.todo @nospell
  (#eq? @text.todo "TODO"))
 
 ((tag
-  (name) @text.note
+  (name) @text.note @nospell
   ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
   ":" @punctuation.delimiter)
   (#any-of? @text.note "NOTE" "XXX"))
 
-("text" @text.note
+("text" @text.note @nospell
  (#any-of? @text.note "NOTE" "XXX"))
 
 ((tag
-  (name) @text.warning
+  (name) @text.warning @nospell
   ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
   ":" @punctuation.delimiter)
   (#any-of? @text.warning "HACK" "WARNING"))
 
-("text" @text.warning
+("text" @text.warning @nospell
  (#any-of? @text.warning "HACK" "WARNING"))
 
 ((tag
-  (name) @text.danger
+  (name) @text.danger @nospell
   ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
   ":" @punctuation.delimiter)
   (#any-of? @text.danger "FIXME" "BUG"))
 
-("text" @text.danger
+("text" @text.danger @nospell
  (#any-of? @text.danger "FIXME" "BUG"))
 
 ; Issue number (#123)
@@ -41,5 +41,5 @@
  (#lua-match? @number "^#[0-9]+$"))
 
 ; User mention (@user)
-("text" @constant
+("text" @constant @nospell
  (#lua-match? @constant "^[@][a-zA-Z0-9_-]+$"))

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -396,6 +396,8 @@
 
 (rune_literal) @string
 
+(raw_string_literal) @string
+
 (escape_sequence) @string.escape
 
 (float_literal) @float

--- a/queries/v/injections.scm
+++ b/queries/v/injections.scm
@@ -4,3 +4,11 @@
 ;; #include <...>
 (hash_statement) @c
 
+
+; regex for the methods defined in `re` module
+((call_expression
+    function: (selector_expression
+      field: (identifier) @_re)
+    arguments: (argument_list
+  (raw_string_literal) @regex (#offset! @regex 0 2 0 -1)))
+  (#any-of? @_re "regex_base" "regex_opt" "compile_opt"))


### PR DESCRIPTION
Inject regex for the methods in the vlib module `re`:

- [`re.regex_base`](https://modules.vlang.io/regex.html#regex_base)
- [`re.regex_opt`](https://modules.vlang.io/regex.html#regex_opt)
- [`re.RE.compile_opt`](https://modules.vlang.io/regex.html#RE.compile_opt)

Some notes:

- It only checks if the name (field of the call expression) is one of regex_base, regex_opt and compile_opt, which I think will be enough of a check, because these are fairly unusual names. But I could also check if the module name is `re`.
- Pattern has to be of node type `raw_string_literal` (thus an `r''` string), but could also include 'normal' strings if wanted
- Noticed raw strings were not highlighted, so also added the highlight for them.