### PR TITLE
fix: Java indent for multiple line arguments

### DIFF
--- a/queries/java/indents.scm
+++ b/queries/java/indents.scm
@@ -2,7 +2,6 @@
   (class_body)
   (enum_body)
   (interface_body)
-  (constructor_declaration)
   (constructor_body)
   (block)
   (switch_block)

--- a/tests/indent/java/constructor_with_arguments_on_multiple_lines.java
+++ b/tests/indent/java/constructor_with_arguments_on_multiple_lines.java
@@ -1,0 +1,5 @@
+public class Testo {
+  public Testo(
+    String a
+  ) {
+}

--- a/tests/indent/java/constructor_with_arguments_on_multiple_lines.java
+++ b/tests/indent/java/constructor_with_arguments_on_multiple_lines.java
@@ -2,4 +2,5 @@ public class Testo {
   public Testo(
     String a
   ) {
+  }
 }

--- a/tests/indent/java/method_with_arguments_on_multiple_lines.java
+++ b/tests/indent/java/method_with_arguments_on_multiple_lines.java
@@ -2,4 +2,5 @@ public class Testo {
   void hello(
     String a
   ) {
+  }
 }

--- a/tests/indent/java/method_with_arguments_on_multiple_lines.java
+++ b/tests/indent/java/method_with_arguments_on_multiple_lines.java
@@ -1,0 +1,5 @@
+public class Testo {
+  void hello(
+    String a
+  ) {
+}

--- a/tests/indent/java_spec.lua
+++ b/tests/indent/java_spec.lua
@@ -31,5 +31,13 @@ describe("indent Java:", function()
     )
     run:new_line("issue_2583.java", { on_line = 4, text = "int x = 1;", indent = 4 })
     run:new_line("method_chaining.java", { on_line = 4, text = '.append("b");', indent = 6 })
+    run:new_line(
+      "constructor_with_arguments_on_multiple_lines.java",
+      { on_line = 4, text = "}", indent = 2 }
+    )
+    run:new_line(
+      "method_with_arguments_on_multiple_lines.java",
+      { on_line = 4, text = "}", indent = 2 }
+    )
   end)
 end)

--- a/tests/indent/java_spec.lua
+++ b/tests/indent/java_spec.lua
@@ -31,13 +31,7 @@ describe("indent Java:", function()
     )
     run:new_line("issue_2583.java", { on_line = 4, text = "int x = 1;", indent = 4 })
     run:new_line("method_chaining.java", { on_line = 4, text = '.append("b");', indent = 6 })
-    run:new_line(
-      "constructor_with_arguments_on_multiple_lines.java",
-      { on_line = 4, text = "}", indent = 2 }
-    )
-    run:new_line(
-      "method_with_arguments_on_multiple_lines.java",
-      { on_line = 4, text = "}", indent = 2 }
-    )
+    run:new_line("constructor_with_arguments_on_multiple_lines.java", { on_line = 4, text = "}", indent = 2 })
+    run:new_line("method_with_arguments_on_multiple_lines.java", { on_line = 4, text = "}", indent = 2 })
   end)
 end)


### PR DESCRIPTION
Fixes #4448 

Both `(constructor_declaration)` and `(constructor_body)` are marked for indent, but it looks like we only need to indent one of them.

NOTE: Java indent tests are not passing for this PR. When I run `./scripts/run_tests.sh indent/java_spec.lua`, I get a failure for the "whole file" test.

```
Fail	||	indent Java: whole file: ./constructor_with_arguments_on_multiple_lines.java
            ./tests/indent/common.lua:80: Incorrect indentation
                       Found:                                       Expected:
                        |public class Testo {                        |public class Testo {
                        |  public Testo(                             |  public Testo(
                        |    String a                                |    String a
                        |  ) {                                       |  ) {
              2 vs 0 => |  }                                         |}

            stack traceback:
            	./tests/indent/common.lua:80: in function 'compare_indent'
            	./tests/indent/common.lua:122: in function 'indent_whole_file'
            	./tests/indent/common.lua:187: in function <./tests/indent/common.lua:186>
```

The problem is that the expected indentation for the "whole file" test is wrong. The test expects an indentation of 0 for the closing `}`, but the actual + correct indentation is 2. I'm not sure how to solve this, so any advice would be appreciated.