### PR TITLE
fix(rust): move @namespace below @type

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -78,47 +78,47 @@
 
 ; Assume that uppercase names in paths are types
 
-(scoped_identifier
-  path: (identifier) @namespace)
-
-(scoped_identifier
- (scoped_identifier
-  name: (identifier) @namespace))
-
-(scoped_type_identifier
-  path: (identifier) @namespace)
-
-(scoped_type_identifier
-  path: (identifier) @type
-  (#lua-match? @type "^[A-Z]"))
-
-(scoped_type_identifier
- (scoped_identifier
-  name: (identifier) @namespace))
-
 ((scoped_identifier
   path: (identifier) @type)
  (#lua-match? @type "^[A-Z]"))
 
 ((scoped_identifier
-    name: (identifier) @type)
+  name: (identifier) @type)
  (#lua-match? @type "^[A-Z]"))
 
 ((scoped_identifier
-    name: (identifier) @constant)
+  name: (identifier) @constant)
  (#lua-match? @constant "^[A-Z][A-Z%d_]*$"))
 
 ((scoped_identifier
   path: (identifier) @type
   name: (identifier) @constant)
-  (#lua-match? @type "^[A-Z]")
-  (#lua-match? @constant "^[A-Z]"))
+ (#lua-match? @type "^[A-Z]")
+ (#lua-match? @constant "^[A-Z]"))
+
+((scoped_type_identifier
+  path: (identifier) @type)
+ (#lua-match? @type "^[A-Z]"))
 
 ((scoped_type_identifier
   path: (identifier) @type
   name: (type_identifier) @constant)
-  (#lua-match? @type "^[A-Z]")
-  (#lua-match? @constant "^[A-Z]"))
+ (#lua-match? @type "^[A-Z]")
+ (#lua-match? @constant "^[A-Z]"))
+
+(scoped_identifier
+  path: (identifier) @namespace)
+
+(scoped_identifier
+ (scoped_identifier
+  name: (identifier) @namespace))
+
+(scoped_type_identifier
+  path: (identifier) @namespace)
+
+(scoped_type_identifier
+ (scoped_identifier
+  name: (identifier) @namespace))
 
 [
   (crate)


### PR DESCRIPTION
This is useful if one wishes to highlight enums (`@namespace`) differently from other types like structs. `@namespace` is more specific than `@type` in this case, so it should be defined last.
I've also changed the indentation to be more consistent.
This is my first tree-sitter contribution, so feedback is welcome!