### PR TITLE
feat(swift): improve highlights

### DIFF
--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -17,6 +17,7 @@
   (property_modifier)
   (parameter_modifier)
   (inheritance_modifier)
+  (mutation_modifier)
 ] @type.qualifier
 
 (function_declaration (simple_identifier) @method)
@@ -59,6 +60,10 @@
 
 (class_body (property_declaration (pattern (simple_identifier) @property)))
 (protocol_property_declaration (pattern (simple_identifier) @property))
+(navigation_expression
+  (navigation_suffix (simple_identifier) @property))
+(value_argument
+  name: (simple_identifier) @property)
 
 (import_declaration ["import" @include])
 
@@ -69,6 +74,8 @@
 (call_expression ; foo.bar.baz(): highlight the baz()
   (navigation_expression
     (navigation_suffix (simple_identifier) @function.call)))
+(call_expression
+  (prefix_expression (simple_identifier) @function.call)) ; .foo()
 ((navigation_expression
    (simple_identifier) @type) ; SomeType.method(): highlight SomeType as a type
    (#lua-match? @type "^[A-Z]"))
@@ -148,7 +155,6 @@
  "try"
  "try?"
  "try!"
- "!"
  "+"
  "-"
  "*"
@@ -178,4 +184,5 @@
 
  "..<"
  "..."
+  (bang)
 ] @operator


### PR DESCRIPTION
- Add hl to “mutating” modifier
- Add hl to property access
- Add hl to argument name
- Add hl to context aware method call

I noticed that the bang operator (`!`) is not being highlighted but if I add `(bang) @operator` it works, I guess this is a parser thing (?). Should I add this highlight?

<details>
<summary>Before/After</summary>

**Before:**
<img width="878" alt="Screenshot 2023-08-12 at 11 59 41" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/25467646/943cbb32-0c28-4a5a-ac40-0261e54bc458">

**After:**
<img width="820" alt="Screenshot 2023-08-12 at 12 23 59" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/25467646/08ed7c2f-6aa1-4335-a02a-bfe1d898ec90">
</details>