### PR TITLE
feat(cpp): improve function.call to support any level of nesting for qualified identifiers

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -49,58 +49,93 @@
 (destructor_name
   (identifier) @method)
 
+; functions
 (function_declarator
-      declarator: (qualified_identifier
-        name: (identifier) @function))
+  (qualified_identifier
+    (identifier) @function))
 (function_declarator
-      declarator: (qualified_identifier
-        name: (qualified_identifier
-          name: (identifier) @function)))
+  (qualified_identifier
+    (qualified_identifier
+      (identifier) @function)))
 (function_declarator
-      declarator: (template_function
-        name: (identifier) @function))
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function))))
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function)))) @_parent
+  (#has-ancestor? @_parent function_declarator))
+
 (function_declarator
-      declarator: (template_method
-        name: (field_identifier) @method))
-((function_declarator
-      declarator: (qualified_identifier
-        name: (identifier) @constructor))
- (#lua-match? @constructor "^[A-Z]"))
+  (template_function
+    (identifier) @function))
 
 (operator_name) @function
 "operator" @function
 "static_assert" @function.builtin
 
 (call_expression
-  function: (qualified_identifier
-              name: (identifier) @function.call))
+  (qualified_identifier
+    (identifier) @function.call))
 (call_expression
-  function: (qualified_identifier
-              name: (qualified_identifier
-                      name: (identifier) @function.call)))
+  (qualified_identifier
+    (qualified_identifier
+      (identifier) @function.call)))
 (call_expression
-  function:
+  (qualified_identifier
+    (qualified_identifier
       (qualified_identifier
-        name: (qualified_identifier
-              name: (qualified_identifier
-                      name: (identifier) @function.call))))
-(call_expression
-  function: (template_function
-              name: (identifier) @function.call))
-(call_expression
-  function: (qualified_identifier
-              name: (template_function
-                      name: (identifier) @function.call)))
-(call_expression
-  function:
+        (identifier) @function.call))))
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
       (qualified_identifier
-        name: (qualified_identifier
-              name: (template_function
-                      name: (identifier) @function.call))))
+        (identifier) @function.call)))) @_parent
+  (#has-ancestor? @_parent call_expression))
 
 (call_expression
-  function: (field_expression
-              field: (field_identifier) @method.call))
+  (template_function
+    (identifier) @function.call))
+(call_expression
+  (qualified_identifier
+    (template_function
+      (identifier) @function.call)))
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (template_function
+        (identifier) @function.call))))
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (template_function
+          (identifier) @function.call)))))
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (template_function
+          (identifier) @function.call))))) @_parent
+  (#has-ancestor? @_parent call_expression))
+
+; methods
+(function_declarator
+  (template_method
+    (field_identifier) @method))
+(call_expression
+  (field_expression
+    (field_identifier) @method.call))
+
+; constructors
+
+((function_declarator
+  (qualified_identifier
+    (identifier) @constructor))
+  (#lua-match? @constructor "^[A-Z]"))
 
 ((call_expression
   function: (identifier) @constructor)

--- a/tests/query/highlights/cpp/static-namespace-functions.cpp
+++ b/tests/query/highlights/cpp/static-namespace-functions.cpp
@@ -1,12 +1,14 @@
 // Issue #2396
 
-int main()                                                                
-{                                                                         
-  B::foo();                                                                 
+int main()
+{
+  B::foo();
   //  ^ @function.call
-  Foo::A::foo();                                                            
+  Foo::A::foo();
   //       ^ @function.call
-  Foo::a::A::foo();                                                            
+  Foo::a::A::foo();
   //          ^ @function.call
-  return 0;                                                                 
-}    
+  Foo::a::A::B::foo();
+  //             ^ @function.call
+  return 0;
+}


### PR DESCRIPTION
Recent commit added support for distinguishing function.call but only supported up to 3 levels of nesting and each were hard coded.

This adds a query that uses `has-ancestor` to support any qualified function call if it detects a nesting level greater than 3 for namespace/type qualifiers.