### PR TITLE
indents(dart): add test for #4632

### DIFF
--- a/tests/indent/dart/try.dart
+++ b/tests/indent/dart/try.dart
@@ -3,3 +3,11 @@ void test() {
   } catch(e) {
   }
 }
+
+// Issue #4632
+class Test {
+  void test(){
+    try {
+    }
+  }
+}

--- a/tests/indent/dart_spec.lua
+++ b/tests/indent/dart_spec.lua
@@ -25,6 +25,9 @@ describe("new line:", function()
   run:new_line("class.dart", { on_line = 6, text = "'100'", indent = 8 }, "expected failure", XFAIL)
   run:new_line("class.dart", { on_line = 7, text = "int five = 5", indent = 2 }, "expected failure", XFAIL)
   run:new_line("try.dart", { on_line = 2, text = "var x;", indent = 4 })
+  for _, content in ipairs { "var x;", "var x" } do
+    run:new_line("try.dart", { on_line = 10, text = content, indent = 6 })
+  end
   run:new_line("switch.dart", { on_line = 3, text = "x = 1;", indent = 6 })
   run:new_line("switch.dart", { on_line = 9, text = "x = 1;", indent = 6 })
   run:new_line("switch.dart", { on_line = 3, text = "case 2:", indent = 4 })


### PR DESCRIPTION
Addresses #4632

Closing brace of incomplete `try` will be correctly indented. Content of incomplete `try` block will still not be indented correctly.