### PR TITLE
fix(dart): try statement wouldn't indent

### DIFF
--- a/queries/dart/indents.scm
+++ b/queries/dart/indents.scm
@@ -10,6 +10,7 @@
   (list_literal)
   (return_statement)
   (arguments)
+  (try_statement)
 ] @indent.begin
 
 [

--- a/tests/indent/dart/try.dart
+++ b/tests/indent/dart/try.dart
@@ -1,0 +1,5 @@
+void test() {
+  try{
+  } catch(e) {
+  }
+}

--- a/tests/indent/dart_spec.lua
+++ b/tests/indent/dart_spec.lua
@@ -17,4 +17,5 @@ end)
 
 describe("new line:", function()
   run:new_line("class.dart", { on_line = 2, text = "var x;", indent = 0 })
+  run:new_line("try.dart", { on_line = 2, text = "var x;", indent = 4 })
 end)


### PR DESCRIPTION
## Before

```dart
void test() {
  try {
  | <--- cursor is here
  } catch(e) {}
}
```

## After

```dart
void test() {
  try {
    | <--- cursor is here
  } catch(e) {}
}
```