### PR TITLE
feat(pem): add parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [ ] [org](https://github.com/milisims/tree-sitter-org)
 - [x] [pascal](https://github.com/Isopod/tree-sitter-pascal.git) (maintained by @Isopod)
 - [x] [passwd](https://github.com/ath3/tree-sitter-passwd) (maintained by @amaanq)
+- [x] [pem](https://github.com/ObserverOfTime/tree-sitter-pem) (maintained by @ObserverOfTime)
 - [x] [perl](https://github.com/ganezdragon/tree-sitter-perl) (maintained by @lcrownover)
 - [x] [php](https://github.com/tree-sitter/tree-sitter-php) (maintained by @tk-shirasaka)
 - [x] [phpdoc](https://github.com/claytonrcarter/tree-sitter-phpdoc) (experimental, maintained by @mikehaertl)

--- a/lockfile.json
+++ b/lockfile.json
@@ -356,6 +356,9 @@
   "passwd": {
     "revision": "20239395eacdc2e0923a7e5683ad3605aee7b716"
   },
+  "pem": {
+    "revision": "3662443335bc95bac0168a338b0f29f87162c244"
+  },
   "perl": {
     "revision": "60aa138f9e1db15becad53070f4d5898b0e8a98c"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1075,6 +1075,14 @@ list.passwd = {
   maintainers = { "@amaanq" },
 }
 
+list.pem = {
+  install_info = {
+    url = "https://github.com/ObserverOfTime/tree-sitter-pem",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@ObserverOfTime" },
+}
+
 list.perl = {
   install_info = {
     url = "https://github.com/ganezdragon/tree-sitter-perl",

--- a/queries/pem/folds.scm
+++ b/queries/pem/folds.scm
@@ -1,0 +1,1 @@
+(content) @fold

--- a/queries/pem/highlights.scm
+++ b/queries/pem/highlights.scm
@@ -1,0 +1,11 @@
+["BEGIN" "END"] @keyword
+
+(dashes) @punctuation.delimiter
+
+(label) @label
+
+(data) @none
+
+(comment) @comment
+
+(ERROR) @error

--- a/queries/pem/injections.scm
+++ b/queries/pem/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment


### PR DESCRIPTION
Should we highlight labels recognised by [OpenSSL](https://github.com/openssl/openssl/blob/master/include/openssl/pem.h#L35-L60) as `@label.builtin` or nah?