### PR TITLE
feat(cpp): simplify namespace query rules now that parser is a bit more consistent

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -63,7 +63,7 @@
     "revision": "eedb93bf9e22e82ed6a67e6c57fd78731b44f591"
   },
   "cpp": {
-    "revision": "03fa93db133d6048a77d4de154a7b17ea8b9d076"
+    "revision": "0b6d0eb9abdf7cea31961cd903eeed5bbd0aae74"
   },
   "css": {
     "revision": "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51"

--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "80ea622cf952a0059e168e5c92a798b2f1925652"
   },
   "arduino": {
-    "revision": "257efffa387da3283a37816b71dedfecf4af5222"
+    "revision": "833b53df97143bc46e014608dee9f64f78d7473c"
   },
   "astro": {
     "revision": "a1f66bf72ed68b87f779bce9a52e5c6521fc867e"

--- a/lockfile.json
+++ b/lockfile.json
@@ -69,7 +69,7 @@
     "revision": "769203d0f9abe1a9a691ac2b9fe4bb4397a73c51"
   },
   "cuda": {
-    "revision": "91c3ca3e42326e0f7b83c82765940bbf7f91c847"
+    "revision": "967e7d74a1a04a680674199e12141963a8dd6336"
   },
   "cue": {
     "revision": "4ffcda8c2bdfee1c2ba786cd503d0508ea92cca2"
@@ -207,7 +207,7 @@
     "revision": "02fa3b79b3ff9a296066da6277adfc3f26cbc9e0"
   },
   "hlsl": {
-    "revision": "306d48516a6b3dbb18a184692e8edffa8403018f"
+    "revision": "fce5ea2e842404ce1af13fffdcf0daa02240c3dd"
   },
   "hocon": {
     "revision": "c390f10519ae69fdb03b3e5764f5592fb6924bcc"

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -45,12 +45,9 @@
 (namespace_identifier) @namespace
 ((namespace_identifier) @type
                         (#lua-match? @type "^[A-Z]"))
-((namespace_identifier) @constant
-                        (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
+
 (case_statement
   value: (qualified_identifier (identifier) @constant))
-(namespace_definition
-  name: (identifier) @namespace)
 
 (using_declaration . "using" . "namespace" . [(qualified_identifier) (identifier)] @namespace)
 

--- a/queries/cpp/locals.scm
+++ b/queries/cpp/locals.scm
@@ -39,7 +39,11 @@
 
 ;; Namespaces
 (namespace_definition
-  name: (identifier) @definition.namespace
+  name: (namespace_identifier) @definition.namespace
+  body: (_) @scope)
+
+(namespace_definition
+  name: (nested_namespace_specifier) @definition.namespace
   body: (_) @scope)
 
 ((namespace_identifier) @reference


### PR DESCRIPTION
Most recent parser version [0b6d0eb9abdf7cea31961cd903eeed5bbd0aae74](https://github.com/tree-sitter/tree-sitter-cpp/commit/0b6d0eb9abdf7cea31961cd903eeed5bbd0aae74) improves the node tree related to namespaces. This deprecates the need for extra rules to try to get @namespace applied to the right nodes.

also, `namespace_identifier` can't name a constant since it only names things guaranteed to be namespaces, or type/enums when in a qualified identifier as part of scope resolution.