### PR TITLE
fix(indent): Make indent ignore trailing spaces/comment

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -138,15 +138,15 @@ function M.get_indent(lnum)
       -- The final node we capture of the previous line can be a comment node, which should also be ignored
       -- Unless the last line is an entire line of comment, ignore the comment range and find the last node again
       local first_node = get_first_node_at_line(root, prevlnum, indent)
+      local _, scol, _, _ = node:range()
       if first_node:id() ~= node:id() then
         -- In case the last captured node is a trailing comment node, re-trim the string
-        prevline = vim.trim(prevline:sub(1, node:start() + 1 - indent))
+        prevline = vim.trim(prevline:sub(1, scol - indent))
         -- Add back indent as indent of prevline was trimmed away
         local col = indent + #prevline - 1
         node = get_last_node_at_line(root, prevlnum, col)
       end
     end
-
     if q.indent["end"][node:id()] then
       node = get_first_node_at_line(root, lnum)
     end

--- a/tests/indent/algorithm/trailing.py
+++ b/tests/indent/algorithm/trailing.py
@@ -1,0 +1,6 @@
+class x: # Ignore comment
+
+class y: 
+    def z(): # Ignore comment
+
+class t:    

--- a/tests/indent/algorithm/trailing_whitespace.html
+++ b/tests/indent/algorithm/trailing_whitespace.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+    <body>
+        <!-- This file deliberately contains trailing whitespace -->
+        <!-- Don't remove them -->
+        <div>   
+            a   
+
+        </div>    
+    </body>     
+</html>

--- a/tests/indent/algorithm_spec.lua
+++ b/tests/indent/algorithm_spec.lua
@@ -1,0 +1,18 @@
+local Runner = require("tests.indent.common").Runner
+-- local XFAIL = require("tests.indent.common").XFAIL
+
+local runner = Runner:new(it, "tests/indent/algorithm", {
+  tabstop = 4,
+  shiftwidth = 4,
+  softtabstop = 4,
+  expandtab = true,
+})
+
+describe("test indent algorithm: ", function()
+  describe("new line:", function()
+    runner:new_line("trailing.py", { on_line = 1, text = "x: str", indent = 4 }, "indent next line, ignore comment")
+    runner:new_line("trailing.py", { on_line = 4, text = "pass", indent = 8 }, "indent next line, ignore comment")
+    runner:new_line("trailing.py", { on_line = 6, text = "pass", indent = 4 }, "indent next line, ignore whitespace")
+    runner:new_line("trailing_whitespace.html", { on_line = 9, text = "x", indent = 8 }, "not ignore @indent.end")
+  end)
+end)


### PR DESCRIPTION
Before this change, the case below was very frequently happening 
- If a trailing whitespace exist, the whitespace will be the position to find the ending smallest range for a node, which means it goes over the node that should have been captured
- If a trailing comment exist, it will be captured, and next line indent will follow indent laws of that comment parser.

Indent algorithm was not ignoring trailing whitespaces and comments, hence we need to trim+ignore the node
With this PR, it makes sure that trailing whitespaces/comments will not be accounted in the indentation calculation of the next line

Examples:
- Notes: `<SP>` is whitespace, while `<CR>` is Enter, and `|` to denote the cursor position after pressing enter
```c
int main(){
  for (x = 1; x <= 10; x++) {
  }<SP><CR>
    |
}
```
- The captured node is not `}` of `for` loop, but rather the `main` func
- If `}` is marked with `@indent.end`, but with a trailing whitespace, the `<SP>` will make `@indent.end` completely ignored

With this change
```c
int main(){
  for (x = 1; x <= 10; x++) {
  }<SP><CR>
  |
}
```
The captured node now will be `}`. 