### PR TITLE
fix(php_inject): add missing @combined to text

### DIFF
--- a/queries/php/injections.scm
+++ b/queries/php/injections.scm
@@ -1,4 +1,4 @@
-(text) @html
+(text) @html @combined
 
 (comment) @phpdoc
 


### PR DESCRIPTION
Resolves #2565

PHP's HTML injection were missing `@combined`, as were specified from upstream queries at https://github.com/tree-sitter/tree-sitter-php/blob/master/queries/injections.scm

