### PR TITLE
highlights(sql): remove `keyword_group_concat` after refactor

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -459,7 +459,7 @@
     "revision": "05f949d3c1c15e3261473a244d3ce87777374dec"
   },
   "sql": {
-    "revision": "f70c2d5da5e437bfe82942be7fee6e6e30177fde"
+    "revision": "d38db87c3e979a692cd542be44524f7f5e46f965"
   },
   "squirrel": {
     "revision": "e8b5835296f931bcaa1477d3c5a68a0c5c2ba034"

--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -7,7 +7,6 @@
   (keyword_brin)
   (keyword_float)
   (keyword_array)
-  (keyword_group_concat)
 ] @function.call
 
 (object_reference


### PR DESCRIPTION
Refactored `group_concat` upstream in https://github.com/DerekStride/tree-sitter-sql/pull/163
