### PR TITLE
feat(hurl): add hurl support

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -233,6 +233,9 @@
   "http": {
     "revision": "6824a247d1326079aab4fa9f9164e9319678081d"
   },
+  "hurl": {
+    "revision": "558808ab822be3a7b3824568321268dbfe0bd6f2"
+  },
   "ini": {
     "revision": "1a0ce072ebf3afac7d5603d9a95bb7c9a6709b44"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -234,7 +234,7 @@
     "revision": "6824a247d1326079aab4fa9f9164e9319678081d"
   },
   "hurl": {
-    "revision": "558808ab822be3a7b3824568321268dbfe0bd6f2"
+    "revision": "0eca909c8338364992e04c4862ac6afc5342cbb8"
   },
   "ini": {
     "revision": "1a0ce072ebf3afac7d5603d9a95bb7c9a6709b44"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -729,6 +729,15 @@ list.http = {
   maintainers = { "@amaanq" },
 }
 
+list.hurl = {
+  install_info = {
+    url = "https://github.com/pfeiferj/tree-sitter-hurl.git",
+    branch = "main",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@pfeiferj" },
+}
+
 list.ini = {
   install_info = {
     url = "https://github.com/justinmk/tree-sitter-ini",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -731,8 +731,7 @@ list.http = {
 
 list.hurl = {
   install_info = {
-    url = "https://github.com/pfeiferj/tree-sitter-hurl.git",
-    branch = "main",
+    url = "https://github.com/pfeiferj/tree-sitter-hurl",
     files = { "src/parser.c" },
   },
   maintainers = { "@pfeiferj" },

--- a/queries/hurl/folds.scm
+++ b/queries/hurl/folds.scm
@@ -1,0 +1,18 @@
+; fold.scm
+
+(comment) @fold
+(entry) @fold
+(request) @fold
+(response) @fold
+(header) @fold
+(request_section) @fold
+(body) @fold
+(response_section) @fold
+(multipart_form_data_section) @fold
+(cookies_section) @fold
+(captures_section) @fold
+(asserts_section) @fold
+(options_section) @fold
+(basic_auth_section) @fold
+(json_object) @fold
+(json_array) @fold

--- a/queries/hurl/folds.scm
+++ b/queries/hurl/folds.scm
@@ -1,18 +1,20 @@
 ; fold.scm
 
-(comment) @fold
-(entry) @fold
-(request) @fold
-(response) @fold
-(header) @fold
-(request_section) @fold
-(body) @fold
-(response_section) @fold
-(multipart_form_data_section) @fold
-(cookies_section) @fold
-(captures_section) @fold
-(asserts_section) @fold
-(options_section) @fold
-(basic_auth_section) @fold
-(json_object) @fold
-(json_array) @fold
+[
+  (comment)
+  (entry)
+  (request)
+  (response)
+  (header)
+  (request_section)
+  (body)
+  (response_section)
+  (multipart_form_data_section)
+  (cookies_section)
+  (captures_section)
+  (asserts_section)
+  (options_section)
+  (basic_auth_section)
+  (json_object)
+  (json_array)
+] @fold

--- a/queries/hurl/highlights.scm
+++ b/queries/hurl/highlights.scm
@@ -1,0 +1,112 @@
+; highlights.scm
+
+"[QueryStringParams]" @property
+"[FormParams]" @property
+"[MultipartFormData]" @property
+"[Cookies]" @property
+"[Captures]" @property
+"[Asserts]" @property
+"[Options]" @property
+"[BasicAuth]" @property
+
+(comment) @comment @spell
+
+(key_string) @property
+(json_key_string) @property
+
+(value_string) @string
+(quoted_string) @string
+(json_string) @string
+(file_value) @string.special
+(regex) @string.regex
+
+"\\" @string.escape
+(regex_escaped_char) @string.escape
+(quoted_string_escaped_char) @string.escape
+(key_string_escaped_char) @string.escape
+(value_string_escaped_char) @string.escape
+(oneline_string_escaped_char) @string.escape
+(multiline_string_escaped_char) @string.escape
+(filename_escaped_char) @string.escape
+(json_string_escaped_char) @string.escape
+
+(method) @type.builtin
+(multiline_string_type) @type
+
+"status" @function.builtin
+"url" @function.builtin
+"header" @function.builtin
+"cookie" @function.builtin
+"body" @function.builtin
+"xpath" @function.builtin
+"jsonpath" @function.builtin
+"regex" @function.builtin
+"variable" @function.builtin
+"duration" @function.builtin
+"sha256" @function.builtin
+"md5" @function.builtin
+"bytes" @function.builtin
+
+(filter) @attribute
+
+(version) @string.special
+
+"null" @constant.builtin
+"cacert" @constant.builtin
+"location" @constant.builtin
+"insecure" @constant.builtin
+"max-redirs" @constant.builtin
+"retry" @constant.builtin
+"retry-interval" @constant.builtin
+"retry-max-count" @constant.builtin
+(variable_option "variable") @constant.builtin
+"verbose" @constant.builtin
+"very-verbose" @constant.builtin
+
+(boolean) @boolean
+
+(variable_name) @variable
+
+"not" @keyword.operator
+"equals" @keyword.operator
+"==" @operator
+"notEquals" @keyword.operator
+"!=" @operator
+"greaterThan" @keyword.operator
+">" @operator
+"greaterThanOrEquals" @keyword.operator
+">=" @operator
+"lessThan" @keyword.operator
+"<" @operator
+"lessThanOrEquals" @keyword.operator
+"<=" @operator
+"startsWith" @keyword.operator
+"endsWith" @keyword.operator
+"contains" @keyword.operator
+"matches" @keyword.operator
+"exists" @keyword.operator
+"includes" @keyword.operator
+"isInteger" @keyword.operator
+"isFloat" @keyword.operator
+"isBoolean" @keyword.operator
+"isString" @keyword.operator
+"isCollection" @keyword.operator
+
+(integer) @number
+(float) @float
+(status) @number
+(json_number) @float
+
+":" @punctuation.delimiter
+"," @punctuation.delimiter
+
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"{{" @punctuation.special
+"}}" @punctuation.special
+
+"base64," @string.special
+"file," @string.special
+"hex," @string.special

--- a/queries/hurl/highlights.scm
+++ b/queries/hurl/highlights.scm
@@ -53,8 +53,11 @@
 
 "null" @constant.builtin
 "cacert" @constant.builtin
+"compressed" @constant.builtin
 "location" @constant.builtin
 "insecure" @constant.builtin
+"path_as_is" @constant.builtin
+"proxy" @constant.builtin
 "max-redirs" @constant.builtin
 "retry" @constant.builtin
 "retry-interval" @constant.builtin

--- a/queries/hurl/highlights.scm
+++ b/queries/hurl/highlights.scm
@@ -56,7 +56,7 @@
   (variable_option "variable")
   "verbose"
   "very-verbose"
-]
+] @constant.builtin
 
 (boolean) @boolean
 

--- a/queries/hurl/highlights.scm
+++ b/queries/hurl/highlights.scm
@@ -1,51 +1,59 @@
 ; highlights.scm
 
-"[QueryStringParams]" @property
-"[FormParams]" @property
-"[MultipartFormData]" @property
-"[Cookies]" @property
-"[Captures]" @property
-"[Asserts]" @property
-"[Options]" @property
-"[BasicAuth]" @property
+[ 
+  "[QueryStringParams]"
+  "[FormParams]"
+  "[MultipartFormData]"
+  "[Cookies]"
+  "[Captures]"
+  "[Asserts]"
+  "[Options]"
+  "[BasicAuth]"
+] @property
 
 (comment) @comment @spell
 
 (key_string) @property
 (json_key_string) @property
 
-(value_string) @string
-(quoted_string) @string
-(json_string) @string
+[ 
+  (value_string)
+  (quoted_string)
+  (json_string)
+] @string
 (file_value) @string.special
 (regex) @string.regex
 
-"\\" @string.escape
-(regex_escaped_char) @string.escape
-(quoted_string_escaped_char) @string.escape
-(key_string_escaped_char) @string.escape
-(value_string_escaped_char) @string.escape
-(oneline_string_escaped_char) @string.escape
-(multiline_string_escaped_char) @string.escape
-(filename_escaped_char) @string.escape
-(json_string_escaped_char) @string.escape
+[ 
+  "\\"
+  (regex_escaped_char)
+  (quoted_string_escaped_char)
+  (key_string_escaped_char)
+  (value_string_escaped_char)
+  (oneline_string_escaped_char)
+  (multiline_string_escaped_char)
+  (filename_escaped_char)
+  (json_string_escaped_char)
+] @string.escape
 
 (method) @type.builtin
 (multiline_string_type) @type
 
-"status" @function.builtin
-"url" @function.builtin
-"header" @function.builtin
-"cookie" @function.builtin
-"body" @function.builtin
-"xpath" @function.builtin
-"jsonpath" @function.builtin
-"regex" @function.builtin
-"variable" @function.builtin
-"duration" @function.builtin
-"sha256" @function.builtin
-"md5" @function.builtin
-"bytes" @function.builtin
+[
+  "status"
+  "url"
+  "header"
+  "cookie"
+  "body"
+  "xpath"
+  "jsonpath"
+  "regex"
+  "variable"
+  "duration"
+  "sha256"
+  "md5"
+  "bytes"
+] @function.builtin
 
 (filter) @attribute
 
@@ -70,45 +78,49 @@
 
 (variable_name) @variable
 
-"not" @keyword.operator
-"equals" @keyword.operator
-"==" @operator
-"notEquals" @keyword.operator
-"!=" @operator
-"greaterThan" @keyword.operator
-">" @operator
-"greaterThanOrEquals" @keyword.operator
-">=" @operator
-"lessThan" @keyword.operator
-"<" @operator
-"lessThanOrEquals" @keyword.operator
-"<=" @operator
-"startsWith" @keyword.operator
-"endsWith" @keyword.operator
-"contains" @keyword.operator
-"matches" @keyword.operator
-"exists" @keyword.operator
-"includes" @keyword.operator
-"isInteger" @keyword.operator
-"isFloat" @keyword.operator
-"isBoolean" @keyword.operator
-"isString" @keyword.operator
-"isCollection" @keyword.operator
+[
+  "not"
+  "equals"
+  "notEquals"
+  "greaterThan"
+  "greaterThanOrEquals"
+  "lessThan"
+  "lessThanOrEquals"
+  "startsWith"
+  "endsWith"
+  "contains"
+  "matches"
+  "exists"
+  "includes"
+  "isInteger"
+  "isFloat"
+  "isBoolean"
+  "isString"
+  "isCollection"
+] @keyword.operator
 
-(integer) @number
-(float) @float
-(status) @number
-(json_number) @float
+[
+  "=="
+  "!="
+  ">"
+  ">="
+  "<"
+  "<="
+] @operator
 
-":" @punctuation.delimiter
-"," @punctuation.delimiter
+[
+  (integer)
+  (status)
+] @number
 
-"[" @punctuation.bracket
-"]" @punctuation.bracket
-"{" @punctuation.bracket
-"}" @punctuation.bracket
-"{{" @punctuation.special
-"}}" @punctuation.special
+[
+  (float)
+  (json_number)
+] @float
+
+[ ":" "," ] @punctuation.delimiter
+
+[ "[" "]" "{" "}" "{{" "}}" ] @punctuation.bracket
 
 "base64," @string.special
 "file," @string.special

--- a/queries/hurl/highlights.scm
+++ b/queries/hurl/highlights.scm
@@ -9,20 +9,9 @@
   "[Asserts]"
   "[Options]"
   "[BasicAuth]"
+  (key_string)
+  (json_key_string)
 ] @property
-
-(comment) @comment @spell
-
-(key_string) @property
-(json_key_string) @property
-
-[ 
-  (value_string)
-  (quoted_string)
-  (json_string)
-] @string
-(file_value) @string.special
-(regex) @string.regex
 
 [ 
   "\\"
@@ -35,9 +24,6 @@
   (filename_escaped_char)
   (json_string_escaped_char)
 ] @string.escape
-
-(method) @type.builtin
-(multiline_string_type) @type
 
 [
   "status"
@@ -55,24 +41,22 @@
   "bytes"
 ] @function.builtin
 
-(filter) @attribute
-
-(version) @string.special
-
-"null" @constant.builtin
-"cacert" @constant.builtin
-"compressed" @constant.builtin
-"location" @constant.builtin
-"insecure" @constant.builtin
-"path_as_is" @constant.builtin
-"proxy" @constant.builtin
-"max-redirs" @constant.builtin
-"retry" @constant.builtin
-"retry-interval" @constant.builtin
-"retry-max-count" @constant.builtin
-(variable_option "variable") @constant.builtin
-"verbose" @constant.builtin
-"very-verbose" @constant.builtin
+[
+  "null"
+  "cacert"
+  "compressed"
+  "location"
+  "insecure"
+  "path_as_is"
+  "proxy"
+  "max-redirs"
+  "retry"
+  "retry-interval"
+  "retry-max-count"
+  (variable_option "variable")
+  "verbose"
+  "very-verbose"
+]
 
 (boolean) @boolean
 
@@ -122,6 +106,28 @@
 
 [ "[" "]" "{" "}" "{{" "}}" ] @punctuation.bracket
 
-"base64," @string.special
-"file," @string.special
-"hex," @string.special
+[ 
+  (value_string)
+  (quoted_string)
+  (json_string)
+] @string
+
+
+[
+  "base64,"
+  "file,"
+  "hex,"
+  (file_value)
+  (version)
+] @string.special
+
+(regex) @string.regex
+
+(multiline_string_type) @type
+
+(comment) @comment @spell
+
+(filter) @attribute
+
+(method) @type.builtin
+

--- a/queries/hurl/highlights.scm
+++ b/queries/hurl/highlights.scm
@@ -47,7 +47,7 @@
   "compressed"
   "location"
   "insecure"
-  "path_as_is"
+  "path-as-is"
   "proxy"
   "max-redirs"
   "retry"

--- a/queries/hurl/indents.scm
+++ b/queries/hurl/indents.scm
@@ -3,12 +3,12 @@
 [
   (json_object)
   (json_array)
-] @indent
+] @indent.begin
 
 [
   "}"
   "]"
-] @branch
+] @indent.branch
 
-(xml_tag) @indent
-(xml_close_tag) @branch
+(xml_tag) @indent.begin
+(xml_close_tag) @indent.branch

--- a/queries/hurl/indents.scm
+++ b/queries/hurl/indents.scm
@@ -1,0 +1,14 @@
+; indents.scm
+
+[
+  (json_object)
+  (json_array)
+] @indent
+
+[
+  "}"
+  "]"
+] @branch
+
+(xml_tag) @indent
+(xml_close_tag) @branch

--- a/queries/hurl/injections.scm
+++ b/queries/hurl/injections.scm
@@ -3,5 +3,5 @@
 (xml) @html
 
 (multiline_string
-  (multiline_string_type) @injection.language
-  (multiline_string_content) @injection.content)
+  (multiline_string_type) @language
+  (multiline_string_content) @content)

