### PR TITLE
fix(windows): fix invalid powershell separator during install

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -301,7 +301,11 @@ end
 ---@return string command
 function M.make_directory_change_for_command(dir, command)
   if fn.has "win32" == 1 then
-    return string.format("pushd %s & %s & popd", cmdpath(dir), command)
+    if vim.o.shell == "powershell" or vim.o.shell == "pwsh" then
+      return string.format("pushd %s ; %s ; popd", cmdpath(dir), command)
+    else
+      return string.format("pushd %s & %s & popd", cmdpath(dir), command)
+    end
   else
     return string.format("cd %s;\n %s", dir, command)
   end

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -301,10 +301,10 @@ end
 ---@return string command
 function M.make_directory_change_for_command(dir, command)
   if fn.has "win32" == 1 then
-    if vim.o.shell == "powershell" or vim.o.shell == "pwsh" then
-      return string.format("pushd %s ; %s ; popd", cmdpath(dir), command)
-    else
+    if string.find(vim.o.shell, "cmd") ~= nil then
       return string.format("pushd %s & %s & popd", cmdpath(dir), command)
+    else
+      return string.format("pushd %s ; %s ; popd", cmdpath(dir), command)
     end
   else
     return string.format("cd %s;\n %s", dir, command)


### PR DESCRIPTION
Fixes nvim installation on vim configuration that use powershell.

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/3316 
Maybe fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1965

There's a similar pull request here https://github.com/nvim-treesitter/nvim-treesitter/pull/4365 but [has potential problems](https://github.com/nvim-treesitter/nvim-treesitter/pull/4365#issuecomment-1445416964) 