### PR TITLE
docs: add note in README on compilation errors with old compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,3 +694,17 @@ require'nvim-treesitter.configs'.setup {
     --
 }
 ```
+
+#### I experience compilation errors when installing certain parsers
+
+Some parsers do not specify a standard for their compilation and rely on the compiler having a sufficient default.
+Check that your compiler is a recent version and update if necessary.
+If you cannot update the compiler, but the one you have supports the minimum standard for the failing parser, you can force compilation via Makefile by adding in your Lua config:
+
+```lua
+local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
+-- For parsers written in c99 or earlier the following line is sufficient.
+parser_config['parser'].install_info.use_makefile = true
+-- For parsers with parts written in c++ you may need to set the following.
+ parser_config['parser'].install_info.cxx_standard = 'c++11'
+```


### PR DESCRIPTION
Motivation:
Several parsers that need to be compiled using the c99 standard do not specify it, because it is the default in recent versions of the compiler (e.g.: awk, latex, vim), however, this is not true at my workplace, where an older compiler is installed to enforce environment stability, thus resulting in compilation errors.

My solution:
With this pull request, I would like to add support for cxx_standard in  select_compiler_args, so if the compiler defaults to a standard that is earlier than what is needed, in init.lua one can specify it like this:

local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
parser_config['awk'].install_info.cxx_standard = 'c99'
parser_config['latex'].install_info.cxx_standard = 'c99'
parser_config['vim'].install_info.cxx_standard = 'c99'

and have the compilation succeded.

I find this a better alternative to bugging individual parsers.

I hope you find this useful.
Thank you for your work on nvim-treesitter.