### PR TITLE
go: register `clear` as a new builtin function

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -35,8 +35,8 @@
 (method_declaration
   name: (field_identifier) @method)
 
-(method_spec 
-  name: (field_identifier) @method) 
+(method_spec
+  name: (field_identifier) @method)
 
 ; Constructors
 
@@ -160,6 +160,7 @@
  (#any-of? @function.builtin
            "append"
            "cap"
+           "clear"
            "close"
            "complex"
            "copy"


### PR DESCRIPTION
The next Version of Go (1.21) introduces a new built-in function `clear`: https://github.com/golang/go/blob/8c445b7c9fe6738cbef2040a1011bd11489b0806/src/builtin/builtin.go#L230-L237. 
So, this PR just registers `clear` as a new built-in function.