### PR TITLE
feat(matlab): threats unary operator as a number.

### DIFF
--- a/queries/matlab/highlights.scm
+++ b/queries/matlab/highlights.scm
@@ -134,6 +134,8 @@
   ":"
 ] @operator
 
+(unary_operator ["+" "-"] @number)
+
 ; Literals
 
 (string) @string


### PR DESCRIPTION
This line got lost during all changes and I think it is a nice one to have. By making the unary operator the same color as number we get two things:

1. It makes negative numbers look more like a number than a sequence of operations.
2. It makes a column distinction in matrices more visible, which is useful when trying to find why MATLAB says that the matrices being concatenated don't have the same dimensions:

```matlab
[1 -1] == [1, -1]
[1 - 1] == [0]
```

In GITHUB both operators are red, but if the first one were blue, it would be easier to spot that MATLAB is starting a new column there.