### PR TITLE
highlights(nix): add hpath_expression

### DIFF
--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -37,7 +37,7 @@
   (#set! "priority" 99)) @string
 
 ; paths and URLs
-[ (path_expression) (spath_expression) (uri_expression) ] @string.special
+[ (path_expression) (hpath_expression) (spath_expression) (uri_expression) ] @string.special
 
 ; escape sequences
 (escape_sequence) @string.escape


### PR DESCRIPTION
A Nix expression like
```nix
builtins.readFile ~/testing
```
parses to
```text
expression: apply_expression [0, 0] - [0, 27]
  function: select_expression [0, 0] - [0, 17]
    expression: variable_expression [0, 0] - [0, 8]
      name: identifier [0, 0] - [0, 8]
    attrpath: attrpath [0, 9] - [0, 17]
      attr: identifier [0, 9] - [0, 17]
  argument: hpath_expression [0, 18] - [0, 27]
    path_fragment [0, 18] - [0, 27]
```
The relative path `~/testing` is captured by [`hpath_expression`](https://github.com/nix-community/tree-sitter-nix/blob/02878b40ac77d2889833519c6b6e9e63cfc690e6/src/grammar.json#L84-L122) which is currently not highlighted properly (it should be highlighted the same as `path_expression` or `spath_expression`).