### PR TITLE
fix(query): allow multiline modeline (inherits/extends)

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -27,8 +27,8 @@
 ((parameters (identifier) @number)
  (#match? @number "^[-+]?[0-9]+(.[0-9]+)?$"))
 
-((program . (comment) @include)
+((program . (comment)* . (comment) @include)
  (#match? @include "^;\ +inherits\ *:"))
 
-((program . (comment) @preproc)
+((program . (comment)* . (comment) @preproc)
  (#match? @preproc "^; +extends"))

--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -28,7 +28,7 @@
  (#match? @number "^[-+]?[0-9]+(.[0-9]+)?$"))
 
 ((program . (comment)* . (comment) @include)
- (#match? @include "^;\ +inherits\ *:"))
+ (#match? @include "^;+ +inherits *:"))
 
 ((program . (comment)* . (comment) @preproc)
- (#match? @preproc "^; +extends"))
+ (#match? @preproc "^;+ +extends"))

--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -28,7 +28,7 @@
  (#match? @number "^[-+]?[0-9]+(.[0-9]+)?$"))
 
 ((program . (comment)* . (comment) @include)
- (#match? @include "^;+ +inherits *:"))
+ (#match? @include "^;+ *inherits *:"))
 
 ((program . (comment)* . (comment) @preproc)
- (#match? @preproc "^;+ +extends"))
+ (#match? @preproc "^;+ *extends"))


### PR DESCRIPTION
`:h treesitter-query-modeline` reads:
```vimdoc
Note: These modeline comments must be at the top of the query, but can be
repeated, for example, the following two modeline blocks are both valid:
>query

    ;; inherits: foo,bar
    ;; extends

    ;; extends
    ;;
    ;; inherits: baz
<
```
This PR just allows multiple comments to start the block.