### PR TITLE
feat(go): highlight builtins min and max

### DIFF
--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -171,6 +171,8 @@
            "imag"
            "len"
            "make"
+           "max"
+           "min"
            "new"
            "panic"
            "print"


### PR DESCRIPTION
According to https://tip.golang.org/doc/go1.21 there will be 3 new builtin functions:
* min
* max
* clear

Clear has already been added, this PR adds min and max.