### PR TITLE
feat(julia): highlight docstrings before short function definitions

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -286,6 +286,7 @@
       (abstract_definition)
       (struct_definition)
       (function_definition)
+      (short_function_definition)
       (assignment)
       (const_statement)
     ])

--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -5,6 +5,7 @@
     (abstract_definition)
     (struct_definition)
     (function_definition)
+    (short_function_definition)
     (assignment)
     (const_statement)
   ]


### PR DESCRIPTION
`string_literal` before a short function definition should be docstring:
```
In [1]: begin
            """
                foo()

            This is a docstring before short function definition.
            """
            foo() = nothing
        end
Out[1]: foo

help?> foo
search: foo ...

  foo()

  This is a docstring before short function definition.
```