### PR TITLE
Add bracket matching for template parameter list

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -234,4 +234,7 @@
 (template_argument_list
   ["<" ">"] @punctuation.bracket)
 
+(template_parameter_list
+  ["<" ">"] @punctuation.bracket)
+
 (literal_suffix) @operator


### PR DESCRIPTION
Template argument lists were already matched this way but not template
parameter lists.  Some people have custom highlighting for @operator and
the current bracket matching for templates is inconsistent.  This diff
below attempts to fix this.
