### PR TITLE
@indent.end should end at the node's end row, @indent.branch should end at the end of its capture

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -182,18 +182,14 @@ function M.get_indent(lnum)
     local is_start_processed = false
     local is_end_processed = false
 
-    if
-      not is_end_processed_by_row[erow]
-      and q.indent["end"][node:id()] and erow < lnum - 1
-    then
+    if not is_end_processed_by_row[erow] and q.indent["end"][node:id()] and erow < lnum - 1 then
       indent = indent - indent_size
       is_end_processed = true
     end
 
     if
       not is_start_processed_by_row[srow]
-      and ((q.indent.branch[node:id()] and srow == lnum - 1) or
-           (q.indent.dedent[node:id()] and srow ~= lnum - 1))
+      and ((q.indent.branch[node:id()] and srow == lnum - 1) or (q.indent.dedent[node:id()] and srow ~= lnum - 1))
     then
       indent = indent - indent_size
       is_start_processed = true

--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -181,15 +181,15 @@ function M.get_indent(lnum)
 
     local is_processed = false
 
+    local did_end = false
     if not is_processed_by_row[erow]
        and (q.indent["end"][node:id()] and q.indent["end"][node:id()]["indent.after"] and erow < lnum - 1)
     then
        --indent = math.max(indent - indent_size, 0)
        indent = indent - indent_size
        is_processed = true
+       did_end = true
     end
-    -- do not process indent, dedent if there's already an end
-    is_processed_by_row[srow] = is_processed_by_row[srow] or is_processed
 
     if not is_processed_by_row[srow]
        and (q.indent["end"][node:id()] and not q.indent["end"][node:id()]["indent.after"] and erow <= lnum - 1)
@@ -197,11 +197,10 @@ function M.get_indent(lnum)
        --indent = math.max(indent - indent_size, 0)
        indent = indent - indent_size
        is_processed = true
+       did_end = true
     end
-    -- do not process indent, dedent if there's already an end
-    is_processed_by_row[srow] = is_processed_by_row[srow] or is_processed
 
-    if not is_processed_by_row[srow]
+    if not is_processed_by_row[srow] and not did_end
        and ((q.indent.branch[node:id()] and srow <= lnum - 1 and erow >= lnum - 1) or
             (q.indent.dedent[node:id()] and srow < lnum - 1 and erow >= lnum - 1))
     then

