### PR TITLE
feat: add gpg config parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [gomod](https://github.com/camdencheek/tree-sitter-go-mod) (maintained by @camdencheek)
 - [x] [gosum](https://github.com/amaanq/tree-sitter-go-sum) (maintained by @amaanq)
 - [x] [gowork](https://github.com/omertuc/tree-sitter-go-work) (maintained by @omertuc)
+- [x] [gpg](https://github.com/ObserverOfTime/tree-sitter-gpg-config) (maintained by @ObserverOfTime)
 - [x] [graphql](https://github.com/bkegley/tree-sitter-graphql) (maintained by @bkegley)
 - [x] [groovy](https://github.com/Decodetalkers/tree-sitter-groovy) (maintained by @Decodetalkers)
 - [ ] [hack](https://github.com/slackhq/tree-sitter-hack)

--- a/lockfile.json
+++ b/lockfile.json
@@ -194,6 +194,9 @@
   "gowork": {
     "revision": "949a8a470559543857a62102c84700d291fc984c"
   },
+  "gpg": {
+    "revision": "af97733568c8141090d8a79dfff66806c96c2cc0"
+  },
   "graphql": {
     "revision": "5e66e961eee421786bdda8495ed1db045e06b5fe"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -623,6 +623,14 @@ list.gowork = {
   maintainers = { "@omertuc" },
 }
 
+list.gpg = {
+  install_info = {
+    url = "https://github.com/ObserverOfTime/tree-sitter-gpg-config",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@ObserverOfTime" },
+}
+
 list.groovy = {
   install_info = {
     url = "https://github.com/Decodetalkers/tree-sitter-groovy",

--- a/queries/gpg/highlights.scm
+++ b/queries/gpg/highlights.scm
@@ -1,0 +1,49 @@
+(option . _ @keyword)
+
+(option
+  ("no-" @parameter)?
+  (name) @parameter)
+
+(string (content) @string)
+
+[
+ (value)
+ "clear"
+] @string.special
+
+(url) @text.uri
+
+(key) @constant
+
+[
+ (number)
+ (expire_time)
+ (iso_time)
+] @number
+
+(format) @character.special
+
+"sensitive:" @type.qualifier
+
+(filter_name) @parameter
+
+(filter_scope) @namespace
+
+(filter_property) @property
+
+(filter_value) @string
+
+[
+ (filter_op0)
+ (filter_op1)
+ (filter_lc)
+ "="
+] @operator
+
+"!" @punctuation.special
+
+[ "\"" "'" "," ] @punctuation.delimiter
+
+(comment) @comment @spell
+
+(ERROR) @error

--- a/queries/gpg/injections.scm
+++ b/queries/gpg/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
Currently only supports `gpg.conf`, but so does Vim.
I might eventually extend it for the other gpg config files (e.g. `gpg-agent.conf`).