### PR TITLE
highlights(sql): refactor `count` to generic `invocation`

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -450,7 +450,7 @@
     "revision": "05f949d3c1c15e3261473a244d3ce87777374dec"
   },
   "sql": {
-    "revision": "9de72fb40cd6d13a64c3aeeabc079c6b8dadb339"
+    "revision": "0f774f4ce1fbc7aa6df6202301e0b08b8c844ae4"
   },
   "squirrel": {
     "revision": "3fefc6b9bb2b4de1b1c461783f675918cd957546"

--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -14,10 +14,6 @@
   (keyword_group_concat)
 ] @function.call
 
-(count
-  name: (keyword_count) @function.call
-  parameter: [(field)]? @parameter)
-
 (table_reference
   name: (identifier) @type)
 


### PR DESCRIPTION
Upstream, we have refactored the `count` node. Since this is also just a normal invocation, we removed this node. Here, we just update the hightlighting of `count`