### PR TITLE
fix: rename filetype for haskell persistent to match vim name

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -655,7 +655,7 @@ list.haskell_persistent = {
     url = "https://github.com/MercuryTechnologies/tree-sitter-haskell-persistent",
     files = { "src/parser.c", "src/scanner.cc" },
   },
-  filetype = "haskell.persistent",
+  filetype = "haskellpersistent",
   maintainers = { "@lykahb" },
 }
 


### PR DESCRIPTION
This is a follow-up for https://github.com/nvim-treesitter/nvim-treesitter/pull/4990 that I opened at about the same time as [PR for Vim](https://github.com/vim/vim/pull/12573) to recognize the filetype for the persistent library.
The recognition is now merged, but with another filetype name. I am grateful to Bram for taking time to explain why the filetype should not have a dot.