### PR TITLE
highlights(go): add some highlights

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -64,6 +64,8 @@
   "&"
   "&&"
   "&="
+  "&^"
+  "&^="
   "%"
   "%="
   "^"
@@ -92,15 +94,12 @@
 
 [
   "break"
-  "chan"
   "const"
   "continue"
   "default"
   "defer"
-  "go"
   "goto"
   "interface"
-  "map"
   "range"
   "select"
   "struct"
@@ -111,6 +110,7 @@
 
 "func" @keyword.function
 "return" @keyword.return
+"go" @keyword.coroutine
 
 "for" @repeat
 
@@ -134,6 +134,8 @@
            "any"
            "bool"
            "byte"
+           "chan"
+           "comparable"
            "complex128"
            "complex64"
            "error"
@@ -144,6 +146,7 @@
            "int32"
            "int64"
            "int8"
+           "map"
            "rune"
            "string"
            "uint"
@@ -206,7 +209,10 @@
  (false)
 ] @boolean
 
-(nil) @constant.builtin
+[
+ (nil)
+ (iota)
+] @constant.builtin
 
 (keyed_element
   . (literal_element (identifier) @field))


### PR DESCRIPTION
- added missing [operators](https://go.dev/ref/spec#Operators_and_punctuation)
- added [iota](https://go.dev/ref/spec#Predeclared_identifiers) constant
- added comparable
- edited go keyword type