### PR TITLE
feat: add some common comment tags

### DIFF
--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -13,10 +13,10 @@
   (name) @text.note @nospell
   ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?
   ":" @punctuation.delimiter)
-  (#any-of? @text.note "NOTE" "XXX" "INFO"))
+  (#any-of? @text.note "NOTE" "XXX" "INFO" "DOCS" "PERF" "TEST"))
 
 ("text" @text.note @nospell
- (#any-of? @text.note "NOTE" "XXX" "INFO"))
+ (#any-of? @text.note "NOTE" "XXX" "INFO" "DOCS" "PERF" "TEST"))
 
 ((tag
   (name) @text.warning @nospell


### PR DESCRIPTION
`PERF` and `TEST` can be found as defaults for example in https://github.com/folke/todo-comments.nvim

all new tags are also common, for example as conventional commit keywords