--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -10,12 +10,6 @@
 ] @indent.begin
 
 (
- (parenthesized_expression) @indent.align
- (#set! indent.open_delimiter "(")
- (#set! indent.close_delimiter ")")
-)
-
-(
   ERROR
     "for" "(" @indent.begin ";" ";" ")" @indent.end)
 (

--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -10,6 +10,12 @@
 ] @indent.begin
 
 (
+ (parenthesized_expression) @indent.align
+ (#set! indent.open_delimiter "(")
+ (#set! indent.close_delimiter ")")
+)
+
+(
   ERROR
     "for" "(" @indent.begin ";" ";" ")" @indent.end)
 (

--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -90,10 +90,13 @@
 )
 
 (compound_statement "}" @indent.end)
+(initializer_list "}" @indent.end)
+(field_declaration_list "}" @indent.end)
+(enumerator_list "}" @indent.end)
+(declaration_list "}" @indent.end)
 
 [
   ")"
-  "}"
   (statement_identifier)
 ] @indent.branch
 

--- a/queries/css/indents.scm
+++ b/queries/css/indents.scm
@@ -3,7 +3,6 @@
   (declaration)
 ] @indent.begin
 
-(block ("}") @indent.branch)
-("}") @indent.dedent
+(block ("}") @indent.end)
 
 (comment) @indent.ignore

--- a/queries/ecma/indents.scm
+++ b/queries/ecma/indents.scm
@@ -38,12 +38,7 @@
 (object "}" @indent.end)
 (statement_block "}" @indent.end)
 
-[
-  (arguments (object))
-  ")"
-  "}"
-  "]"
-] @indent.branch
+(")" @indent.branch)
 (statement_block "{" @indent.branch)
 
 (parenthesized_expression ("(" (_) ")" @indent.end))

--- a/queries/gdscript/indents.scm
+++ b/queries/gdscript/indents.scm
@@ -15,8 +15,8 @@
 ] @indent.begin
 
 [
-  (elif_clause)
-  (else_clause)
+  "else"
+  "elif"
 ] @indent.branch
 
 [

--- a/queries/go/indents.scm
+++ b/queries/go/indents.scm
@@ -15,18 +15,13 @@
   (struct_type)
 ] @indent.begin
 
-[
-  "}"
-] @indent.branch
-
 (const_declaration ")" @indent.branch)
 (import_spec_list ")" @indent.branch)
 (var_declaration ")" @indent.branch)
 
-[
- "}"
- ")"
-] @indent.end
+("}" @indent.end)
+(")" @indent.end
+ (#set! indent.after 1))
 
 (parameter_list ")" @indent.branch)
 

--- a/queries/lua/indents.scm
+++ b/queries/lua/indents.scm
@@ -26,15 +26,12 @@
     (function_call))) @indent.dedent
 
 [
-  "end"
   "then"
   "until"
   "}"
   ")"
   "elseif"
-  (elseif_statement)
   "else"
-  (else_statement)
 ] @indent.branch
 
 (comment) @indent.auto

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -96,11 +96,12 @@
 (tuple_pattern ")" @indent.end)
 (list_pattern "]" @indent.end)
 
-
-((return_statement) @indent.end)
-((raise_statement) @indent.end)
-((break_statement) @indent.end)
-((continue_statement) @indent.end)
+[
+    (return_statement)
+    (raise_statement)
+    (break_statement)
+    (continue_statement)
+] @indent.end
 
 [
   ")"

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -1,6 +1,4 @@
 [
-  (import_from_statement)
-
   (parenthesized_expression)
   (generator_expression)
   (list_comprehension)
@@ -19,14 +17,17 @@
 ((list) @indent.align
  (#set! indent.open_delimiter "[")
  (#set! indent.close_delimiter "]")
+ (#set! indent.dedent_hanging_closing 1)
 )
 ((dictionary) @indent.align
  (#set! indent.open_delimiter "{")
  (#set! indent.close_delimiter "}")
+ (#set! indent.dedent_hanging_closing 1)
 )
 ((set) @indent.align
  (#set! indent.open_delimiter "{")
  (#set! indent.close_delimiter "}")
+ (#set! indent.dedent_hanging_closing 1)
 )
 
 ((match_statement) @indent.begin
@@ -69,14 +70,20 @@
 (ERROR "(" @indent.align (#set! indent.open_delimiter "(") (#set! indent.close_delimiter ")") . (_)) 
 ((argument_list) @indent.align
  (#set! indent.open_delimiter "(")
- (#set! indent.close_delimiter ")"))
+ (#set! indent.close_delimiter ")")
+ (#set! indent.dedent_hanging_closing 1))
 ((parameters) @indent.align
  (#set! indent.open_delimiter "(")
  (#set! indent.close_delimiter ")")
  (#set! indent.avoid_last_matching_next 1))
 ((tuple) @indent.align
  (#set! indent.open_delimiter "(")
- (#set! indent.close_delimiter ")"))
+ (#set! indent.close_delimiter ")")
+ (#set! indent.dedent_hanging_closing 1))
+((import_from_statement "(" _ ")") @indent.align 
+ (#set! indent.open_delimiter "(")
+ (#set! indent.close_delimiter ")")
+ (#set! indent.dedent_hanging_closing 1))
 
 (ERROR "[" @indent.align (#set! indent.open_delimiter "[") (#set! indent.close_delimiter "]") . (_)) 
 
@@ -91,22 +98,39 @@
 (tuple_pattern ")" @indent.end)
 (list_pattern "]" @indent.end)
 
-[
-    (return_statement)
-    (raise_statement)
-    (break_statement)
-    (continue_statement)
-] @indent.end
+((return_statement) @indent.end
+ (#set! indent.after 1))
+((raise_statement) @indent.end
+ (#set! indent.after 1))
+((break_statement) @indent.end
+ (#set! indent.after 1))
+((continue_statement) @indent.end
+ (#set! indent.after 1))
 
-[
-  ")"
-  "]"
-  "}"
-  (elif_clause)
-  (else_clause)
-  (except_clause)
-  (finally_clause)
-] @indent.branch
+(
+ (except_clause
+  "except" @indent.branch
+  (_) @indent.begin)
+)
+
+(
+ (finally_clause
+  "finally" @indent.branch
+  (_) @indent.begin)
+)
+
+(
+ (elif_clause
+  "elif" @indent.branch
+  consequence: (_) @indent.begin)
+)
+
+(
+ (else_clause
+  "else" @indent.branch
+  body: (_) @indent.begin
+ )
+)
 
 (string) @indent.auto
 

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -29,6 +29,10 @@
  (#set! indent.close_delimiter "}")
 )
 
+((match_statement) @indent.begin
+ (#set! indent.immediate 1))
+((case_clause) @indent.begin
+ (#set! indent.immediate 1))
 ((for_statement) @indent.begin
  (#set! indent.immediate 1))
 ((if_statement) @indent.begin
@@ -93,22 +97,10 @@
 (list_pattern "]" @indent.end)
 
 
-(return_statement
-  [
-    (_) @indent.end
-    (_
-      [
-        (_)
-        ")"
-        "}"
-        "]"
-      ] @indent.end .)
-    (attribute 
-      attribute: (_) @indent.end)
-    (call
-      arguments: (_ ")" @indent.end))
-    "return" @indent.end
-  ] .)
+((return_statement) @indent.end)
+((raise_statement) @indent.end)
+((break_statement) @indent.end)
+((continue_statement) @indent.end)
 
 [
   ")"

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -82,11 +82,6 @@
 
 (ERROR "{" @indent.align (#set! indent.open_delimiter "{") (#set! indent.close_delimiter "}") . (_)) 
 
-[
-  (break_statement)
-  (continue_statement)
-] @indent.dedent
-
 (parenthesized_expression ")" @indent.end)
 (generator_expression ")" @indent.end)
 (list_comprehension "]" @indent.end)

--- a/queries/ruby/indents.scm
+++ b/queries/ruby/indents.scm
@@ -29,10 +29,6 @@
 ] @indent.end
 
 [
-  "end"
-  ")"
-  "}"
-  "]"
   (when)
   (elsif)
   (else)

--- a/queries/rust/indents.scm
+++ b/queries/rust/indents.scm
@@ -39,6 +39,8 @@
   body: (field_declaration_list "}" @indent.end))
 (trait_item
   body: (declaration_list "}" @indent.end))
+(function_item
+ body: (block "}" @indent.end))
 
 (impl_item (where_clause) @indent.dedent)
 
@@ -46,9 +48,11 @@
   "where"
   ")"
   "]"
-  "}"
 ] @indent.branch
-(impl_item (declaration_list) @indent.branch)
+(impl_item (declaration_list "{" @indent.branch))
+
+
+("}" @indent.end)
 
 [
   (line_comment)

--- a/tests/indent/python/break_continue.py
+++ b/tests/indent/python/break_continue.py
@@ -7,3 +7,22 @@ def f():
     for x in range(1, 2):
         if x == 1:
             continue
+
+def a():
+    for x in range(20):
+        break
+
+def a():
+    for x in range(20):
+        continue
+
+def a():
+    for x in range(20):
+        for y in range(20):
+            break
+
+def a():
+    for x in range(20):
+        for y in range(20):
+            continue
+

--- a/tests/indent/python/break_continue.py
+++ b/tests/indent/python/break_continue.py
@@ -25,4 +25,3 @@ def a():
     for x in range(20):
         for y in range(20):
             continue
-

--- a/tests/indent/python/raise_dedent.py
+++ b/tests/indent/python/raise_dedent.py
@@ -1,0 +1,15 @@
+def a():
+    raise Exception()
+
+def a():
+    raise Exception(
+        "bad things happened"
+    )
+
+def a():
+    raise Exception(
+        "bad things happened {}".format(
+            "terrible things"
+        )
+    )
+

--- a/tests/indent/python_spec.lua
+++ b/tests/indent/python_spec.lua
@@ -102,6 +102,5 @@ describe("indent Python:", function()
     run:new_line("raise_dedent.py", { on_line = 2, text = "x", indent = 0 })
     run:new_line("raise_dedent.py", { on_line = 7, text = "x", indent = 0 })
     run:new_line("raise_dedent.py", { on_line = 14, text = "x", indent = 0 })
-    
   end)
 end)

--- a/tests/indent/python_spec.lua
+++ b/tests/indent/python_spec.lua
@@ -90,9 +90,18 @@ describe("indent Python:", function()
     run:new_line("match_case.py", { on_line = 15, text = "pass", indent = 12 })
     run:new_line("break_continue.py", { on_line = 4, text = "pass", indent = 8 })
     run:new_line("break_continue.py", { on_line = 9, text = "pass", indent = 8 })
+    run:new_line("break_continue.py", { on_line = 13, text = "pass", indent = 4 })
+    run:new_line("break_continue.py", { on_line = 17, text = "pass", indent = 4 })
+    run:new_line("break_continue.py", { on_line = 22, text = "pass", indent = 8 })
+    run:new_line("break_continue.py", { on_line = 27, text = "pass", indent = 8 })
 
     for _, line in ipairs { 2, 5, 8, 11, 16, 21, 24, 27, 34, 39 } do
       run:new_line("return_dedent.py", { on_line = line, text = "x", indent = 0 })
     end
+
+    run:new_line("raise_dedent.py", { on_line = 2, text = "x", indent = 0 })
+    run:new_line("raise_dedent.py", { on_line = 7, text = "x", indent = 0 })
+    run:new_line("raise_dedent.py", { on_line = 14, text = "x", indent = 0 })
+    
   end)
 end)


### PR DESCRIPTION
The impetus for these changes are from looking at #4554

One of interesting cases there was

```
def foo(x):
    return bar(1,
               2,
               3)<CR>
```

Which failed to dedent properly.  It became clear when looking at this that the dedent wasn't occurring because an ```argument_list``` had already been processed which was considered to cover the return line - and the @indent.end was considered unnecessary because that line had already been processed.

To fix that, we can track processing for node ends separately to starts.

We can also simplify the return capture treatment with this approach (and add exceptions, break, continue etc). 

This also dedents correctly inside nested indentations.

What is troublesome is that the branch and dedents are still tracked at node start - if I alter them completely to operate on node end, which seems intuitive, cascading if-else in c gets messed up and doesn't dedent correctly - so I need to  think about that and would welcome some other's input on it too.  It is not totally clear why this would need to be the case to me.  I could sort of buy @indent.branch  needing to be tracked at node start.  And maybe what's needed is clarity in the docs about which, it's possible that the c indents just bake in assumptions about where the branch and dedent apply which could be adjusted.  

So I am marking this as draft as I imagine it will need some thinking.

Cascading ifs in c may actually not be correct even before this change.

For example

```
int f() {
    if (a && b && c &&
            d > 5) { // should be 4 less

    } else if (a == 4 and b ==6 &&
            4 == j) { // should be 3 more

    }
}
```
