### PR TITLE
fix(ecma): enable highlight for @keyword.export

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -341,6 +341,10 @@
   "finally"
 ] @exception
 
+[
+  "export"
+] @keyword.export
+
 (export_statement
   "default" @keyword)
 (switch_default


### PR DESCRIPTION
Enable highlight for `export` keyword in `javascript` filetype