### PR TITLE
Fix injection based on "call_expression" for "ecma"

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -3,10 +3,13 @@
 
 (comment) @comment
 
-(call_expression
+; html(`...`), sql(...) etc
+(call_expression 
  function: ((identifier) @language)
- arguments: ((template_string) @content
-   (#offset! @content 0 1 0 -1)))
+ arguments: (arguments
+   (template_string) @content
+     (#offset! @content 0 1 0 -1))
+)
 
 (call_expression
  function: ((identifier) @_name


### PR DESCRIPTION
Also add a comment what the query does.

Before:
![before](https://user-images.githubusercontent.com/1206309/224540774-8c866c03-9a41-4b3e-8f0b-62fe2ddf7af4.png)

After:
![after](https://user-images.githubusercontent.com/1206309/224540779-0ec4abf9-d5dd-417f-81d1-307867ad4046.png)
