### PR TITLE
feat(bash): add various shell builtins

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -105,8 +105,15 @@
 
 ((command_name (word) @function.builtin)
  (#any-of? @function.builtin
-    "alias" "cd" "clear" "echo" "eval" "exit" "getopts" "popd"
-    "pushd" "return" "set" "shift" "shopt" "source" "test"))
+    "alias" "bg" "bind" "break" "builtin" "caller" "cd"
+    "command" "compgen" "complete" "compopt" "continue"
+    "coproc" "dirs" "disown" "echo" "enable" "eval"
+    "exec" "exit" "fc" "fg" "getopts" "hash" "help"
+    "history" "jobs" "kill" "let" "logout" "mapfile"
+    "popd" "printf" "pushd" "pwd" "read" "readarray"
+    "return" "set" "shift" "shopt" "source" "suspend"
+    "test" "time" "times" "trap" "type" "typeset"
+    "ulimit" "umask" "unalias" "wait"))
 
 (command
   argument: [


### PR DESCRIPTION
I noticed that many shell builtins were missing in the highlights, so I added them.

Moreover:
* added `break` and `continue` as conditionals because it just makes sense
* added `let` and moved `set` and `return` to keywords since they are more akin to things like `declare`, `local` and `unset` which were already there