### PR TITLE
fix(parsers): ownership transfer of elvish

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -401,10 +401,10 @@ list.elsa = {
 
 list.elvish = {
   install_info = {
-    url = "https://github.com/ckafi/tree-sitter-elvish",
+    url = "https://github.com/elves/tree-sitter-elvish",
     files = { "src/parser.c" },
   },
-  maintainers = { "@ckafi" },
+  maintainers = { "@elves" },
 }
 
 list.embedded_template = {


### PR DESCRIPTION
I've transferred the ownership of the elvish grammer to @elves, which is the org that develops elvish.