### PR TITLE
injections(html): various <script type>

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -119,6 +119,29 @@ query.add_predicate("has-type?", function(match, _pattern, _bufnr, pred)
   return vim.tbl_contains(types, node:type())
 end)
 
+local html_script_type_languages = {
+  ["importmap"] = "json",
+  ["module"] = "javascript",
+  ["application/ecmascript"] = "javascript",
+  ["text/ecmascript"] = "javascript",
+}
+
+---@param match string
+---@param metadata table
+---@return boolean|nil
+query.add_directive("set-lang-from-mimetype!", function(match, pattern, bufnr, predicate, metadata)
+  local capture_id = predicate[2]
+  local node = match[capture_id]
+  local type_attr_value = vim.treesitter.get_node_text(node, bufnr)
+  local configured = html_script_type_languages[type_attr_value]
+  if configured then
+    metadata.language = configured
+  else
+    local parts = vim.split(type_attr_value, "/", {})
+    metadata.language = parts[#parts]
+  end
+end)
+
 -- Just avoid some annoying warnings for this directive
 query.add_directive("make-range!", function() end)
 

--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -27,23 +27,23 @@
       (#not-match? @_no_type_lang "\\s(lang|type)\\s*\\=")
     (raw_text) @javascript))
 
-(
-  (script_element
-    (start_tag
-      (attribute
-        (attribute_name) @_type
-        (quoted_attribute_value (attribute_value) @_javascript)))
-    (raw_text) @javascript)
-  (#eq? @_type "type")
-  (#any-of? @_javascript "text/javascript" "module")
-)
+; <script type="mimetype-or-well-known-script-type">
+(script_element
+   (start_tag
+      ((attribute
+           (attribute_name) @_attr (#eq? @_attr "type")
+           (quoted_attribute_value (attribute_value) @_type))))
+   (raw_text) @content (#set-lang-from-mimetype! @_type))
 
+; <a style="/* css */">
 ((attribute
    (attribute_name) @_attr
    (quoted_attribute_value (attribute_value) @css))
  (#eq? @_attr "style"))
 
 ; lit-html style template interpolation
+; <a @click=${e => console.log(e)}>
+; <a @click="${e => console.log(e)}">
 ((attribute
   (quoted_attribute_value (attribute_value) @javascript))
   (#match? @javascript "\\$\\{")

--- a/tests/query/injections/ecma/ecma-test-injections.js
+++ b/tests/query/injections/ecma/ecma-test-injections.js
@@ -1,0 +1,9 @@
+html`<p></p>`;
+   // ^ html
+html(`<p></p>`);
+   // ^ html
+svg`<p></p>`;
+   // ^ html
+svg(`<p></p>`);
+   // ^ html
+

--- a/tests/query/injections/html/test-html-injections.html
+++ b/tests/query/injections/html/test-html-injections.html
@@ -14,18 +14,51 @@
   </head>
   <body>
     <script> const x = 1 </script>
-    <!--        ^ javascript -->
+           <!-- ^ javascript -->
     <script defer> const x = 1 </script>
-    <!--              ^ javascript -->
+                  <!-- ^ javascript -->
+    <script async defer> const x = 1 </script>
+                     <!-- ^ javascript -->
     <script type="text/javascript"> const x = 1 </script>
-    <!--                              ^ javascript -->
+                                  <!-- ^ javascript -->
+    <script type="text/ecmascript"> const x = 1 </script>
+                                  <!-- ^ javascript -->
+    <script type="application/ecmascript"> const x = 1 </script>
+                                       <!-- ^ javascript -->
+    <script type="application/javascript"> const x = 1 </script>
+                                       <!-- ^ javascript -->
     <script type="module"> import { foo } from "bar" </script>
-    <!--                              ^ javascript -->
+                                 <!-- ^ javascript -->
     <script defer type="text/javascript"> const x = 1 </script>
                                         <!-- ^ javascript -->
+    <script type="text/markdown">## Hello *World*!</script>
+                              <!-- ^ markdown -->
+    <script type="application/graphql">query OK { dokey }</script>
+                                      <!-- ^ graphql -->
+    <script type="application/typescript">type A = number;</script>
+                                      <!-- ^ typescript -->
+    <script type="application/json">{ "true": false }</script>
+                                      <!-- ^ json -->
+    <script type="importmap">{ "true": false }</script>
+                                  <!-- ^ json -->
+    <script type="module">html`<p></p>`</script>
+                             <!-- ^ html -->
+    <script type="module">html(`<p></p>`)</script>
+                             <!-- ^ html -->
+    <script type="module">svg`<p></p>`</script>
+                             <!-- ^ html -->
+    <script type="module">svg(`<p></p>`)</script>
+                             <!-- ^ html -->
+
     <div style="height: 100%">
-<!--                ^ css      -->
+               <!-- ^ css -->
       Test div to test css injections for style attributes
     </div>
+
+    <input pattern="[0-9]+">
+                  <!-- ^ regex -->
+    <input pattern=[0-9]+ type="tel">
+                <!-- ^ regex -->
+
   </body>
 </html>

--- a/tests/query/injections/html/test-html-injections.html
+++ b/tests/query/injections/html/test-html-injections.html
@@ -41,15 +41,6 @@
                                       <!-- ^ json -->
     <script type="importmap">{ "true": false }</script>
                                   <!-- ^ json -->
-    <script type="module">html`<p></p>`</script>
-                             <!-- ^ html -->
-    <script type="module">html(`<p></p>`)</script>
-                             <!-- ^ html -->
-    <script type="module">svg`<p></p>`</script>
-                             <!-- ^ html -->
-    <script type="module">svg(`<p></p>`)</script>
-                             <!-- ^ html -->
-
     <div style="height: 100%">
                <!-- ^ css -->
       Test div to test css injections for style attributes


### PR DESCRIPTION
Replaces the `<script type>` parts from #2577 

![image](https://user-images.githubusercontent.com/1466420/225867486-7f40c22d-9749-499c-b8a4-3e9462f230eb.png)

<details><summary>test file</summary>

```html
<script>
  html`<p></p>`
  html(`<p></p>`)
  svg`<p></p>`
  svg(`<p></p>`)
</script>

<script type="module">
  html`<p></p>`
  html(`<p></p>`)
  svg`<p></p>`
  svg(`<p></p>`)
</script>

<input pattern="[0-9]+">
<input pattern=[0-9]+ type="tel">

<script type="application/json">{ "true": false }</script>
<script type="importmap">{ "true": false }</script>
<script type="text/markdown">## Hello *World*!</script>
<script type="application/graphql">query OK { dokey }</script>
<script type="javascript">function foo () {}</script>
<script type="module">function foo() {}</script>
<script type="application/ecmascript">function foo() {}</script>
<script type="text/ecmascript">function foo() {}</script>
<script type="text/javascript">function foo() {}</script>
```

</details>