### PR TITLE
refactor(html_inject): Use lua-match instead of match

### DIFF
--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -5,7 +5,8 @@
 (
   (style_element
     (start_tag) @_no_type_lang
-      (#not-match? @_no_type_lang "\\s(lang|type)\\s*\\=")
+      (#not-lua-match? @_no_type_lang "%slang%s*=")
+      (#not-lua-match? @_no_type_lang "%stype%s*=")
     (raw_text) @css))
 
 (


### PR DESCRIPTION
Use equivalent pattern to `match? (a|b)` using lua-match instead.