### PR TITLE
refactor: move mapping of quarto filetype to parser into quarto-nvim

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -39,7 +39,6 @@ for ft, lang in pairs {
   sty = "latex",
   pandoc = "markdown",
   rmd = "markdown",
-  quarto = "markdown",
   dosini = "ini",
   confini = "ini",
 } do


### PR DESCRIPTION
With the new neovim treesitter api I have also added the mapping of the quarto filetype to the markdown parser to the `quarto-nvim` plugin directly:

https://github.com/quarto-dev/quarto-nvim/blob/9839eed2b7f2151721a0eb820e5a85a547201b63/plugin/quarto.lua#L26

So we don't need the mapping in nvim-treesitter anymore. Would that be reasonable? I think this will reduce friction when we end up adding a dedicated quarto grammar.