### PR TITLE
fix(python): fields should not match uppercase-beginning names

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -29,7 +29,7 @@
 
 ((attribute
     attribute: (identifier) @field)
- (#lua-match? @field "^.*%l.*$"))
+ (#lua-match? @field "^[%l_].*$"))
 
 ((assignment
   left: (identifier) @type.definition


### PR DESCRIPTION
Closes #4732 