### PR TITLE
highlights(wgsl_bevy): add support for naga_oil features

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -582,7 +582,7 @@
     "revision": "40259f3c77ea856841a4e0c4c807705f3e4a2b65"
   },
   "wgsl_bevy": {
-    "revision": "7cd38d6895060b023353e04f7af099ec64add5d1"
+    "revision": "9e3273e64bdd3f74d1514674286838f9075ee9e4"
   },
   "wing": {
     "revision": "23712eff9768576bdd852cb9b989a9cd44af014a"

--- a/queries/wgsl_bevy/highlights.scm
+++ b/queries/wgsl_bevy/highlights.scm
@@ -1,10 +1,21 @@
 ; inherits wgsl
 
 [
+ "virtual"
+ "override"
+] @keyword
+
+[
  "#import"
  "#define_import_path"
+ "as"
 ] @include
+
 "::" @punctuation.delimiter
+
+(function_declaration
+  (import_path
+    ((identifier) @function .)))
 
 (import_path (identifier) @namespace (identifier))
 


### PR DESCRIPTION
Bevy has switched to https://github.com/bevyengine/naga_oil which allows new syntax constructs.