### PR TITLE
fix(spell): do not spell check certain types of strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,10 @@ Used for XML-like tags.
 @nospell ; for defining regions that should NOT be spellchecked
 ```
 
+The main types of nodes which are spell checked are:
+- Comments
+- Strings; where it makes sense. Strings that have interpolation or are typically used for non text purposes are not spell checked (e.g. bash).
+
 #### Priority
 
 Captures can be assigned a priority to control precedence of highlights via the

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -40,12 +40,15 @@
  "!="
  ] @operator
 
+; Do *not* spell check strings since they typically have some sort of
+; interpolation in them, or, are typically used for things like filenames, URLs,
+; flags and file content.
 [
  (string)
  (raw_string)
  (ansi_c_string)
  (heredoc_body)
-] @string @spell
+] @string
 
 (variable_assignment (word) @string)
 


### PR DESCRIPTION
    - Document that only certain kinds of strings are spell checked, and
      reasons why they may not.

    - Remove spell checking for bash strings.
