### PR TITLE
feat(awk): highlight builtin variables & shebang

### DIFF
--- a/queries/awk/highlights.scm
+++ b/queries/awk/highlights.scm
@@ -6,6 +6,44 @@
 ] @variable
 (field_ref (_) @variable)
 
+; https://www.gnu.org/software/gawk/manual/html_node/Auto_002dset.html
+((identifier) @constant.builtin
+ (#any-of? @constant.builtin
+           "ARGC"
+           "ARGV"
+           "ARGIND"
+           "ENVIRON"
+           "ERRNO"
+           "FILENAME"
+           "FNR"
+           "NF"
+           "FUNCTAB"
+           "NR"
+           "PROCINFO"
+           "RLENGTH"
+           "RSTART"
+           "RT"
+           "SYMTAB"))
+
+; https://www.gnu.org/software/gawk/manual/html_node/User_002dmodified.html
+((identifier) @variable.builtin
+ (#any-of? @variable.builtin
+           "BINMODE"
+           "CONVFMT"
+           "FIELDWIDTHS"
+           "FPAT"
+           "FS"
+           "IGNORECASE"
+           "LINT"
+           "OFMT"
+           "OFS"
+           "ORS"
+           "PREC"
+           "ROUNDMODE"
+           "RS"
+           "SUBSEP"
+           "TEXTDOMAIN"))
+
 (number) @number
 
 (string) @string
@@ -13,6 +51,9 @@
 (escape_sequence) @string.escape
 
 (comment) @comment @spell
+
+((program . (comment) @preproc)
+  (#lua-match? @preproc "^#!/"))
 
 (ns_qualified_name (namespace) @namespace)
 (ns_qualified_name "::" @punctuation.delimiter)


### PR DESCRIPTION
Using `@constant.builtin` to differentiate [auto-set](https://www.gnu.org/software/gawk/manual/html_node/Auto_002dset.html) from [user-modified](https://www.gnu.org/software/gawk/manual/html_node/User_002dmodified.html) variables even though they're not (all) constants.