### PR TITLE
feat(t32): Add query support for extended HLL expression support

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1512,7 +1512,7 @@ list.t32 = {
   install_info = {
     url = "https://codeberg.org/xasc/tree-sitter-t32",
     files = { "src/parser.c", "src/scanner.c" },
-    revision = "1dd98248b01e4a3933c1b85b58bab0875e2ba437",
+    revision = "767f3c52fe649e4a6ab3551ac287e5b6038c9148",
   },
   maintainers = { "@xasc" },
 }

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1510,9 +1510,9 @@ list.systemtap = {
 
 list.t32 = {
   install_info = {
-    url = "https://codeberg.org/xasc/tree-sitter-t32",
+    url = "https://gitlab.com/xasc/tree-sitter-t32",
     files = { "src/parser.c", "src/scanner.c" },
-    revision = "767f3c52fe649e4a6ab3551ac287e5b6038c9148",
+    revision = "9d2520ae9886d3a768a352ec80db8762afb5232d",
   },
   maintainers = { "@xasc" },
 }

--- a/queries/t32/highlights.scm
+++ b/queries/t32/highlights.scm
@@ -1,3 +1,4 @@
+; Keywords, punctuation and operators
 [
   "="
   "^^"
@@ -28,49 +29,128 @@
   "&"
   "->"
   "*"
+  "-="
+  "+="
+  "*="
+  "/="
+  "%="
+  "|="
+  "&="
+  "^="
+  ">>="
+  "<<="
+  "--"
+  "++"
 ] @operator
 
 [
- "("
- ")"
- "{"
- "}"
- "["
- "]"
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
 ] @punctuation.bracket
 
 [
   ","
   "."
-  ";"
 ] @punctuation.delimiter
 
 [
-  (access_class)
+  "enum"
+  "struct"
+  "union"
+] @keyword
+
+"sizeof" @keyword.operator
+
+[
+  "const"
+  "volatile"
+] @type.qualifier
+
+
+; Operators in comma and conditional HLL expressions
+(hll_comma_expression
+  "," @operator)
+
+(hll_conditional_expression
+  [
+   "?"
+   ":"
+] @conditional.ternary)
+
+
+; Strings and others literal types
+(access_class) @constant.builtin
+
+[
   (address)
   (bitmask)
   (file_handle)
-  (frequency)
   (integer)
-  (percentage)
-  (time)
+  (hll_number_literal)
 ] @number
 
-(float) @float
+[
+  (float)
+  (frequency)
+  (percentage)
+  (time)
+] @float
 
-(string) @string
+[
+  (string)
+  (hll_string_literal)
+] @string
+
+(hll_escape_sequence) @string.escape
 
 (path) @string.special
-
 (symbol) @symbol
 
-(character) @character
+[
+  (character)
+  (hll_char_literal)
+] @character
+
+
+; Types in HLL expressions
+[
+ (hll_type_identifier)
+ (hll_type_descriptor)
+] @type
+
+(hll_type_qualifier) @type.qualifier
+
+(hll_primitive_type) @type.builtin
+
+
+; HLL expressions
+(hll_call_expression
+  function: (identifier) @function.call)
+
+(hll_call_expression
+  function: (hll_field_expression
+    field: (hll_field_identifier) @function.call))
+
+
+; HLL variables
+(identifier) @variable
+(hll_field_identifier) @field
+
 
 ; Commands
 (command_expression
   command: (identifier) @keyword)
+
 (macro_definition
   command: (identifier) @keyword)
+
+(call_expression
+  function: (identifier) @function.builtin)
+
 
 ; Returns
 (
@@ -84,20 +164,23 @@
   (#lua-match? @keyword.return "^[rR][eE][tT][uU][rR][nN]$")
 )
 
+
 ; Subroutine calls
 (subroutine_call_expression
   command: (identifier) @keyword
   subroutine: (identifier) @function.call)
 
+
 ; Variables, constants and labels
 (macro) @variable.builtin
-(internal_c_variable) @variable.builtin
+(trace32_hll_variable) @variable.builtin
 
 (argument_list
-  (identifier) @constant)
+  (identifier) @constant.builtin)
+
 (
- (argument_list (identifier) @constant.builtin)
- (#lua-match? @constant.builtin "^[%%/][%l%u][%l%u%d.]*$")
+  (argument_list (identifier) @constant.builtin)
+  (#lua-match? @constant.builtin "^[%%/][%l%u][%l%u%d.]*$")
 )
 
 (
@@ -106,23 +189,33 @@
     arguments: (argument_list . (identifier) @label))
   (#lua-match? @keyword "^[gG][oO][tT][oO]$")
 )
+
 (labeled_expression
   label: (identifier) @label)
 
+(option_expression
+  (identifier) @constant.builtin)
+
+(format_expression
+  (identifier) @constant.builtin)
+
+
 ; Subroutine blocks
 (subroutine_block
-  command: (identifier) @keyword
+  command: (identifier) @keyword.function
   subroutine: (identifier) @function)
 
 (labeled_expression
   label: (identifier) @function
   (block))
 
+
 ; Parameter declarations
 (parameter_declaration
   command: (identifier) @keyword
   (identifier)? @constant.builtin
   macro: (macro) @parameter)
+
 
 ; Control flow
 (if_block
@@ -135,8 +228,5 @@
 (repeat_block
   command: (identifier) @repeat)
 
-(call_expression
-  function: (identifier) @function.builtin)
 
-(type_identifier) @type
 (comment) @comment @spell

--- a/queries/t32/locals.scm
+++ b/queries/t32/locals.scm
@@ -13,7 +13,7 @@
 (command_expression
   command: (identifier)
   arguments: (argument_list
-    variable: (identifier) @definition.var))
+    declarator: (trace32_hll_variable) @definition.var))
 
 ; Function definitions
 (subroutine_block
@@ -32,4 +32,7 @@
   (#set! reference.kind "function")
 )
 
-(macro) @reference
+[
+  (macro)
+  (trace32_hll_variable)
+] @reference

--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -99,7 +99,7 @@ local function do_check()
 end
 
 local ok, result = pcall(do_check)
-local allowed_to_fail = { "t32" } -- codeberg hoster is unreliable
+local allowed_to_fail = vim.split(vim.env.ALLOWED_INSTALLATION_FAILURES or "", ",", true)
 
 for k, v in pairs(require("nvim-treesitter.parsers").get_parser_configs()) do
   if not require("nvim-treesitter.parsers").has_parser(k) then

--- a/tests/indent/t32/if_block.cmm
+++ b/tests/indent/t32/if_block.cmm
@@ -1,0 +1,49 @@
+IF &a
+  STOP
+
+IF (TRUE())
+(
+  BREAK
+)
+
+IF (&b+CouNT())
+(
+  continue
+)
+
+IF FOUND()
+  STOP
+ELSE
+  CONTinue
+
+IF &c
+  CONTinue
+ELSE IF FALSE()
+  Break
+ELSE
+  stop
+
+IF &d
+(
+  STOP
+)
+ELSE IF &e
+; comment A
+(
+  CONTINUE
+)
+ELSE
+; comment B
+(
+  BREAK
+)
+
+IF &f
+  IF &g
+    stop
+  ELSE
+    IF &h
+  (
+    continue
+  )
+

--- a/tests/indent/t32/repeat_block.cmm
+++ b/tests/indent/t32/repeat_block.cmm
@@ -1,0 +1,27 @@
+RePeaT 10. PRINT "A"
+
+RePeaT &a
+  print
+
+REPEAT 0xaAfF09
+(
+  cont
+)
+
+RPT
+(
+  b
+)
+
+rpt
+(
+  s
+)
+WHILE &a
+
+REPEAT TRUE()
+; comment
+(
+  cont
+)
+

--- a/tests/indent/t32/subroutine_block.cmm
+++ b/tests/indent/t32/subroutine_block.cmm
@@ -1,0 +1,23 @@
+printA:
+(
+  PRINT "A"
+  RETURN
+)
+
+sUBROUtINE printB
+(
+  ENTRY &in
+
+  PRINT "&in"
+  RETURN
+)
+
+SUBROUTINE printC
+// comment
+(
+  PARAMETERS &a &b
+
+  PRINT "&a"+"&b"
+  ENDDO
+)
+

--- a/tests/indent/t32/while_block.cmm
+++ b/tests/indent/t32/while_block.cmm
@@ -1,0 +1,14 @@
+WHILE &a
+  Step
+
+WHILE (sYmbol.EXIT(main))
+(
+  Step
+  Break
+)
+
+WHILE (FALSE())
+// comment
+(
+  ECHO "test"
+)

--- a/tests/indent/t32_spec.lua
+++ b/tests/indent/t32_spec.lua
@@ -1,0 +1,123 @@
+local Runner = require("tests.indent.common").Runner
+local XFAIL = require("tests.indent.common").XFAIL
+
+local runner = Runner:new(it, "tests/indent/t32", {
+  tabstop = 2,
+  shiftwidth = 2,
+  softtabstop = 0,
+  expandtab = true,
+})
+
+describe("indent t32:", function()
+  describe("whole file:", function()
+    runner:whole_file "."
+  end)
+
+  describe("new line:", function()
+    runner:new_line("if_block.cmm", { on_line = 2, text = "GOTO start", indent = 0 }, "command after IF", XFAIL)
+
+    runner:new_line("if_block.cmm", { on_line = 5, text = "GOTO start", indent = 2 }, "command in IF then block")
+
+    runner:new_line("if_block.cmm", { on_line = 4, text = "(", indent = 0 }, "block after IF")
+
+    for ii, test in ipairs {
+      { 1, 2 },
+      { 14, 2 },
+      { 19, 2 },
+      { 21, 2 },
+      { 41, 2 },
+      { 42, 4 },
+    } do
+      runner:new_line(
+        "if_block.cmm",
+        { on_line = test[1], text = "&x=1.", indent = test[2] },
+        "command in IF then[" .. ii .. "]"
+      )
+    end
+
+    runner:new_line("if_block.cmm", { on_line = 45, text = "&x=1.", indent = 2 }, "command in IF then")
+
+    for ii, test in ipairs {
+      { 16, 2 },
+      { 21, 2 },
+      { 23, 2 },
+      { 44, 4 },
+    } do
+      runner:new_line(
+        "if_block.cmm",
+        { on_line = test[1], text = "(\n", indent = test[2] },
+        "command in IF else[" .. ii .. "]"
+      )
+    end
+
+    runner:new_line("while_block.cmm", { on_line = 2, text = "&x=1.", indent = 2 }, "command after WHILE")
+
+    runner:new_line("while_block.cmm", { on_line = 4, text = "&x=1.", indent = 0 }, "command after WHILE")
+
+    runner:new_line("while_block.cmm", { on_line = 1, text = "(\n", indent = 0 }, "block in WHILE then")
+
+    for ii, test in ipairs {
+      { 5, 2 },
+      { 12, 2 },
+    } do
+      runner:new_line(
+        "while_block.cmm",
+        { on_line = test[1], text = "&x=1.", indent = test[2] },
+        "command in WHILE then block[" .. ii .. "]"
+      )
+    end
+
+    for ii, test in ipairs {
+      { 1, 0, nil },
+      { 4, 2, XFAIL },
+    } do
+      runner:new_line(
+        "repeat_block.cmm",
+        { on_line = test[1], text = "&x=1.", indent = test[2] },
+        "command after RePeaT[" .. ii .. "]"
+      )
+    end
+
+    runner:new_line("repeat_block.cmm", { on_line = 3, text = "(\n", indent = 0 }, "block in RePeaT then")
+
+    for ii, test in ipairs {
+      { 7, 2, XFAIL },
+      { 18, 2, nil },
+      { 24, 2, XFAIL },
+    } do
+      runner:new_line(
+        "repeat_block.cmm",
+        { on_line = test[1], text = "&x=1.", indent = test[2] },
+        "command in RePeaT then block [" .. ii .. "]"
+      )
+    end
+
+    runner:new_line("subroutine_block.cmm", { on_line = 1, text = "(\n", indent = 0 }, "block after call label")
+
+    for ii, test in ipairs {
+      { 2, 2, XFAIL },
+      { 3, 2, nil },
+      { 8, 2, XFAIL },
+      { 12, 2, nil },
+      { 19, 2, XFAIL },
+    } do
+      runner:new_line(
+        "subroutine_block.cmm",
+        { on_line = test[1], text = "&x=1.", indent = test[2] },
+        "command in subroutine block[" .. ii .. "]"
+      )
+    end
+
+    for ii, test in ipairs {
+      { 5, 2 },
+      { 13, 2 },
+      { 23, 2 },
+    } do
+      runner:new_line(
+        "subroutine_block.cmm",
+        { on_line = test[1], text = "&x=1.", indent = test[2] },
+        "command after subroutine block[" .. ii .. "]"
+      )
+    end
+  end)
+end)

--- a/tests/query/highlights/t32/comments.cmm
+++ b/tests/query/highlights/t32/comments.cmm
@@ -1,0 +1,10 @@
+// This is a comment
+; <- comment
+
+; Another comment
+; <- comment
+
+ECHO &a // This is a trailing comment
+;       ^ comment
+
+// vim: set ft=t32:

--- a/tests/query/highlights/t32/keywords.cmm
+++ b/tests/query/highlights/t32/keywords.cmm
@@ -1,0 +1,108 @@
+PRIVATE &password
+; <- keyword
+;        ^ variable.builtin
+ENTRY &password
+; <- keyword
+;        ^ parameter
+
+ENTRY %LINE &salt
+; <- keyword
+;      ^ constant.builtin
+;            ^ parameter
+
+IF "&password"==""
+; <- conditional
+;  ^ string
+;    ^ variable.builtin
+;             ^ operator
+(
+    ECHO "Failed to provide password."
+    ENDDO
+;   ^ keyword.return
+)
+ELSE
+; <- conditional
+(
+    PRIVATE &pass
+
+    &pass=FALSE()
+;          ^ function.builtin
+    WHILE !&pass
+;         ^ operator
+    (
+        GOSUB verify_password "&password"
+;             ^ function.call
+        RETURNVALUES &pass
+;                     ^ parameter
+        WAIT 10.ms
+;            ^ number
+    )
+
+    IF !&pass
+        GOTO fail
+;            ^ label
+    ELSE
+    (
+        GOSUB start_debug
+;             ^ function.call
+    )
+)
+
+LOCAL &num
+;      ^ variable.builtin
+
+&num = 2.
+;      ^ number
+
+RePeaT &num PRINT "Password: &password"
+;       ^ variable.builtin
+;                             ^ variable.builtin
+
+WinCLEAR
+FramePOS ,,,,Maximized
+;        ^ punctuation.delimiter
+;            ^ constant
+WinPOS 0% 50% 100% 35%
+;      ^ number
+COVerage.ListFunc
+
+ENDDO
+
+
+fail:
+; <- label
+    PRINT %ERROR "Password verification failed."
+    END
+;   ^ keyword.return
+
+
+verify_password:
+; <- function
+(
+    PARAMETERS &password
+;               ^ parameter
+
+    SYStem.Option.KEYCODE "&password"
+    SYStem.JtagClock  1kHz
+;                     ^ number
+    SYStem.Mode.Attach
+
+    Data.Set EAXI:0x34000000 %Long 0x34000100 0x34000021 /verify
+;            ^ number
+;                             ^ constant.builtin
+;                                                         ^ constant
+
+    RETURN TRUE()
+;   ^ keyword.return
+)
+
+
+SUBROUTINE start_debug
+;          ^ function
+(
+    Go main
+    RETURN
+;   ^ keyword.return
+)
+
+// vim: set ft=t32:

--- a/tests/query/highlights/t32/keywords.cmm
+++ b/tests/query/highlights/t32/keywords.cmm
@@ -35,7 +35,7 @@ ELSE
         RETURNVALUES &pass
 ;                     ^ parameter
         WAIT 10.ms
-;            ^ number
+;            ^ float
     )
 
     IF !&pass
@@ -61,9 +61,9 @@ RePeaT &num PRINT "Password: &password"
 WinCLEAR
 FramePOS ,,,,Maximized
 ;        ^ punctuation.delimiter
-;            ^ constant
+;            ^ constant.builtin
 WinPOS 0% 50% 100% 35%
-;      ^ number
+;      ^ float
 COVerage.ListFunc
 
 ENDDO
@@ -84,13 +84,16 @@ verify_password:
 
     SYStem.Option.KEYCODE "&password"
     SYStem.JtagClock  1kHz
-;                     ^ number
+;                     ^ float
     SYStem.Mode.Attach
 
-    Data.Set EAXI:0x34000000 %Long 0x34000100 0x34000021 /verify
-;            ^ number
-;                             ^ constant.builtin
-;                                                         ^ constant
+    Data.Set N: EAXI:0x34000000 %Long 0x34000100 0x34000021 /verify
+;            ^ constant.builtin
+;               ^ constant.builtin
+;                    ^ number
+;                                ^ constant.builtin
+;                                     ^ number
+;                                                            ^ constant.builtin
 
     RETURN TRUE()
 ;   ^ keyword.return
@@ -98,8 +101,20 @@ verify_password:
 
 
 SUBROUTINE start_debug
+; <- keyword.function
 ;          ^ function
 (
+    COVerage.ListModule %MULTI.OBC \sieve
+;    ^ keyword
+;                        ^ constant.builtin
+;                                  ^ symbol
+
+    Var.DRAW flags[0..16] /Alternate 3
+;    ^ keyword
+;             ^ variable
+;                          ^ constant.builtin
+;                                    ^ number
+
     Go main
     RETURN
 ;   ^ keyword.return

--- a/tests/query/highlights/t32/literals.cmm
+++ b/tests/query/highlights/t32/literals.cmm
@@ -1,0 +1,38 @@
+WinPOS ,,1000.,,,,myWatchWindow
+;        ^ number
+
+PRinTer.OPEN "~~~/varwatch.txt" ASCIIE
+;            ^ string
+
+sYmbol.NEW _InitialSP   0x34000100
+;                       ^ number
+
+DO ~~~~/test.cmm
+;  ^ string.special
+
+WAIT 1.ns
+;    ^ number
+
+SYStem.JtagClock  100.GHZ
+;                 ^ number
+
+DATA.SET P:&HEAD+0x4 %LONG DATA.LONG(EA:&HEAD+0x4)&0xFFFFFF
+;                                    ^ number
+
+List `main`
+;    ^ symbol
+
+&range = 'a'--'z'||'0'--'9'
+;        ^ character
+;           ^ operator
+;                       ^ character
+
+Data.Set N: 0xffff800000 0y0011xx01xx&&a
+;        ^ number
+;                        ^ number
+;                                    ^ operator
+
+WinPOS 0% 85% 100% 15%
+;             ^ number
+
+// vim: set ft=t32:

--- a/tests/query/highlights/t32/literals.cmm
+++ b/tests/query/highlights/t32/literals.cmm
@@ -11,13 +11,13 @@ DO ~~~~/test.cmm
 ;  ^ string.special
 
 WAIT 1.ns
-;    ^ number
+;    ^ float
 
 SYStem.JtagClock  100.GHZ
-;                 ^ number
+;                 ^ float
 
 DATA.SET P:&HEAD+0x4 %LONG DATA.LONG(EA:&HEAD+0x4)&0xFFFFFF
-;                                    ^ number
+;                                    ^ constant.builtin
 
 List `main`
 ;    ^ symbol
@@ -28,11 +28,12 @@ List `main`
 ;                       ^ character
 
 Data.Set N: 0xffff800000 0y0011xx01xx&&a
-;        ^ number
+;        ^ constant.builtin
+;           ^ number
 ;                        ^ number
 ;                                    ^ operator
 
 WinPOS 0% 85% 100% 15%
-;             ^ number
+;             ^ float
 
 // vim: set ft=t32:

--- a/tests/query/highlights/t32/var.cmm
+++ b/tests/query/highlights/t32/var.cmm
@@ -1,0 +1,27 @@
+Var.NEWGLOBAL char[4][32] \myarr
+; <- keyword
+;             ^ type
+;                          ^ variable.builtin
+LOCAL &i &data
+
+&data="zero|one|two|three"
+
+&i=0.
+WHILE &i<4
+(
+    PRIVATE &val
+    &val=STRing.SPLIT("&data","|",&i)
+    Var.Assign \myarr[&i]="&val"
+;              ^ variable.builtin
+    &i=&i+1.
+)
+
+Var.NEWLOCAL \x
+; <- keyword
+;             ^ variable.builtin
+Var.set \x=func3(5,3)
+;       ^ variable.builtin
+PRINT Var.VALUE(\x)
+;               ^ variable.builtin
+
+// vim: set ft=t32:

--- a/tests/query/highlights/t32/var.cmm
+++ b/tests/query/highlights/t32/var.cmm
@@ -1,6 +1,6 @@
 Var.NEWGLOBAL char[4][32] \myarr
 ; <- keyword
-;             ^ type
+;             ^ type.builtin
 ;                          ^ variable.builtin
 LOCAL &i &data
 
@@ -13,6 +13,7 @@ WHILE &i<4
     &val=STRing.SPLIT("&data","|",&i)
     Var.Assign \myarr[&i]="&val"
 ;              ^ variable.builtin
+;                        ^ operator
     &i=&i+1.
 )
 
@@ -21,7 +22,54 @@ Var.NEWLOCAL \x
 ;             ^ variable.builtin
 Var.set \x=func3(5,3)
 ;       ^ variable.builtin
+;          ^ function.call
+;                ^ number
 PRINT Var.VALUE(\x)
 ;               ^ variable.builtin
+PRINT Var.VALUE('a')
+;               ^ character
+Var.Assign (*ap)[2..4] = &a
+;            ^ variable
+;                         ^ variable
+Var.Assign sp = &s.n+offset
+;          ^ variable
+;                ^ variable
+;                  ^ field
+;                    ^ variable
+Var.Assign padd = (CAddition const * volatile)&d
+;          ^ variable
+;                  ^ type
+;                            ^ type.qualifier
+;                                    ^ type.qualifier
+;                                              ^ variable
+Var.Assign e1 = (enum e2)&e
+;          ^ variable
+;                ^ keyword
+;                     ^ type
+;                         ^ variable
+Var.Assign *vector = (struct Vector3d*)&acceleration
+;           ^ variable
+;                     ^ keyword
+;                            ^ type
+;                                       ^ variable
+Var.Assign z = (union foo)x
+;          ^ variable
+;               ^ keyword
+;                     ^ type
+;                         ^ variable
+Var.Assign b = -a
+;          ^ variable
+;               ^ variable
+Var.Assign c = i++
+;          ^ variable
+;              ^ variable
+Var.Assign d = sizeof(int)
+;          ^ variable
+;              ^ keyword.operator
+;                     ^ type.builtin
+Var.call strcmp(key,buffer)
+;        ^ function.call
+;               ^ variable
+;                   ^ variable
 
 // vim: set ft=t32:


### PR DESCRIPTION
Version 2.1 of the grammar has improved support for commands with HLL (high-level language, think C or C++) expressions. This change should update the existing queries accordingly.

Even though the syntax for HLL expressions is very close to C, it is, from my point of view, not really possible to add the support via language injection. The two main problems are that in contrast to C
- whitespaces or the lack thereof matters in weird ways, and that
- there are syntax extensions on top, like a slice operator for arrays (e.g. `Var.DRAW flags[0..16]`) or HLL variables that can be defined on the fly (e.g. `Var.set \x=func3(5,3)`).

That's why I tried to extract the relevant parts from tree-sitter-c, but keep most of the node definitions consistent.