### PR TITLE
fix: `get_range` shim for playground

### DIFF
--- a/lua/nvim-treesitter/compat.lua
+++ b/lua/nvim-treesitter/compat.lua
@@ -1,5 +1,6 @@
 -- Shim module to address deprecations across nvim versions
-local tsq = vim.treesitter.query
+local ts = vim.treesitter
+local tsq = ts.query
 
 local M = {}
 
@@ -13,6 +14,10 @@ end
 
 function M.parse_query(lang, query)
   return (tsq.parse or tsq.parse_query)(lang, query)
+end
+
+function M.get_range(node, source, metadata)
+  return (ts.get_range or tsq.get_range)(node, source, metadata)
 end
 
 return M

--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -4,7 +4,7 @@
 
 local queries = require "nvim-treesitter.query"
 local ts_utils = require "nvim-treesitter.ts_utils"
-local ts_query = vim.treesitter.query
+local ts = vim.treesitter
 local api = vim.api
 
 local M = {}
@@ -170,7 +170,7 @@ M.get_definitions_lookup_table = ts_utils.memoize_by_buf_tick(function(bufnr)
       local scopes = M.get_definition_scopes(node_entry.node, bufnr, node_entry.scope)
       -- Always use the highest valid scope
       local scope = scopes[#scopes]
-      local node_text = ts_query.get_node_text(node_entry.node, bufnr)
+      local node_text = ts.get_node_text(node_entry.node, bufnr)
       local id = M.get_definition_id(scope, node_text)
 
       result[id] = node_entry
@@ -223,7 +223,7 @@ end
 ---@return string|nil kind
 function M.find_definition(node, bufnr)
   local def_lookup = M.get_definitions_lookup_table(bufnr)
-  local node_text = ts_query.get_node_text(node, bufnr)
+  local node_text = ts.get_node_text(node, bufnr)
 
   for scope in M.iter_scope_tree(node, bufnr) do
     local id = M.get_definition_id(scope, node_text)
@@ -244,7 +244,7 @@ end
 ---@return TSNode[]: a list of nodes
 function M.find_usages(node, scope_node, bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
-  local node_text = ts_query.get_node_text(node, bufnr)
+  local node_text = ts.get_node_text(node, bufnr)
 
   if not node_text or #node_text < 1 then
     return {}
@@ -254,11 +254,7 @@ function M.find_usages(node, scope_node, bufnr)
   local usages = {}
 
   for match in M.iter_locals(bufnr, scope_node) do
-    if
-      match.reference
-      and match.reference.node
-      and ts_query.get_node_text(match.reference.node, bufnr) == node_text
-    then
+    if match.reference and match.reference.node and ts.get_node_text(match.reference.node, bufnr) == node_text then
       local def_node, _, kind = M.find_definition(match.reference.node, bufnr)
 
       if kind == nil or def_node == node then

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -14,7 +14,7 @@
 ((function_call
   name: (_) @_vimcmd_identifier
   arguments: (arguments (string content: _ @query) .))
-  (#any-of? @_vimcmd_identifier "vim.treesitter.query.set" "vim.treesitter.query.parse_query"))
+  (#any-of? @_vimcmd_identifier "vim.treesitter.query.set" "vim.treesitter.query.parse_query" "vim.treesitter.query.parse"))
 
 ;; highlight string as query if starts with `;; query`
 ((string ("string_content") @query) (#lua-match? @query "^%s*;+%s?query"))


### PR DESCRIPTION
This PR adds more shims in the `nvim-treesitter.compat` module and reroutes every
occurrence of the old function calls to the new ones, to comply with the
breaking neovim/neovim@cbbf8bd.

I have made this pull request to quickly solve deprecation messages for those on
neovim nightly, such as in nvim-treesitter/playground#120.
