### PR TITLE
fix(julia): symbol highlighting

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -13,7 +13,9 @@
 (macro_definition
   name: (identifier) @function.macro)
 
-(quote_expression ":" [(identifier) (operator)]) @symbol
+(quote_expression
+  ":" @symbol
+  [(identifier) (operator)] @symbol)
 
 (field_expression
   (identifier) @field .)


### PR DESCRIPTION
Update the `@symbol` capture to enable highlighting symbols and variables differently.

See https://github.com/tree-sitter/tree-sitter-julia/issues/110