### PR TITLE
feat(go): highlight constructors

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -15,9 +15,6 @@
 
 (label_name) @label
 
-((identifier) @constant
- (#eq? @constant "_"))
-
 (const_spec
   name: (identifier) @constant)
 
@@ -40,6 +37,14 @@
 
 (method_spec 
   name: (field_identifier) @method) 
+
+; Constructors
+
+((call_expression (identifier) @constructor)
+  (#lua-match? @constructor "^[nN]ew.+$"))
+
+((call_expression (identifier) @constructor)
+  (#lua-match? @constructor "^[mM]ake.+$"))
 
 ; Operators
 


### PR DESCRIPTION
Priority is to beat the lsp, removed _ as that's not a constant but more a discard, could be `@comment` like Gleam but `@constant` is just wrong