### PR TITLE
refactor(t32): remove revision pinning

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1512,7 +1512,6 @@ list.t32 = {
   install_info = {
     url = "https://gitlab.com/xasc/tree-sitter-t32",
     files = { "src/parser.c", "src/scanner.c" },
-    revision = "9d2520ae9886d3a768a352ec80db8762afb5232d",
   },
   maintainers = { "@xasc" },
 }


### PR DESCRIPTION
The grammar is approaching feature completeness, so I expect to have fewer breaking changes in the future. `nvim-treesitter` could follow the latest version of the grammar.