### PR TITLE
tests: fix failed tests

### DIFF
--- a/queries/t32/indents.scm
+++ b/queries/t32/indents.scm
@@ -6,7 +6,6 @@
 ; Control flow statements
 (
   (if_block
-    _*
     condition: (_)
     . (_) @_then) @indent.begin
   (#not-has-type? @_then block)
@@ -20,17 +19,16 @@
 (
   (else_block
     (if_block
-      _*
       condition: (_)
       . (_) @_then)) @indent.branch
   (#not-has-type? @_then block)
 )
 
 (while_block
-  (command_expression)) @indent.begin
+  (command_expression)) @indent.auto
 
 (repeat_block
-  (command_expression)) @indent.begin
+  (command_expression)) @indent.auto
 
 
-(comment) @indent.ignore
+(comment) @indent.auto

--- a/queries/tiger/indents.scm
+++ b/queries/tiger/indents.scm
@@ -34,6 +34,7 @@
 (parameters ")" @indent.end)
 
 (function_call) @indent.begin
+(function_call ")" @indent.end)
 (method_call) @indent.begin
 ")" @indent.branch
 

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -5,9 +5,12 @@ vim.cmd.runtime { "plugin/nvim-treesitter.lua", bang = true }
 vim.filetype.add {
   extension = {
     conf = "hocon",
+    cmm = "t32",
     ncl = "nickel",
+    tig = "tiger",
     usd = "usd",
     usda = "usd",
+    wgsl = "wgsl",
   },
 }
 

--- a/tests/indent/t32_spec.lua
+++ b/tests/indent/t32_spec.lua
@@ -16,7 +16,7 @@ describe("indent t32:", function()
   describe("new line:", function()
     runner:new_line("if_block.cmm", { on_line = 2, text = "GOTO start", indent = 0 }, "command after IF", XFAIL)
 
-    runner:new_line("if_block.cmm", { on_line = 5, text = "GOTO start", indent = 2 }, "command in IF then block", XFAIL)
+    runner:new_line("if_block.cmm", { on_line = 5, text = "GOTO start", indent = 2 }, "command in IF then block")
 
     runner:new_line("if_block.cmm", { on_line = 4, text = "(", indent = 0 }, "block after IF")
 
@@ -31,12 +31,11 @@ describe("indent t32:", function()
       runner:new_line(
         "if_block.cmm",
         { on_line = test[1], text = "&x=1.", indent = test[2] },
-        "command in IF then[" .. ii .. "]",
-        XFAIL
+        "command in IF then[" .. ii .. "]"
       )
     end
 
-    runner:new_line("if_block.cmm", { on_line = 45, text = "&x=1.", indent = 4 }, "command in IF then")
+    runner:new_line("if_block.cmm", { on_line = 45, text = "&x=1.", indent = 2 }, "command in IF then")
 
     for ii, test in ipairs {
       { 16, 2 },
@@ -47,12 +46,11 @@ describe("indent t32:", function()
       runner:new_line(
         "if_block.cmm",
         { on_line = test[1], text = "(\n", indent = test[2] },
-        "command in IF else[" .. ii .. "]",
-        XFAIL
+        "command in IF else[" .. ii .. "]"
       )
     end
 
-    runner:new_line("while_block.cmm", { on_line = 2, text = "&x=1.", indent = 0 }, "command after WHILE", XFAIL)
+    runner:new_line("while_block.cmm", { on_line = 2, text = "&x=1.", indent = 2 }, "command after WHILE")
 
     runner:new_line("while_block.cmm", { on_line = 4, text = "&x=1.", indent = 0 }, "command after WHILE")
 
@@ -65,20 +63,18 @@ describe("indent t32:", function()
       runner:new_line(
         "while_block.cmm",
         { on_line = test[1], text = "&x=1.", indent = test[2] },
-        "command in WHILE then block[" .. ii .. "]",
-        XFAIL
+        "command in WHILE then block[" .. ii .. "]"
       )
     end
 
     for ii, test in ipairs {
       { 1, 0, nil },
-      { 4, 0, XFAIL },
+      { 4, 2, XFAIL },
     } do
       runner:new_line(
         "repeat_block.cmm",
         { on_line = test[1], text = "&x=1.", indent = test[2] },
-        "command after RePeaT[" .. ii .. "]",
-        test[3]
+        "command after RePeaT[" .. ii .. "]"
       )
     end
 
@@ -92,8 +88,7 @@ describe("indent t32:", function()
       runner:new_line(
         "repeat_block.cmm",
         { on_line = test[1], text = "&x=1.", indent = test[2] },
-        "command in RePeaT then block[" .. ii .. "]",
-        test[3]
+        "command in RePeaT then block [" .. ii .. "]"
       )
     end
 
@@ -109,8 +104,7 @@ describe("indent t32:", function()
       runner:new_line(
         "subroutine_block.cmm",
         { on_line = test[1], text = "&x=1.", indent = test[2] },
-        "command in subroutine block[" .. ii .. "]",
-        test[3]
+        "command in subroutine block[" .. ii .. "]"
       )
     end
 
@@ -122,8 +116,7 @@ describe("indent t32:", function()
       runner:new_line(
         "subroutine_block.cmm",
         { on_line = test[1], text = "&x=1.", indent = test[2] },
-        "command after subroutine block[" .. ii .. "]",
-        XFAIL
+        "command after subroutine block[" .. ii .. "]"
       )
     end
   end)

--- a/tests/indent/tiger_spec.lua
+++ b/tests/indent/tiger_spec.lua
@@ -1,5 +1,4 @@
 local Runner = require("tests.indent.common").Runner
-local XFAIL = require("tests.indent.common").XFAIL
 
 local runner = Runner:new(it, "tests/indent/tiger", {
   tabstop = 2,
@@ -14,62 +13,46 @@ describe("indent Tiger:", function()
   end)
 
   describe("new line:", function()
-    runner:new_line(
-      "classes.tig",
-      { on_line = 1, text = "var a := 0", indent = 2 },
-      "class declaration beginning",
-      XFAIL
-    )
+    runner:new_line("classes.tig", { on_line = 1, text = "var a := 0", indent = 2 }, "class declaration beginning")
     runner:new_line("classes.tig", { on_line = 2, text = "var a := 0", indent = 2 }, "class declaration after field")
     runner:new_line("classes.tig", { on_line = 4, text = "var a := 0", indent = 2 }, "class declaration after method")
     runner:new_line("classes.tig", { on_line = 5, text = "var a := 0", indent = 0 }, "after class declaration")
-    runner:new_line("classes.tig", { on_line = 7, text = "var a := 0", indent = 2 }, "class type beginning", XFAIL)
+    runner:new_line("classes.tig", { on_line = 7, text = "var a := 0", indent = 2 }, "class type beginning")
     runner:new_line("classes.tig", { on_line = 8, text = "var a := 0", indent = 2 }, "class type after field")
-    runner:new_line("classes.tig", { on_line = 10, text = "self.a := 0", indent = 4 }, "inside method", XFAIL)
+    runner:new_line("classes.tig", { on_line = 10, text = "self.a := 0", indent = 4 }, "inside method")
     runner:new_line("classes.tig", { on_line = 13, text = "var a := 0", indent = 2 }, "class type after method")
     runner:new_line("classes.tig", { on_line = 14, text = "var a := 0", indent = 0 }, "after class type")
 
-    runner:new_line("control-flow.tig", { on_line = 2, text = "true", indent = 4 }, "if condition", XFAIL)
-    runner:new_line("control-flow.tig", { on_line = 4, text = "true", indent = 4 }, "if consequence", XFAIL)
-    runner:new_line("control-flow.tig", { on_line = 4, text = "true", indent = 4 }, "if alternative", XFAIL)
-    runner:new_line("control-flow.tig", { on_line = 10, text = "start := 0", indent = 4 }, "for index start", XFAIL)
-    runner:new_line("control-flow.tig", { on_line = 12, text = "the_end", indent = 4 }, "for index end", XFAIL)
-    runner:new_line("control-flow.tig", { on_line = 14, text = "break", indent = 4 }, "for body", XFAIL)
-    runner:new_line("control-flow.tig", { on_line = 18, text = "true", indent = 4 }, "while condition", XFAIL)
-    runner:new_line("control-flow.tig", { on_line = 20, text = "break", indent = 4 }, "while body", XFAIL)
+    runner:new_line("control-flow.tig", { on_line = 2, text = "true", indent = 4 }, "if condition")
+    runner:new_line("control-flow.tig", { on_line = 4, text = "true", indent = 4 }, "if consequence")
+    runner:new_line("control-flow.tig", { on_line = 4, text = "true", indent = 4 }, "if alternative")
+    runner:new_line("control-flow.tig", { on_line = 10, text = "start := 0", indent = 4 }, "for index start")
+    runner:new_line("control-flow.tig", { on_line = 12, text = "the_end", indent = 4 }, "for index end")
+    runner:new_line("control-flow.tig", { on_line = 14, text = "break", indent = 4 }, "for body")
+    runner:new_line("control-flow.tig", { on_line = 18, text = "true", indent = 4 }, "while condition")
+    runner:new_line("control-flow.tig", { on_line = 20, text = "break", indent = 4 }, "while body")
 
-    runner:new_line(
-      "functions.tig",
-      { on_line = 1, text = "parameter: int,", indent = 2 },
-      "parameter list beginning",
-      XFAIL
-    )
+    runner:new_line("functions.tig", { on_line = 1, text = "parameter: int,", indent = 2 }, "parameter list beginning")
     runner:new_line("functions.tig", { on_line = 2, text = "parameter: int,", indent = 2 }, "parameter list middle")
     runner:new_line("functions.tig", { on_line = 4, text = ",parameter: int", indent = 2 }, "parameter list end")
     runner:new_line("functions.tig", { on_line = 5, text = "var a := 0", indent = 0 }, "after parameter list")
-    runner:new_line("functions.tig", { on_line = 7, text = "print(a)", indent = 2 }, "function body", XFAIL)
-    runner:new_line("functions.tig", { on_line = 9, text = "a,", indent = 6 }, "function call beginning", XFAIL)
+    runner:new_line("functions.tig", { on_line = 7, text = "print(a)", indent = 2 }, "function body")
+    runner:new_line("functions.tig", { on_line = 9, text = "a,", indent = 6 }, "function call beginning")
     runner:new_line("functions.tig", { on_line = 10, text = "a,", indent = 6 }, "function call middle")
     runner:new_line("functions.tig", { on_line = 12, text = ",a", indent = 6 }, "function call end")
     runner:new_line("functions.tig", { on_line = 13, text = "; print(a)", indent = 4 }, "after function call")
-    runner:new_line(
-      "functions.tig",
-      { on_line = 14, text = "var a := 12", indent = 0 },
-      "after function declaration",
-      XFAIL
-    )
+    runner:new_line("functions.tig", { on_line = 14, text = "var a := 12", indent = 0 }, "after function declaration")
 
     runner:new_line("groupings.tig", { on_line = 2, text = "var b := 0", indent = 2 }, "let declarations")
-    runner:new_line("groupings.tig", { on_line = 3, text = "a := a + 1", indent = 2 }, "after 'in'", XFAIL)
-    runner:new_line("groupings.tig", { on_line = 4, text = "a := a + 1;", indent = 4 }, "sequence", XFAIL)
+    runner:new_line("groupings.tig", { on_line = 3, text = "a := a + 1", indent = 2 }, "after 'in'")
+    runner:new_line("groupings.tig", { on_line = 4, text = "a := a + 1;", indent = 4 }, "sequence")
     runner:new_line("groupings.tig", { on_line = 8, text = "a := a + 1;", indent = 2 }, "after sequence")
     runner:new_line("groupings.tig", { on_line = 10, text = "+ 1", indent = 0 }, "after 'end'")
 
     runner:new_line(
       "values-and-expressions.tig",
       { on_line = 4, text = "field: record,", indent = 4 },
-      "record type beginning",
-      XFAIL
+      "record type beginning"
     )
     runner:new_line(
       "values-and-expressions.tig",
@@ -85,39 +68,31 @@ describe("indent Tiger:", function()
     runner:new_line(
       "values-and-expressions.tig",
       { on_line = 10, text = "0", indent = 4 },
-      "variable declaration init value",
-      XFAIL
+      "variable declaration init value"
     )
     runner:new_line(
       "values-and-expressions.tig",
       { on_line = 11, text = "+ a", indent = 4 },
       "variable declaration init follow-up"
     )
-    runner:new_line("values-and-expressions.tig", { on_line = 13, text = "a", indent = 4 }, "array index", XFAIL)
+    runner:new_line("values-and-expressions.tig", { on_line = 13, text = "a", indent = 4 }, "array index")
     runner:new_line("values-and-expressions.tig", { on_line = 14, text = "+ a", indent = 4 }, "array index follow-up")
     runner:new_line("values-and-expressions.tig", { on_line = 15, text = "+ a", indent = 2 }, "after array value")
+    runner:new_line("values-and-expressions.tig", { on_line = 18, text = "a", indent = 4 }, "array expression size")
     runner:new_line(
       "values-and-expressions.tig",
-      { on_line = 18, text = "a", indent = 4 },
-      "array expression size",
-      XFAIL
-    )
-    runner:new_line(
-      "values-and-expressions.tig",
-      { on_line = 20, text = "of", indent = 2 },
+      { on_line = 20, text = "of", indent = 4 },
       "array expression after size"
     )
     runner:new_line(
       "values-and-expressions.tig",
       { on_line = 21, text = "a", indent = 4 },
-      "array expression init value",
-      XFAIL
+      "array expression init value"
     )
     runner:new_line(
       "values-and-expressions.tig",
       { on_line = 25, text = "field = 0,", indent = 4 },
-      "record expression beginning",
-      XFAIL
+      "record expression beginning"
     )
     runner:new_line(
       "values-and-expressions.tig",

--- a/tests/indent/wgsl_spec.lua
+++ b/tests/indent/wgsl_spec.lua
@@ -2,8 +2,8 @@ local Runner = require("tests.indent.common").Runner
 --local XFAIL = require("tests.indent.common").XFAIL
 
 local run = Runner:new(it, "tests/indent/wgsl", {
-  tabstop = 4,
-  shiftwidth = 4,
+  tabstop = 2,
+  shiftwidth = 2,
   softtabstop = 0,
   expandtab = true,
 })


### PR DESCRIPTION
Similar to #4900 but for master, testing to see why something works/not work

These filetypes were not recognized, so the tests were always marked with `XFAIL`, because they never run.

Therefore, Removing XFAIL for most of the tests, alongside adding ft to these unrecognized extensions