### PR TITLE
feat: add py-script injections for html

### DIFF
--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -1,1 +1,24 @@
 ; inherits html_tags
+
+(element
+  (start_tag
+    (tag_name) @_py_script)
+  (text) @python
+  (#any-of? @_py_script "py-script" "py-repl"))
+
+(script_element
+  (start_tag
+    (attribute
+      (attribute_name) @_attr 
+      (quoted_attribute_value 
+        (attribute_value) @_type)))
+  (raw_text) @python
+  (#eq? @_attr "type")
+  ; not adding type="py" here as it's handled by html_tags 
+  (#any-of? @_type "pyscript" "py-script"))
+
+(element
+  (start_tag
+    (tag_name) @_py_config)
+  (text) @toml
+  (#eq? @_py_config "py-config"))


### PR DESCRIPTION
Too niche, maybe?

I put this in html instead of `html_tags` as there can definitely be some cases where people name their components `py-script`, but this can't happen in html.

Infos are from

- https://docs.pyscript.net/latest/tutorials/index.html
- https://github.com/pyscript/pyscript/