### PR TITLE
feat(c): highlight parenthesized function pointer decl identifiers as `@function`

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -130,7 +130,6 @@
 
 [
  (type_identifier)
- (sized_type_specifier)
  (type_descriptor)
 ] @type
 
@@ -145,6 +144,8 @@
   declarator: (type_identifier) @type.definition)
 
 (primitive_type) @type.builtin
+
+(sized_type_specifier _ @type.builtin type: _)
 
 ((identifier) @constant
  (#lua-match? @constant "^[A-Z][A-Z0-9_]+$"))
@@ -171,6 +172,10 @@
     field: (field_identifier) @function.call))
 (function_declarator
   declarator: (identifier) @function)
+(function_declarator
+  declarator: (parenthesized_declarator
+                (pointer_declarator
+                  declarator: (field_identifier) @function)))
 (preproc_function_def
   name: (identifier) @function.macro)
 


### PR DESCRIPTION
Motivation - function pointers in struct fields

Before:
![image](https://user-images.githubusercontent.com/29718261/233542536-330864da-23d1-4ff0-ba1f-bb06cae498db.png)

After:
![image](https://user-images.githubusercontent.com/29718261/233542562-942c9698-4c61-4432-b6bf-c0c51ec0e50e.png)
