### PR TITLE
fix(ecma): Highlight regex flags

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -190,6 +190,7 @@
 (template_string) @string
 (escape_sequence) @string.escape
 (regex_pattern) @string.regex
+(regex_flags) @character.special
 (regex "/" @punctuation.bracket) ; Regex delimiters
 
 (number) @number


### PR DESCRIPTION
I don't know if the flag should be highlighted the same as the regex, but it does look weird without any highlight at all.