### PR TITLE
fix(cpp): nullptr should be `@constant.builtin`

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -114,7 +114,7 @@
 ; Constants
 
 (this) @variable.builtin
-(nullptr) @constant
+(nullptr) @constant.builtin
 
 (true) @boolean
 (false) @boolean


### PR DESCRIPTION
cc @dwuertz

Closes #4527 