### PR TITLE
feat: use `-bundle` to build parsers on macOS

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -110,9 +110,13 @@ function M.select_compiler_args(repo, compiler)
       "parser.so",
       "-I./src",
       repo.files,
-      "-shared",
       "-Os",
     }
+    if fn.has "mac" == 1 then
+      table.insert(args, "-bundle")
+    else
+      table.insert(args, "-shared")
+    end
     if
       #vim.tbl_filter(function(file) ---@param file string
         local ext = vim.fn.fnamemodify(file, ":e")


### PR DESCRIPTION
This will make the parsers align more closely to the ones bundled with
Neovim, because CMake uses the `-bundle` flag (instead of `-shared`) on
macOS when a library is compiled as a `MODULE`.

See, for example: https://github.com/neovim/neovim/blob/10baf89712724b4b95f7c641f2012f051737003c/cmake.deps/cmake/TreesitterParserCMakeLists.txt#L6-L9

Additional context available at https://github.com/neovim/neovim/issues/21749#issuecomment-1418427487.
