### PR TITLE
fix(ruby): bare_symbol should be `@symbol`

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -150,12 +150,12 @@
  ] @string
 
 [
- (bare_symbol)
  (heredoc_beginning)
  (heredoc_end)
  ] @constant
 
 [
+ (bare_symbol)
  (simple_symbol)
  (delimited_symbol)
  (hash_key_symbol)


### PR DESCRIPTION
Right now symbol is placed in the same category as heredoc which is not quite right. I as a user expect to see array of symbols highlighted in the same color as `simple_symbol`

|before|after|
|------|-----|
|<img width="600" alt="Screenshot 2023-04-16 at 9 03 43 PM" src="https://user-images.githubusercontent.com/20648459/232332637-421ac1f6-bd6f-49bb-b60a-79172cad9aea.png">|<img width="600" alt="Screenshot 2023-04-16 at 9 06 25 PM" src="https://user-images.githubusercontent.com/20648459/232332737-252c1641-ec51-4525-bc99-10c530a7f22c.png">|


more examples
<img width="1152" alt="Screenshot 2023-04-16 at 9 12 01 PM" src="https://user-images.githubusercontent.com/20648459/232333099-cca8bdc2-25e2-40ec-9379-9ca288fdcc80.png">

I don't see that Ruby has any tests right now but if I need to add smth let me know, appreciate any help on this


P.S.
here is an example from tree-sitter-ruby repo
https://github.com/tree-sitter/tree-sitter-ruby/blob/master/queries/highlights.scm#L104-L109