### PR TITLE
feat: Add Robot Framework parser and highlights

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -440,6 +440,9 @@
   "rnoweb": {
     "revision": "502c1126dc6777f09af5bef16e72a42f75bd081e"
   },
+  "robot": {
+    "revision": "f1142bfaa6acfce95e25d2c6d18d218f4f533927"
+  },
   "ron": {
     "revision": "ce6086b2c9e8e71065b8129d6c2289c5f66d1879"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1309,6 +1309,15 @@ list.rnoweb = {
   maintainers = { "@bamonroe" },
 }
 
+list.robot = {
+  install_info = {
+    url = "https://github.com/Hubro/tree-sitter-robot",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@ema2159" },
+  experimental = true,
+}
+
 list.ron = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-ron",

--- a/queries/robot/highlights.scm
+++ b/queries/robot/highlights.scm
@@ -1,22 +1,21 @@
-(comment) @comment
-(ellipses) @punctuation.delimiter
-
-(section_header) @keyword
-(extra_text) @comment
-
-(setting_statement) @keyword
-
-(variable_definition (variable_name) @variable)
-
-(keyword_definition (name) @function)
-(keyword_definition (body (keyword_setting) @keyword))
-
-(test_case_definition (name) @property)
+(argument (dictionary_variable) @string.special)
+(argument (list_variable) @string.special)
+(argument (scalar_variable) @string.special)
+(argument (text_chunk) @string)
 
 (keyword_invocation (keyword) @function)
 
-(argument (text_chunk) @string)
-(argument (scalar_variable) @string.special)
-(argument (list_variable) @string.special)
-(argument (dictionary_variable) @string.special)
+(test_case_definition (name) @property)
 
+(keyword_definition (body (keyword_setting) @keyword))
+(keyword_definition (name) @function)
+
+(variable_definition (variable_name) @variable)
+
+(setting_statement) @keyword
+
+(extra_text) @comment
+(section_header) @keyword
+
+(ellipses) @punctuation.delimiter
+(comment) @comment

--- a/queries/robot/highlights.scm
+++ b/queries/robot/highlights.scm
@@ -1,0 +1,22 @@
+(comment) @comment
+(ellipses) @punctuation.delimiter
+
+(section_header) @keyword
+(extra_text) @comment
+
+(setting_statement) @keyword
+
+(variable_definition (variable_name) @variable)
+
+(keyword_definition (name) @function)
+(keyword_definition (body (keyword_setting) @keyword))
+
+(test_case_definition (name) @property)
+
+(keyword_invocation (keyword) @function)
+
+(argument (text_chunk) @string)
+(argument (scalar_variable) @string.special)
+(argument (list_variable) @string.special)
+(argument (dictionary_variable) @string.special)
+


### PR DESCRIPTION
Added a parser and syntax highlighting for Robot Framework files.
The parser seems to be very basic, but sufficient, as it was added to Helix not so long ago [here](https://github.com/helix-editor/helix/pull/6611).

Let me know if anything else is needed.