### PR TITLE
ref(java): highlight `Foo<Bar>` as `@punctuation.delimiter`

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -258,6 +258,9 @@
 
 [ "(" ")" ] @punctuation.bracket
 
+(type_arguments [ "<" ">" ] @punctuation.bracket)
+(type_parameters [ "<" ">" ] @punctuation.bracket)
+
 ; Exceptions
 
 [


### PR DESCRIPTION
It is currently highlighted as `@operator`

Let me know if anything needs to be changed, or feel free to close if it isn't appropriate