### PR TITLE
highlights(typescript): `is` and `:` in type predicate

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -13,6 +13,7 @@
   "satisfies"
   "module"
   "infer"
+  "is"
 ] @keyword
 
 (as_expression "as" @keyword)
@@ -55,6 +56,9 @@
   "&" @punctuation.delimiter)
 
 (type_annotation
+  ":" @punctuation.delimiter)
+
+(type_predicate_annotation
   ":" @punctuation.delimiter)
 
 (index_signature


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| ![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/4299733/e8a4ae15-9d21-448a-871a-dbe79fa4c6f6) | ![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/4299733/ebd30e78-b13d-4b38-8322-1bcdc6902add) |