### PR TITLE
ci: dont hardcode the rockspec version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
           name: nvim-treesitter
-          version: 0.1
-          license: apache 2
           detailed_description: |
             The goal of nvim-treesitter is both to provide a simple and easy way to use the interface for tree-sitter in Neovim
             and to provide some basic functionality such as highlighting based on it.


### PR DESCRIPTION
sry for that but picking up the old PR, I forgot to remove some cruft as mentioned by @mrcjkb see https://github.com/nvim-treesitter/nvim-treesitter/pull/4403#pullrequestreview-1575769713 .

Seems like I've lost the ability to set LUAROCKS_API_KEY (but I should have already added one) and tag a release so once this is merged, it would be nice if an admin could tag a release to make sure this works and the rockspec is properly uploaded to luarocks.org