### PR TITLE
injections(nix): dynamic language injection via comments

### DIFF
--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -1,6 +1,15 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
 
+((comment) @injection.language
+  . ; this is to make sure only adjacent comments are accounted for the injections
+  [
+    (string_expression (string_fragment) @injection.content)
+    (indented_string_expression (string_fragment) @injection.content)
+  ]
+  (#gsub! @injection.language "/%*%s*([%w%p]+)%s*%*/" "%1")
+  (#set! injection.combined))
+
 (apply_expression
   function: (_) @_func
   argument: [


### PR DESCRIPTION
continuation of #3902 since https://github.com/neovim/neovim/pull/21548 is in stable

requires https://github.com/neovim/neovim/pull/23015 to work correctly since `#gsub!` is bugged in neovim 0.9.0

this allows doing things like this to highlight code blocks of arbitrary languages with comments

```nix
/* lua */ ''
  print("Hello, world")
''
```