### PR TITLE
feat: add SystemTap

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -500,6 +500,9 @@
   "sxhkdrc": {
     "revision": "440d5f913d9465c9c776a1bd92334d32febcf065"
   },
+  "systemtap": {
+    "revision": "1af543a96d060b1f808982037bfc54cc02218edd"
+  },
   "t32": {
     "revision": "4e581fcd17d76651aa92759a68f9a8186b9fe8dc"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1473,6 +1473,14 @@ list.sxhkdrc = {
   maintainers = { "@RaafatTurki" },
 }
 
+list.systemtap = {
+  install_info = {
+    url = "https://github.com/ok-ryoko/tree-sitter-systemtap",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@ok-ryoko" },
+}
+
 list.t32 = {
   install_info = {
     url = "https://codeberg.org/xasc/tree-sitter-t32",

--- a/queries/systemtap/folds.scm
+++ b/queries/systemtap/folds.scm
@@ -1,0 +1,18 @@
+[
+  (preprocessor_macro_definition)
+  (preprocessor_macro_expansion)
+  (conditional_preprocessing)
+  (embedded_code)
+  (probe_point_definition)
+  (probe_point_alias_prologue)
+  (probe_point_alias_epilogue)
+  (variable_declaration)
+  (function_definition)
+  (if_statement)
+  (while_statement)
+  (for_statement)
+  (foreach_statement)
+  (try_statement)
+  (catch_clause)
+  (comment)
+] @fold

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -109,7 +109,6 @@
 
 [
   "delete"
-  "global"
   "limit"
   "next"
   "private"
@@ -150,3 +149,5 @@
 ] @preproc
 
 "@define" @define
+
+"global" @storageclass

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -99,6 +99,8 @@
 ] @punctuation.delimiter
 
 [
+  "%{"
+  "%}"
   "("
   ")"
   "["
@@ -142,8 +144,6 @@
   "%)"
   "%:"
   "%?"
-  "%{"
-  "%}"
   (preprocessor_tokens)
   (embedded_code)
 ] @preproc

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -1,7 +1,7 @@
 (identifier) @variable
 
 (preprocessor_macro_definition
-  name: (identifier) @define)
+  name: (identifier) @function.macro)
 
 (preprocessor_macro_expansion) @function.macro
 
@@ -26,7 +26,7 @@
 
 (type) @type.builtin
 
-(aggregation_operator) @function.macro
+(aggregation_operator) @attribute
 
 (member_expression
   member: (identifier) @field)
@@ -108,8 +108,6 @@
 ] @punctuation.bracket
 
 [
-  "break"
-  "continue"
   "delete"
   "global"
   "limit"
@@ -128,6 +126,8 @@
 ] @conditional
 
 [
+  "break"
+  "continue"
   "for"
   "foreach"
   "while"

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -34,18 +34,14 @@
 (call_expression
   function: (identifier) @function.call)
 
-(
-  (call_expression
+((call_expression
     function: (identifier) @function.builtin)
   (#any-of? @function.builtin
     "print" "printd" "printdln" "printf" "println"
-    "sprint" "sprintd" "sprintdln" "sprintf" "sprintln")
-)
+    "sprint" "sprintd" "sprintdln" "sprintf" "sprintln"))
 
-(
-  (identifier) @variable.builtin
-  (#lua-match? @variable.builtin "^\$+[0-9A-Z_a-z]+\$*$")
-)
+((identifier) @variable.builtin
+  (#lua-match? @variable.builtin "^\$+[0-9A-Z_a-z]+\$*$"))
 
 (shebang_line) @preproc
 

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -113,7 +113,6 @@
   "delete"
   "limit"
   "next"
-  "private"
   "probe"
 ] @keyword
 
@@ -150,4 +149,5 @@
 
 "@define" @define
 
+"private" @type.qualifier
 "global" @storageclass

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -1,0 +1,156 @@
+(identifier) @variable
+
+(preprocessor_macro_definition
+  name: (identifier) @define)
+
+(preprocessor_macro_expansion) @function.macro
+
+(preprocessor_constant) @constant.macro
+
+(number) @number
+(string) @string
+(escape_sequence) @string.escape
+
+[
+  (script_argument_string)
+  (script_argument_number)
+] @constant
+
+(probe_point_component) @function
+
+(function_definition
+  name: (identifier) @function)
+
+(parameter
+  name: (identifier) @parameter)
+
+(type) @type.builtin
+
+(aggregation_operator) @function.macro
+
+(member_expression
+  member: (identifier) @field)
+
+(call_expression
+  function: (identifier) @function.call)
+
+(
+  (call_expression
+    function: (identifier) @function.builtin)
+  (#any-of? @function.builtin
+    "print" "printd" "printdln" "printf" "println"
+    "sprint" "sprintd" "sprintdln" "sprintf" "sprintln")
+)
+
+(
+  (identifier) @variable.builtin
+  (#lua-match? @variable.builtin "^\$+[0-9A-Z_a-z]+\$*$")
+)
+
+(shebang_line) @preproc
+
+(comment) @comment @spell
+
+[
+  "!"
+  "!="
+  "!~"
+  "$"
+  "$$"
+  "%"
+  "%="
+  "&"
+  "&&"
+  "&="
+  "*"
+  "*="
+  "+"
+  "++"
+  "+="
+  "-"
+  "--"
+  "-="
+  "->"
+  "."
+  ".="
+  "/"
+  "/="
+  ":"
+  "<"
+  "<<"
+  "<<<"
+  "<<="
+  "<="
+  "="
+  "=="
+  "=~"
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "?"
+  "^"
+  "^="
+  "|"
+  "|="
+  "||"
+  "~"
+] @operator
+
+[
+  ","
+  (null_statement)
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "break"
+  "continue"
+  "delete"
+  "global"
+  "limit"
+  "next"
+  "private"
+  "probe"
+] @keyword
+
+"function" @keyword.function
+"in" @keyword.operator
+"return" @keyword.return
+
+[
+  "if"
+  "else"
+] @conditional
+
+[
+  "for"
+  "foreach"
+  "while"
+] @repeat
+
+[
+  "try"
+  "catch"
+] @exception
+
+[
+  "%("
+  "%)"
+  "%:"
+  "%?"
+  "%{"
+  "%}"
+  (preprocessor_tokens)
+  (embedded_code)
+] @preproc
+
+"@define" @define

--- a/queries/systemtap/injections.scm
+++ b/queries/systemtap/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment

--- a/queries/systemtap/injections.scm
+++ b/queries/systemtap/injections.scm
@@ -1,1 +1,2 @@
 (comment) @comment
+(embedded_code) @c

--- a/queries/systemtap/locals.scm
+++ b/queries/systemtap/locals.scm
@@ -1,0 +1,35 @@
+[
+  (function_definition)
+  (statement_block)
+  (if_statement)
+  (while_statement)
+  (for_statement)
+  (foreach_statement)
+  (catch_clause)
+] @scope
+
+(init_declarator
+  name: (identifier) @definition.var)
+
+(array_declarator
+  name: (identifier) @definition.var)
+
+(function_definition
+  name: (identifier) @definition.function)
+
+(parameter
+  name: (identifier) @definition.parameter)
+
+(tuple_capture
+  (identifier) @definition.var)
+
+(catch_clause
+  parameter: (identifier) @definition.var)
+
+(assignment_expression
+  left: (identifier) @definition.var)
+
+(call_expression
+  function: (identifier) @reference)
+
+(identifier) @reference


### PR DESCRIPTION
[SystemTap] is a Red Hat-driven Linux instrumentation framework that’s been around since 2005. It exposes a scripting language inspired by C and awk. I’ve written a complete [grammar] and have shown up to contribute nvim-treesitter queries.

Here’s the highlights query in action on some of my code:

![systemtap-nvim-treesitter-highlights](https://github.com/nvim-treesitter/nvim-treesitter/assets/59705845/654c418d-ef66-426c-b841-2ea1684875c4)

There’s very little SystemTap in the wild, so I would consider this PR to be a relatively low priority.

Your feedback is greatly appreciated, even if this PR doesn’t succeed. Thank you for your work on nvim-treesitter!

[grammar]: https://github.com/ok-ryoko/tree-sitter-systemtap
[SystemTap]: https://sourceware.org/systemtap/