### PR TITLE
feat(python): add return/raise dedents

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -61,6 +61,7 @@ local get_indents = tsutils.memoize_by_buf_tick(function(bufnr, root, lang)
       ignore = {},
       align = {},
       zero = {},
+      ["follow-parent"] = {},
     },
   }
 
@@ -176,6 +177,14 @@ function M.get_indent(lnum)
     end
 
     local srow, _, erow = node:range()
+
+    if
+      node:parent()
+      and (q.indent["follow-parent"][node:id()] and erow < lnum - 1 )
+      and (node:parent():start() ~= srow)
+    then
+      return vim.fn.indent(node:parent():start() + 1)
+    end
 
     local is_processed = false
 

--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -249,18 +249,20 @@ function M.get_indent(lnum)
           if should_process then
             indent = indent + indent_size * 1
             if c_is_last_in_line then
-              -- If current line is outside the range of a node marked with `@aligned_indent`
-              -- Then its indent level shouldn't be affected by `@aligned_indent` node
+              -- If current line is outside the range of a node marked with `@indent.align`
+              -- Then its indent level shouldn't be affected by `@indent.align` node
+              -- This will just reset what has been added right above,
+              -- instead of resetting indent level to max(indent - indent_size, 0)
               if c_srow and c_srow < lnum - 1 then
-                indent = math.max(indent - indent_size, 0)
+                indent = indent - indent_size
               end
             end
           end
         else
           -- aligned indent
           if c_is_last_in_line and c_srow and o_srow ~= c_srow and c_srow < lnum - 1 then
-            -- If current line is outside the range of a node marked with `@aligned_indent`
-            -- Then its indent level shouldn't be affected by `@aligned_indent` node
+            -- If current line is outside the range of a node marked with `@indent.align`
+            -- Then its indent level shouldn't be affected by `@indent.align` node
             indent = math.max(indent - indent_size, 0)
           else
             indent = o_scol + (metadata["indent.increment"] or 1)

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -81,34 +81,65 @@
 [
   (break_statement)
   (continue_statement)
+  (raise_statement)
+  (return_statement)
 ] @indent.dedent
 
