### PR TITLE
feat(c): update parser, add K&R-style function parameter support

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -33,7 +33,7 @@
     "revision": "7f1a5df44861291d6951b6b2146a9fef4c226e14"
   },
   "c": {
-    "revision": "54fa1febf4f3b1baaba1066a615e569f58c8e765"
+    "revision": "a2b7bac3b313efbaa683d9a276ff63cdc544d960"
   },
   "c_sharp": {
     "revision": "1648e21b4f087963abf0101ee5221bb413107b07"
@@ -69,7 +69,7 @@
     "revision": "f4b3cbc8b0bd4e13035d39940fef09f1392e8739"
   },
   "cpp": {
-    "revision": "77cecd88d28032bf4f54fd4ee68efb53a6c8c9a5"
+    "revision": "ab1065fa23a43a447bd7e619a3af90253867af24"
   },
   "css": {
     "revision": "5f2c94b897601b4029fedcce7db4c6d76ce8a128"

--- a/queries/arduino/injections.scm
+++ b/queries/arduino/injections.scm
@@ -1,14 +1,4 @@
-((preproc_def
- (preproc_arg) @injection.content)
- (#lua-match? @injection.content "\n")
- (#set! injection.language "arduino"))
-
-(preproc_function_def
- (preproc_arg) @injection.content
- (#set! injection.language "arduino"))
-
-(preproc_call
- (preproc_arg) @injection.content
+((preproc_arg) @injection.content
  (#set! injection.language "arduino"))
 
 ((comment) @injection.content 

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -244,6 +244,29 @@
 (parameter_declaration
   declarator: (pointer_declarator) @parameter)
 
+; K&R functions
+; To enable support for K&R functions,
+; add the following lines to your own query config and uncomment them.
+; They are commented out as they'll conflict with C++
+; Note that you'll need to have `; extends` at the top of your query file.
+;
+; (parameter_list (identifier) @parameter)
+;
+; (function_definition
+;   declarator: _
+;   (declaration
+;     declarator: (identifier) @parameter))
+;
+; (function_definition
+;   declarator: _
+;   (declaration
+;     declarator: (array_declarator) @parameter))
+;
+; (function_definition
+;   declarator: _
+;   (declaration
+;     declarator: (pointer_declarator) @parameter))
+
 (preproc_params (identifier) @parameter)
 
 [

--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -1,14 +1,4 @@
-((preproc_def
- (preproc_arg) @injection.content)
- (#lua-match? @injection.content "\n")
- (#set! injection.language "c"))
-
-(preproc_function_def
- (preproc_arg) @injection.content
- (#set! injection.language "c"))
-
-(preproc_call
- (preproc_arg) @injection.content
+((preproc_arg) @injection.content
  (#set! injection.language "c"))
 
 ((comment) @injection.content

--- a/queries/cpp/injections.scm
+++ b/queries/cpp/injections.scm
@@ -1,14 +1,4 @@
-((preproc_def
- (preproc_arg) @injection.content)
- (#lua-match? @injection.content "\n")
- (#set! injection.language "cpp"))
-
-(preproc_function_def
- (preproc_arg) @injection.content
- (#set! injection.language "cpp"))
-
-(preproc_call
- (preproc_arg) @injection.content
+((preproc_arg) @injection.content
  (#set! injection.language "cpp"))
 
 ((comment) @injection.content 

--- a/queries/cuda/injections.scm
+++ b/queries/cuda/injections.scm
@@ -1,14 +1,4 @@
-((preproc_def
- (preproc_arg) @injection.content)
- (#lua-match? @injection.content "\n")
- (#set! injection.language "cuda"))
-
-(preproc_function_def
- (preproc_arg) @injection.content
- (#set! injection.language "cuda"))
-
-(preproc_call
- (preproc_arg) @injection.content
+((preproc_arg) @injection.content
  (#set! injection.language "cuda"))
 
 ((comment) @injection.content 

--- a/queries/glsl/injections.scm
+++ b/queries/glsl/injections.scm
@@ -1,14 +1,4 @@
-((preproc_def
- (preproc_arg) @injection.content)
- (#lua-match? @injection.content "\n")
- (#set! injection.language "glsl"))
-
-(preproc_function_def
- (preproc_arg) @injection.content
- (#set! injection.language "glsl"))
-
-(preproc_call
- (preproc_arg) @injection.content
+((preproc_arg) @injection.content
  (#set! injection.language "glsl"))
 
 ((comment) @injection.content 

--- a/queries/hlsl/injections.scm
+++ b/queries/hlsl/injections.scm
@@ -1,14 +1,4 @@
-((preproc_def
- (preproc_arg) @injection.content)
- (#lua-match? @injection.content "\n")
- (#set! injection.language "hlsl"))
-
-(preproc_function_def
- (preproc_arg) @injection.content
- (#set! injection.language "hlsl"))
-
-(preproc_call
- (preproc_arg) @injection.content
+((preproc_arg) @injection.content
  (#set! injection.language "hlsl"))
 
 ((comment) @injection.content


### PR DESCRIPTION
```c
int foo(bar, baz, qux)
int bar, baz;
char *qux;
{
}
```

Is now supported

Well an issue might be that C++ just doesn't support this at all..