### PR TITLE
Update queries/cpp/highlights.scm to distinction between a variable declaration and use.

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -16,6 +16,19 @@
 
 ;(field_expression) @parameter ;; How to highlight this?
 
+; variable declaration and init
+(declaration
+  declarator: (identifier) @variable.definition)
+
+(pointer_declarator
+  declarator: (identifier) @variable.definition)
+
+(init_declarator
+  declarator: (identifier) @variable.definition)
+
+(init_declarator
+  declarator: (reference_declarator) @variable.definition)
+
 (((field_expression
      (field_identifier) @method)) @_parent
  (#has-parent? @_parent template_method function_declarator))


### PR DESCRIPTION
Add variable declaration and init to **variable.definition** hightlight group, so that distinction between a variable declaration and use.

I am not familiar with Scheme, but this is effective and enough for me.

Maybe this PR solved the issue **_https://github.com/nvim-treesitter/nvim-treesitter/issues/1625_** or not, but it provided a way of thinking.
