### PR TITLE
feat(matlab)!: replace parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -303,7 +303,7 @@
     "revision": "231f3163cd27d48f91a4517cfdf72d167a9ef164"
   },
   "matlab": {
-    "revision": "dd95e1fc1b5514aa3a882d5fb8ddbf4683e953f0"
+    "revision": "47cd9bde20c53a106cbd9ab1bd18fbfc600264e6"
   },
   "menhir": {
     "revision": "db7953acb0d5551f207373c81fa07a57d7b085cb"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -926,10 +926,10 @@ list.markdown_inline = {
 
 list.matlab = {
   install_info = {
-    url = "https://github.com/mstanciu552/tree-sitter-matlab",
-    files = { "src/parser.c" },
+    url = "https://github.com/acristoffers/tree-sitter-matlab",
+    files = { "src/parser.c", "src/scanner.c" },
   },
-  maintainers = { "@amaanq" },
+  maintainers = { "@acristoffers" },
 }
 
 list.menhir = {

--- a/queries/matlab/folds.scm
+++ b/queries/matlab/folds.scm
@@ -1,16 +1,11 @@
-[
-  (function_definition)
-
-  (if_statement)
-
-  (for_statement)
-  (while_statement)
-
-  (switch_statement)
-  (case_statement)
-
-  (otherwise_statement)
-
-  (try_statement)
-  (catch_statement)
-] @fold
+[(if_statement)
+ (for_statement)
+ (while_statement)
+ (switch_statement)
+ (try_statement)
+ (function_definition)
+ (class_definition)
+ (enumeration)
+ (events)
+ (methods)
+ (properties)] @fold

--- a/queries/matlab/highlights.scm
+++ b/queries/matlab/highlights.scm
@@ -1,106 +1,153 @@
-; Functions
+; Includes
 
-(function_definition
-  function_name: (identifier) @function
-  (end) @keyword.function)
-
-(parameter_list (identifier) @parameter)
+((command_name) @include
+  (#eq? @include "import"))
 
 ; Keywords
 
-((identifier) @keyword
-  (#eq? @keyword "end"))
-
-(function_keyword) @keyword.function
-
 [
-  "return"
-] @keyword.return
+  "arguments"
+  "classdef"
+  "end"
+  "enumeration"
+  "events"
+  "global"
+  "methods"
+  "persistent"
+  "properties"
+] @keyword
 
 ; Conditionals
 
-[
-  "if"
-  "elseif"
-  "else"
-  "switch"
-  "case"
-  "otherwise"
-] @conditional
-
-(if_statement (end) @conditional)
-(switch_statement (end) @conditional)
+(if_statement [ "if" "end" ] @conditional)
+(elseif_clause "elseif" @conditional)
+(else_clause "else" @conditional)
+(switch_statement [ "switch" "end" ] @conditional)
+(case_clause "case" @conditional)
+(otherwise_clause "otherwise" @conditional)
+(break_statement) @conditional
 
 ; Repeats
 
-[
-  "for" 
-  "while"
-  "break"
-  "continue"
-] @repeat
-
-(for_statement (end) @repeat)
-(while_statement (end) @repeat)
+(for_statement [ "for" "parfor" "end" ] @repeat)
+(while_statement [ "while" "end" ] @repeat)
+(continue_statement) @repeat
 
 ; Exceptions
 
-[
-  "try"
-  "catch"
-] @exception
+(try_statement [ "try" "end" ] @exception)
+(catch_clause "catch" @exception)
 
-(try_statement (end) @exception)
+; Variables
+
+(identifier) @variable
+
+; Constants
+
+(events (identifier) @constant)
+(attribute (identifier) @constant)
+
+"~" @constant.builtin
+
+; Fields/Properties
+
+(field_expression field: (identifier) @field)
+
+(superclass "." (identifier) @property)
+
+(property_name "." (identifier) @property)
+
+(property name: (identifier) @property)
+
+; Types
+
+(class_definition name: (identifier) @type)
+
+(attributes (identifier) @constant)
+
+(enum . (identifier) @type)
+
+((identifier) @type
+  (#lua-match? @type "^_*[A-Z][a-zA-Z0-9_]+$"))
+
+; Functions
+
+(function_definition
+  "function" @keyword.function
+  name: (identifier) @function
+  [ "end" "endfunction" ]? @keyword.function)
+
+(function_signature name: (identifier) @function)
+
+(function_call
+  name: (identifier) @function.call)
+
+(handle_operator (identifier) @function)
+
+(validation_functions (identifier) @function)
+
+(command (command_name) @function.call)
+(command_argument) @parameter
+
+(return_statement) @keyword.return
+
+; Parameters
+
+(function_arguments (identifier) @parameter)
 
 ; Punctuation
 
-[
-  ","
-  ";"
-  ":"
-] @punctuation.delimiter
+[ ";" "," "." ] @punctuation.delimiter
 
-[ "{" "}" ] @punctuation.bracket
-
-[ "[" "]" ] @punctuation.bracket
-
-[ "(" ")" ] @punctuation.bracket
+[ "(" ")" "[" "]" "{" "}" ] @punctuation.bracket
 
 ; Operators
 
-[ 
-  ">"
-  "<"
-  "=="
-  "<="
-  ">="
-  "=<"
-  "=>"
-  "~="
+[
+  "+"
+  ".+"
+  "-"
+  ".*"
   "*"
   ".*"
   "/"
-  "\\"
   "./"
+  "\\"
+  ".\\"
   "^"
   ".^"
-  "+"
+  "'"
+  ".'"
+  "|"
+  "&"
+  "?"
+  "@"
+  "<"
+  "<="
+  ">"
+  ">="
+  "=="
+  "~="
   "="
   "&&"
   "||"
+  ":"
 ] @operator
 
 ; Literals
 
-(number) @number
-
 (string) @string
 
-[ "true" "false" ] @boolean
+(escape_sequence) @string.escape
+(formatting_sequence) @string.special
+
+(number) @number
+
+(boolean) @boolean
 
 ; Comments
 
-(comment) @comment @spell
+[ (comment) (line_continuation) ] @comment @spell
 
 ; Errors
 

--- a/queries/matlab/indents.scm
+++ b/queries/matlab/indents.scm
@@ -1,0 +1,35 @@
+"end" @indent.end @indent.branch
+
+[
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (switch_statement)
+  (try_statement)
+  (function_definition)
+  (class_definition)
+  (enumeration)
+  (events)
+  (methods)
+  (properties)
+] @indent.begin
+
+[
+  "elseif"
+  "else"
+  "case"
+  "otherwise"
+  "catch"
+] @indent.branch
+
+((matrix (row) @indent.align)
+ (#set! indent.open_delimiter "[")
+ (#set! indent.close_delimiter "]"))
+((cell (row) @indent.align)
+ (#set! indent.open_delimiter "{")
+ (#set! indent.close_delimiter "}"))
+((parenthesis) @indent.align
+ (#set! indent.open_delimiter "(")
+ (#set! indent.close_delimiter ")"))
+
+(comment) @indent.auto

--- a/queries/matlab/locals.scm
+++ b/queries/matlab/locals.scm
@@ -1,0 +1,20 @@
+; References
+
+(identifier) @reference
+
+; Definitions
+
+(function_definition
+  name: (identifier) @definition.function
+  (function_arguments
+    (identifier)* @definition.parameter
+    ("," (identifier) @definition.parameter)*)?) @scope
+
+(assignment left: (identifier) @definition.var)
+(multioutput_variable (identifier) @definition.var)
+
+(iterator . (identifier) @definition.var)
+(lambda (arguments (identifier) @definition.parameter))
+(global_operator (identifier) @definition.var)
+(persistent_operator (identifier) @definition.var)
+(catch_clause (identifier) @definition)


### PR DESCRIPTION
I wrote a MATLAB parser which has more features than the current one:

- It detects commands. The code
```matlab
variable P(1, 2, 3) semidefinte
```
returns a `function_call` token with 2 `argument` tokens, which is how matlab sees it. I use a scanner to correctly detect the line, so it won't mix it with a function call followed by a identifier.
- It detects string escapes and formatting. This returns a string with two tokens inside, differentiating escape sequences from formatting options. Unfortunately there is an issue with tree-sitter that prevents me from doing it with single-quoted string at the moment, but it works fine with double-quoted ones.
```matlab
"Format: \t %2.3f"
```
- It detects line continuations, lambdas, parfor statement, arguments statements (a kind of MATLAB block), two more operators, superclass function call, and when it comes to classes, it correctly detects and generates specific tokens for everything (MATLAB has some weird constructs, like the properties block).

The parser also generates more tokens, which allows to better handle not only syntax highlighting, but specially textobjects. For instance, matrices and cells are composed of rows with values, which allows the creation of textobjects to operate on those, which is something I was missing a lot. At this point I believe I have implemented everything in MATLAB's grammar.