### PR TITLE
indents(fish): Add "end" and "case"

### DIFF
--- a/queries/fish/indents.scm
+++ b/queries/fish/indents.scm
@@ -8,9 +8,11 @@
 ] @indent.begin
 
 [
- (else_if_clause)
- (else_clause)
+ "else" ; else and else if must both start the line with "else", so tag the string directly
+ "case"
  "end"
 ] @indent.branch
+
+"end" @indent.end
 
 (comment) @indent.ignore


### PR DESCRIPTION
Previously, "end" and "case" were not captured, leading to ending a line with such keyword makes the next line to continue the indentation.

Closes #5026.
@lewisacidic Can you have a test to see if this is the desired behavior