### PR TITLE
Partially Revert "fix(ecma): properly capture constants in const declarations"

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -29,11 +29,6 @@
 ((shorthand_property_identifier) @constant
  (#lua-match? @constant "^_*[A-Z][A-Z%d_]*$"))
 
-(lexical_declaration
-  "const"
-  . (variable_declarator
-      . name: (identifier) @constant))
-
 ((identifier) @variable.builtin
  (#vim-match? @variable.builtin "^(arguments|module|console|window|document)$"))
 


### PR DESCRIPTION
This partially reverts commit c553e6c5608ba54e210e9131bf9ba5e36ef18e57.

Closes #4466

I was a bit naive in understanding how js consts work (I only use it for writing tree-sitter grammars..oops)