### PR TITLE
add `-f` argument to "mv" command to avoid updating error

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -213,7 +213,7 @@ function M.select_mv_cmd(from, to, cwd)
     return {
       cmd = "mv",
       opts = {
-        args = { from, to },
+        args = { "-f", from, to },
         cwd = cwd,
       },
     }


### PR DESCRIPTION
Hi, I found there is an error when I update nvim-treesitter from lazy.nvim, after updated and re-open nvim, I get the following error.
[![asciicast](https://asciinema.org/a/D5eyrVYvfrlNlrOtFu9uSWbQx.svg)](https://asciinema.org/a/D5eyrVYvfrlNlrOtFu9uSWbQx)

It seems that the new compiled `parser.so` can't be move to target directory because it exists, to avoid the error, I have to remove target directory manually, and re-open nvim again..

So I'd like to propose a `-f` argument to "mv" command to avoid such issue.  I've confirmed that `-f` flag exists on Linux, MacOS, and Nushell
