### PR TITLE
ci: bump actions to latest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Lint with stylua
-        uses: JohnnyMorganz/stylua-action@v2
+        uses: JohnnyMorganz/stylua-action@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -48,7 +48,7 @@ jobs:
           git clean -xf
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           title: "Update lockfile.json: ${{ env.UPDATED_PARSERS }}"
           branch: update-lockfile-pr

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -33,7 +33,7 @@ jobs:
           git clean -xf
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Update README
           title: Update README


### PR DESCRIPTION
`create-pull-request@v4` has deprecation warnings