### PR TITLE
fix: remove unnecessary offset from html injection

### DIFF
--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -71,5 +71,4 @@
 (attribute
   (attribute_name) @_name
   (#lua-match? @_name "^on[a-z]+$")
-  (#offset! @javascript 0 1 0 -1)
-  (quoted_attribute_value) @javascript)
+  (quoted_attribute_value (attribute_value) @javascript))


### PR DESCRIPTION
Don't see why this is necessary when the insides can be captured directly