### PR TITLE
fix(scala): Added scala block comment highlighting

### DIFF
--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -233,6 +233,7 @@
 "return" @keyword.return
 
 (comment) @comment @spell
+(block_comment) @comment @spell
 
 ((comment) @comment.documentation
   (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))

--- a/queries/scala/injections.scm
+++ b/queries/scala/injections.scm
@@ -1,1 +1,2 @@
 (comment) @comment
+(block_comment) @comment


### PR DESCRIPTION
A dual of https://github.com/tree-sitter/tree-sitter-scala/pull/282 - this makes block comments get correctly highlighted. 

Let me know if there's anything else I need to do!