### PR TITLE
ci: tighten run requirements, apply formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,14 +41,14 @@ body:
   - type: textarea
     attributes:
       label: Output of `:checkhealth nvim-treesitter`
-      render: markdown
+      render: Markdown
     validations:
       required: true
 
   - type: textarea
     attributes:
       label: Output of `nvim --version`
-      render: text
+      render: Text
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/highlighting_issue.yml
+++ b/.github/ISSUE_TEMPLATE/highlighting_issue.yml
@@ -81,14 +81,14 @@ body:
   - type: textarea
     attributes:
       label: Output of `:checkhealth nvim-treesitter`
-      render: markdown
+      render: Markdown
     validations:
       required: true
 
   - type: textarea
     attributes:
       label: Output of `nvim --version`
-      render: text
+      render: Text
     validations:
       required: true
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,9 +12,9 @@ pull_request_rules:
   - name: Prepare for merge
     conditions:
       - and:
-        - "-draft"
-        - "#approved-reviews-by=1"
-        - "#review-requested=0"
+          - "-draft"
+          - "#approved-reviews-by=1"
+          - "#review-requested=0"
     actions:
       comment:
         message: |
@@ -25,13 +25,13 @@ pull_request_rules:
   - name: Merge on approval
     conditions:
       - and:
-        - or:
-          - "#approved-reviews-by>=2"
-          - and:
-            - "#approved-reviews-by=1"
-            - "updated-at>=1 day ago"
-        - "-draft"
-        - "#review-requested=0"
+          - or:
+              - "#approved-reviews-by>=2"
+              - and:
+                  - "#approved-reviews-by=1"
+                  - "updated-at>=1 day ago"
+          - "-draft"
+          - "#review-requested=0"
     actions:
       merge:
         method: rebase

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,15 @@ name: Linting and style checking
 
 on:
   push:
+    paths:
+      - "lua/**"
+      - "scripts/**"
+      - "tests/**"
   pull_request:
+    paths:
+      - "lua/**"
+      - "scripts/**"
+      - "tests/**"
 
 jobs:
   luacheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: "release"
 on:
   push:
     tags:
-      - '*'
+      - "*"
 jobs:
   luarocks-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - "master"
+    paths:
+      - "lockfile.json"
+      - "queries/**"
   pull_request:
     branches:
       - "master"
+    paths:
+      - "lockfile.json"
+      - "queries/**"
 
 # Cancel any in-progress CI runs for a PR if it is updated
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,21 @@ on:
   push:
     branches:
       - "master"
+    paths:
+      - "lockfile.json"
+      - "lua/**"
+      - "queries/**"
+      - "scripts/**"
+      - "tests/**"
   pull_request:
     branches:
       - "master"
+    paths:
+      - "lockfile.json"
+      - "lua/**"
+      - "queries/**"
+      - "scripts/**"
+      - "tests/**"
 
 # Cancel any in-progress CI runs for a PR if it is updated
 concurrency:

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -44,7 +44,7 @@ jobs:
           git add lockfile.json
           UPDATED_PARSERS=$(/tmp/jd -f merge /tmp/old_lockfile.json lockfile.json | jq -r 'keys | join(", ")')
           echo "UPDATED_PARSERS=$UPDATED_PARSERS" >> $GITHUB_ENV
-          git commit -m "Update parsers: $UPDATED_PARSERS" || echo 'No commit necessary!'
+          git commit -m "chore(parsers): update $UPDATED_PARSERS" || echo 'No commit necessary!'
           git clean -xf
 
       - name: Create Pull Request

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - lua/nvim-treesitter/parsers.lua
   workflow_dispatch:
 
 jobs:
@@ -29,7 +31,7 @@ jobs:
           git config user.name "Github Actions"
           ./nvim.appimage --headless -c "luafile ./scripts/update-readme.lua" -c "q" || echo "Needs update"
           git add README.md
-          git commit -m "Update README" || echo 'No commit necessary!'
+          git commit -m "docs: update README" || echo 'No commit necessary!'
           git clean -xf
 
       - name: Create Pull Request

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 
 <!--This section of the README is automatically updated by a CI job-->
 <!--parserinfo-->
+
 - [x] [ada](https://github.com/briot/tree-sitter-ada) (maintained by @briot)
 - [x] [agda](https://github.com/AusCyberman/tree-sitter-agda) (maintained by @Decodetalkers)
 - [x] [arduino](https://github.com/ObserverOfTime/tree-sitter-arduino) (maintained by @ObserverOfTime)

--- a/scripts/update-readme.lua
+++ b/scripts/update-readme.lua
@@ -17,7 +17,7 @@ table.sort(sorted_parsers, function(a, b)
   return a.name < b.name
 end)
 
-local generated_text = ""
+local generated_text = "\n"
 
 ---@param v Parser
 for _, v in ipairs(sorted_parsers) do


### PR DESCRIPTION
* For example, a typo fix doesn't need every action to run
* Added a \n above the parsers list in the README as formatting specs indicate it should be there, and this will alleviate people using autoformatters having to remove that

