### PR TITLE
Update parser: kotlin

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -255,7 +255,7 @@
     "revision": "e36f054a60c4d9e5ae29567d439fdb8790b53b30"
   },
   "kotlin": {
-    "revision": "826ef28d605d0925a86a99022cd222c96f2d0952"
+    "revision": "c84d16e7f75032cdd8c4ad986a76ca9e1fe4e639"
   },
   "lalrpop": {
     "revision": "7744b56f03ac1e5643fad23c9dd90837fe97291e"

--- a/queries/kotlin/locals.scm
+++ b/queries/kotlin/locals.scm
@@ -23,8 +23,9 @@
 ;;; Variables
 
 (function_declaration
-	(parameter
-		(simple_identifier) @definition.parameter))
+	(function_value_parameters
+		(parameter
+			(simple_identifier) @definition.parameter)))
 
 (lambda_literal
 	(lambda_parameters


### PR DESCRIPTION
Update `queries/kotlin/locals.scm` to use the the newly exposed `function_value_parameters` node.