### PR TITLE
bash: add "until" highlighting

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -65,6 +65,7 @@
  "do"
  "done"
  "select"
+ "until"
  "while"
  ] @repeat
 


### PR DESCRIPTION
Adds "until" highlighting as it is a keyword for while loops per the bash grammar https://github.com/tree-sitter/tree-sitter-bash/pull/168 