### PR TITLE
ref(rust): highlight debug macros as `@debug`

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -306,3 +306,5 @@
  (#eq? @_ident "panic"))
 (macro_invocation macro: (identifier) @_ident @exception "!" @exception
  (#contains? @_ident "assert"))
+(macro_invocation macro: (identifier) @_ident @debug "!" @debug
+ (#contains? @_ident "dbg" "debug"))

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -307,4 +307,4 @@
 (macro_invocation macro: (identifier) @_ident @exception "!" @exception
  (#contains? @_ident "assert"))
 (macro_invocation macro: (identifier) @_ident @debug "!" @debug
- (#contains? @_ident "dbg" "debug"))
+ (#eq? @_ident "dbg"))


### PR DESCRIPTION
E.g. `dbg!` and `debug_assert!`

They are currently just highlighted as `@macro`, which is accurate, but there is a dedicated capture for debug keywords so it seems right.

The order of `assert` and `debug` can be swapped if it's desired to let `debug_assert` show as `@exception`

Let me know if anything needs to be changed, or feel free to close if it isn't appropriate