### PR TITLE
fix(html): distinguish <hX> levels

### DIFF
--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -7,7 +7,25 @@
 (text) @text @spell
 
 ((element (start_tag (tag_name) @_tag) (text) @text.title)
- (#match? @_tag "^(h[0-9]|title)$"))
+ (#eq? @_tag "title"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.title.1)
+ (#eq? @_tag "h1"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.title.2)
+ (#eq? @_tag "h2"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.title.3)
+ (#eq? @_tag "h3"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.title.4)
+ (#eq? @_tag "h4"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.title.5)
+ (#eq? @_tag "h5"))
+
+((element (start_tag (tag_name) @_tag) (text) @text.title.6)
+ (#eq? @_tag "h6"))
 
 ((element (start_tag (tag_name) @_tag) (text) @text.strong)
  (#any-of? @_tag "strong" "b"))


### PR DESCRIPTION
Removes expensive regex `#match?`; make similar distinction as for Markdown
