### PR TITLE
fix(lua): properly highlight labels

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -8,8 +8,6 @@
  "local"
 ] @keyword
 
-(label_statement) @label
-
 (break_statement) @keyword
 
 (do_statement
@@ -109,6 +107,7 @@
 [
   ";"
   ":"
+  "::"
   ","
   "."
 ] @punctuation.delimiter
@@ -135,6 +134,12 @@
    attribute: (attribute
      (["<" ">"] @punctuation.bracket
       (identifier) @attribute)))
+
+;; Labels
+
+(label_statement (identifier) @label)
+
+(goto_statement (identifier) @label)
 
 ;; Constants
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/29718261/226223089-51f4ae81-c3bf-4a67-9541-08cfa539adc1.png)

After:

![image](https://user-images.githubusercontent.com/29718261/226223196-620cdf5e-7939-43f4-8eec-f47c7ac8f8fd.png)

The label identifier should be `@label`, the double colons `@punctuation.delimiter`