### PR TITLE
ref(c_sharp): highlight `<`, `>` as bracket only in type param list

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -305,9 +305,9 @@
  "}"
  "("
  ")"
- "<"
- ">"
 ] @punctuation.bracket
+
+(type_argument_list ["<" ">"] @punctuation.bracket)
 
 [
  (this_expression)


### PR DESCRIPTION
This allows `x > 4` to show `>` as `@operator`, whereas it is currently `@punctuation.bracket`

Let me know if anything needs to be changed, or feel free to close if it isn't appropriate