### PR TITLE
fix(promql): bump parser, fix queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -396,7 +396,7 @@
     "revision": "eca2596a355b1a9952b4f80f8f9caed300a272b5"
   },
   "promql": {
-    "revision": "655afc4fe6813f38bde087d6493d8fd4920d6d4a"
+    "revision": "4b6b9f399dc58e408c81da8d8fd7e66ab617eef3"
   },
   "proto": {
     "revision": "42d82fa18f8afe59b5fc0b16c207ee4f84cb185f"

--- a/queries/promql/highlights.scm
+++ b/queries/promql/highlights.scm
@@ -17,13 +17,6 @@
 ] @operator
 
 [
-  "and"
-  "unless"
-  "or"
-  "bool"
-] @keyword.operator
-
-[
   "{"
   "}"
   "["
@@ -43,11 +36,6 @@
 (label_value) @text.underline @string.regex
 
 (function_name) @function.call
-
-[ 
-  "by"
-  "without"
-] @function
 
 (comment) @comment @spell
 (ERROR) @error


### PR DESCRIPTION
The removed tokens are now case insensitive via an ugly regular expression; we cannot use them in captures here anymore.