### PR TITLE
feat(lua): update highlights query for functions

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -180,13 +180,40 @@
 
 (parameters (identifier) @parameter)
 
-(function_call name: (identifier) @function.call)
-(function_declaration name: (identifier) @function)
+(function_declaration
+  name: [
+    (identifier) @function
+    (dot_index_expression
+      field: (identifier) @function)
+  ])
 
-(function_call name: (dot_index_expression field: (identifier) @function.call))
-(function_declaration name: (dot_index_expression field: (identifier) @function))
+(function_declaration
+  name: (method_index_expression
+    method: (identifier) @method))
 
-(method_index_expression method: (identifier) @method.call)
+(assignment_statement
+  (variable_list .
+    name: [
+      (identifier) @function
+      (dot_index_expression
+        field: (identifier) @function)
+    ])
+  (expression_list .
+    value: (function_definition)))
+
+(table_constructor
+  (field
+    name: (identifier) @function
+    value: (function_definition)))
+
+(function_call
+  name: [
+    (identifier) @function.call
+    (dot_index_expression
+      field: (identifier) @function.call)
+    (method_index_expression
+      method: (identifier) @method.call)
+  ])
 
 (function_call
   (identifier) @function.builtin


### PR DESCRIPTION
Make functions higlight a bit nicer. These will now be highlighted as function:

```lua
local func_one = function() end
--    ^

local tbl = {
  func_one = function() end,
  --  ^
}
```

---

On related note:

I just realized I can't test highlights in https://github.com/MunifTanjim/tree-sitter-lua using `tree-sitter test`, because upstream `tree-sitter` treats highlight queries differently than Neovim. Is there any plan to unify that?