### PR TITLE
fix(ruby): @conditional highlights

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -44,16 +44,8 @@
  "if"
  "unless"
  "when"
+ "then"
  ] @conditional
-
-(if
-  "end" @conditional)
-(if
-  (then) @conditional)
-(unless
-  (then) @conditional)
-(elsif
-  (then) @conditional)
 
 [
  "for"

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -47,6 +47,9 @@
  "then"
  ] @conditional
 
+(if
+  "end" @conditional)
+
 [
  "for"
  "until"


### PR DESCRIPTION
These highlight queries caused some odd highlighting for me when I have nested modules inside of a conditional:

![Screenshot 2023-03-30 at 3 17 40 PM](https://user-images.githubusercontent.com/5440884/228967253-f37e4626-f7f4-4ab8-a369-1acede50437f.png)

In the above screenshot I do not expect the `::` between constants to be red, but they're getting the `@conditional.ruby` highlight.

The `(then)` node in `(if (then))` is actually the entire block guarded by the conditional, not just the "then" keyword, which I think was the intended target of these queries. 