### PR TITLE
fix(rockspec): add doc folder to rockspec

### DIFF
--- a/nvim-treesitter-scm-1.rockspec
+++ b/nvim-treesitter-scm-1.rockspec
@@ -29,6 +29,7 @@ build = {
   },
   copy_directories = {
     'autoload',
+    'doc',
     'plugin',
     'queries'
   }


### PR DESCRIPTION
The `doc` folder should be copied, so documentation can be accessed when installing through luarocks. 