### PR TITLE
ref(c_sharp): highlight ternary operators as `@conditional.ternary`

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -298,6 +298,8 @@
  ":"
 ] @punctuation.delimiter
 
+(conditional_expression ["?" ":"] @conditional.ternary)
+
 [
  "["
  "]"


### PR DESCRIPTION
The `?` is highlighted `@operator` and the `:` is highlighted as `@punctuation.delimiter`. The `@conditional.ternary` group exists for this purpose, so it seems right.

Let me know if anything needs to be changed, or feel free to close if it isn't appropriate