### PR TITLE
refactor: remove `include-children` from queries

### DIFF
--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -5,8 +5,7 @@
     (tag_name) @_py_script)
   (text) @injection.content
   (#any-of? @_py_script "py-script" "py-repl")
-  (#set! injection.language "python")
-  (#set! injection.include-children))
+  (#set! injection.language "python"))
 
 (script_element
   (start_tag
@@ -18,13 +17,11 @@
   (#eq? @_attr "type")
   ; not adding type="py" here as it's handled by html_tags 
   (#any-of? @_type "pyscript" "py-script")
-  (#set! injection.language "python")
-  (#set! injection.include-children))
+  (#set! injection.language "python"))
 
 (element
   (start_tag
     (tag_name) @_py_config)
   (text) @injection.content
   (#eq? @_py_config "py-config")
-  (#set! injection.language "toml")
-  (#set! injection.include-children))
+  (#set! injection.language "toml"))

--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -7,8 +7,7 @@
     (raw_text) @injection.content)
   (#not-lua-match? @_no_type_lang "%slang%s*=")
   (#not-lua-match? @_no_type_lang "%stype%s*=")
-  (#set! injection.language "css")
-  (#set! injection.include-children))
+  (#set! injection.language "css"))
 
 ((style_element
    (start_tag
@@ -18,8 +17,7 @@
    (raw_text) @injection.content)
  (#eq? @_type "type")
  (#eq? @_css "text/css")
- (#set! injection.language "css")
- (#set! injection.include-children))
+ (#set! injection.language "css"))
 
 ; <script>...</script>
 ; <script defer>...</script>
@@ -28,8 +26,7 @@
    (raw_text) @injection.content)
  (#not-lua-match? @_no_type_lang "%slang%s*=")
  (#not-lua-match? @_no_type_lang "%stype%s*=")
- (#set! injection.language "javascript")
- (#set! injection.include-children))
+ (#set! injection.language "javascript"))
 
 ; <script type="mimetype-or-well-known-script-type">
 (script_element
@@ -37,16 +34,14 @@
     ((attribute
          (attribute_name) @_attr (#eq? @_attr "type")
          (quoted_attribute_value (attribute_value) @_type))))
-  (raw_text) @injection.content (#set-lang-from-mimetype! @_type)
-  (#set! injection.include-children))
+  (raw_text) @injection.content (#set-lang-from-mimetype! @_type))
 
 ; <a style="/* css */">
 ((attribute
    (attribute_name) @_attr
    (quoted_attribute_value (attribute_value) @injection.content))
  (#eq? @_attr "style")
- (#set! injection.language "css")
- (#set! injection.include-children))
+ (#set! injection.language "css"))
 
 ; lit-html style template interpolation
 ; <a @click=${e => console.log(e)}>
@@ -55,15 +50,13 @@
   (quoted_attribute_value (attribute_value) @injection.content))
   (#lua-match? @injection.content "%${")
   (#offset! @injection.content 0 2 0 -1)
-  (#set! injection.language "javascript")
-  (#set! injection.include-children))
+  (#set! injection.language "javascript"))
 
 ((attribute
   (attribute_value) @injection.content)
   (#lua-match? @injection.content "%${")
   (#offset! @injection.content 0 2 0 -2)
-  (#set! injection.language "javascript")
-  (#set! injection.include-children))
+  (#set! injection.language "javascript"))
 
 ; <input pattern="[0-9]"> or <input pattern=[0-9]>
 (element (_
@@ -73,13 +66,11 @@
       (quoted_attribute_value (attribute_value) @injection.content)
       (attribute_value) @injection.content
     ] (#eq? @_attr "pattern")))
-  (#set! injection.language "regex")
-  (#set! injection.include-children)))
+  (#set! injection.language "regex")))
 
 ; <input type="checkbox" onchange="this.closest('form').elements.output.value = this.checked">
 (attribute
   (attribute_name) @_name
   (#lua-match? @_name "^on[a-z]+$")
   (quoted_attribute_value (attribute_value) @injection.content)
-  (#set! injection.language "javascript")
-  (#set! injection.include-children))
+  (#set! injection.language "javascript"))

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -33,10 +33,10 @@
  (#lua-match? @injection.content "^%s*;+%s?query")
  (#set! injection.language "query"))
 
-((comment) @injection.content
-  (#lua-match? @injection.content "^[-][-][-][%s]*@")
+(comment
+  content: (_) @injection.content
+  (#lua-match? @injection.content "^[-][%s]*@")
   (#set! injection.language "luadoc")
-  (#set! injection.include-children)
   (#offset! @injection.content 0 3 0 0))
 
 ; string.match("123", "%d+")
@@ -87,6 +87,6 @@
                  (#set! injection.language "luap")
                  (#set! injection.include-children))))
 
-((comment) @injection.content
-  (#set! injection.language "comment")
-  (#set! injection.include-children))
+(comment
+   content: (_) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/markdown_inline/injections.scm
+++ b/queries/markdown_inline/injections.scm
@@ -1,8 +1,6 @@
 ((html_tag) @injection.content
  (#set! injection.language "html")
- (#set! injection.combined)
- (#set! injection.include-children))
+ (#set! injection.combined))
 
 ((latex_block) @injection.content
- (#set! injection.language "latex")
- (#set! injection.include-children))
+ (#set! injection.language "latex"))

--- a/queries/svelte/injections.scm
+++ b/queries/svelte/injections.scm
@@ -8,15 +8,13 @@
     (raw_text) @injection.content)
   (#eq? @_attr "lang")
   (#any-of? @_lang "scss" "postcss" "less")
-  (#set! injection.language "scss")
-  (#set! injection.include-children))
+  (#set! injection.language "scss"))
 
 ([
   (raw_text_expr)
   (raw_text_each)
 ] @injection.content
- (#set! injection.language "javascript")
- (#set! injection.include-children))
+ (#set! injection.language "javascript"))
 
 ((script_element
     (start_tag
@@ -26,8 +24,7 @@
     (raw_text) @injection.content)
  (#eq? @_attr "lang") 
  (#any-of? @_lang "ts" "typescript")
- (#set! injection.language "typescript")
- (#set! injection.include-children))
+ (#set! injection.language "typescript"))
 
 ((element
    (start_tag
@@ -37,5 +34,4 @@
          (attribute_value) @injection.language)))
    (text) @injection.content)
  (#eq? @_attr "lang") 
- (#eq? @injection.language "pug")
- (#set! injection.include-children))
+ (#eq? @injection.language "pug"))

--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -8,8 +8,7 @@
         (quoted_attribute_value (attribute_value) @injection.language)))
     (raw_text) @injection.content)
     (#eq? @_lang "lang")
-    (#any-of? @injection.language "css" "scss")
-    (#set! injection.include-children))
+    (#any-of? @injection.language "css" "scss"))
 
 ; TODO: When nvim-treesitter has postcss and less parsers, use @injection.language and @injection.content instead
 ; <script lang="scss">
@@ -21,8 +20,7 @@
     (raw_text) @injection.content
     (#eq? @_lang "lang")
     (#any-of? @_scss "less" "postcss")
-    (#set! injection.language "scss")
-    (#set! injection.include-children)))
+    (#set! injection.language "scss")))
 
 ; <script lang="js">
 ((script_element
@@ -33,8 +31,7 @@
     (raw_text) @injection.content)
     (#eq? @_lang "lang")
     (#eq? @_js "js")
-    (#set! injection.language "javascript")
-    (#set! injection.include-children))
+    (#set! injection.language "javascript"))
 
 ; <script lang="ts">
 ((script_element
@@ -45,8 +42,7 @@
     (raw_text) @injection.content)
     (#eq? @_lang "lang")
     (#eq? @_ts "ts")
-    (#set! injection.language "typescript")
-    (#set! injection.include-children))
+    (#set! injection.language "typescript"))
 
 ; <script lang="tsx">
 ; <script lang="jsx">
@@ -57,24 +53,20 @@
         (quoted_attribute_value (attribute_value) @injection.language)))
     (#eq? @_attr "lang")
     (#any-of? @injection.language "tsx" "jsx")
-    (raw_text) @injection.content)
-    (#set! injection.include-children))
+    (raw_text) @injection.content))
 
 ((interpolation
   (raw_text) @injection.content)
-  (#set! injection.language "javascript")
-  (#set! injection.include-children))
+  (#set! injection.language "javascript"))
 
 (directive_attribute
   (quoted_attribute_value
     (attribute_value) @injection.content
-    (#set! injection.language "javascript")
-    (#set! injection.include-children)))
+    (#set! injection.language "javascript")))
 
 (template_element
     (start_tag
       (attribute
         (quoted_attribute_value (attribute_value) @injection.language)))
     (text) @injection.content
-    (#eq? @injection.language "pug")
-    (#set! injection.include-children))
+    (#eq? @injection.language "pug"))


### PR DESCRIPTION
As the injection range issue has been resolved, there isn't any reason to keep the workarounds anymore

I will do some extra experiment with markdown later, as that's the final `include-children` that we still have