### PR TITLE
feat(jsonnet): add "for", "function" keyword and update highlights for operators

### DIFF
--- a/queries/jsonnet/highlights.scm
+++ b/queries/jsonnet/highlights.scm
@@ -30,11 +30,27 @@
   ":::"
 ] @punctuation.delimiter
 
-(expr
-  operator: (_) @operator)
+(unaryop) @operator
 [
   "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "^"
+  "=="
+  "!="
+  "<="
+  ">="
+  "<"
+  ">"
   "="
+  "&"
+  "|"
+  "<<"
+  ">>"
+  "&&"
+  "||"
 ] @operator
 
 "for" @repeat


### PR DESCRIPTION
A simple Jsonnet snippet to verify this change:
```jsonnet
{
  local numbers = std.range(1, 10),
  a: [x ^ 2 for x in std.map(function(x) x + 2, numbers)],
  assert 5 % 2 == 1,
}
```