### PR TITLE
feat(scala): sync highlights with latest upstream

### DIFF
--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -23,7 +23,10 @@
 (class_parameter 
   name: (identifier) @parameter)
 
-(interpolation) @none
+(self_type (identifier) @parameter)
+
+(interpolation (identifier) @none)
+(interpolation (block) @none)
 
 ;; types
 


### PR DESCRIPTION
This accounts for a correction in interpolations and also adding support for `self_type`.

This is a follow-up to #4920.