### PR TITLE
feat(parsers): use gdamore/tree-sitter-d parser for D

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [css](https://github.com/tree-sitter/tree-sitter-css) (maintained by @TravonteD)
 - [x] [cuda](https://github.com/theHamsta/tree-sitter-cuda) (maintained by @theHamsta)
 - [x] [cue](https://github.com/eonpatapon/tree-sitter-cue) (maintained by @amaanq)
-- [x] [d](https://github.com/CyberShadow/tree-sitter-d) (experimental, maintained by @nawordar)
+- [x] [d](https://github.com/gdamore/tree-sitter-d) (maintained by @ljmf00)
 - [x] [dart](https://github.com/UserNobody14/tree-sitter-dart) (maintained by @akinsho)
 - [x] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree) (maintained by @jedrzejboczar)
 - [x] [dhall](https://github.com/jbellerb/tree-sitter-dhall) (maintained by @amaanq)

--- a/lockfile.json
+++ b/lockfile.json
@@ -78,7 +78,7 @@
     "revision": "0deecf48944aa54bb73e5383ba8acfbf9f2c44b4"
   },
   "d": {
-    "revision": "c2fbf21bd3aa45495fe13247e040ad5815250032"
+    "revision": "9120816fd0852b3797eae3bad7bf2b8a966f7f70"
   },
   "dart": {
     "revision": "8aa8ab977647da2d4dcfb8c4726341bee26fbce4"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -289,13 +289,10 @@ list.cue = {
 
 list.d = {
   install_info = {
-    url = "https://github.com/CyberShadow/tree-sitter-d",
-    files = { "src/parser.c", "src/scanner.cc" },
-    requires_generate_from_grammar = true,
+    url = "https://github.com/gdamore/tree-sitter-d",
+    files = { "src/parser.c", "src/scanner.c" },
   },
-  -- Generating grammar takes ~60s
-  experimental = true,
-  maintainers = { "@nawordar" },
+  maintainers = { "@ljmf00" },
 }
 
 list.dart = {

--- a/queries/d/folds.scm
+++ b/queries/d/folds.scm
@@ -1,1 +1,4 @@
-(block_statement) @fold
+[
+  (block_statement)
+  (aggregate_body)
+] @fold

--- a/queries/d/highlights.scm
+++ b/queries/d/highlights.scm
@@ -1,21 +1,75 @@
+;; Variables
+(identifier) @variable
+
 ;; Misc
 
-[
-  (line_comment)
-  (block_comment)
-  (nesting_block_comment)
-] @comment @spell
+(comment) @comment @spell
 
-((line_comment) @comment.documentation
+((comment) @comment.documentation
   (#lua-match? @comment.documentation "^///[^/]"))
-((line_comment) @comment.documentation
+
+((comment) @comment.documentation
   (#lua-match? @comment.documentation "^///$"))
 
-((block_comment) @comment.documentation
+((comment) @comment.documentation
   (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
 
-((nesting_block_comment) @comment.documentation
+((comment) @comment.documentation
   (#lua-match? @comment.documentation "^/[+][+][^+].*[+]/$"))
+
+(directive) @preproc
+(shebang) @preproc
+
+;; Operators
+
+[
+  "/="
+  "/"
+  ".."
+  "..."
+  "&"
+  "&="
+  "&&"
+  "|"
+  "|="
+  "||"
+  "-"
+  "-="
+  "--"
+  "+"
+  "+="
+  "++"
+  "<"
+  "<="
+  "<<"
+  "<<="
+  ">"
+  ">="
+  ">>="
+  ">>>="
+  ">>"
+  ">>>"
+  "!"
+  "!="
+  "?"
+  "$"
+  "="
+  "=="
+  "*"
+  "*="
+  "%"
+  "%="
+  "^"
+  "^="
+  "^^"
+  "^^="
+  "~"
+  "~="
+  "@"
+  "=>"
+] @operator
+
+;; Punctuation
 
 [
   "(" ")"
@@ -35,254 +89,196 @@
   "$"
 ] @punctuation.special
 
-;; Constants
-
-[
-  "__FILE_FULL_PATH__"
-  "__FILE__"
-  "__FUNCTION__"
-  "__LINE__"
-  "__MODULE__"
-  "__PRETTY_FUNCTION__"
-] @constant.macro
-
-[
-  (wysiwyg_string)
-  (alternate_wysiwyg_string)
-  (double_quoted_string)
-  (hex_string)
-  (delimited_string)
-  (token_string)
-] @string
-
-(character_literal) @character
-
-(integer_literal) @number
-
-(float_literal) @float
-
-[
-  "true"
-  "false"
-] @boolean
-
-;; Functions
-
-(func_declarator
-  (identifier) @function
-)
-
-[
-  "__traits"
-  "__vector"
-  "assert"
-  "is"
-  "mixin"
-  "pragma"
-  "typeid"
-] @function.builtin
-
-(import_expression
-  "import" @function.builtin
-)
-
-(parameter
-  (var_declarator
-    (identifier) @parameter
-  )
-)
-
-(function_literal
-  (identifier) @parameter
-)
-
-(constructor
-  "this" @constructor
-)
-
-(destructor
-  "this" @constructor
-)
-
 ;; Keywords
 
-[
-  "case"
-  "default"
-  "else"
-  "if"
-  "switch"
-] @conditional
+; these are listed first, because they override keyword queries
+(identity_expression (in) @keyword.operator)
+(identity_expression (is) @keyword.operator)
 
 [
-  "break"
-  "continue"
-  "do"
-  "for"
-  "foreach"
-  "foreach_reverse"
-  "while"
-] @repeat
-
-[
-  "__parameters"
-  "alias"
-  "align"
-  "asm"
-  "auto"
-  "body"
-  "class"
-  "debug"
-  "enum"
-  "export"
-  "goto"
-  "interface"
-  "invariant"
-  "macro"
-  "out"
-  "override"
-  "package"
-  "static"
-  "struct"
-  "template"
-  "union"
-  "unittest"
-  "version"
-  "with"
-] @keyword
-
-[
-  "delegate"
-  "function"
-] @keyword.function
-
-"return" @keyword.return
-
-[
-  "cast"
-  "new"
+  (not_in)
+  (not_is)
 ] @keyword.operator
 
 [
-  "+"
-  "++"
-  "+="
-  "-"
-  "--"
-  "-="
-  "*"
-  "*="
-  "%"
-  "%="
-  "^"
-  "^="
-  "^^"
-  "^^="
-  "/"
-  "/="
-  "|"
-  "|="
-  "||"
-  "~"
-  "~="
-  "="
-  "=="
-  "=>"
-  "<"
-  "<="
-  "<<"
-  "<<="
-  ">"
-  ">="
-  ">>"
-  ">>="
-  ">>>"
-  ">>>="
-  "!"
-  "!="
-  "&"
-  "&&"
-] @operator
-
-[
-  "catch"
-  "finally"
-  "throw"
-  "try"
-] @exception
-
-"null" @constant.builtin
-
-[
-  "__gshared"
-  "const"
-  "immutable"
-  "shared"
-] @storageclass
-
-[
-  "abstract"
-  "deprecated"
-  "extern"
-  "final"
-  "inout"
-  "lazy"
-  "nothrow"
-  "private"
-  "protected"
-  "public"
-  "pure"
-  "ref"
-  "scope"
-  "synchronized"
+  (const)
+  (immutable)
+  (inout)
+  (shared)
 ] @type.qualifier
 
-(alias_assignment
-  . (identifier) @type.definition)
+[
+  (gshared)
+  (scope)
+  (abstract)
+  (final)
+  (override)
+  (lazy)
+  (align)
+  (extern)
+  (static)
+  (synchronized)
+  (auto)
+  (ref)
+  (nothrow)
+  (pure)
+  (deprecated)
+] @storageclass
 
-(module_declaration
-  "module" @include
-)
+(parameter_attribute (return) @storageclass)
+(parameter_attribute (in) @storageclass)
+(parameter_attribute (out) @storageclass)
 
-(import_declaration
-  "import" @include
-)
+[
+  (case)
+  (default)
+  (if)
+  (else)
+  (switch)
+] @conditional
 
-(type) @type
+[
+  (break)
+  (continue)
+  (do)
+  (for)
+  (while)
+  (foreach)
+  (foreach_reverse)
+] @repeat
 
-(catch_parameter
-  (qualified_identifier) @type
-)
+[
+  (delegate)
+  (function)
+] @keyword.function
 
-(var_declarations
-  (qualified_identifier) @type
-)
+(return) @keyword.return
 
-(func_declaration
-  (qualified_identifier) @type
-)
+(debug) @debug
+(import) @include
 
-(parameter
-  (qualified_identifier) @type
-)
+[
+  (abstract)
+  (alias)
+  (align)
+  (asm)
+  (assert)
+  (cast)
+  (class)
+  (delete)
+  (enum)
+  (export)
+  (extern)
+  (final)
+  (in)
+  (inout)
+  (interface)
+  (invariant)
+  (is)
+  (lazy)
+  ; "macro" - obsolete
+  (mixin)
+  (module)
+  (new)
+  (nothrow)
+  (out)
+  (override)
+  (package)
+  (pragma)
+  (private)
+  (protected)
+  (public)
+  (pure)
+  (ref)
+  (static)
+  (struct)
+  (super)
+  (synchronized)
+  (template)
+  (this)
+  (typeid)
+  (typeof)
+  (union)
+  (unittest)
+  (version)
+  (with)
+  (gshared)
+  (traits)
+  (vector)
+  (parameters_)
+] @keyword
 
-(class_declaration
-  (identifier) @type
-)
+[
+  (catch)
+  (finally)
+  (throw)
+  (try)
+] @exception
 
-(fundamental_type) @type.builtin
-
-(module_fully_qualified_name (packages (package_name) @namespace))
-(module_name) @namespace
+(label (identifier) @label)
+(goto_statement (goto) @keyword (identifier) @label)
 
 (at_attribute) @attribute
 
-(user_defined_attribute
-  "@" @attribute
-)
+;; Literals
 
-;; Variables
+(int_literal) @number
+(float_literal) @float
+(char_literal) @character
+(string_literal) @string
 
-(primary_expression
-  "this" @variable.builtin
-)
+[
+  (true)
+  (false)
+] @boolean
+
+;; Constants
+
+(null) @constant.builtin
+(special_keyword) @constant.builtin
+
+;; Types
+
+[
+  (void)
+  (bool)
+  (byte)
+  (ubyte)
+  (char)
+  (short)
+  (ushort)
+  (wchar)
+  (dchar)
+  (int)
+  (uint)
+  (long)
+  (ulong)
+  (real)
+  (double)
+  (float)
+
+  ; considered deprecated builtin types
+  (cent)
+  (ucent)
+  (ireal)
+  (idouble)
+  (ifloat)
+  (creal)
+  (double)
+  (cfloat)
+] @type.builtin
+
+(type (identifier) @type)
+
+;; Functions
+
+(function_declaration (identifier) @function)
+
+(call_expression (identifier) @function.call)
+(call_expression (type (identifier) @function.call))
+
+; everything after __EOF_ is plain text
+(end_file) @text
+
+; special node for errors
+(ERROR) @error

--- a/queries/d/indents.scm
+++ b/queries/d/indents.scm
@@ -1,17 +1,24 @@
 [
+  (parameters)
+  (template_parameters)
+  (expression_statement)
+  (aggregate_body)
+  (function_body)
+  (scope_statement)
   (block_statement)
   (case_statement)
-  (token_string)
 ] @indent.begin
 
+(comment) @indent.auto
+
 [
-  "(" ")"
-  "{" "}"
-  "[" "]"
+  (case)
+  (default)
+  "}"
+  "]"
 ] @indent.branch
 
 [
-  (line_comment)
-  (block_comment)
-  (nesting_block_comment)
-] @indent.ignore
+  (directive)
+  (shebang)
+] @indent.zero

--- a/queries/d/injections.scm
+++ b/queries/d/injections.scm
@@ -1,7 +1,1 @@
-[
-  (line_comment)
-  (block_comment)
-  (nesting_block_comment)
-] @comment
-
-(token_string_tokens) @d
+(comment) @comment

--- a/queries/d/locals.scm
+++ b/queries/d/locals.scm
@@ -1,0 +1,36 @@
+;; Definitions
+
+(module_def (module_declaration (module_fqn) @definition.namespace) (#set! "definition.namespace.scope" "global"))
+
+((enum_declaration (enum) . (identifier) @definition.type))
+(enum_declaration ((enum_member . (identifier) @definition.enum)))
+
+((class_declaration (class) . (identifier) @definition.type))
+((struct_declaration (struct) . (identifier) @definition.type))
+(union_declaration (union) . (identifier) @definition.type)
+(alias_declaration (alias_initializer . (identifier) @definition.type))
+
+((constructor (this) @definition.method))
+((destructor (this) @definition.method))
+((postblit (this) @definition.method))
+
+((manifest_declarator . (identifier) @definition.constant))
+(anonymous_enum_declaration ((enum_member . (identifier) @definition.constant)))
+
+((aggregate_body (variable_declaration (type) @definition.associated (declarator (identifier) @definition.field))))
+((aggregate_body (function_declaration (identifier) @definition.method)))
+
+(variable_declaration (type) @definition.associated (declarator (identifier) @definition.var))
+(function_declaration (identifier) @definition.function)
+
+;; Scope
+
+[
+  (source_file)
+  (block_statement)
+  (aggregate_body)
+] @scope
+
+;; References
+
+(identifier) @reference


### PR DESCRIPTION
CC @gdamore @nawordar

This tree-sitter parser is better maintained (manual parser field names) and is now mentioned officially by the tree-sitter org. 

Perhaps, are you comfortable co-maintaining this with me @nawordar ?