### PR TITLE
Bash: add "select" highlighting

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -64,6 +64,7 @@
  "for"
  "do"
  "done"
+ "select"
  "while"
  ] @repeat
 


### PR DESCRIPTION
"select" is an opening keyword for select statements which are characterized as "for_statement" nodes per the bash language grammar. This adds the corresponding highlight for it under the @repeat group