### PR TITLE
feat: markdown indents

### DIFF
--- a/queries/markdown/indents.scm
+++ b/queries/markdown/indents.scm
@@ -1,0 +1,3 @@
+[
+  (list_item)
+] @indent.auto


### PR DESCRIPTION
Should resolve #2178

`indents.scm` only works if there's an `indents.scm` file, and because the root node doesn't have it, there was no root tree, leading to treesitter indents not working, which is the cause of the issue