### PR TITLE
injections(query): add `#gsub!` pattern

### DIFF
--- a/runtime/queries/query/injections.scm
+++ b/runtime/queries/query/injections.scm
@@ -12,5 +12,12 @@
  (#set! injection.language "luap")
  (#offset! @injection.content 0 1 0 -1))
 
+((predicate
+   name: (identifier) @_name
+   parameters: (parameters (string) @injection.content . (string) .))
+ (#any-of? @_name "gsub" "not-gsub")
+ (#set! injection.language "luap")
+ (#offset! @injection.content 0 1 0 -1))
+
 ((comment) @injection.content
  (#set! injection.language "comment"))


### PR DESCRIPTION
Example: 

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/29790821/8a230cb7-d943-4921-b0a0-e9b12b1d9898)
