### PR TITLE
fix: query missing dedent for "]"

### DIFF
--- a/queries/query/indents.scm
+++ b/queries/query/indents.scm
@@ -6,3 +6,7 @@
   "["
   "]"
 ] @indent.begin
+
+[
+  "]"
+] @indent.branch


### PR DESCRIPTION
```scheme
[
  ...
  ]
```

now should become
```scheme
[
  ...
]
```