### PR TITLE
feat(parsers): add support for RBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [r](https://github.com/r-lib/tree-sitter-r) (maintained by @echasnovski)
 - [ ] [racket](https://github.com/6cdh/tree-sitter-racket)
 - [x] [rasi](https://github.com/Fymyte/tree-sitter-rasi) (maintained by @Fymyte)
+- [x] [rbs](https://github.com/apexatoll/tree-sitter-rbs) (maintained by @apexatoll)
 - [x] [regex](https://github.com/tree-sitter/tree-sitter-regex) (maintained by @theHamsta)
 - [x] [rego](https://github.com/FallenAngel97/tree-sitter-rego) (maintained by @FallenAngel97)
 - [x] [rnoweb](https://github.com/bamonroe/tree-sitter-rnoweb) (maintained by @bamonroe)

--- a/lockfile.json
+++ b/lockfile.json
@@ -434,6 +434,9 @@
   "rasi": {
     "revision": "371dac6bcce0df5566c1cfebde69d90ecbeefd2d"
   },
+  "rbs": {
+    "revision": "843be6548cd52ed7c57280093acf30544ad0ed96"
+  },
   "regex": {
     "revision": "2354482d7e2e8f8ff33c1ef6c8aa5690410fbc96"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1297,7 +1297,7 @@ list.rasi = {
 list.rbs = {
   install_info = {
     url = "https://github.com/apexatoll/tree-sitter-rbs",
-    files = { "src/parser.c"},
+    files = { "src/parser.c" },
   },
   maintainers = { "@apexatoll" },
 }

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1294,6 +1294,14 @@ list.rasi = {
   maintainers = { "@Fymyte" },
 }
 
+list.rbs = {
+  install_info = {
+    url = "https://github.com/apexatoll/tree-sitter-rbs",
+    files = { "src/parser.c"},
+  },
+  maintainers = { "@apexatoll" },
+}
+
 list.regex = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-regex",

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -1,0 +1,42 @@
+["(" ")" "{" "}" "[" "]"] @punctuation.brackets
+["," "."]                 @punctuation.delimiter
+(method_signatures "|"    @punctuation.special)
+
+["class" "interface" "module" "end" "def" "alias"] @scope
+
+["=" "->" "<" "::"]           @operator
+(supertype)                   @operator
+(union_type "|")              @operator
+(intersection_type "&")       @operator
+[":" "?"]                     @operator.special
+(splat_parameter "*")         @operator.special
+(double_splat_parameter "**") @operator.special
+
+["type" (visibility) (unchecked) (variance)] @keyword
+
+["include" "extend" "prepend"] @include
+
+[(class_name) (constant_name) (module_name) (interface_name)] @type.constant
+
+(builtin_type)  @type.builtin
+(type_variable) @type.variable
+(alias_name)    @type.alias
+
+[(method_name) (singleton_method_name)] @function
+(attribute_type) @function.macro
+
+(var_name)    @variable
+(ivar_name)   @variable.instance
+(global_name) @variable.global
+
+(singleton_method      "self"  @variable.builtin)
+(singleton_method_name "self"  @variable.builtin)
+(module_function       "self?" @variable.builtin)
+
+[(symbol_literal) (attribute_name) (hash_key)] @symbol
+
+(string_literal) @string
+
+[(true_literal) (false_literal)] @boolean
+
+(comment) @comment

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -2,7 +2,7 @@
 ["," "."]                 @punctuation.delimiter
 (method_signatures "|"    @punctuation.special)
 
-["class" "interface" "module" "end" "def" "alias"] @scope
+["class" "interface" "module" "end" "def" "alias"] @keyword.scope
 
 ["=" "->" "<" "::"]           @operator
 (supertype)                   @operator

--- a/queries/rbs/indents.scm
+++ b/queries/rbs/indents.scm
@@ -1,0 +1,4 @@
+[(class) (module) (interface)] @indent.begin
+
+"end" @indent.dedent
+"end" @indent.branch

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -13,6 +13,7 @@ vim.filetype.add {
     usda = "usd",
     wgsl = "wgsl",
     w = "wing",
+    rbs = "rbs",
   },
 }
 


### PR DESCRIPTION
- This PR adds language support for the RBS typing language for Ruby.
- https://github.com/apexatoll/tree-sitter-rbs
- Changes
    - Add parser to parser list at `lua/nvim-treesitter/parsers.lua`
    - Add parser to README list
    - Copy queries into `queries/rbs`

- Please let me know if I have missed anything out!
