### PR TITLE
Fix highlighting for Python

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -247,11 +247,11 @@
 [
   "def"
   "lambda"
+  "class"
 ] @keyword.function
 
 [
   "assert"
-  "class"
   "exec"
   "global"
   "nonlocal"
@@ -336,7 +336,7 @@
 ((class_definition
   (block
     (function_definition
-      name: (identifier) @constructor)))
+      name: (identifier) @constructor.function)))
  (#any-of? @constructor "__new__" "__init__"))
 
 ;; Error


### PR DESCRIPTION
Plugin `vscode.nvim` is based on `nvim-treesitter.nvim`. Currently, there is a bug in the highlighting which should be addressed.

The following code snippet looks like this in VSCode:
<img width="207" alt="Screenshot 2023-03-29 at 13 24 32" src="https://user-images.githubusercontent.com/62666255/228522599-74a25bcb-98bd-4d95-9f4e-e6e5d3cc8904.png">

whereas it looks as follows when using `vscode.nvim` - `nvim-treesitter.nvim`:
<img width="195" alt="Screenshot 2023-03-29 at 13 24 15" src="https://user-images.githubusercontent.com/62666255/228522618-bb46edbb-6b5e-4579-9236-3b926074154d.png">


- keyword "class" should be coloured like "def" or "lambda"
- it should distinguish between constructor function definition from constructor call (this is the case in VSCode)