### PR TITLE
comment(highlights): reduce user mention priority

### DIFF
--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -42,4 +42,5 @@
 
 ; User mention (@user)
 ("text" @constant @nospell
- (#lua-match? @constant "^[@][a-zA-Z0-9_-]+$"))
+ (#lua-match? @constant "^[@][a-zA-Z0-9_-]+$")
+ (#set! "priority" 95))


### PR DESCRIPTION
This prevents it from overwriting luadoc (or other) highlights.