### PR TITLE
fix(scala): Add missing locals definitions for scala

### DIFF
--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -4,6 +4,7 @@
   (template_body)
   (lambda_expression)
   (function_declaration)
+  (block)
 ] @scope
 
 ; References
@@ -19,6 +20,9 @@
   name: (identifier) @definition.function)
 
 (parameter
+  name: (identifier) @definition.parameter)
+
+(class_parameter
   name: (identifier) @definition.parameter)
 
 (binding


### PR DESCRIPTION
I noticed that some locals definitions were missing for scala language. This PR adds `block` scope and `class` level parameters. 

