### PR TITLE
indents(sql): initial support

### DIFF
--- a/queries/sql/indents.scm
+++ b/queries/sql/indents.scm
@@ -1,0 +1,26 @@
+[
+ (select_expression)
+ (cte)
+ (column_definitions)
+ (case)
+ (keyword_when)
+ (keyword_else)
+ (subquery)
+] @indent.begin
+
+
+(compound_statement
+  (keyword_begin)
+  (statement) @indent.begin
+)
+
+(column_definitions "(" @indent.begin)
+(column_definitions ")" @indent.branch)
+(subquery ")" @indent.branch)
+(subquery "(" @indent.begin)
+
+[
+ (keyword_end)
+] @indent.branch
+
+ (keyword_from) @indent.align

--- a/queries/sql/indents.scm
+++ b/queries/sql/indents.scm
@@ -12,11 +12,9 @@
   (keyword_begin)
 ) @indent.begin
 
-(column_definitions "(" @indent.begin)
 (column_definitions ")" @indent.branch)
 
 (subquery ")" @indent.branch)
-(subquery "(" @indent.begin)
 
 (cte ")" @indent.branch)
 

--- a/queries/sql/indents.scm
+++ b/queries/sql/indents.scm
@@ -1,26 +1,29 @@
 [
- (select_expression)
+ (select)
  (cte)
  (column_definitions)
  (case)
- (keyword_when)
- (keyword_else)
  (subquery)
+ (insert)
 ] @indent.begin
 
 
 (compound_statement
   (keyword_begin)
-  (statement) @indent.begin
-)
+) @indent.begin
 
 (column_definitions "(" @indent.begin)
 (column_definitions ")" @indent.branch)
+
 (subquery ")" @indent.branch)
 (subquery "(" @indent.begin)
 
+(cte ")" @indent.branch)
+
 [
  (keyword_end)
+ (keyword_values)
+ (keyword_into)
 ] @indent.branch
 
- (keyword_from) @indent.align
+(keyword_end) @indent.end

--- a/tests/indent/sql/case.sql
+++ b/tests/indent/sql/case.sql
@@ -1,0 +1,8 @@
+select
+    case
+        when a = 1 then '1'
+        when a = 2 then '2'
+        when a = 3 then '3'
+        else '0'
+    end as stmt1
+from tab;

--- a/tests/indent/sql/compound.sql
+++ b/tests/indent/sql/compound.sql
@@ -1,0 +1,3 @@
+begin
+    create table foo (bar int);
+end;

--- a/tests/indent/sql/create.sql
+++ b/tests/indent/sql/create.sql
@@ -1,0 +1,4 @@
+create table my_table (
+    id bigint,
+    date date
+);

--- a/tests/indent/sql/cte.sql
+++ b/tests/indent/sql/cte.sql
@@ -1,0 +1,7 @@
+with data as (
+    select
+        a,
+        b
+    from tab
+)
+select * from data;

--- a/tests/indent/sql/insert.sql
+++ b/tests/indent/sql/insert.sql
@@ -1,0 +1,5 @@
+insert into mytable
+    (column1, column2)
+values
+    ('john', 123),
+    ('jane', 124);

--- a/tests/indent/sql/select.sql
+++ b/tests/indent/sql/select.sql
@@ -1,0 +1,4 @@
+select
+    a,
+    b
+from tab;

--- a/tests/indent/sql/subquery.sql
+++ b/tests/indent/sql/subquery.sql
@@ -1,0 +1,9 @@
+select
+    id
+from foo
+where id < (
+    select
+        id
+    from bar
+    limit 1
+);

--- a/tests/indent/sql_spec.lua
+++ b/tests/indent/sql_spec.lua
@@ -15,9 +15,5 @@ describe("indent SQL:", function()
     })
   end)
 
-  
-  describe("new line:", function()
-  end)
-
+  describe("new line:", function() end)
 end)
-

--- a/tests/indent/sql_spec.lua
+++ b/tests/indent/sql_spec.lua
@@ -1,0 +1,23 @@
+local Runner = require("tests.indent.common").Runner
+--local XFAIL = require("tests.indent.common").XFAIL
+
+local run = Runner:new(it, "tests/indent/sql", {
+  tabstop = 4,
+  shiftwidth = 4,
+  softtabstop = 0,
+  expandtab = true,
+})
+
+describe("indent SQL:", function()
+  describe("whole file:", function()
+    run:whole_file(".", {
+      expected_failures = {},
+    })
+  end)
+
+  
+  describe("new line:", function()
+  end)
+
+end)
+


### PR DESCRIPTION
As mentioned in #4852 I want to add indentation rules for SQL. 

Some of them are not working as intended and I don't know why. I have added test cases, but I also don't know how to run the tests locally and how the spec file should be written. Here is the indented SQL file for all the test cases with comments what is currently working/not working:
```SQL
-- first term in select_expression is not indented
select
a,
    b
from tab;

-- closing bracket of cte is not dedented
with data as (
    select
    a,
        b
    from tab
    )
select * from data;

-- this works!
create table my_table (
    id bigint,
    date date
);

-- case when then end works
-- issue is again the first term
-- of the select_expression
select
    case
        when a = 1 then '1'
        when a = 2 then '2'
        when a = 3 then '3'
        else '0'
    end as stmt1
from tab;

-- this may require a new node type
-- like a column_list or values_list
insert into mytable
( column1, column2)
values
('john', 123),
('jane', 124);

-- should indent the statement node
begin
create table foo (bar int);
end;

-- opening bracket of subquery should indent
-- or at least I am not sure if thats good style
-- if not, then this also works.. I guess?
select 
id
from foo
where id <
(
    select
    id
    from bar
    limit 1
);
```

I suspect, that for the `insert` statement, we require an extra layer in the AST for the column and values lists to be queriable, right?

Ping @lucario387 