### PR TITLE
indents(vue): Update dedent logic for <template>

### DIFF
--- a/queries/vue/indents.scm
+++ b/queries/vue/indents.scm
@@ -4,4 +4,4 @@
   (template_element)
 ] @indent
 
-(template_element (end_tag "</" @branch ">" @indent_end))
+(template_element (end_tag ">" @indent_end) @branch)


### PR DESCRIPTION
"</" was previously used as a workaround to pass tests, but doesn't really work well in actual usage

"</" usage was also replicating usage for JSX template fragment, but in actuality it should be similar to normal HTML elements instead of that

Changing dedent logic to `(end_tag)` instead of relying on anchors

@amaanq have a look