### PR TITLE
ref(rust): highlight include macros as `@include`

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -306,3 +306,5 @@
  (#eq? @_ident "panic"))
 (macro_invocation macro: (identifier) @_ident @exception "!" @exception
  (#contains? @_ident "assert"))
+(macro_invocation macro: (identifier) @_ident @include "!" @include
+ (#contains? @_ident "include"))


### PR DESCRIPTION
e.g. `include_str!`

They are currently highlighted as `@macro`, which is accurate, but the `@include` group feels more precise (and similar to C, where `#include` is highlighted with this group)

Let me know if anything needs to be changed, or feel free to close if it isn't appropriate