### PR TITLE
vim: switch to parser maintained by Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [vala](https://github.com/vala-lang/tree-sitter-vala) (maintained by @Prince781)
 - [x] [verilog](https://github.com/tree-sitter/tree-sitter-verilog) (maintained by @zegervdv)
 - [x] [vhs](https://github.com/charmbracelet/tree-sitter-vhs) (maintained by @caarlos0)
-- [x] [vim](https://github.com/vigoux/tree-sitter-viml) (maintained by @vigoux)
+- [x] [vim](https://github.com/neovim/tree-sitter-vim) (maintained by @clason)
 - [x] [vimdoc](https://github.com/neovim/tree-sitter-vimdoc) (maintained by @clason)
 - [x] [vue](https://github.com/ikatyang/tree-sitter-vue) (maintained by @WhyNotHugo)
 - [x] [wgsl](https://github.com/szebniok/tree-sitter-wgsl) (maintained by @szebniok)

--- a/lockfile.json
+++ b/lockfile.json
@@ -519,7 +519,7 @@
     "revision": "77fd8a8fcc0b4788e0b1569b1a4fa070b36add28"
   },
   "vim": {
-    "revision": "e39a7bbcfdcfc7900629962b785c7e14503ae590"
+    "revision": "2886b52143d570d81f97c98be7a1e204ce9d3bcd"
   },
   "vimdoc": {
     "revision": "15c2fdcc57f51f1caef82fe75e1ffb733626dcae"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1536,10 +1536,10 @@ list.vhs = {
 
 list.vim = {
   install_info = {
-    url = "https://github.com/vigoux/tree-sitter-viml",
+    url = "https://github.com/neovim/tree-sitter-vim",
     files = { "src/parser.c", "src/scanner.c" },
   },
-  maintainers = { "@vigoux" },
+  maintainers = { "@clason" },
 }
 
 list.vimdoc = {


### PR DESCRIPTION
The current vimscript parser has not been maintained for a while, which was a blocker for packaging the coming Neovim release. It was therefore forked to https://github.com/neovim/tree-sitter-vim/ and will be maintained there going forward.

Right now, only some already reviewed PRs were merged and a bit of general cleanup was performed, but we might consider replacing the parser implementation completely if a better one comes along. (The point is to have a stable and maintained URL for Neovim's bundled vimscript parser, just like for the vimdoc parser.)
