### PR TITLE
Update README.md to reflect name of git_config parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [func](https://github.com/amaanq/tree-sitter-func) (maintained by @amaanq)
 - [x] [fusion](https://gitlab.com/jirgn/tree-sitter-fusion.git) (maintained by @jirgn)
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by @PrestonKnopp)
-- [x] [gitconfig](https://github.com/the-mikedavis/tree-sitter-git-config) (maintained by @amaanq)
+- [x] [git_config](https://github.com/the-mikedavis/tree-sitter-git-config) (maintained by @amaanq)
 - [x] [git_rebase](https://github.com/the-mikedavis/tree-sitter-git-rebase) (maintained by @gbprod)
 - [x] [gitattributes](https://github.com/ObserverOfTime/tree-sitter-gitattributes) (maintained by @ObserverOfTime)
 - [x] [gitcommit](https://github.com/gbprod/tree-sitter-gitcommit) (maintained by @gbprod)

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [func](https://github.com/amaanq/tree-sitter-func) (maintained by @amaanq)
 - [x] [fusion](https://gitlab.com/jirgn/tree-sitter-fusion.git) (maintained by @jirgn)
 - [x] [Godot (gdscript)](https://github.com/PrestonKnopp/tree-sitter-gdscript) (maintained by @PrestonKnopp)
-- [x] [git_config](https://github.com/the-mikedavis/tree-sitter-git-config) (maintained by @amaanq)
+- [x] [gitconfig](https://github.com/the-mikedavis/tree-sitter-git-config) (maintained by @amaanq)
 - [x] [git_rebase](https://github.com/the-mikedavis/tree-sitter-git-rebase) (maintained by @gbprod)
 - [x] [gitattributes](https://github.com/ObserverOfTime/tree-sitter-gitattributes) (maintained by @ObserverOfTime)
 - [x] [gitcommit](https://github.com/gbprod/tree-sitter-gitcommit) (maintained by @gbprod)

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -508,7 +508,7 @@ list.gitcommit = {
   maintainers = { "@gbprod" },
 }
 
-list.git_config = {
+list.gitconfig = {
   install_info = {
     url = "https://github.com/the-mikedavis/tree-sitter-git-config",
     files = { "src/parser.c" },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -508,14 +508,14 @@ list.gitcommit = {
   maintainers = { "@gbprod" },
 }
 
-list.gitconfig = {
+list.git_config = {
   install_info = {
     url = "https://github.com/the-mikedavis/tree-sitter-git-config",
     files = { "src/parser.c" },
   },
   filetype = "gitconfig",
   maintainers = { "@amaanq" },
-  readme_name = "gitconfig",
+  readme_name = "git_config",
 }
 
 list.gitignore = {


### PR DESCRIPTION
the parser is installed (via ":TSInstall") using the name "git_config" so this might save someone 5 seconds