### PR TITLE
feat(markdown): configured aliases for fenced code block languages

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -1,5 +1,30 @@
 local query = require "vim.treesitter.query"
 
+local html_script_type_languages = {
+  ["importmap"] = "json",
+  ["module"] = "javascript",
+  ["application/ecmascript"] = "javascript",
+  ["text/ecmascript"] = "javascript",
+}
+
+local injection_language_aliases = {
+  ex = "elixir",
+  fc = "func",
+  fir = "firrtl",
+  ha = "hare",
+  hs = "haskell",
+  js = "javascript",
+  kt = "kotlin",
+  ml = "ocaml",
+  pl = "perl",
+  py = "python",
+  ts = "typescript",
+  rs = "rust",
+  sh = "bash",
+  ungram = "ungrammar",
+  uxn = "uxntal",
+}
+
 local function error(str)
   vim.api.nvim_err_writeln(str)
 end
@@ -119,19 +144,17 @@ query.add_predicate("has-type?", function(match, _pattern, _bufnr, pred)
   return vim.tbl_contains(types, node:type())
 end)
 
-local html_script_type_languages = {
-  ["importmap"] = "json",
-  ["module"] = "javascript",
-  ["application/ecmascript"] = "javascript",
-  ["text/ecmascript"] = "javascript",
-}
-
----@param match string
----@param metadata table
+---@param match (TSNode|nil)[]
+---@param _ string
+---@param bufnr integer
+---@param pred string[]
 ---@return boolean|nil
-query.add_directive("set-lang-from-mimetype!", function(match, pattern, bufnr, predicate, metadata)
-  local capture_id = predicate[2]
+query.add_directive("set-lang-from-mimetype!", function(match, _, bufnr, pred, metadata)
+  local capture_id = pred[2]
   local node = match[capture_id]
+  if not node then
+    return
+  end
   local type_attr_value = vim.treesitter.get_node_text(node, bufnr)
   local configured = html_script_type_languages[type_attr_value]
   if configured then
@@ -139,6 +162,26 @@ query.add_directive("set-lang-from-mimetype!", function(match, pattern, bufnr, p
   else
     local parts = vim.split(type_attr_value, "/", {})
     metadata.language = parts[#parts]
+  end
+end)
+
+---@param match (TSNode|nil)[]
+---@param _ string
+---@param bufnr integer
+---@param pred string[]
+---@return boolean|nil
+query.add_directive("set-lang-from-alias!", function(match, _, bufnr, pred, metadata)
+  local capture_id = pred[2]
+  local node = match[capture_id]
+  if not node then
+    return
+  end
+  local injection_alias = vim.treesitter.get_node_text(node, bufnr)
+  local configured = injection_language_aliases[injection_alias]
+  if configured then
+    metadata.language = configured
+  else
+    metadata.language = injection_alias
   end
 end)
 

--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -15,7 +15,7 @@ local non_filetype_match_injection_language_aliases = {
   ts = "typescript",
 }
 
-local function get_language_name_from_fenced_code_block_tag(injection_alias)
+local function get_parser_from_markdown_info_string(injection_alias)
   local match = vim.filetype.match { filename = "a." .. injection_alias }
   return match or non_filetype_match_injection_language_aliases[injection_alias] or injection_alias
 end
@@ -165,14 +165,14 @@ end)
 ---@param bufnr integer
 ---@param pred string[]
 ---@return boolean|nil
-query.add_directive("set-lang-from-alias!", function(match, _, bufnr, pred, metadata)
+query.add_directive("set-lang-from-info-string!", function(match, _, bufnr, pred, metadata)
   local capture_id = pred[2]
   local node = match[capture_id]
   if not node then
     return
   end
   local injection_alias = vim.treesitter.get_node_text(node, bufnr)
-  metadata.language = get_language_name_from_fenced_code_block_tag(injection_alias)
+  metadata.language = get_parser_from_markdown_info_string(injection_alias)
 end)
 
 -- Just avoid some annoying warnings for this directive

--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -7,23 +7,18 @@ local html_script_type_languages = {
   ["text/ecmascript"] = "javascript",
 }
 
-local injection_language_aliases = {
+local non_filetype_match_injection_language_aliases = {
   ex = "elixir",
-  fc = "func",
-  fir = "firrtl",
-  ha = "hare",
-  hs = "haskell",
-  js = "javascript",
-  kt = "kotlin",
-  ml = "ocaml",
   pl = "perl",
-  py = "python",
-  ts = "typescript",
-  rs = "rust",
   sh = "bash",
-  ungram = "ungrammar",
   uxn = "uxntal",
+  ts = "typescript",
 }
+
+local function get_language_name_from_fenced_code_block_tag(injection_alias)
+  local match = vim.filetype.match { filename = "a." .. injection_alias }
+  return match or non_filetype_match_injection_language_aliases[injection_alias] or injection_alias
+end
 
 local function error(str)
   vim.api.nvim_err_writeln(str)
@@ -177,12 +172,7 @@ query.add_directive("set-lang-from-alias!", function(match, _, bufnr, pred, meta
     return
   end
   local injection_alias = vim.treesitter.get_node_text(node, bufnr)
-  local configured = injection_language_aliases[injection_alias]
-  if configured then
-    metadata.language = configured
-  else
-    metadata.language = injection_alias
-  end
+  metadata.language = get_language_name_from_fenced_code_block_tag(injection_alias)
 end)
 
 -- Just avoid some annoying warnings for this directive

--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -4,7 +4,7 @@
   (#not-match? @_lang "elm") ; prevent segfault when using elm parser
   (code_fence_content)
     @content
-    (#set-lang-from-info-string @_lang)
+    (#set-lang-from-info-string! @_lang)
     (#exclude_children! @content))
 
 ((html_block) @html)

--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -4,7 +4,7 @@
   (#not-match? @_lang "elm") ; prevent segfault when using elm parser
   (code_fence_content)
     @content
-    (#set-lang-from-alias! @_lang)
+    (#set-lang-from-info-string @_lang)
     (#exclude_children! @content))
 
 ((html_block) @html)

--- a/queries/markdown/injections.scm
+++ b/queries/markdown/injections.scm
@@ -1,8 +1,11 @@
 (fenced_code_block
   (info_string
-    (language) @language)
-  (#not-match? @language "elm")
-  (code_fence_content) @content (#exclude_children! @content))
+    (language) @_lang)
+  (#not-match? @_lang "elm") ; prevent segfault when using elm parser
+  (code_fence_content)
+    @content
+    (#set-lang-from-alias! @_lang)
+    (#exclude_children! @content))
 
 ((html_block) @html)
 


### PR DESCRIPTION
Closes #2131  

This PR, in the same vein as #4522, hard codes configuration for certain language aliases, namely `sh => bash`, `js => javascript` and `ts => typescript`

before:

![Screenshot from 2023-04-15 20-51-06](https://user-images.githubusercontent.com/1466420/232245403-e5136bb8-353e-476b-b4ed-d52376d03bc4.png)

after:
![Screenshot from 2023-04-15 20-51-12](https://user-images.githubusercontent.com/1466420/232245408-fdc27df6-dad1-48ad-bf62-5c8f335bc846.png)
