### PR TITLE
fix(yaml): typo in promql injection

### DIFF
--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -45,7 +45,7 @@
                (flow_node) @promql))))
 
 (block_mapping_pair
-  key: (flow_node) @_expr (#eq @_expr "expr")
+  key: (flow_node) @_expr (#eq? @_expr "expr")
   value: (block_node
            (block_sequence
              (block_sequence_item


### PR DESCRIPTION
This PR adds a missing `?` to `#eq` predicate in `promql` injection into `yaml`.

Appeared after b64ea2ec444c27efd8d3bd2377a8b24589954363