### PR TITLE
update gleam grammar

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -153,7 +153,7 @@
     "revision": "f4685bf11ac466dd278449bcfe5fd014e94aa504"
   },
   "gleam": {
-    "revision": "cfcbca3f8f734773878e00d7bfcedea98eb10be2"
+    "revision": "ae79782c00656945db69641378e688cdb78d52c1"
   },
   "glimmer": {
     "revision": "40cfb72a53654cbd666451ca04ffd500257c7b73"


### PR DESCRIPTION
Warning: This grammar actually does not work with nvim right now. 

I don't know why it breaks, when I try this locally with the current version of nvim and nvim-treesitter I get this:

```
E5108: Error executing lua: ...e/nvim/site/pack/packer/start/harpoon/lua/harpoon/ui.lua:195: Vim(append):Error executing lua callback: /usr/share/nvim/runtime/filetype.lua:22: Error executing lua: /usr/share/nvim/runtime/filetype.lua:23: Vim(append):Error executing lua callback: Failed to load 
parser: uv_dlopen: /home/despairblue/.local/share/nvim/site/pack/packer/start/nvim-treesitter/parser/gleam.so: undefined symbol: tree_sitter_gleam_external_scanner_create                                                                                                                             
stack traceback:                                                                                                                                                                                                                                                                                       
        [C]: in function '_ts_add_language'                                                                                                                                                                                                                                                            
        /usr/share/nvim/runtime/lua/vim/treesitter/language.lua:42: in function 'require_language'                                                                                                                                                                                                     
        /usr/share/nvim/runtime/lua/vim/treesitter.lua:38: in function '_create_parser'                                                                                                                                                                                                                
        /usr/share/nvim/runtime/lua/vim/treesitter.lua:96: in function 'get_parser'                                                                                                                                                                                                                    
        /usr/share/nvim/runtime/lua/vim/treesitter.lua:329: in function 'start'                                                                                                                                                                                                                        
        .../start/nvim-treesitter/lua/nvim-treesitter/highlight.lua:20: in function 'attach'                                                                                                                                                                                                           
        ...er/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:511: in function 'attach_module'                                                                                                                                                                                                   
        ...er/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:534: in function 'reattach_module'                                                                                                                                                                                                 
        ...er/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:135: in function <...er/start/nvim-treesitter/lua/nvim-treesitter/configs.lua:134>                                                                                                                                                 
        [C]: in function 'nvim_cmd'                                                                                                                                                                                                                                                                    
        /usr/share/nvim/runtime/filetype.lua:23: in function </usr/share/nvim/runtime/filetype.lua:22>                                                                                                                                                                                                 
        [C]: in function 'nvim_buf_call'                                                                                                                                                                                                                                                               
        /usr/share/nvim/runtime/filetype.lua:22: in function </usr/share/nvim/runtime/filetype.lua:11>                                                                                                                                                                                                 
        [C]: in function 'nvim_set_current_buf'                                                                                                                                                                                                                                                        
        ...e/nvim/site/pack/packer/start/harpoon/lua/harpoon/ui.lua:195: in function 'nav_file'                                                                                                                                                                                                        
        ...lue/.dotfiles/nvim/.config/nvim/after/plugin/harpoon.lua:10: in function <...lue/.dotfiles/nvim/.config/nvim/after/plugin/harpoon.lua:9>                                                                                                                                                    
stack traceback:                                                                                                                                                                                                                                                                                       
        [C]: in function 'nvim_cmd'                                                                                                                                                                                                                                                                    
        /usr/share/nvim/runtime/filetype.lua:23: in function </usr/share/nvim/runtime/filetype.lua:22>                                                                                                                                                                                                 
        [C]: in function 'nvim_buf_call'                                                                                                                                                                                                                                                               
        /usr/share/nvim/runtime/filetype.lua:22: in function </usr/share/nvim/runtime/filetype.lua:11>                                                                                                                                                                                                 
        [C]: in function 'nvim_set_current_buf'                                                                                                                                                                                                                                                        
        ...e/nvim/site/pack/packer/start/harpoon/lua/harpoon/ui.lua:195: in function 'nav_file'                                                                                                                                                                                                        
        ...lue/.dotfiles/nvim/.config/nvim/after/plugin/harpoon.lua:10: in function <...lue/.dotfiles/nvim/.config/nvim/after/plugin/harpoon.lua:9>                                                                                                                                                    
stack traceback:                                                                                                                                                                                                                                                                                       
        [C]: in function 'nvim_buf_call'                                                                                                                                                                                                                                                               
        /usr/share/nvim/runtime/filetype.lua:22: in function </usr/share/nvim/runtime/filetype.lua:11>                                                                                                                                                                                                 
        [C]: in function 'nvim_set_current_buf'                                                                                                                                                                                                                                                        
        ...e/nvim/site/pack/packer/start/harpoon/lua/harpoon/ui.lua:195: in function 'nav_file'                                                                                                                                                                                                        
        ...lue/.dotfiles/nvim/.config/nvim/after/plugin/harpoon.lua:10: in function <...lue/.dotfiles/nvim/.config/nvim/after/plugin/harpoon.lua:9>                                                                                                                                                    
stack traceback:                                                                                                                                                                                                                                                                                       
        [C]: in function 'nvim_set_current_buf'                                                                                                                                                                                                                                                        
        ...e/nvim/site/pack/packer/start/harpoon/lua/harpoon/ui.lua:195: in function 'nav_file'                                                                                                                                                                                                        
        ...lue/.dotfiles/nvim/.config/nvim/after/plugin/harpoon.lua:10: in function <...lue/.dotfiles/nvim/.config/nvim/after/plugin/harpoon.lua:9>
```

I don't know what the issue is. The symbol is defined here: 
https://github.com/gleam-lang/tree-sitter-gleam/blob/ae79782c00656945db69641378e688cdb78d52c1/src/scanner.c#L7

The version that is currently locked in nvim-treesitter is outdated and does not support newer syntax.

Let me know how I can help with this.