### PR TITLE
 fix(rust): highlight SNAKE_CASE scoped identifier name as @constant 

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -82,6 +82,9 @@
 ((scoped_identifier
     name: (identifier) @type)
  (#lua-match? @type "^[A-Z]"))
+((scoped_identifier
+    name: (identifier) @constant)
+ (#lua-match? @constant "^[A-Z][A-Z%d_]*$"))
 
 [
   (crate)


### PR DESCRIPTION


<details>
<summary>outdated</summary>

fix(rust): don't highlight scoped constant as @type
* This rule is redundant because the `@type` rule at line 8 already does the job and is not overriden by other rule.
* This rule falsely overrides the rule for `@constant`, which resulted in CONSTANT_ITEM in Self::CONSTANT_ITEM being highlighted as `@type`.

</details>
