### PR TITLE
fix(windows): escape windows path with shellescape

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -8,7 +8,7 @@ local utils = require "nvim-treesitter.utils"
 local function cmdpath(p)
   if vim.opt.shellslash:get() then
     local r = p:gsub("/", "\\")
-    return r
+    return fn.shellescape(r)
   else
     return p
   end


### PR DESCRIPTION
This prevents errors with paths containing whitespaces