### PR TITLE
fix(v): add `vlang` as filetype

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1480,6 +1480,7 @@ list.v = {
     files = { "src/parser.c", "src/scanner.c" },
     location = "tree_sitter_v",
   },
+  filetype = "vlang",
   maintainers = { "@kkharji" },
 }
 


### PR DESCRIPTION
This PR extends highlighting for V files to file types set to `vlang`.

Currently, highlighting requires `ft=v`. However, until the recent merge to also include `ft=v` in nvim-lspconfig, `vls` required `ft=vlang`, which will disable tree-sitter highlighting for V. 

Since the recommendations to set the file type for V are just becoming more consistent and both are valid, this PR makes it work interchangeably.