### PR TITLE
improve scheme/racket quote highlight

### DIFF
--- a/queries/racket/highlights.scm
+++ b/queries/racket/highlights.scm
@@ -47,10 +47,6 @@
 (extension) @keyword
 (lang_name) @variable.builtin
 
-;; quote ;;
-
-(quote) @symbol
-
 ;; list ;;
 
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
@@ -124,7 +120,7 @@
 ;;                         Solve conflicts                          ;;
 ;;------------------------------------------------------------------;;
 
-;; See `:h treesitter`, and search `priority`
+;; See `:h treesitter-highlight-priority`
 
 (list
  .
@@ -132,10 +128,17 @@
  (#eq? @include "require")
  (#set! "priority" 101))
 
-(quote
-  .
-  (symbol)
-  (#set! "priority" 105)) @symbol
+;; quote
+
+(quote (#set! "priority" 105)) @symbol
+
+(list
+ .
+ (symbol) @_f
+ (#eq? @_f "quote")
+ (#set! "priority" 105)) @symbol
+
+
 
 ((sexp_comment) @comment
  (#set! "priority" 110))

--- a/queries/scheme/highlights.scm
+++ b/queries/scheme/highlights.scm
@@ -9,11 +9,6 @@
 [(comment)
  (block_comment)] @comment @spell
 
-;; highlight for datum comment
-;; copied from ../clojure/highlights.scm
-([(comment) (directive)] @comment
- (#set! "priority" 105))
-
 (escape_sequence) @string.escape
 
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
@@ -78,17 +73,6 @@
 
 ((symbol) @conditional
  (#any-of? @conditional "if" "cond" "case" "when" "unless"))
-
-;; quote
-
-(quote
- "'"
- (symbol)) @symbol
-
-(list
- .
- (symbol) @_f
- (#eq? @_f "quote")) @symbol
 
 ;; library
 
@@ -179,4 +163,26 @@
   "write" "display" "newline" "write-char"
   ;; system
   "load" "transcript-on" "transcript-off"))
+
+;;------------------------------------------------------------------;;
+;;                         Solve conflicts                          ;;
+;;------------------------------------------------------------------;;
+
+;; See `:h treesitter-highlight-priority`
+
+;; quote
+
+(quote (#set! "priority" 105)) @symbol
+
+(list
+ .
+ (symbol) @_f
+ (#eq? @_f "quote")
+ (#set! "priority" 105)) @symbol
+
+;; sexp comment
+
+([(comment) (directive)] @comment
+ (#set! "priority" 110))
+
 


### PR DESCRIPTION
Now it can highlight code like

```
'(list a b c)
(quote a b c)
```

as `@symbol`. It may require a specific colorscheme to work properly.