### PR TITLE
feat(promql,yaml): add parser and yaml injections

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -392,6 +392,9 @@
   "prisma": {
     "revision": "eca2596a355b1a9952b4f80f8f9caed300a272b5"
   },
+  "promql": {
+    "revision": "655afc4fe6813f38bde087d6493d8fd4920d6d4a"
+  },
   "proto": {
     "revision": "42d82fa18f8afe59b5fc0b16c207ee4f84cb185f"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1179,6 +1179,15 @@ list.prisma = {
   maintainers = { "@elianiva" },
 }
 
+list.promql = {
+  install_info = {
+    url = "https://github.com/MichaHoffmann/tree-sitter-promql",
+    files = { "src/parser.c" },
+    experimental = true,
+  },
+  maintainers = { "@MichaHoffmann" },
+}
+
 list.proto = {
   install_info = {
     url = "https://github.com/mitchellh/tree-sitter-proto",

--- a/queries/promql/highlights.scm
+++ b/queries/promql/highlights.scm
@@ -1,0 +1,54 @@
+; highlights.scm
+
+[
+  "*"
+  "/"
+  "%"
+  "+"
+  "-"
+  ">"
+  ">="
+  "<"
+  "<="
+  "="
+  "=~"
+  "!="
+  "!~"
+] @operator
+
+[
+  "and"
+  "unless"
+  "or"
+  "bool"
+] @keyword.operator
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+  "("
+  ")"
+] @punctuation.bracket
+
+(float_literal) @float
+(string_literal) @string
+
+(metric_name) @type
+(range_selection) @text.strong @type
+(subquery_range_selection) @text.strong @type
+
+(label_name) @field
+(label_value) @text.underline @string.regex
+
+(function_name) @function.call
+
+[ 
+  "by"
+  "without"
+] @function
+
+(comment) @comment @spell
+(ERROR) @error
+

--- a/queries/promql/injections.scm
+++ b/queries/promql/injections.scm
@@ -1,0 +1,1 @@
+((label_value) @regex (#offset! @regex 0 1 0 -1))

--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -25,3 +25,29 @@
              (block_sequence_item
                (block_node
                   (block_scalar) @bash (#offset! @bash 0 1 0 0))))))
+
+;; Prometheus Alertmanager ("expr")
+(block_mapping_pair
+  key: (flow_node) @_expr (#eq? @_expr "expr")
+  value: (flow_node
+           (plain_scalar) @promql))
+
+(block_mapping_pair
+  key: (flow_node) @_expr (#eq? @_expr "expr")
+  value: (block_node
+           (block_scalar) @promql (#offset! @promql 0 2 0 0)))
+
+(block_mapping_pair
+  key: (flow_node) @_expr (#eq? @_expr "expr")
+  value: (block_node
+           (block_sequence
+             (block_sequence_item
+               (flow_node) @promql))))
+
+(block_mapping_pair
+  key: (flow_node) @_expr (#eq @_expr "expr")
+  value: (block_node
+           (block_sequence
+             (block_sequence_item
+               (block_node
+                  (block_scalar) @promql (#offset! @promql 0 2 0 0))))))

--- a/tests/query/injections/yaml/promql-on-prometheus-rules.yaml
+++ b/tests/query/injections/yaml/promql-on-prometheus-rules.yaml
@@ -1,0 +1,12 @@
+groups:
+- name: Hardware alerts
+  rules:
+  - alert: Node down
+    expr: up{job="node_exporter"} == 0
+    #     ^ promql
+    for: 3m
+    labels:
+      severity: warning
+    annotations:
+      title: Node {{ $labels.instance }} is down
+      description: Failed to scrape {{ $labels.job }} on {{ $labels.instance }} for more than 3 minutes. Node seems down.


### PR DESCRIPTION
This is an effort so we can get promql highlighted in prometheus rule manifests:

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/17451647/4c6ea2d0-7548-4183-ad57-33b1bd46a573)