-(parenthesized_expression ")" @indent.end)
-(generator_expression ")" @indent.end)
-(list_comprehension "]" @indent.end)
-(set_comprehension "}" @indent.end)
-(dictionary_comprehension "}" @indent.end)
+(return_statement 
+  [
+    ; indent.align
+    (list "]" @indent.dedent)
+    (dictionary "}" @indent.dedent)
+    (set "}" @indent.dedent)
+    (tuple ")" @indent.dedent)
+    (call
+      arguments: (argument_list ")" @indent.dedent))
+    (await
+      (call
+        arguments: (argument_list ")" @indent.dedent)))
+  ] 
+)
+
+(return_statement
+  [
+    ; indent.begin -> dedent twice 
+    (parenthesized_expression ")" @indent.dedent)
+    (generator_expression ")" @indent.dedent)
+    (list_comprehension "]" @indent.dedent)
+    (set_comprehension "}" @indent.dedent)
+    (dictionary_comprehension "}" @indent.dedent)
+    ; (tuple_pattern "(" @indent.begin ")" @indent.dedent)
+    ; (list_pattern "]" @indent.dedent)
+
+    ; functions
+    ; (call)
+    ; (await)
+  ]
+)
+
+(raise_statement
+  (call
+    arguments: (argument_list ")" @indent.dedent)))
+
+(parenthesized_expression 
+  ")" @indent.end
+  (#not-has-parent? @indent.end return_statement raise_statement))
+(generator_expression 
+  ")" @indent.end
+  (#not-has-parent? @indent.end return_statement raise_statement))
+(list_comprehension 
+  "]" @indent.end
+  (#not-has-parent? @indent.end return_statement raise_statement))
+(set_comprehension 
+  "}" @indent.end
+  (#not-has-parent? @indent.end return_statement raise_statement))
+(dictionary_comprehension 
+  "}" @indent.end
+  (#not-has-parent? @indent.end return_statement raise_statement))
 
 (tuple_pattern ")" @indent.end)
 (list_pattern "]" @indent.end)
 
-
-(return_statement
-  [
-    (_) @indent.end
-    (_
-      [
-        (_)
-        ")"
-        "}"
-        "]"
-      ] @indent.end .)
-    (attribute 
-      attribute: (_) @indent.end)
-    (call
-      arguments: (_ ")" @indent.end))
-    "return" @indent.end
-  ] .)
 
 [
   ")"

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -81,61 +81,29 @@
 [
   (break_statement)
   (continue_statement)
-  (raise_statement)
-  (return_statement)
 ] @indent.dedent
 
-(return_statement 
+(block
   [
-    ; indent.align
-    (list "]" @indent.dedent)
-    (dictionary "}" @indent.dedent)
-    (set "}" @indent.dedent)
-    (tuple ")" @indent.dedent)
-    (call
-      arguments: (argument_list ")" @indent.dedent))
-    (await
-      (call
-        arguments: (argument_list ")" @indent.dedent)))
-  ] 
-)
+    (return_statement) 
+    (raise_statement)
+  ]) @indent.follow-parent
 
-(return_statement
-  [
-    ; indent.begin -> dedent twice 
-    (parenthesized_expression ")" @indent.dedent)
-    (generator_expression ")" @indent.dedent)
-    (list_comprehension "]" @indent.dedent)
-    (set_comprehension "}" @indent.dedent)
-    (dictionary_comprehension "}" @indent.dedent)
-    ; (tuple_pattern "(" @indent.begin ")" @indent.dedent)
-    ; (list_pattern "]" @indent.dedent)
-
-    ; functions
-    ; (call)
-    ; (await)
-  ]
-)
-
-(raise_statement
-  (call
-    arguments: (argument_list ")" @indent.dedent)))
-
-(parenthesized_expression 
-  ")" @indent.end
-  (#not-has-parent? @indent.end return_statement raise_statement))
-(generator_expression 
-  ")" @indent.end
-  (#not-has-parent? @indent.end return_statement raise_statement))
-(list_comprehension 
-  "]" @indent.end
-  (#not-has-parent? @indent.end return_statement raise_statement))
-(set_comprehension 
-  "}" @indent.end
-  (#not-has-parent? @indent.end return_statement raise_statement))
-(dictionary_comprehension 
-  "}" @indent.end
-  (#not-has-parent? @indent.end return_statement raise_statement))
+(((_) @_return_raise
+  (parenthesized_expression ")" @indent.end)) 
+  (#not-has-type? @_return_raise return_statement raise_statement))
+(((_) @_return_raise
+  (generator_expression ")" @indent.end)) 
+  (#not-has-type? @_return_raise return_statement raise_statement))
+(((_) @_return_raise
+  (list_comprehension "]" @indent.end)) 
+  (#not-has-type? @_return_raise return_statement raise_statement))
+(((_) @_return_raise
+  (set_comprehension "}" @indent.end)) 
+  (#not-has-type? @_return_raise return_statement raise_statement))
+(((_) @_return_raise
+  (dictionary_comprehension "}" @indent.end)) 
+  (#not-has-type? @_return_raise return_statement raise_statement))
 
 (tuple_pattern ")" @indent.end)
 (list_pattern "]" @indent.end)

--- a/tests/indent/python/exceptions.py
+++ b/tests/indent/python/exceptions.py
@@ -1,0 +1,10 @@
+def x():
+    if true:
+        raise Exception
+    if true:
+        raise Exception("exception")
+    if true:
+        raise Exception(
+
+        )
+    raise Exception

--- a/tests/indent/python/return_dedent.py
+++ b/tests/indent/python/return_dedent.py
@@ -1,39 +1,104 @@
 def a():
+    if true:
+        return
+
+def a():
+    if true:
+        return True
+
+def a():
+    if true:
+        return (1)
+
+def a():
+    if true:
+        return [
+            1
+        ]
+
+def a():
+    if true:
+        return x.y.z
+
+def a():
+    if true:
+        return (1, 2, 3)
+
+def a():
+    if true:
+        return (
+            1,
+            2
+        )
+
+def a():
+    if true:
+        return a(1)
+
+def a():
+    if true:
+        return a(
+            1
+        )
+
+def a():
+    if true:
+        return await a(1)
+
+def a():
+    if true:
+        return await a(
+            1
+        )
+
+def a():
+    if true:
+        return [
+            a for a in range(1, 3)
+        ]
+
+def a():
     return
 
 def a():
     return True
 
 def a():
-    return (1, 2, 3)
+    return (1)
 
 def a():
     return x.y.z
 
 def a():
+    return (1, 2, 3)
+
+def a():
     return (
-        1, 2, 3
+        1,
+        2
     )
 
 def a():
-    return b(
-        1, 2, 3
+    return a(1)
+
+def a():
+    return a(
+        1
     )
 
 def a():
-    return [1, 2, 3]
+    return await a(1)
 
 def a():
-    return {1, 2, 3}
-
-def a():
-    return {
-        "a": 1,
-        "b": 2,
-        "c": 3
-    }
+    return await a(
+        1
+    )
 
 def a():
     return [
-        a for a in range (1, 3)
+        a for a in range(1, 3)
     ]
+
+def a():
+    if true:
+        return (1 + a for a in range (1, 2))

--- a/tests/indent/python_spec.lua
+++ b/tests/indent/python_spec.lua
@@ -91,8 +91,14 @@ describe("indent Python:", function()
     run:new_line("break_continue.py", { on_line = 4, text = "pass", indent = 8 })
     run:new_line("break_continue.py", { on_line = 9, text = "pass", indent = 8 })
 
-    for _, line in ipairs { 2, 5, 8, 11, 16, 21, 24, 27, 34, 39 } do
+    for _, line in ipairs { 3, 7, 11, 17, 21, 25, 32, 36, 42, 46, 52, 58 } do
+      run:new_line("return_dedent.py", { on_line = line, text = "x", indent = 4 })
+    end
+    for _, line in ipairs { 61, 64, 67, 70, 73, 79, 82, 87, 90, 95, 100 } do
       run:new_line("return_dedent.py", { on_line = line, text = "x", indent = 0 })
+    end
+    for _, line in ipairs { 3, 5, 9 } do
+      run:new_line("exceptions.py", { on_line = line, text = "x", indent = 4 })
     end
   end)
 end)


### PR DESCRIPTION
(random plan that I come up with, instead of changing `@indent.end` behavior, I will add a directive to allow control over it, either that or add some extra queries to make sure it works)


- [ ] Add the new directive/capture 
  - It will most likely follow Helix's [`@extend.prevent-once`](https://docs.helix-editor.com/guides/indent.html#capture-types)
- [ ] add raise exceptions dedents
- [ ] fix return dedents
- [x] add tests for both cases

