### PR TITLE
chore: Add notes for indents.scm files

### DIFF
--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -1,7 +1,7 @@
 [
-  (compound_statement) 
+  (compound_statement)          ; Most { ... } blocks
   (field_declaration_list)
-  (case_statement)
+  (case_statement)              ; whatever comes after `case Foo:` 
   (enumerator_list)
   (compound_literal_expression)
   (initializer_list)
@@ -121,6 +121,8 @@
 ((ERROR (parameter_declaration)) @indent.align
  (#set! indent.open_delimiter "(")
  (#set! indent.close_delimiter ")"))
+
+; Functions arguments, i.e. `x(...)`
 ([(argument_list) (parameter_list)] @indent.align
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")"))


### PR DESCRIPTION
Why this should be done?
- `indents.scm` files are a mess
- `insert someone` don't remember what some queries/captures do after a while
- Having some notes on what each capture would be used for will help alleviate the case above (somewhat)
- Easier for other people to jump in and know what they do (No, traversing the whole tree just to know what a node's supposed to stand for is not easy to everyone)

So I'm adding it to languages that I'm fond of, and can recognize what the queries are for. At the very least, the list should contain:
- [ ] ecma(js, ts, tsx)
- [ ] html, vue
- [ ] css, scss
- [ ] c, cpp
- [x] java #4828 
- [ ] lua
- [ ] ocaml
- [ ] python
- [x] swift (I should not forget it that fast, right, well hopefully so)
- [ ] go?

Feel free to push commits/suggest fixes. Specifically cc-ing @amaanq as he has a lot of ts parsers under his maintenance, having notes will be useful for future maintainers