### PR TITLE
go: register `max` and `min` as new builtin functions

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -171,6 +171,8 @@
            "imag"
            "len"
            "make"
+           "max"
+           "min"
            "new"
            "panic"
            "print"


### PR DESCRIPTION
The next version of Go (1.21) introduces new builtin functions: `max` and `min`:
https://github.com/golang/go/blob/a031f4ef83/src/builtin/builtin.go#L211-L221