### PR TITLE
fix(c): only inject in preproc function calls/definitions

### DIFF
--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -1,4 +1,5 @@
-(preproc_arg) @c
+(preproc_function_def (preproc_arg) @c)
+(preproc_call (preproc_arg) @c)
 
 (comment) @comment
 


### PR DESCRIPTION
`#define FOO BAR` does not need an injection