### PR TITLE
fix: set filetype for markdown_inline parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -894,6 +894,7 @@ list.markdown_inline = {
     files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@MDeiml" },
+  filetype = "markdown",
   readme_name = "markdown_inline (needed for full highlighting)",
   experimental = true,
 }


### PR DESCRIPTION
## Problem:

`markdown_inline` doesn't have a connected filetype, which means the newly merged feature `vim.treesitter.language.get_filetypes` won't work as expected for markdown if the parser is used.

## Solution

Set `filetype = "markdown"` on the `markdown_inline` parser for it to correctly refer back to markdown as the filetype for the parser

## Context

https://github.com/neovim/neovim/pull/22643#issuecomment-1490040341