### PR TITLE
highlights(scala): add support for using directives

### DIFF
--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -252,3 +252,7 @@
   (identifier) @function.builtin
   (#lua-match? @function.builtin "^super$")
 )
+
+;; Scala CLI using directives
+(using_directive_key) @parameter
+(using_directive_value) @string


### PR DESCRIPTION
This accounts for the updates in https://github.com/tree-sitter/tree-sitter-scala/pull/273.
