### PR TITLE
Add extra language injections for latex

### DIFF
--- a/runtime/queries/latex/injections.scm
+++ b/runtime/queries/latex/injections.scm
@@ -10,6 +10,16 @@
   (source_code) @injection.content 
   (#set! injection.language "python"))
 
+(sagesilent_environment
+  code: 
+  (source_code) @injection.content 
+  (#set! injection.language "python"))
+
+(sageblock_environment
+  code: 
+  (source_code) @injection.content 
+  (#set! injection.language "python"))
+
 (minted_environment
   (begin
     language: (curly_group_text


### PR DESCRIPTION
Following a recent [pull request](https://github.com/latex-lsp/tree-sitter-latex/pull/89) to [the latex parser](https://github.com/latex-lsp/tree-sitter-latex/) treating environments defined by the `sagetex` latex package as "special". This pull request to `nvim-treesitter` is to enable Python language injections in these environments as they contain SageMath code (very similar to python, but there is no SageMath tree-sitter grammar available).

##### Minimal example:

```latex
\documentclass{article}
\usepackage{sagetex}

\begin{document}

\begin{sagesilent}
# python comment
print("Hello, SageTeX!")
\end{sagesilent}

\begin{sageblock}
# python comment
print("Hello, SageTeX!")
\end{sageblock}

\end{document}
```