### PR TITLE
v: inject regex for some methods in `re` module

### DIFF
--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -396,6 +396,8 @@
 
 (rune_literal) @string
 
+(raw_string_literal) @string
+
 (escape_sequence) @string.escape
 
 (float_literal) @float

--- a/queries/v/injections.scm
+++ b/queries/v/injections.scm
@@ -4,3 +4,10 @@
 ;; #include <...>
 (hash_statement) @c
 
+;; regex for the methods defined in `re` module
+((call_expression
+    function: (selector_expression
+      field: (identifier) @_re)
+    arguments: (argument_list
+  (raw_string_literal) @regex (#offset! @regex 0 2 0 -1)))
+  (#any-of? @_re "regex_base" "regex_opt" "compile_opt"))


### PR DESCRIPTION
Inject regex for the methods in the vlib module re:

- [re.regex_base](https://modules.vlang.io/regex.html#regex_base)
- [re.regex_opt](https://modules.vlang.io/regex.html#regex_opt)
- [re.RE.compile_opt](https://modules.vlang.io/regex.html#RE.compile_opt)

Some notes:

- It only checks if the name (field of the call expression) is one of regex_base, regex_opt and compile_opt, which I think will be enough of a check, because these are fairly unusual names. But I could also check if the module name is re.
- Pattern has to be of node type raw_string_literal (thus an r'' string), but could also include 'normal' strings if wanted
- Noticed raw strings were not highlighted, so also added the highlight for them.
- Are there formatters available for the scheme files? I'm not sure how to format them correctly