### PR TITLE
fix(ecma): template literal injections

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -11,6 +11,19 @@
      (#offset! @content 0 1 0 -1))
 )
 
+; html`...`, sql`...` etc
+(call_expression 
+ function: ((identifier) @language)
+ arguments: ((template_string) @content
+     (#offset! @content 0 1 0 -1))
+)
+
+; svg`...`, which uses the html parser
+(call_expression
+ function: ((identifier) @_name (#eq? @_name "svg"))
+ arguments: ((template_string) @html
+     (#offset! @html 0 1 0 -1)))
+
 (call_expression
  function: ((identifier) @_name
    (#eq? @_name "gql"))

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -16,14 +16,14 @@
 
 ; svg`...` or svg(`...`), which uses the html parser, so is not included in the previous query
 (call_expression
- function: ((identifier) @svg)
+ function: ((identifier) @_name (#eq? @_name "svg"))
  arguments: [
              (arguments
-              (template_string) @content)
-             (template_string) @content
+              (template_string) @html)
+             (template_string) @html
             ]
-     (#offset! @content 0 1 0 -1)
-     (#eq? @content "svg"))
+     (#offset! @html 0 1 0 -1))
+
 
 (call_expression
  function: ((identifier) @_name

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -3,26 +3,27 @@
 
 (comment) @comment
 
-; html(`...`), sql(...) etc
-(call_expression 
- function: ((identifier) @language)
- arguments: (arguments
-   (template_string) @content
-     (#offset! @content 0 1 0 -1))
-)
-
-; html`...`, sql`...` etc
-(call_expression 
- function: ((identifier) @language)
- arguments: ((template_string) @content
-     (#offset! @content 0 1 0 -1))
-)
-
-; svg`...`, which uses the html parser
+; html(`...`), html`...`, sql(...) etc
 (call_expression
- function: ((identifier) @_name (#eq? @_name "svg"))
- arguments: ((template_string) @html
-     (#offset! @html 0 1 0 -1)))
+ function: ((identifier) @language)
+ arguments: [
+             (arguments
+              (template_string) @content)
+             (template_string) @content
+            ]
+     (#offset! @content 0 1 0 -1)
+     (#not-eq? @content "svg"))
+
+; svg`...` or svg(`...`), which uses the html parser, so is not included in the previous query
+(call_expression
+ function: ((identifier) @svg)
+ arguments: [
+             (arguments
+              (template_string) @content)
+             (template_string) @content
+            ]
+     (#offset! @content 0 1 0 -1)
+     (#eq? @content "svg"))
 
 (call_expression
  function: ((identifier) @_name


### PR DESCRIPTION
The change in https://github.com/nvim-treesitter/nvim-treesitter/commit/e3ebc8ec5d586162f3c408417621daa59ba8ea62 broke lit-html highlighting. 

Here is the new, broken injection:

![Screenshot from 2023-03-17 09-35-28](https://user-images.githubusercontent.com/1466420/225842359-a2280cd3-e7a5-4637-84f4-9a6a081a02a5.png)

Here it is with the parens, which causes a runtime error
![Screenshot from 2023-03-17 09-35-34](https://user-images.githubusercontent.com/1466420/225842353-00b214c9-2667-46f4-bd4d-e28d94914ba3.png)
I'd now need to wrap the template literal in parens, which is not the same kind of function call, as demonstrated in this screenshot:
![Screenshot from 2023-03-17 09-53-54](https://user-images.githubusercontent.com/1466420/225845976-30c099a4-5030-4ab0-b562-9ff0d22aa335.png)

This also assigns the HTML parser for SVG tagged literals, since svg uses the HTML parser
```js
svg`<svg>...</svg>`
```

