### PR TITLE
fix(dart_indent): Fix dart case/default indent

### DIFF
--- a/queries/dart/indents.scm
+++ b/queries/dart/indents.scm
@@ -12,6 +12,13 @@
   (try_statement)
 ] @indent.begin
 
+(switch_block
+  (_) @indent.begin
+  (#set! indent.immediate 1)
+  (#set! indent.start_at_same_line 1))
+
+(switch_label) @indent.branch
+
 [
   "("
   ")"
@@ -24,6 +31,9 @@
 [
  "}"
 ] @indent.end
+
+(return_statement ";" @indent.end)
+(break_statement ";" @indent.end)
 
 ; this one is for dedenting the else block
 (if_statement (block) @indent.branch)

--- a/tests/indent/dart/switch.dart
+++ b/tests/indent/dart/switch.dart
@@ -1,0 +1,30 @@
+void test() {
+  switch(a) {
+    case 1:
+  }
+}
+
+void test() {
+  switch(a) {
+    default:
+  }
+}
+
+void test_break_dedent() {
+  switch(x) {
+    case 1:
+      break;
+  }
+  switch(y) {
+    case 2:
+      return;
+  }
+}
+
+
+void test_multi_case() {
+  switch(x) { 
+    case 1:
+    case 2:
+  }
+}

--- a/tests/indent/dart_spec.lua
+++ b/tests/indent/dart_spec.lua
@@ -1,9 +1,9 @@
 local Runner = require("tests.indent.common").Runner
 
 local run = Runner:new(it, "tests/indent/dart", {
-  tabstop = 4,
+  tabstop = 2,
   shiftwidth = 2,
-  softtabstop = 0,
+  softtabstop = 2,
   expandtab = true,
 })
 
@@ -18,6 +18,13 @@ end)
 describe("new line:", function()
   run:new_line("class.dart", { on_line = 2, text = "var x;", indent = 0 })
   run:new_line("try.dart", { on_line = 2, text = "var x;", indent = 4 })
+  run:new_line("switch.dart", { on_line = 3, text = "x = 1;", indent = 6 })
+  run:new_line("switch.dart", { on_line = 9, text = "x = 1;", indent = 6 })
+  run:new_line("switch.dart", { on_line = 3, text = "case 2:", indent = 4 })
+  run:new_line("switch.dart", { on_line = 16, text = "abc;", indent = 4 })
+  run:new_line("switch.dart", { on_line = 20, text = "abc;", indent = 4 })
+  run:new_line("switch.dart", { on_line = 28, text = "y++;", indent = 6 })
+
   run:new_line("multiple_arguments.dart", { on_line = 10, text = "var x;", indent = 4 })
   run:new_line("multiple_arguments.dart", { on_line = 11, text = "var x;", indent = 4 })
 end)


### PR DESCRIPTION
~~Closes~~ Workaround for #4639 

This breaks `=` motion (it wasn't working before, or after this change, but this PR will make it look out of place)

@RobertBrunhage have a test