### PR TITLE
feat(typescript): add various missing function/method captures

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -66,6 +66,7 @@
 
 "?." @punctuation.delimiter
 
+(method_signature "?" @punctuation.special)
 (property_signature "?" @punctuation.special)
 (optional_parameter "?" @punctuation.special)
 
@@ -104,3 +105,20 @@
 ;; a => null
 (arrow_function
   parameter: (identifier) @parameter)
+
+;; function signatures
+(ambient_declaration
+  (function_signature
+    name: (identifier) @function))
+
+;; method signatures
+(method_signature name: (_) @method)
+
+;; property signatures
+(property_signature
+  name: (property_identifier) @method
+  type: (type_annotation
+          [
+            (union_type (parenthesized_type (function_type)))
+            (function_type)
+          ]))


### PR DESCRIPTION
The problem is methods in declarations, class fields, and interface fields were being higlighted as fields no matter what. For declarations and classes, this was a simple fix as seen in the changes to highlights.scm

For interfaces, this is a bit tricky as we can have a union type be a function or undefined, see the following example:
```ts
interface ScriptInvocationListenerCallbacks {
	/**
	 * Called synchronously when a thread is about to enter the target function.
	 */
	onEnter?: ((this: InvocationContext, args: InvocationArguments) => void) | undefined;

	/**
	 * Called synchronously when a thread is about to leave the target function.
	 */
	onLeave?: ((this: InvocationContext, retval: InvocationReturnValue) => void) | undefined;
}
```

onEnter is a maybe undefined/null type, with the non-null type being a function.  The issue is, the tree looks something like this:

![image](https://user-images.githubusercontent.com/29718261/226219936-a0bdbcfe-949c-4a11-8d4b-c83b57c49f13.png)

The actual capture to check if the field is a function is nested in a union and parenthesized type, and this can be mixed/matched in all sorts of ways.

This PR introduces a new group of predicates, `#has-child?` and `#has-descendent?`, so we can then check if the interface field's type annotation contains a function descendant. If it does, it is a method type then and should be highlighted as such.

cc @lewis6991 as I'm not great w/ Lua code and mostly derived my implementation from the `has_ancestor` function

I'm not fully aware of the performance implications this could have, but I did test this out in a 7k LoC TypeScript file and performance seemed to be more or less the same with and without the predicate.