### PR TITLE
fix(sql): fix highlights order for `invocation`

### DIFF
--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -1,8 +1,3 @@
-(invocation
-  (object_reference
-    name: (identifier) @function.call
-    parameter: [(field)]? @parameter))
-
 [
   (keyword_gist)
   (keyword_btree)
@@ -17,6 +12,11 @@
 
 (object_reference
   name: (identifier) @type)
+
+(invocation
+  (object_reference
+    name: (identifier) @function.call
+    parameter: [(field)]? @parameter))
 
 (relation
   alias: (identifier) @variable)


### PR DESCRIPTION
Fixes the query order in SQL highlighting introduced due to changes in #4979 