### PR TITLE
scfg: new parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [ruby](https://github.com/tree-sitter/tree-sitter-ruby) (maintained by @TravonteD)
 - [x] [rust](https://github.com/tree-sitter/tree-sitter-rust) (maintained by @amaanq)
 - [x] [scala](https://github.com/tree-sitter/tree-sitter-scala) (maintained by @stevanmilic)
+- [x] [scfg](https://git.sr.ht/~rockorager/tree-sitter-scfg) (maintained by @WhyNotHugo)
 - [ ] [scheme](https://github.com/6cdh/tree-sitter-scheme)
 - [x] [scss](https://github.com/serenadeai/tree-sitter-scss) (maintained by @elianiva)
 - [x] [slint](https://github.com/jrmoulton/tree-sitter-slint) (experimental, maintained by @jrmoulton)

--- a/lockfile.json
+++ b/lockfile.json
@@ -461,6 +461,9 @@
   "scala": {
     "revision": "8062487fb3b7f3ce1bb7ce1fd1c84bed60c75203"
   },
+  "scfg": {
+    "revision": "6deae0cbb458c849a4d1e2985093e9c9c32d7fd0"
+  },
   "scheme": {
     "revision": "ca8af220aaf2a80aaf609bfb0df193817e4f064b"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1367,6 +1367,15 @@ list.scala = {
   maintainers = { "@stevanmilic" },
 }
 
+list.scfg = {
+  install_info = {
+    url = "https://git.sr.ht/~rockorager/tree-sitter-scfg",
+    files = { "src/parser.c" },
+    requires_generate_from_grammar = true,
+  },
+  maintainers = { "@WhyNotHugo" },
+}
+
 list.scheme = {
   install_info = {
     url = "https://github.com/6cdh/tree-sitter-scheme",

--- a/queries/scfg/highlights.scm
+++ b/queries/scfg/highlights.scm
@@ -1,0 +1,8 @@
+[
+ "{"
+ "}"
+] @punctuation.bracket
+
+(comment) @comment @spell
+(directive_name) @type
+(directive_params) @parameter

--- a/queries/scfg/injections.scm
+++ b/queries/scfg/injections.scm
@@ -1,0 +1,1 @@
+(comment) @comment


### PR DESCRIPTION
This introduces a new parser for scfg. The highlights.scm file was copied from the repository for tree-sitter-scfg (and I have retained the license accordingly).

I don't think that there is a mechanism to copy the scm files from the parser repository itself, but that would be ideal in this case, especially since upstream targets neovim in this particular case.

Cc: @rockorager