### PR TITLE
highlights(ecma): convert eligible `@keyword.operator`s

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -256,7 +256,7 @@
 (binary_expression "/" @operator)
 (ternary_expression ["?" ":"] @conditional.ternary)
 (unary_expression ["!" "~" "-" "+"] @operator)
-(unary_expression ["delete" "void" "typeof"] @keyword.operator)
+(unary_expression ["delete" "void"] @keyword.operator)
 
 [
   "("
@@ -305,13 +305,10 @@
   "export"
   "extends"
   "get"
-  "in"
-  "instanceof"
   "let"
   "set"
   "static"
   "target"
-  "typeof"
   "var"
   "with"
 ] @keyword
@@ -333,6 +330,9 @@
 [
   "new"
   "delete"
+  "in"
+  "instanceof"
+  "typeof"
 ] @keyword.operator
 
 [

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -6,16 +6,19 @@
   "export"
   "implements"
   "interface"
-  "keyof"
   "type"
   "namespace"
   "override"
-  "satisfies"
   "module"
   "infer"
 ] @keyword
 
-(as_expression "as" @keyword)
+[
+  "keyof"
+  "satisfies"
+] @keyword.operator
+
+(as_expression "as" @keyword.operator)
 
 [
   "abstract"

--- a/tests/query/highlights/typescript/as.ts
+++ b/tests/query/highlights/typescript/as.ts
@@ -5,4 +5,4 @@ export { foo as bar };
 //           ^ include
 
 const n = 5 as number;
-//          ^ keyword
+//          ^ keyword.operator


### PR DESCRIPTION
This is a follow-up for #4835.