### PR TITLE
chore(injections)!: Move to upstream syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,17 +284,29 @@ query.
 ### Injections
 
 Some captures are related to language injection (like markdown code blocks). They are used in `injections.scm`.
-You can directly use the name of the language that you want to inject (e.g. `@html` to inject html).
 
-If you want to dynamically detect the language (e.g. for Markdown blocks) use the `@language` to capture
-the node describing the language and `@content` to describe the injection region.
+If you want to dynamically detect the language (e.g. for Markdown blocks) use the `@injection.language` to capture
+the node describing the language and `@injection.content` to describe the injection region.
+
+For regions that don't have a corresponding `@injection.language`, you need to manually set the language 
+through `(#set injection.language "lang_name")`
 
 ```scheme
-@{lang}   ; e.g. @html to describe a html region
+@injection.language ; dynamic detection of the injection language (i.e. the text of the captured node describes the language)
+@injection.content  ; region for the dynamically detected language
+```
+To combine all matches of a pattern as one single block of content, add `(#set! injection.combined)` to such pattern
 
-@language ; dynamic detection of the injection language (i.e. the text of the captured node describes the language)
-@content  ; region for the dynamically detected language
-@combined ; combine all matches of a pattern as one single block of content
+For example, to inject javascript into HTML's `<script>` tag
+
+```html
+<script>someJsCode();</script>
+```
+
+```query
+(script_element
+  (raw_text) @injection.content
+  (#set! injection.language "javascript")) ; set the parser language for @injection.content region to javascript
 ```
 
 ### Indents

