### PR TITLE
Add if_statement to PHP indents.scm

### DIFF
--- a/queries/php/indents.scm
+++ b/queries/php/indents.scm
@@ -13,6 +13,11 @@
   "["
 ] @indent.begin
 
+(
+ if_statement
+  condition: (_) @indent.begin
+)
+
 [
   ")"
   "}"


### PR DESCRIPTION
EDIT: this PR is incomplete, PHP `if`/`else`/`else_if` indentation is still kinda broken, will update if I can put together a fix. 

This PR fixes the indentation issue seen in the following if statement:

```php
<?php
if (true) {
    if (empty($a)) {
        echo "test";
        if (
        true                  // <----------- should be indented by 1 more
            || false
            || false
    ) {                       // <----------- should be indented by 1 more
            echo "hello";
        }
    } else {
        echo "elsebranch";
    }
}
```

Caveat: I'm very new to Treesitter queries, but ran this through some example files and didn't see any problems.