--- a/queries/hurl/injections.scm
+++ b/queries/hurl/injections.scm
@@ -1,0 +1,7 @@
+; injections.scm
+(json_value) @json
+(xml) @html
+
+(multiline_string
+  (multiline_string_type) @language
+  (multiline_string_content) @content @include-children @combined)

--- a/queries/hurl/injections.scm
+++ b/queries/hurl/injections.scm
@@ -3,5 +3,5 @@
 (xml) @html
 
 (multiline_string
-  (multiline_string_type) @language
-  (multiline_string_content) @content @include-children @combined)
+  (multiline_string_type) @injection.language
+  (multiline_string_content) @injection.content)

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -6,6 +6,7 @@ vim.filetype.add {
   extension = {
     conf = "hocon",
     cmm = "t32",
+    hurl = "hurl",
     ncl = "nickel",
     tig = "tiger",
     usd = "usd",


### PR DESCRIPTION
Adds support for the hurl file extension. Hurl is a command-line rest api runner/testing engine. 

Note: .hurl files are not currently detected by vim/neovim. I have opened a PR to vim for hurl file type detection https://github.com/vim/vim/pull/12631

Grammar: https://github.com/pfeiferj/tree-sitter-hurl/
Hurl file format: https://hurl.dev/docs/hurl-file.html