--- a/runtime/queries/arduino/injections.scm
+++ b/runtime/queries/arduino/injections.scm
@@ -1,3 +1,5 @@
-(preproc_arg) @arduino
+((preproc_arg) @injection.content
+ (#set! injection.language "arduino"))
 
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/astro/injections.scm
+++ b/runtime/queries/astro/injections.scm
@@ -1,19 +1,23 @@
-; inherits: html
+; inherits: html_tags
 
-((frontmatter
-    (raw_text) @typescript))
+(frontmatter
+  (raw_text) @injection.content
+  (#set! injection.language "typescript"))
 
-((interpolation
-    (raw_text) @tsx))
+(interpolation
+  (raw_text) @injection.content
+  (#set! injection.language "tsx"))
 
-((script_element
-    (raw_text) @typescript))
+(script_element
+  (raw_text) @injection.content
+  (#set! injection.language "typescript"))
 
-((style_element
-   (start_tag
-     (attribute
-       (attribute_name) @_lang_attr
-       (quoted_attribute_value (attribute_value) @_lang_value)))
-   (raw_text) @scss)
+(style_element
+ (start_tag
+   (attribute
+     (attribute_name) @_lang_attr
+     (quoted_attribute_value (attribute_value) @_lang_value)))
+ (raw_text) @injection.content
  (#eq? @_lang_attr "lang")
- (#eq? @_lang_value "scss"))
+ (#eq? @_lang_value "scss")
+ (#set! injection.language "scss"))

--- a/runtime/queries/awk/injections.scm
+++ b/runtime/queries/awk/injections.scm
@@ -1,2 +1,5 @@
-(comment) @comment
-(regex) @regex
+((comment) @injection.content 
+ (#set! injection.language "comment"))
+
+((regex) @injection.content 
+ (#set! injection.language "regex"))

--- a/runtime/queries/bash/injections.scm
+++ b/runtime/queries/bash/injections.scm
@@ -1,3 +1,5 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))
 
-(regex) @regex
+((regex) @injection.content 
+ (#set! injection.language "regex"))

--- a/runtime/queries/bass/injections.scm
+++ b/runtime/queries/bass/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/bicep/injections.scm
+++ b/runtime/queries/bicep/injections.scm
@@ -1,4 +1,5 @@
-[
- (comment)
- (diagnostic_comment)
-] @comment
+([
+  (comment)
+  (diagnostic_comment)
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/c/injections.scm
+++ b/runtime/queries/c/injections.scm
@@ -1,3 +1,5 @@
-(preproc_arg) @c
+((preproc_arg) @injection.content 
+ (#set! injection.language "c"))
 
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/c_sharp/injections.scm
+++ b/runtime/queries/c_sharp/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/capnp/injections.scm
+++ b/runtime/queries/capnp/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/chatito/injections.scm
+++ b/runtime/queries/chatito/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/clojure/injections.scm
+++ b/runtime/queries/clojure/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/cpon/injections.scm
+++ b/runtime/queries/cpon/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/cpp/injections.scm
+++ b/runtime/queries/cpp/injections.scm
@@ -1,7 +1,9 @@
-(preproc_arg) @cpp
+((preproc_arg) @injection.content 
+ (#set! injection.language "cpp"))
 
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))
 
 (raw_string_literal
-  delimiter: (raw_string_delimiter) @language
-  (raw_string_content) @content)
+  delimiter: (raw_string_delimiter) @injection.language
+  (raw_string_content) @injection.content)

--- a/runtime/queries/css/injections.scm
+++ b/runtime/queries/css/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/cuda/injections.scm
+++ b/runtime/queries/cuda/injections.scm
@@ -1,3 +1,5 @@
-(preproc_arg) @cuda
+((preproc_arg) @injection.content 
+ (#set! injection.language "cuda"))
 
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/cue/injections.scm
+++ b/runtime/queries/cue/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/d/injections.scm
+++ b/runtime/queries/d/injections.scm
@@ -1,7 +1,9 @@
-[
+([
   (line_comment)
   (block_comment)
   (nesting_block_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment")) 
 
-(token_string_tokens) @d
+((token_string_tokens) @injection.content
+ (#set! injection.language "d"))

--- a/runtime/queries/dart/injections.scm
+++ b/runtime/queries/dart/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/devicetree/injections.scm
+++ b/runtime/queries/devicetree/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/dhall/injections.scm
+++ b/runtime/queries/dhall/injections.scm
@@ -1,4 +1,5 @@
-[
+([
   (line_comment)
   (block_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/dockerfile/injections.scm
+++ b/runtime/queries/dockerfile/injections.scm
@@ -1,3 +1,5 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))
 
-(shell_command) @bash
+((shell_command) @injection.content 
+ (#set! injection.language "bash"))

--- a/runtime/queries/dot/injections.scm
+++ b/runtime/queries/dot/injections.scm
@@ -1,2 +1,5 @@
-(html_internal) @html
-(comment) @comment
+((html_internal) @injection.content 
+ (#set! injection.language "html"))
+
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/ecma/injections.scm
+++ b/runtime/queries/ecma/injections.scm
@@ -1,59 +1,67 @@
 (((comment) @_jsdoc_comment
-  (#lua-match? @_jsdoc_comment "^/[*][*][^*].*[*]/$")) @jsdoc)
+  (#lua-match? @_jsdoc_comment "^/[*][*][^*].*[*]/$")) @injection.content
+  (#set! injection.language "jsdoc"))
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 ; html(`...`), html`...`, sql(...) etc
 (call_expression
- function: ((identifier) @language)
+ function: ((identifier) @injection.language)
  arguments: [
              (arguments
-              (template_string) @content)
-             (template_string) @content
+              (template_string) @injection.content)
+             (template_string) @injection.content
             ]
-     (#offset! @content 0 1 0 -1)
-     (#not-eq? @content "svg"))
+     (#offset! @injection.content 0 1 0 -1)
+     (#not-eq? @injection.language "svg"))
 
 ; svg`...` or svg(`...`), which uses the html parser, so is not included in the previous query
 (call_expression
  function: ((identifier) @_name (#eq? @_name "svg"))
  arguments: [
              (arguments
-              (template_string) @html)
-             (template_string) @html
+              (template_string) @injection.content)
+             (template_string) @injection.content
             ]
-     (#offset! @html 0 1 0 -1))
+     (#offset! @injection.content 0 1 0 -1)
+     (#set! injection.language "html"))
 
 
 (call_expression
  function: ((identifier) @_name
    (#eq? @_name "gql"))
- arguments: ((template_string) @graphql
-   (#offset! @graphql 0 1 0 -1)))
+ arguments: ((template_string) @injection.content
+   (#offset! @injection.content 0 1 0 -1)
+   (#set! injection.language "graphql")))
 
 (call_expression
  function: ((identifier) @_name
    (#eq? @_name "hbs"))
- arguments: ((template_string) @glimmer
-   (#offset! @glimmer 0 1 0 -1)))
+ arguments: ((template_string) @injection.content
+   (#offset! @injection.content 0 1 0 -1)
+   (#set! injection.language "glimmer")))
 
-((glimmer_template) @glimmer)
+((glimmer_template) @injection.content
+ (#set! injection.language "glimmer"))
 
 ; styled.div`<css>`
 (call_expression
  function: (member_expression
    object: (identifier) @_name
      (#eq? @_name "styled"))
- arguments: ((template_string) @css
-   (#offset! @css 0 1 0 -1)))
+ arguments: ((template_string) @injection.content
+   (#offset! @injection.content 0 1 0 -1)
+   (#set! injection.language "css")))
 
 ; styled(Component)`<css>`
 (call_expression
  function: (call_expression
    function: (identifier) @_name
      (#eq? @_name "styled"))
- arguments: ((template_string) @css
-   (#offset! @css 0 1 0 -1)))
+ arguments: ((template_string) @injection.content
+   (#offset! @injection.content 0 1 0 -1)
+   (#set! injection.language "css")))
 
 ; styled.div.attrs({ prop: "foo" })`<css>`
 (call_expression
@@ -62,8 +70,9 @@
     object: (member_expression
       object: (identifier) @_name
         (#eq? @_name "styled"))))
- arguments: ((template_string) @css
-   (#offset! @css 0 1 0 -1)))
+ arguments: ((template_string) @injection.content
+   (#offset! @injection.content 0 1 0 -1)
+   (#set! injection.language "css")))
 
 
 ; styled(Component).attrs({ prop: "foo" })`<css>`
@@ -73,31 +82,34 @@
     object: (call_expression
       function: (identifier) @_name
         (#eq? @_name "styled"))))
- arguments: ((template_string) @css
-   (#offset! @css 0 1 0 -1)))
+ arguments: ((template_string) @injection.content
+   (#offset! @injection.content 0 1 0 -1)
+   (#set! injection.language "css")))
 
-(regex_pattern) @regex
+((regex_pattern) @injection.content
+ (#set! injection.language "regex"))
 
 ; ((comment) @_gql_comment
 ;   (#eq? @_gql_comment "/* GraphQL */")
-;   (template_string) @graphql)
+;   (template_string) @injection.content
+;   (#set! injection.language "graphql"))
 
-((template_string) @graphql
-  (#lua-match? @graphql "^`#graphql")
-  (#offset! @graphql 0 1 0 -1))
+((template_string) @injection.content
+  (#lua-match? @injection.content "^`#graphql")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.language "graphql"))
 
 ; el.innerHTML = `<html>`
-(assignment_expression
-  left: (member_expression
-          property: (property_identifier) @_prop
-           (#any-of? @_prop "innerHTML" "outerHTML"))
-  right: (template_string) @html
-    (#offset! @html 0 1 0 -1))
-
 ; el.innerHTML = '<html>'
 (assignment_expression
-   left: (member_expression
-           property: (property_identifier) @_prop
-            (#any-of? @_prop "innerHTML" "outerHTML"))
-   right: (string) @html
-            (#offset! @html 0 1 0 -1))
+  left: 
+    (member_expression
+      property: (property_identifier) @_prop
+      (#any-of? @_prop "outerHTML" "innerHTML"))
+  right: 
+    [
+      (template_string)
+      (string)
+    ] @injection.content
+    (#offset! @injection.content 0 1 0 -1)
+    (#set! injection.language "html"))

--- a/runtime/queries/eex/injections.scm
+++ b/runtime/queries/eex/injections.scm
@@ -1,5 +1,8 @@
 ; EEx expressions are Elixir
-(expression) @elixir
+((expression) @injection.content 
+ (#set! injection.language "elixir"))
 
 ; EEx expressions can span multiple interpolated lines
-(partial_expression) @elixir @combined
+((partial_expression) @injection.content
+ (#set! injection.language "elixir")
+ (#set! injection.combined))

--- a/runtime/queries/elixir/injections.scm
+++ b/runtime/queries/elixir/injections.scm
@@ -1,5 +1,6 @@
 ; Comments
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))
 
 ; Documentation
 (unary_operator
@@ -7,42 +8,49 @@
   operand: (call
     target: ((identifier) @_identifier (#any-of? @_identifier "moduledoc" "typedoc" "shortdoc" "doc"))
     (arguments [
-      (string (quoted_content) @markdown)
-      (sigil (quoted_content) @markdown)
-    ])))
+      (string (quoted_content) @injection.content)
+      (sigil (quoted_content) @injection.content)
+    ]) 
+    (#set! injection.language "markdown")))
 
 ; HEEx
 (sigil
   (sigil_name) @_sigil_name
-  (quoted_content) @heex
-(#eq? @_sigil_name "H"))
+  (quoted_content) @injection.content
+ (#eq? @_sigil_name "H")
+ (#set! injection.language "heex"))
 
 ; Surface
 (sigil
   (sigil_name) @_sigil_name
-  (quoted_content) @surface
-(#eq? @_sigil_name "F"))
+  (quoted_content) @injection.content
+ (#eq? @_sigil_name "F")
+ (#set! injection.language "surface"))
 
 ; Zigler
 (sigil
   (sigil_name) @_sigil_name
-  (quoted_content) @eex
-(#any-of? @_sigil_name "E" "L"))
+  (quoted_content) @injection.content
+ (#any-of? @_sigil_name "E" "L")
+ (#set! injection.language "eex"))
 
 (sigil
   (sigil_name) @_sigil_name
-  (quoted_content) @zig
-(#any-of? @_sigil_name "z" "Z"))
+  (quoted_content) @injection.content
+ (#any-of? @_sigil_name "z" "Z")
+ (#set! injection.language "zig"))
 
 ; Regex
 (sigil
   (sigil_name) @_sigil_name
-  (quoted_content) @regex
-(#any-of? @_sigil_name "r" "R"))
+  (quoted_content) @injection.content
+ (#any-of? @_sigil_name "r" "R")
+ (#set! injection.language "regex"))
 
-; Jason
+; Json
 (sigil
   (sigil_name) @_sigil_name
-  (quoted_content) @json
-(#any-of? @_sigil_name "j" "J"))
+  (quoted_content) @injection.content
+ (#any-of? @_sigil_name "j" "J")
+ (#set! injection.language "json"))
 

--- a/runtime/queries/elm/injections.scm
+++ b/runtime/queries/elm/injections.scm
@@ -1,3 +1,8 @@
-[(line_comment) (block_comment)] @comment
+([
+  (line_comment) 
+  (block_comment)
+ ] @injection.content
+ (#set! injection.language "comment"))
 
-(glsl_content) @glsl
+((glsl_content) @injection.content
+ (#set! injection.language "glsl"))

--- a/runtime/queries/elsa/injections.scm
+++ b/runtime/queries/elsa/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/elvish/injections.scm
+++ b/runtime/queries/elvish/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/embedded_template/injections.scm
+++ b/runtime/queries/embedded_template/injections.scm
@@ -1,2 +1,7 @@
-(content) @html @combined
-(code) @ruby @combined
+((content) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.combined))
+
+((code) @injection.content
+ (#set! injection.language "ruby")
+ (#set! injection.combined))

--- a/runtime/queries/fennel/injections.scm
+++ b/runtime/queries/fennel/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/firrtl/injections.scm
+++ b/runtime/queries/firrtl/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/fish/injections.scm
+++ b/runtime/queries/fish/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/foam/injections.scm
+++ b/runtime/queries/foam/injections.scm
@@ -1,12 +1,20 @@
 ;; Pass code blocks to Cpp highlighter
-(code (code_body) @cpp)
+(code 
+  (code_body) @injection.content 
+  (#set! injection.language "cpp"))
 
 ;; Pass identifiers to Go highlighter (Cheating I know)
-;;((identifier) @lua)
+;; ((identifier) @injection.content
+;;  (#set! injection.language "lua")
 
 ;; Highlight regex syntax inside literal strings
-((string_literal) @regex)
+((string_literal) @injection.content 
+ (#set! injection.language "regex"))
 
 ;; Highlight PyFoam syntax as Python statements
-(pyfoam_variable code_body: (_) @python)
-(pyfoam_expression code_body: (_) @python)
+(pyfoam_variable
+  code_body: (_) @injection.content
+  (#set! injection.language "python"))
+(pyfoam_expression
+  code_body: (_) @injection.content
+  (#set! injection.language "python"))

--- a/runtime/queries/gdscript/injections.scm
+++ b/runtime/queries/gdscript/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/git_rebase/injections.scm
+++ b/runtime/queries/git_rebase/injections.scm
@@ -1,5 +1,6 @@
 ((operation
    (command) @_command
-   (message) @bash)
+   (message) @injection.content)
+(#set! injection.language "bash")
 (#any-of? @_command "exec" "x"))
 

--- a/runtime/queries/gitattributes/injections.scm
+++ b/runtime/queries/gitattributes/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/gitcommit/injections.scm
+++ b/runtime/queries/gitcommit/injections.scm
@@ -1,2 +1,5 @@
-((diff) @diff (#exclude_children! @diff))
-(rebase_command) @git_rebase
+((diff) @injection.content
+ (#set! injection.language "diff"))
+
+((rebase_command) @injection.content 
+ (#set! injection.language "git_rebase"))

--- a/runtime/queries/gleam/injections.scm
+++ b/runtime/queries/gleam/injections.scm
@@ -1,6 +1,7 @@
 ; Comments
-[
+([
   (module_comment)
   (statement_comment) 
   (comment) 
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/glsl/injections.scm
+++ b/runtime/queries/glsl/injections.scm
@@ -1,3 +1,5 @@
-(preproc_arg) @glsl
+((preproc_arg) @injection.content 
+ (#set! injection.language "glsl"))
 
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/go/injections.scm
+++ b/runtime/queries/go/injections.scm
@@ -1,4 +1,5 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))
 
 (call_expression
   (selector_expression) @_function (#any-of? @_function
@@ -10,4 +11,10 @@
                                     "regexp.MustCompile"
                                     "regexp.MustCompilePOSIX")
   (argument_list
-    . [(raw_string_literal) (interpreted_string_literal)] @regex (#offset! @regex 0 1 0 -1)))
+    . 
+    [
+     (raw_string_literal) 
+     (interpreted_string_literal)
+    ] @injection.content
+    (#offset! @injection.content 0 1 0 -1)
+    (#set! injection.language "regex")))

--- a/runtime/queries/gomod/injections.scm
+++ b/runtime/queries/gomod/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/gowork/injections.scm
+++ b/runtime/queries/gowork/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/graphql/injections.scm
+++ b/runtime/queries/graphql/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/hare/injections.scm
+++ b/runtime/queries/hare/injections.scm
@@ -1,8 +1,10 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 ((call_expression
   . (_) @_fnname
   . "("
-  . (_ [(string_content) (raw_string_content)] @regex)
+  . (_ [(string_content) (raw_string_content)] @injection.content)
   . ")")
-  (#any-of? @_fnname "compile" "regex::compile"))
+  (#any-of? @_fnname "compile" "regex::compile")
+  (#set! injection.language "regex"))

--- a/runtime/queries/haskell/injections.scm
+++ b/runtime/queries/haskell/injections.scm
@@ -2,11 +2,12 @@
 ;; General language injection
 
 (quasiquote
- ((quoter) @language)
- ((quasiquote_body) @content)
+ ((quoter) @injection.language)
+ ((quasiquote_body) @injection.content)
 )
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 ;; -----------------------------------------------------------------------------
 ;; shakespeare library
@@ -17,35 +18,36 @@
 ; (quasiquote
 ;  (quoter) @_name
 ;  (#eq? @_name "coffee")
-;  ((quasiquote_body) @coffeescript)
+;  ((quasiquote_body) @injection.content
+;   (#set! injection.language "coffeescript")))
 
 ; CSS: Text.Cassius, Text.Lucius
 (quasiquote
  (quoter) @_name
  (#any-of? @_name "cassius" "lucius")
- ((quasiquote_body) @css)
-)
+ ((quasiquote_body) @injection.content)
+ (#set! injection.language "css"))
 
 ; HTML: Text.Hamlet
 (quasiquote
  (quoter) @_name
  (#any-of? @_name "shamlet" "xshamlet" "hamlet" "xhamlet" "ihamlet")
- ((quasiquote_body) @html)
-)
+ ((quasiquote_body) @injection.content)
+ (#set! injection.language "html"))
 
 ; JS: Text.Julius
 (quasiquote
  (quoter) @_name
  (#any-of? @_name "js" "julius")
- ((quasiquote_body) @javascript)
-)
+ ((quasiquote_body) @injection.content)
+ (#set! injection.language "javascript"))
 
 ; TS: Text.TypeScript
 (quasiquote
  (quoter) @_name
  (#any-of? @_name "tsc" "tscJSX")
- ((quasiquote_body) @typescript)
-)
+ ((quasiquote_body) @injection.content)
+ (#set! injection.language "typescript"))
 
 
 ;; -----------------------------------------------------------------------------
@@ -54,8 +56,8 @@
 (quasiquote
  (quoter) @_name
  (#eq? @_name "hsx")
- ((quasiquote_body) @html)
-)
+ ((quasiquote_body) @injection.content)
+ (#set! injection.language "html"))
 
 ;; -----------------------------------------------------------------------------
 ;; Inline JSON from aeson
@@ -63,8 +65,8 @@
 (quasiquote
   (quoter) @_name
   (#eq? @_name "aesonQQ")
-  ((quasiquote_body) @json)
-)
+  ((quasiquote_body) @injection.content)
+  (#set! injection.language "json"))
 
 
 ;; -----------------------------------------------------------------------------
@@ -72,7 +74,6 @@
 
 ; postgresql-simple
 (quasiquote
-  (quoter) @_name 
-  (#eq? @_name "sql")
-  ((quasiquote_body) @sql)
-)
+  (quoter) @injection.language
+  (#eq? @injection.language "sql")
+  ((quasiquote_body) @injection.content))

--- a/runtime/queries/hcl/injections.scm
+++ b/runtime/queries/hcl/injections.scm
@@ -1,7 +1,7 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 (heredoc_template
-  (template_literal) @content
-  (heredoc_identifier) @language
-  (#set! "language" @language)
-  (#downcase! "language"))
+  (template_literal) @injection.content
+  (heredoc_identifier) @injection.language
+  (#downcase! @injection.language))

--- a/runtime/queries/heex/injections.scm
+++ b/runtime/queries/heex/injections.scm
@@ -2,10 +2,15 @@
 (directive [
   (expression_value) 
   (partial_expression_value)
-] @elixir @combined)  
+] @injection.content
+  (#set! injection.language "elixir")
+  (#set! injection.combined))  
 
 ; HEEx Elixir expressions are always within a tag or component
-(expression (expression_value) @elixir)
+(expression 
+  (expression_value) @injection.content 
+  (#set! injection.language "elixir"))
 
 ; HEEx comments
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/hjson/injections.scm
+++ b/runtime/queries/hjson/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/hlsl/injections.scm
+++ b/runtime/queries/hlsl/injections.scm
@@ -1,3 +1,5 @@
-(preproc_arg) @hlsl
+((preproc_arg) @injection.content
+ (#set! injection.language "hlsl"))
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/hocon/injections.scm
+++ b/runtime/queries/hocon/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/html/injections.scm
+++ b/runtime/queries/html/injections.scm
@@ -3,8 +3,10 @@
 (element
   (start_tag
     (tag_name) @_py_script)
-  (text) @python
-  (#any-of? @_py_script "py-script" "py-repl"))
+  (text) @injection.content
+  (#any-of? @_py_script "py-script" "py-repl")
+  (#set! injection.language "python")
+  (#set! injection.include-children))
 
 (script_element
   (start_tag
@@ -12,13 +14,17 @@
       (attribute_name) @_attr 
       (quoted_attribute_value 
         (attribute_value) @_type)))
-  (raw_text) @python
+  (raw_text) @injection.content
   (#eq? @_attr "type")
   ; not adding type="py" here as it's handled by html_tags 
-  (#any-of? @_type "pyscript" "py-script"))
+  (#any-of? @_type "pyscript" "py-script")
+  (#set! injection.language "python")
+  (#set! injection.include-children))
 
 (element
   (start_tag
     (tag_name) @_py_config)
-  (text) @toml
-  (#eq? @_py_config "py-config"))
+  (text) @injection.content
+  (#eq? @_py_config "py-config")
+  (#set! injection.language "toml")
+  (#set! injection.include-children))

--- a/runtime/queries/htmldjango/injections.scm
+++ b/runtime/queries/htmldjango/injections.scm
@@ -1,1 +1,3 @@
-(content) @html @combined
+((content) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.combined))

--- a/runtime/queries/http/injections.scm
+++ b/runtime/queries/http/injections.scm
@@ -1,7 +1,11 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))
 
-(json_body) @json
+((json_body) @injection.content
+ (#set! injection.language "json"))
 
-; (xml_body) @xml
+; ((xml_body) @injection.content
+;  (#set! injection.language "xml"))
 
-; (graphql_body) @graphql Not used as of now..
+; ((graphql_body) @injection.content 
+;  (#set! injection.language "graphql")) ; Not used as of now..

--- a/runtime/queries/janet_simple/injections.scm
+++ b/runtime/queries/janet_simple/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/java/injections.scm
+++ b/runtime/queries/java/injections.scm
@@ -1,4 +1,5 @@
-[
+([
   (block_comment)
   (line_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/jq/injections.scm
+++ b/runtime/queries/jq/injections.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+((comment) @injection.content (#set! injection.language "comment"))
 
 ; test(val)
 (query
@@ -12,7 +12,10 @@
              "splits"
              "sub"
              "gsub"))
-  (args . (query (string) @regex)))
+  (args . 
+    (query 
+      (string) @injection.content
+      (#set! injection.language "regex"))))
 
 
 ; test(regex; flags)
@@ -28,4 +31,6 @@
              "sub"
              "gsub"))
   (args . (args
-    (query (string) @regex))))
+    (query 
+      (string) @injection.content
+      (#set! injection.language "regex")))))

--- a/runtime/queries/json5/injections.scm
+++ b/runtime/queries/json5/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/jsonc/injections.scm
+++ b/runtime/queries/jsonc/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/jsx/injections.scm
+++ b/runtime/queries/jsx/injections.scm
@@ -3,6 +3,7 @@
   (jsx_opening_element
     (identifier) @_name (#eq? @_name "style")
     (jsx_attribute) @_attr (#eq? @_attr "jsx"))
-  (jsx_expression (template_string) @css
-    (#offset! @css 0 1 0 -1))
-)
+  (jsx_expression 
+    ((template_string) @injection.content 
+     (#set! injection.language "css"))
+     (#offset! @injection.content 0 1 0 -1)))

--- a/runtime/queries/julia/injections.scm
+++ b/runtime/queries/julia/injections.scm
@@ -1,5 +1,5 @@
 ;; Inject markdown in docstrings 
-((string_literal) @markdown
+((string_literal) @injection.content
   . [
     (module_definition)
     (abstract_definition)
@@ -8,15 +8,18 @@
     (assignment)
     (const_declaration)
   ]
- (#lua-match? @markdown "^\"\"\"")
- (#offset! @markdown 0 3 0 -3))
+ (#lua-match? @injection.content "^\"\"\"")
+ (#set! injection.language "markdown")
+ (#offset! @injection.content 0 3 0 -3))
 
-[
+([
   (line_comment)
   (block_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))
 
 ((prefixed_string_literal
-   prefix: (identifier) @_prefix) @regex
+   prefix: (identifier) @_prefix) @injection.content
  (#eq? @_prefix "r")
- (#offset! @regex 0 2 0 -1))
+ (#set! injection.language "regex")
+ (#offset! @injection.content 0 2 0 -1))

--- a/runtime/queries/kdl/injections.scm
+++ b/runtime/queries/kdl/injections.scm
@@ -1,4 +1,5 @@
-[
+([
   (single_line_comment)
   (multi_line_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/kotlin/injections.scm
+++ b/runtime/queries/kotlin/injections.scm
@@ -1,35 +1,36 @@
-[
+([
   (line_comment)
   (multiline_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))
 
 ; There are 3 ways to define a regex
 ;    - "[abc]?".toRegex()
 (call_expression
-	(navigation_expression
-		((string_literal) @regex)
-		(navigation_suffix
-			((simple_identifier) @_function
-			(#eq? @_function "toRegex")))))
+  (navigation_expression
+    ((string_literal) @injection.content (#set! injection.language "regex"))
+      (navigation_suffix
+	((simple_identifier) @_function
+	  (#eq? @_function "toRegex")))))
 
 ;    - Regex("[abc]?")
 (call_expression
-	((simple_identifier) @_function
-	(#eq? @_function "Regex"))
-	(call_suffix
-		(value_arguments
-			(value_argument
-				(string_literal) @regex))))
+  ((simple_identifier) @_function
+    (#eq? @_function "Regex"))
+  (call_suffix
+    (value_arguments
+      (value_argument
+        (string_literal) @injection.content (#set! injection.language "regex")))))
 
 ;    - Regex.fromLiteral("[abc]?")
 (call_expression
-	(navigation_expression
-		((simple_identifier) @_class
-		(#eq? @_class "Regex"))
-		(navigation_suffix
-			((simple_identifier) @_function
-			(#eq? @_function "fromLiteral"))))
-	(call_suffix
-		(value_arguments
-			(value_argument
-				(string_literal) @regex))))
+  (navigation_expression
+    ((simple_identifier) @_class
+                         (#eq? @_class "Regex"))
+    (navigation_suffix
+      ((simple_identifier) @_function
+                           (#eq? @_function "fromLiteral"))))
+  (call_suffix
+    (value_arguments
+      (value_argument
+        (string_literal) @injection.content (#set! injection.language "regex")))))

--- a/runtime/queries/lalrpop/injections.scm
+++ b/runtime/queries/lalrpop/injections.scm
@@ -1,9 +1,11 @@
-[
- (normal_action)
- (failible_action)
-] @rust
+([
+  (normal_action)
+  (failible_action)
+ ] @injection.content
+ (#set! injection.language "rust"))
 
-(use) @rust
+((use) @injection.content (#set! injection.language "rust"))
 
-((regex_literal) @regex
- (#offset! @regex 0 2 0 -1))
+((regex_literal) @injection.content
+ (#set! injection.language "regex")
+ (#offset! @injection.content 0 2 0 -1))

--- a/runtime/queries/latex/injections.scm
+++ b/runtime/queries/latex/injections.scm
@@ -1,22 +1,25 @@
-[
- (line_comment)
- (block_comment)
- (comment_environment)
-] @comment
+([
+  (line_comment)
+  (block_comment)
+  (comment_environment)
+ ] @injection.content
+ (#set! injection.language "comment"))
 
 (pycode_environment
-  code: (source_code) @python
-)
+  code: 
+  (source_code) @injection.content 
+  (#set! injection.language "python"))
 
 (minted_environment
   (begin
     language: (curly_group_text
-               (text) @language))
-  (source_code) @content)
+               (text) @injection.language))
+  (source_code) @injection.content)
 
 ((generic_environment
   (begin
    name: (curly_group_text
-           (text) @_env))) @c
+           (text) @_env))) @injection.content
+   (#set! injection.language "c")
    (#any-of? @_env "asy" "asydef"))
 

--- a/runtime/queries/ledger/injections.scm
+++ b/runtime/queries/ledger/injections.scm
@@ -1,2 +1,5 @@
-(comment) @comment
-(note) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
+((note) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/lua/injections.scm
+++ b/runtime/queries/lua/injections.scm
@@ -3,57 +3,65 @@
     (identifier) @_cdef_identifier
     (_ _ (identifier) @_cdef_identifier)
   ]
-  arguments: (arguments (string content: _ @c)))
+  arguments: 
+    (arguments 
+      (string content: _ @injection.content)))
+  (#set! injection.language "c")
   (#eq? @_cdef_identifier "cdef"))
 
 ((function_call
   name: (_) @_vimcmd_identifier
-  arguments: (arguments . (string content: _ @vim)))
+  arguments: (arguments (string content: _ @injection.content)))
+  (#set! injection.language "vim")
   (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec" "vim.api.nvim_exec2"))
 
 ((function_call
   name: (_) @_vimcmd_identifier
-  arguments: (arguments (string content: _ @query) .))
+  arguments: (arguments (string content: _ @injection.content) .))
+  (#set! injection.language "query")
   (#any-of? @_vimcmd_identifier "vim.treesitter.query.set" "vim.treesitter.query.parse_query" "vim.treesitter.query.parse"))
 
-; vim.rcprequest(123, "nvim_exec_lua", "return vim.api.nvim_buf_get_lines(0, 0, -1, false)", false)
 ((function_call
   name: (_) @_vimcmd_identifier
-  arguments: (arguments . (_) . (string content: _ @_method) . (string content: _ @lua)))
+  arguments: (arguments . (_) . (string content: _ @_method) . (string content: _ @injection.content)))
   (#any-of? @_vimcmd_identifier "vim.rpcrequest" "vim.rpcnotify")
-  (#eq? @_method "nvim_exec_lua"))
+  (#eq? @_method "nvim_exec_lua")
+  (#set! injection.language "lua"))
 
-; highlight string as query if starts with `;; query`
-(string content: _ @query (#lua-match? @query "^%s*;+%s?query"))
+;; highlight string as query if starts with `;; query`
+(string content: _ @injection.content 
+ (#lua-match? @injection.content "^%s*;+%s?query")
+ (#set! injection.language "query"))
 
-((comment) @luadoc
-  (#lua-match? @luadoc "[-][-][-][%s]*@")
-  (#offset! @luadoc 0 3 0 0))
+((comment) @injection.content
+  (#lua-match? @injection.content "[-][-][-][%s]*@")
+  (#set! injection.language "luadoc")
+  (#offset! @injection.content 0 3 0 0))
 
 ; string.match("123", "%d+")
 (function_call
   (dot_index_expression
     field: (identifier) @_method
     (#any-of? @_method "find" "match"))
-  arguments: (arguments (_) . (string content: _ @luap)))
+  arguments: (arguments (_) . (string content: _ @injection.content (#set! injection.language "luap"))))
 
 (function_call
   (dot_index_expression
     field: (identifier) @_method
     (#any-of? @_method "gmatch" "gsub"))
-  arguments: (arguments (_) (string content: _ @luap)))
+  arguments: (arguments (_) (string content: _ @injection.content (#set! injection.language "luap"))))
 
 ; ("123"):match("%d+")
 (function_call
   (method_index_expression
     method: (identifier) @_method
     (#any-of? @_method "find" "match"))
-    arguments: (arguments . (string content: _ @luap)))
+    arguments: (arguments . (string content: _ @injection.content (#set! injection.language "luap"))))
 
 (function_call
   (method_index_expression
     method: (identifier) @_method
     (#any-of? @_method "gmatch" "gsub"))
-    arguments: (arguments (string content: _ @luap)))
+    arguments: (arguments (string content: _ @injection.content (#set! injection.language "luap"))))
 
-(comment) @comment
+((comment) @injection.content (#set! injection.language "comment"))

--- a/runtime/queries/luau/injections.scm
+++ b/runtime/queries/luau/injections.scm
@@ -3,37 +3,44 @@
     (identifier) @_cdef_identifier
     (_ _ (identifier) @_cdef_identifier)
   ]
-  arguments: (arguments (string content: _ @c)))
-  (#eq? @_cdef_identifier "cdef"))
+  arguments: (arguments (string content: _ @injection.content)))
+  (#eq? @_cdef_identifier "cdef")
+  (#set! injection.language "c"))
 
-((comment) @luadoc
-  (#lua-match? @luadoc "[-][-][-][%s]*@")
-  (#offset! @luadoc 0 3 0 0))
+((comment) @injection.content
+  (#lua-match? @injection.content "[-][-][-][%s]*@")
+  (#offset! @injection.content 0 3 0 0)
+  (#set! injection.language "luadoc"))
 
 ; string.match("123", "%d+")
 (function_call
   (dot_index_expression
     field: (identifier) @_method
     (#any-of? @_method "find" "format" "match"))
-  arguments: (arguments (_) . (string content: _ @luap)))
+  arguments: (arguments (_) . (string content: _ @injection.content))
+    (#set! injection.language "luap"))
 
 (function_call
   (dot_index_expression
     field: (identifier) @_method
     (#any-of? @_method "gmatch" "gsub"))
-  arguments: (arguments (_) (string content: _ @luap)))
+  arguments: (arguments (_) (string content: _ @injection.content))
+    (#set! injection.language "luap"))
 
 ; ("123"):match("%d+")
 (function_call
   (method_index_expression
     method: (identifier) @_method
     (#any-of? @_method "find" "format" "match"))
-    arguments: (arguments . (string content: _ @luap)))
+    arguments: (arguments . (string content: _ @injection.content))
+    (#set! injection.language "luap"))
 
 (function_call
   (method_index_expression
     method: (identifier) @_method
     (#any-of? @_method "gmatch" "gsub"))
-    arguments: (arguments (string content: _ @luap)))
+    arguments: (arguments (string content: _ @injection.content))
+    (#set! injection.language "luap"))
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/m68k/injections.scm
+++ b/runtime/queries/m68k/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/make/injections.scm
+++ b/runtime/queries/make/injections.scm
@@ -1,4 +1,7 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
-(shell_text) @bash
-(shell_command) @bash
+((shell_text) @injection.content
+ (#set! injection.language "bash"))
+((shell_command) @injection.content
+ (#set! injection.language "bash"))

--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -1,18 +1,28 @@
 (fenced_code_block
   (info_string
     (language) @_lang)
+  (code_fence_content) @injection.content
+
   (#not-match? @_lang "elm") ; prevent segfault when using elm parser
-  (code_fence_content)
-    @content
-    (#set-lang-from-info-string! @_lang)
-    (#exclude_children! @content))
+  (#set-lang-from-info-string! @_lang))
 
-((html_block) @html @combined)
+((html_block) @injection.content 
+ (#set! injection.language "html")
+ (#set! injection.combined)
+ (#set! injection.include-children))
 
-((minus_metadata) @yaml (#offset! @yaml 1 0 -1 0))
-((plus_metadata) @toml (#offset! @toml 1 0 -1 0))
+((minus_metadata) @injection.content 
+ (#set! injection.language "yaml") 
+ (#offset! @injection.content 1 0 -1 0)
+ (#set! injection.include-children))
+
+((plus_metadata) @injection.content 
+ (#set! injection.language "toml") 
+ (#offset! @injection.content 1 0 -1 0)
+ (#set! injection.include-children))
 
 ([
   (inline)
   (pipe_table_cell)
- ] @markdown_inline (#exclude_children! @markdown_inline))
+ ] @injection.content
+ (#set! injection.language "markdown_inline"))

--- a/runtime/queries/markdown_inline/injections.scm
+++ b/runtime/queries/markdown_inline/injections.scm
@@ -1,2 +1,8 @@
-((html_tag) @html @combined)
-((latex_block) @latex)
+((html_tag) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.combined)
+ (#set! injection.include-children))
+
+((latex_block) @injection.content
+ (#set! injection.language "latex")
+ (#set! injection.include-children))

--- a/runtime/queries/matlab/injections.scm
+++ b/runtime/queries/matlab/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/menhir/injections.scm
+++ b/runtime/queries/menhir/injections.scm
@@ -1,1 +1,2 @@
-(ocaml) @ocaml
+((ocaml) @injection.content
+ (#set! injection.language "ocaml"))

--- a/runtime/queries/meson/injections.scm
+++ b/runtime/queries/meson/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -1,19 +1,24 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 (apply_expression
   function: (_) @_func
   argument: [
-    (string_expression (string_fragment) @regex)
-    (indented_string_expression (string_fragment) @regex)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "regex")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "regex")))
   ]
-  (#match? @_func "(^|\\.)match$"))
-  @combined
+  (#match? @_func "(^|\\.)match$")
+  (#set! injection.combined))
 
 (binding
   attrpath: (attrpath (identifier) @_path)
   expression: [
-    (string_expression (string_fragment) @bash)
-    (indented_string_expression (string_fragment) @bash)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "bash")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "bash")))
   ]
   (#match? @_path "(^\\w+(Phase|Hook)|(pre|post)[A-Z]\\w+|script)$"))
 
@@ -22,87 +27,105 @@
   argument: (_ (_)* (_ (_)* (binding
     attrpath: (attrpath (identifier) @_path)
     expression: [
-      (string_expression (string_fragment) @bash)
-      (indented_string_expression (string_fragment) @bash)
+      (string_expression 
+        ((string_fragment) @injection.content (#set! injection.language "bash")))
+      (indented_string_expression 
+        ((string_fragment) @injection.content (#set! injection.language "bash")))
     ])))
   (#match? @_func "(^|\\.)writeShellApplication$")
-  (#match? @_path "^text$"))
-  @combined
+  (#match? @_path "^text$")
+  (#set! injection.combined))
 
 (apply_expression
   function: (apply_expression
     function: (apply_expression function: (_) @_func))
   argument: [
-    (string_expression (string_fragment) @bash)
-    (indented_string_expression (string_fragment) @bash)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "bash")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "bash")))
   ]
-  (#match? @_func "(^|\\.)runCommand((No)?CC)?(Local)?$"))
-  @combined
+  (#match? @_func "(^|\\.)runCommand((No)?CC)?(Local)?$")
+  (#set! injection.combined))
 
 ((apply_expression
   function: (apply_expression function: (_) @_func)
   argument: [
-    (string_expression (string_fragment) @bash)
-    (indented_string_expression (string_fragment) @bash)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "bash")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "bash")))
   ])
-  (#match? @_func "(^|\\.)write(Bash|Dash|ShellScript)(Bin)?$"))
-  @combined
+  (#match? @_func "(^|\\.)write(Bash|Dash|ShellScript)(Bin)?$")
+  (#set! injection.combined))
 
 ((apply_expression
   function: (apply_expression function: (_) @_func)
   argument: [
-    (string_expression (string_fragment) @fish)
-    (indented_string_expression (string_fragment) @fish)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "fish")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "fish")))
   ])
-  (#match? @_func "(^|\\.)writeFish(Bin)?$"))
-  @combined
+  (#match? @_func "(^|\\.)writeFish(Bin)?$")
+  (#set! injection.combined))
 
 ((apply_expression
   function: (apply_expression
     function: (apply_expression function: (_) @_func))
   argument: [
-    (string_expression (string_fragment) @haskell)
-    (indented_string_expression (string_fragment) @haskell)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "haskell")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "haskell")))
   ])
-  (#match? @_func "(^|\\.)writeHaskell(Bin)?$"))
-  @combined
+  (#match? @_func "(^|\\.)writeHaskell(Bin)?$")
+  (#set! injection.combined))
 
 ((apply_expression
   function: (apply_expression
     function: (apply_expression function: (_) @_func))
   argument: [
-    (string_expression (string_fragment) @javascript)
-    (indented_string_expression (string_fragment) @javascript)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "javascript")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "javascript")))
   ])
-  (#match? @_func "(^|\\.)writeJS(Bin)?$"))
-  @combined
+  (#match? @_func "(^|\\.)writeJS(Bin)?$")
+  (#set! injection.combined))
 
 ((apply_expression
   function: (apply_expression
     function: (apply_expression function: (_) @_func))
   argument: [
-    (string_expression (string_fragment) @perl)
-    (indented_string_expression (string_fragment) @perl)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "perl")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "perl")))
   ])
-  (#match? @_func "(^|\\.)writePerl(Bin)?$"))
-  @combined
+  (#match? @_func "(^|\\.)writePerl(Bin)?$")
+  (#set! injection.combined))
 
 ((apply_expression
   function: (apply_expression
     function: (apply_expression function: (_) @_func))
   argument: [
-    (string_expression (string_fragment) @python)
-    (indented_string_expression (string_fragment) @python)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "python")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "python")))
   ])
-  (#match? @_func "(^|\\.)write(PyPy|Python)[23](Bin)?$"))
-  @combined
+  (#match? @_func "(^|\\.)write(PyPy|Python)[23](Bin)?$")
+  (#set! injection.combined))
 
 ((apply_expression
   function: (apply_expression
     function: (apply_expression function: (_) @_func))
   argument: [
-    (string_expression (string_fragment) @rust)
-    (indented_string_expression (string_fragment) @rust)
+    (string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "rust")))
+    (indented_string_expression 
+      ((string_fragment) @injection.content (#set! injection.language "rust")))
   ])
-  (#match? @_func "(^|\\.)writeRust(Bin)?$"))
-  @combined
+  (#match? @_func "(^|\\.)writeRust(Bin)?$")
+  (#set! injection.combined))

--- a/runtime/queries/ocaml/injections.scm
+++ b/runtime/queries/ocaml/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/ocamllex/injections.scm
+++ b/runtime/queries/ocamllex/injections.scm
@@ -1,3 +1,5 @@
-(ocaml) @ocaml
+((ocaml) @injection.content
+ (#set! injection.language "ocaml"))
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/odin/injections.scm
+++ b/runtime/queries/odin/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/pascal/injections.scm
+++ b/runtime/queries/pascal/injections.scm
@@ -1,4 +1,7 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
 ; There is no parser for assembly language yet. Add an injection here when we
 ; have a parser.
-; (asmBody) @asm
+; ((asmBody) @injection.content
+;  (#set! injection.language "asm"))

--- a/runtime/queries/perl/injections.scm
+++ b/runtime/queries/perl/injections.scm
@@ -1,1 +1,2 @@
-(comments) @comment
+((comments) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/php/injections.scm
+++ b/runtime/queries/php/injections.scm
@@ -1,20 +1,34 @@
-(text) @html @combined
+((text) @injection.content
+ (#set! injection.language "html")
+ (#set! injection.combined))
 
-(comment) @phpdoc
+((comment) @injection.content
+ (#set! injection.language "phpdoc"))
 
 ;; regex
 
 ((function_call_expression
   function: (_) @_preg_func_identifier
-  arguments: (arguments . (argument (_ (string_value) @regex))))
+  arguments: 
+    (arguments . 
+      (argument 
+        (_ (string_value) @injection.content))))
+    (#set! injection.language "regex")
     (#lua-match? @_preg_func_identifier "^preg_"))
 
 ;; bash
 
 ((function_call_expression
   function: (_) @_shell_func_identifier
-  arguments: (arguments . (argument (_ (string_value) @bash))))
+  arguments: 
+    (arguments . 
+      (argument 
+        (_ (string_value) @injection.content))))
+  (#set! injection.language "bash")
   (#any-of? @_shell_func_identifier "shell_exec" "escapeshellarg" 
    "escapeshellcmd" "exec" "passthru" "proc_open" "shell_exec" "system"))
 
-((expression_statement (shell_command_expression (string_value) @bash)))
+(expression_statement 
+  (shell_command_expression 
+    (string_value) @injection.content)
+    (#set! injection.language "bash"))

--- a/runtime/queries/pioasm/injections.scm
+++ b/runtime/queries/pioasm/injections.scm
@@ -1,10 +1,15 @@
- [ (line_comment) (block_comment) ] @comment
+([ 
+   (line_comment) 
+   (block_comment) 
+ ] @injection.content
+ (#set! injection.language "comment"))
 
 ((code_block
   (code_block_language) @_language
-  (code_block_body) @c)
- (#eq? @_language "c-sdk"))
+  (code_block_body) @injection.content)
+ (#eq? @_language "c-sdk")
+ (#set! injection.language "c"))
 
 (code_block
-  (code_block_language) @language
-  (code_block_body) @content)
+  (code_block_language) @injection.language
+  (code_block_body) @injection.content)

--- a/runtime/queries/po/injections.scm
+++ b/runtime/queries/po/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/poe_filter/injections.scm
+++ b/runtime/queries/poe_filter/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/pony/injections.scm
+++ b/runtime/queries/pony/injections.scm
@@ -1,4 +1,5 @@
-[
+([
   (line_comment)
   (block_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/prql/injections.scm
+++ b/runtime/queries/prql/injections.scm
@@ -1,13 +1,13 @@
-(
- (s_string) @sql
- (#offset! @sql 0 2 0 -1)
-)
+((s_string) @injection.content
+ (#set! injection.language "sql")
+ (#offset! @injection.content 0 2 0 -1))
 
 (from_text
   (keyword_from_text)
   (keyword_json)
-  (literal) @json
-  (#offset! @json 0 3 0 -3)
-)
+  (literal) @injection.content
+  (#set! injection.language "json")
+  (#offset! @injection.content 0 3 0 -3))
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/pug/injections.scm
+++ b/runtime/queries/pug/injections.scm
@@ -1,7 +1,8 @@
-(javascript) @javascript
+((javascript) @injection.content
+ (#set! injection.language "javascript"))
 
-(
-   (attribute_name) @_attribute_name
-   (quoted_attribute_value (attribute_value )  @javascript)
-   (#match? @_attribute_name "^(:|v-bind|v-|\\@)")
-)
+((attribute_name) @_attribute_name
+  (quoted_attribute_value 
+    (attribute_value) @injection.content
+    (#set! injection.language "javascript"))
+  (#match? @_attribute_name "^(:|v-bind|v-|\\@)"))

--- a/runtime/queries/puppet/injections.scm
+++ b/runtime/queries/puppet/injections.scm
@@ -1,4 +1,6 @@
-((regex) @regex
-  (#offset! @regex 0 1 0 -1))
+((regex) @injection.content
+  (#set! injection.language "regex")
+  (#offset! @injection.content 0 1 0 -1))
 
-(comment) @comment
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/runtime/queries/python/injections.scm
+++ b/runtime/queries/python/injections.scm
@@ -1,8 +1,10 @@
 ((call
   function: (attribute
 	  object: (identifier) @_re)
-  arguments: (argument_list (string) @regex))
+  arguments: (argument_list (string) @injection.content))
  (#eq? @_re "re")
- (#lua-match? @regex "^r.*"))
+ (#lua-match? @injection.content "^r.*")
+ (#set! injection.language "regex"))
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/ql/injections.scm
+++ b/runtime/queries/ql/injections.scm
@@ -1,5 +1,6 @@
-[
+([
   (line_comment)
   (block_comment)
   (qldoc)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/qmldir/injections.scm
+++ b/runtime/queries/qmldir/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/query/injections.scm
+++ b/runtime/queries/query/injections.scm
@@ -1,13 +1,16 @@
 ((predicate 
   name: (identifier) @_name
-  parameters: (parameters (string) @regex))
+  parameters: (parameters (string) @injection.content))
  (#match? @_name "^#?(not-)?(match|vim-match)$")
- (#offset! @regex 0 1 0 -1))
+ (#set! injection.language "regex")
+ (#offset! @injection.content 0 1 0 -1))
 
 ((predicate
   name: (identifier) @_name
-  parameters: (parameters (string) @luap))
+  parameters: (parameters (string) @injection.content))
  (#match? @_name "^#?(not-)?lua-match$")
- (#offset! @luap 0 1 0 -1))
+ (#set! injection.language "luap")
+ (#offset! @injection.content 0 1 0 -1))
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/r/injections.scm
+++ b/runtime/queries/r/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/racket/injections.scm
+++ b/runtime/queries/racket/injections.scm
@@ -1,2 +1,5 @@
-[(comment)
- (block_comment)] @comment
+([
+  (comment)
+  (block_comment)
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/rego/injections.scm
+++ b/runtime/queries/rego/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/rnoweb/injections.scm
+++ b/runtime/queries/rnoweb/injections.scm
@@ -1,7 +1,12 @@
-(latex) @latex @combined
+((latex) @injection.content
+ (#set! injection.language "latex")
+ (#set! injection.combined))
+
 (rchunk
-	(renv_content) @r @combined
-)
+  (renv_content) @injection.content
+  (#set! injection.language "r")
+  (#set! injection.combined))
+
 (rinline
-	(renv_content) @r
-)
+  (renv_content) @injection.content
+  (#set! injection.language "r"))

--- a/runtime/queries/ron/injections.scm
+++ b/runtime/queries/ron/injections.scm
@@ -1,4 +1,5 @@
-[
+([
   (line_comment)
   (block_comment)
-] @comment
+] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/rst/injections.scm
+++ b/runtime/queries/rst/injections.scm
@@ -1,9 +1,11 @@
-(doctest_block) @python
+((doctest_block) @injection.content
+ (#set! injection.language "python"))
 
 ;; Directives with nested content without arguments nor options
 ((directive
    name: (type) @_type
-   body: (body) @rst)
+   body: (body) @injection.content)
+ (#set! injection.language "rst")
  (#any-of?
   @_type
   "attention" "caution" "danger" "error" "hint" "important" "note" "tip" "warning" "admonition"
@@ -15,7 +17,8 @@
 ;; Directives with nested content without arguments, but with options
 ((directive
    name: (type) @_type
-   body: (body (options) (content) @rst))
+   body: (body (options) (content) @injection.content))
+ (#set! injection.language "rst")
  (#any-of?
   @_type
   "attention" "caution" "danger" "error" "hint" "important" "note" "tip" "warning" "admonition"
@@ -24,7 +27,8 @@
 ;; Directives with nested content with arguments and options
 ((directive
    name: (type) @_type
-   body: (body (content) @rst))
+   body: (body (content) @injection.content))
+ (#set! injection.language "rst")
  (#any-of?
   @_type
   "figure"
@@ -35,37 +39,42 @@
 ;; Special directives
 ((directive
    name: (type) @_type
-   body: (body (arguments) @language (content) @content))
+   body: (body (arguments) @injection.language (content) @injection.content))
  (#any-of? @_type "code" "code-block" "sourcecode"))
 
 ((directive
    name: (type) @_type
-   body: (body (arguments) @language (content) @content))
+   body: (body (arguments) @injection.language (content) @injection.content))
  (#eq? @_type "raw"))
 
 ((directive
    name: (type) @_type
-   body: (body (content) @latex))
+   body: (body (content) @injection.content))
+ (#set! injection.language "latex")
  (#eq? @_type "math"))
 
 ; TODO: re-add when a parser for csv is added.
 ; ((directive
 ;    name: (type) @_type
-;    body: (body (content) @csv))
+;    body: (body (content) @injection.content))
+;  (#set! injection.language "csv")
 ;  (#eq? @_type "csv-table"))
 
 ;; Special roles - prefix
 
 ((interpreted_text
   (role) @_role
-  "interpreted_text" @latex)
- (#eq? @_role ":math:"))
+  "interpreted_text" @injection.content)
+ (#eq? @_role ":math:")
+ (#set! injection.language "latex"))
 
 ;; Special roles - suffix
 
 ((interpreted_text
-  "interpreted_text" @latex
+  "interpreted_text" @injection.content
   (role) @_role)
- (#eq? @_role ":math:"))
+ (#eq? @_role ":math:")
+ (#set! injection.language "latex"))
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/ruby/injections.scm
+++ b/runtime/queries/ruby/injections.scm
@@ -1,9 +1,12 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))
 
 (heredoc_body
- (heredoc_content) @content
- (heredoc_end) @language
- (#set! "language" @language)
+ (heredoc_content) @injection.content
+ (heredoc_end) @injection.language
+ (#set! "language" @injection.language)
  (#downcase! "language"))
 
-(regex (string_content) @regex)
+(regex 
+  (string_content) @injection.content 
+  (#set! injection.language "regex"))

--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -1,34 +1,39 @@
 (macro_invocation
-  (token_tree) @rust)
+  (token_tree) @injection.content (#set! injection.language "rust"))
 
 (macro_definition
   (macro_rule
-    left: (token_tree_pattern) @rust
-    right: (token_tree) @rust))
+    left: (token_tree_pattern) @injection.content 
+    (#set! injection.language "rust")))
 
-[
+(macro_definition
+  (macro_rule
+    right: (token_tree) @injection.content
+    (#set! injection.language "rust")))
+
+([
   (line_comment)
   (block_comment)
-] @comment
+] @injection.content
+ (#set! injection.language "comment"))
 
-(
-  (macro_invocation
-    macro: ((identifier) @_html_def)
-    (token_tree) @html)
-
-    (#eq? @_html_def "html")
-)
+((macro_invocation
+   macro: ((identifier) @injection.language)
+   (token_tree) @injection.content)
+ (#eq? @injection.language "html"))
 
 (call_expression
   function: (scoped_identifier
     path: (identifier) @_regex (#eq? @_regex "Regex")
     name: (identifier) @_new (#eq? @_new "new"))
   arguments: (arguments
-    (raw_string_literal) @regex))
+    (raw_string_literal) @injection.content)
+    (#set! injection.language "regex"))
 
 (call_expression
   function: (scoped_identifier
     path: (scoped_identifier (identifier) @_regex (#eq? @_regex "Regex").)
     name: (identifier) @_new (#eq? @_new "new"))
   arguments: (arguments
-    (raw_string_literal) @regex))
+    (raw_string_literal) @injection.content)
+    (#set! injection.language "regex"))

--- a/runtime/queries/scala/injections.scm
+++ b/runtime/queries/scala/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/scheme/injections.scm
+++ b/runtime/queries/scheme/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/smali/injections.scm
+++ b/runtime/queries/smali/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/sparql/injections.scm
+++ b/runtime/queries/sparql/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/sql/injections.scm
+++ b/runtime/queries/sql/injections.scm
@@ -1,3 +1,6 @@
-(comment) @comment
-(marginalia) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
+((marginalia) @injection.content
+ (#set! injection.language "comment"))
 

--- a/runtime/queries/squirrel/injections.scm
+++ b/runtime/queries/squirrel/injections.scm
@@ -1,9 +1,12 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
-((verbatim_string) @html
-  (#lua-match? @html "^@\"<html")
-  (#offset! @html 0 2 0 -1))
+((verbatim_string) @injection.content
+  (#lua-match? @injection.content "^@\"<html")
+  (#set! injection.language "html")
+  (#offset! @injection.content 0 2 0 -1))
 
-((verbatim_string) @html
-  (#lua-match? @html "@\"<!DOCTYPE html>")
-  (#offset! @html 0 2 0 -1))
+((verbatim_string) @injection.content
+  (#lua-match? @injection.content "@\"<!DOCTYPE html>")
+  (#set! injection.languge "html")
+  (#offset! @injection.content 0 2 0 -1))

--- a/runtime/queries/supercollider/injections.scm
+++ b/runtime/queries/supercollider/injections.scm
@@ -1,4 +1,5 @@
-[
+([
   (line_comment)
   (block_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/surface/injections.scm
+++ b/runtime/queries/surface/injections.scm
@@ -1,8 +1,10 @@
 ; Surface expressions and components are Elixir code
-[
+([
   (expression_value)
   (component_name)
-] @elixir
+] @injection.content
+ (#set! injection.language "elixir"))
 
 ; Surface comments are nvim-treesitter comments
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/svelte/injections.scm
+++ b/runtime/queries/svelte/injections.scm
@@ -1,40 +1,41 @@
 ; inherits: html_tags
 
-(
-  (style_element
+((style_element
     (start_tag
       (attribute
         (attribute_name) @_attr
         (quoted_attribute_value (attribute_value) @_lang)))
-    (raw_text) @scss)
+    (raw_text) @injection.content)
   (#eq? @_attr "lang")
   (#any-of? @_lang "scss" "postcss" "less")
-)
+  (#set! injection.language "scss")
+  (#set! injection.include-children))
 
-[
+([
   (raw_text_expr)
   (raw_text_each)
-] @javascript
+] @injection.content
+ (#set! injection.language "javascript")
+ (#set! injection.include-children))
 
-(
-  (script_element
+((script_element
     (start_tag
       (attribute
         (attribute_name) @_attr
         (quoted_attribute_value (attribute_value) @_lang)))
-    (raw_text) @typescript)
-  (#eq? @_attr "lang") 
-  (#any-of? @_lang "ts" "typescript")
-)
+    (raw_text) @injection.content)
+ (#eq? @_attr "lang") 
+ (#any-of? @_lang "ts" "typescript")
+ (#set! injection.language "typescript")
+ (#set! injection.include-children))
 
-(
-  (element
-    (start_tag
-      (attribute
-        (attribute_name) @_attr
-        (quoted_attribute_value
-          (attribute_value) @_lang)))
-    (text) @pug)
-  (#eq? @_attr "lang") 
-  (#eq? @_lang "pug")
-)
+((element
+   (start_tag
+     (attribute
+       (attribute_name) @_attr
+       (quoted_attribute_value
+         (attribute_value) @injection.language)))
+   (text) @injection.content)
+ (#eq? @_attr "lang") 
+ (#eq? @injection.language "pug")
+ (#set! injection.include-children))

--- a/runtime/queries/sxhkdrc/injections.scm
+++ b/runtime/queries/sxhkdrc/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/t32/injections.scm
+++ b/runtime/queries/t32/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/tablegen/injections.scm
+++ b/runtime/queries/tablegen/injections.scm
@@ -1,7 +1,9 @@
-((code) @cpp
-  (#offset! @cpp 0 2 0 -2))
+((code) @injection.content
+  (#set! injection.language "cpp")
+  (#offset! @injection.content 0 2 0 -2))
 
 ((tablegen_file
-  (comment) @bash)
-  (#lua-match? @bash "^.*RUN")
-  (#offset! @bash 0 8))
+  (comment) @injection.content)
+  (#lua-match? @injection.content "^.*RUN")
+  (#set! injection.language "bash")
+  (#offset! @injection.content 0 8))

--- a/runtime/queries/teal/injections.scm
+++ b/runtime/queries/teal/injections.scm
@@ -3,12 +3,13 @@
     (index
       (identifier) @_cdef_identifier)
     (arguments
-      (string) @c)
+      (string) @injection.content)
   )
 
   (#eq? @_cdef_identifier "cdef")
-  (#lua-match? @c "^[\"']")
-  (#offset! @c 0 1 0 -1)
+  (#lua-match? @injection.content "^[\"']")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.language "c")
 )
 
 (
@@ -16,12 +17,14 @@
     (index
       (identifier) @_cdef_identifier)
     (arguments
-      (string) @c)
+      (string) @injection.content)
   )
 
   (#eq? @_cdef_identifier "cdef")
-  (#lua-match? @c "^%[%[")
-  (#offset! @c 0 2 0 -2)
+  (#lua-match? @injection.content "^%[%[")
+  (#offset! @injection.content 0 2 0 -2)
+  (#set! injection.language "c")
 )
 
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/thrift/injections.scm
+++ b/runtime/queries/thrift/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/tiger/injections.scm
+++ b/runtime/queries/tiger/injections.scm
@@ -1,3 +1,4 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 ; vim: sw=2 foldmethod=marker

--- a/runtime/queries/tlaplus/injections.scm
+++ b/runtime/queries/tlaplus/injections.scm
@@ -1,4 +1,5 @@
-[
+([
   (comment)
   (block_comment_text)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/toml/injections.scm
+++ b/runtime/queries/toml/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/turtle/injections.scm
+++ b/runtime/queries/turtle/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/twig/injections.scm
+++ b/runtime/queries/twig/injections.scm
@@ -1,2 +1,3 @@
-(content) @html
+((content) @injection.content
+ (#set! injection.language "html"))
 

--- a/runtime/queries/ungrammar/injections.scm
+++ b/runtime/queries/ungrammar/injections.scm
@@ -1,2 +1,3 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 

--- a/runtime/queries/uxntal/injections.scm
+++ b/runtime/queries/uxntal/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/v/injections.scm
+++ b/runtime/queries/v/injections.scm
@@ -1,13 +1,16 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 ;; asm_statement if asm ever highlighted :)
 
 ;; #include <...>
-(hash_statement) @c
+((hash_statement) @injection.content
+ (#set! injection.language "c"))
 
 ;; regex for the methods defined in `re` module
 ((call_expression
     function: (selector_expression
       field: (identifier) @_re)
     arguments: (argument_list
-  (raw_string_literal) @regex (#offset! @regex 0 2 0 -1)))
-  (#any-of? @_re "regex_base" "regex_opt" "compile_opt"))
+  (raw_string_literal) @injection.content (#offset! @injection.content 0 2 0 -1)))
+  (#any-of? @_re "regex_base" "regex_opt" "compile_opt")
+  (#set! injection.language "regex"))

--- a/runtime/queries/verilog/injections.scm
+++ b/runtime/queries/verilog/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/vim/injections.scm
+++ b/runtime/queries/vim/injections.scm
@@ -1,18 +1,35 @@
-(lua_statement (script (body) @lua))
-(lua_statement (chunk) @lua)
-(ruby_statement (script (body) @ruby))
-(ruby_statement (chunk) @ruby)
-(python_statement (script (body) @python))
-(python_statement (chunk) @python)
+(lua_statement 
+  (script 
+    (body) @injection.content
+    (#set! injection.language "lua")))
+(lua_statement 
+  (chunk) @injection.content
+  (#set! injection.language "lua"))
+(ruby_statement 
+  (script 
+    (body) @injection.content 
+    (#set! injection.language "ruby")))
+(ruby_statement 
+  (chunk) @injection.content 
+  (#set! injection.language "ruby"))
+(python_statement 
+  (script 
+    (body) @injection.content 
+    (#set! injection.language "python")))
+(python_statement 
+  (chunk) @injection.content 
+  (#set! injection.language "python"))
 ;; If we support perl at some point...
 ;; (perl_statement (script (body) @perl))
 ;; (perl_statement (chunk) @perl)
 
-(autocmd_statement (pattern) @regex)
+(autocmd_statement 
+  (pattern) @injection.content 
+  (#set! injection.language "regex"))
 
 ((set_item
    option: (option_name) @_option
-   value: (set_value) @vim)
+   value: (set_value) @injection.content)
   (#any-of? @_option
     "includeexpr" "inex"
     "printexpr" "pexpr"
@@ -22,6 +39,8 @@
     "foldexpr" "fde"
     "diffexpr" "dex"
     "patchexpr" "pex"
-    "charconvert" "ccv"))
+    "charconvert" "ccv")
+  (#set! injection.language "vim"))
 
-(comment) @comment
+((comment) @injection.content 
+ (#set! injection.language "comment"))

--- a/runtime/queries/vimdoc/injections.scm
+++ b/runtime/queries/vimdoc/injections.scm
@@ -1,3 +1,4 @@
-(codeblock
-  (language) @language
-  (code) @content)
+((codeblock
+  (language) @injection.language
+  (code) @injection.content)
+  (#set! injection.include-children)) 

--- a/runtime/queries/vue/injections.scm
+++ b/runtime/queries/vue/injections.scm
@@ -5,30 +5,36 @@
     (start_tag
       (attribute
         (attribute_name) @_lang
-        (quoted_attribute_value (attribute_value) @_css)))
+        (quoted_attribute_value (attribute_value) @injection.language)))
+    (raw_text) @injection.content)
     (#eq? @_lang "lang")
-    (#eq? @_css "css")
-    (raw_text) @css))
+    (#any-of? @injection.language "css" "scss")
+    (#set! injection.include-children))
 
-; TODO: When nvim-treesitter have postcss and less parser, use @language and @content instead
+; TODO: When nvim-treesitter has postcss and less parsers, use @injection.language and @injection.content instead
 ; <script lang="scss">
 ((style_element
     (start_tag
       (attribute
         (attribute_name) @_lang
         (quoted_attribute_value (attribute_value) @_scss)))
+    (raw_text) @injection.content
     (#eq? @_lang "lang")
-    (#any-of? @_scss "scss" "less" "postcss")
-    (raw_text) @scss))
+    (#any-of? @_scss "less" "postcss")
+    (#set! injection.language "scss")
+    (#set! injection.include-children)))
+
 ; <script lang="js">
 ((script_element
     (start_tag
       (attribute
         (attribute_name) @_lang
         (quoted_attribute_value (attribute_value) @_js)))
+    (raw_text) @injection.content)
     (#eq? @_lang "lang")
     (#eq? @_js "js")
-    (raw_text) @javascript))
+    (#set! injection.language "javascript")
+    (#set! injection.include-children))
 
 ; <script lang="ts">
 ((script_element
@@ -36,9 +42,11 @@
       (attribute
         (attribute_name) @_lang
         (quoted_attribute_value (attribute_value) @_ts)))
+    (raw_text) @injection.content)
     (#eq? @_lang "lang")
     (#eq? @_ts "ts")
-    (raw_text) @typescript))
+    (#set! injection.language "typescript")
+    (#set! injection.include-children))
 
 ; <script lang="tsx">
 ; <script lang="jsx">
@@ -46,21 +54,27 @@
     (start_tag
       (attribute
         (attribute_name) @_attr
-        (quoted_attribute_value (attribute_value) @language)))
+        (quoted_attribute_value (attribute_value) @injection.language)))
     (#eq? @_attr "lang")
-    (#any-of? @language "tsx" "jsx")
-    (raw_text) @content))
+    (#any-of? @injection.language "tsx" "jsx")
+    (raw_text) @injection.content)
+    (#set! injection.include-children))
 
 ((interpolation
-  (raw_text) @javascript))
+  (raw_text) @injection.content)
+  (#set! injection.language "javascript")
+  (#set! injection.include-children))
 
-((directive_attribute
-    (quoted_attribute_value
-      (attribute_value) @javascript)))
+(directive_attribute
+  (quoted_attribute_value
+    (attribute_value) @injection.content
+    (#set! injection.language "javascript")
+    (#set! injection.include-children)))
 
-((template_element
+(template_element
     (start_tag
       (attribute
-        (quoted_attribute_value (attribute_value) @_lang)))
-    (#eq? @_lang "pug")
-    (text) @pug))
+        (quoted_attribute_value (attribute_value) @injection.language)))
+    (text) @injection.content
+    (#eq? @injection.language "pug")
+    (#set! injection.include-children))

--- a/runtime/queries/yaml/injections.scm
+++ b/runtime/queries/yaml/injections.scm
@@ -1,22 +1,27 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 ;; Github actions ("run") / Gitlab CI ("scripts")
 (block_mapping_pair
   key: (flow_node) @_run (#any-of? @_run "run" "script" "before_script" "after_script")
   value: (flow_node
-           (plain_scalar) @bash))
+           (plain_scalar) @injection.content
+           (#set! injection.language "bash")))
 
 (block_mapping_pair
   key: (flow_node) @_run (#any-of? @_run "run" "script" "before_script" "after_script")
   value: (block_node
-           (block_scalar) @bash (#offset! @bash 0 1 0 0)))
+           (block_scalar) @injection.content 
+           (#set! injection.language "bash")
+           (#offset! @injection.content 0 1 0 0)))
 
 (block_mapping_pair
   key: (flow_node) @_run (#any-of? @_run "run" "script" "before_script" "after_script")
   value: (block_node
            (block_sequence
              (block_sequence_item
-               (flow_node) @bash))))
+                (flow_node) @injection.content
+                (#set! injection.language "bash")))))
 
 (block_mapping_pair
   key: (flow_node) @_run (#any-of? @_run "script" "before_script" "after_script")
@@ -24,4 +29,6 @@
            (block_sequence
              (block_sequence_item
                (block_node
-                  (block_scalar) @bash (#offset! @bash 0 1 0 0))))))
+                  (block_scalar) @injection.content 
+                  (#set! injection.language "bash")
+                  (#offset! @injection.content 0 1 0 0))))))

--- a/runtime/queries/yang/injections.scm
+++ b/runtime/queries/yang/injections.scm
@@ -1,6 +1,8 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))
 
 ((statement
   (statement_keyword "pattern")
-  (argument (string) @regex))
- (#offset! @regex 0 1 0 -1))
+  (argument (string) @injection.content))
+ (#set! injection.language "regex")
+ (#offset! @injection.content 0 1 0 -1))

--- a/runtime/queries/yuck/injections.scm
+++ b/runtime/queries/yuck/injections.scm
@@ -1,1 +1,2 @@
-(comment) @comment
+((comment) @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/zig/injections.scm
+++ b/runtime/queries/zig/injections.scm
@@ -1,5 +1,7 @@
-[
+([
   (container_doc_comment)
   (doc_comment)
   (line_comment)
-] @comment
+ ] @injection.content
+ (#set! injection.language "comment"))
+  


### PR DESCRIPTION
Since 0.9, `@lang` syntax is still available fallback but will soon be deprecated.
Because of that, new syntax should be adopted once 0.9 becomes the baseline requirements for nvim-treesitter

Todo:
- [ ] Update queries
  - [x] Odin
  - [x] Usd 
- [ ] Rebase + Update if necessary

Blocker:
- neovim/neovim#23409
- Some parsers, notably can be seen in HTML/Vue/JS will not work properly sometimes without `include-children`. The `<script></script>` range can be considered as jsx elements when there's no non-whitespace characters in the middle of it
  - For those cases, the injected region was zero-byte, leading to a top-level tree unexpectedly
-  ...