### PR TITLE
highlights(cmake): match digits in unquoted arguments

### DIFF
--- a/queries/cmake/highlights.scm
+++ b/queries/cmake/highlights.scm
@@ -1,7 +1,7 @@
 (normal_command
   (identifier)
   (argument (unquoted_argument)) @constant
-  (#lua-match? @constant "^%u[%u_]+$")
+  (#lua-match? @constant "^[%u@][%u%d_]+$")
 )
 
 [


### PR DESCRIPTION
Before
![Bildschirmfoto vom 2023-03-11 16-02-26](https://user-images.githubusercontent.com/115270/224491899-e0321acf-370a-4fb9-8b9e-eeb50d04d482.png)
After
![Bildschirmfoto vom 2023-03-11 16-02-00](https://user-images.githubusercontent.com/115270/224491908-ee3b9290-d108-4b1f-9721-223e01dd6a17.png)

CC @uyha.