### PR TITLE
fix: Correct scope definition for scala

### DIFF
--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -3,7 +3,7 @@
 [
   (template_body)
   (lambda_expression)
-  (function_declaration)
+  (function_definition)
   (block)
 ] @scope
 


### PR DESCRIPTION
`@scope` included `function_declaration` while is should have included `function_definition` instead. The former one is used to declare abstract functions while the latter one is used to define functions together with their bodies.