### PR TITLE
Use pre-generated parser files for sql grammar

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -429,7 +429,7 @@
     "revision": "05f949d3c1c15e3261473a244d3ce87777374dec"
   },
   "sql": {
-    "revision": "d6963a2426972a6ffa08ff92a5dba7922d68c1f5"
+    "revision": "4cb5b36d70687bfe4687c68483b4dacde309ae6f"
   },
   "squirrel": {
     "revision": "3fefc6b9bb2b4de1b1c461783f675918cd957546"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1277,7 +1277,7 @@ list.sql = {
   install_info = {
     url = "https://github.com/derekstride/tree-sitter-sql",
     files = { "src/parser.c" },
-    requires_generate_from_grammar = true,
+    branch = "gh-pages",
   },
   maintainers = { "@derekstride" },
 }


### PR DESCRIPTION
## What

As of https://github.com/derekstride/tree-sitter-sql/pull/100 we're publishing the `parser.c` source code artifact on the `gh-pages` branch, which should make it easier to install.

I tried running `scripts/update-lockfile.sh sql` to bump the lockfile to use the revision on the new branch but that didn't seem to work. I'd commit the new revision manually but I'm concerned it's an issue with the script. I'll investigate.