### PR TITLE
fix(go): Indent on type switch case properly

### DIFF
--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -7,6 +7,7 @@
   (literal_value)
   (expression_case)
   (communication_case)
+  (type_case)
   (default_case)
   (block)
   (call_expression)

--- a/tests/indent/go/switch.go
+++ b/tests/indent/go/switch.go
@@ -11,4 +11,10 @@ func test(ch byte) {
 	case 'l':
 		return
 	}
+
+	var i interface{}
+	switch i.(type) {
+	case int:
+		return
+	}
 }


### PR DESCRIPTION
The type switch construct emits a `type_case` node rather than an `expression_case`, so we need to explicitly ident on it.