### PR TITLE
injections(go): add back Cgo injections

### DIFF
--- a/queries/go/injections.scm
+++ b/queries/go/injections.scm
@@ -18,3 +18,25 @@
     ] @injection.content
     (#offset! @injection.content 0 1 0 -1)
     (#set! injection.language "regex")))
+
+(
+  (comment)+ @injection.content
+  .
+  (import_declaration
+    (import_spec path: (interpreted_string_literal) @_import_c))
+  (#eq? @_import_c "\"C\"")
+  (#lua-match? @injection.content "^/%*.*%*/$")
+  (#set! injection.language "c")
+  (#offset! @injection.content 0 2 0 -2)
+  (#set! injection.combined))
+
+(
+  (comment)+ @injection.content 
+  .
+  (import_declaration
+    (import_spec path: (interpreted_string_literal) @_import_c))
+  (#eq? @_import_c "\"C\"")
+  (#lua-match? @injection.content "^//")
+  (#set! injection.language "c")
+  (#offset! @injection.content 0 2 0 0)
+  (#set! injection.combined))


### PR DESCRIPTION
Re-add query that was removed in #3275, with anchors to limit injections to adjacent regions

Hopefully doesn't re-introduce performance issue in #3187, #3263

@rhinoxi, @marcelbeumer, and also @nikklassen, sorry for interrupting, but can you perf test this to check whether the problem is still resolved even with this query added?