### PR TITLE
Update tree-sitter-robot version and maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [rego](https://github.com/FallenAngel97/tree-sitter-rego) (maintained by @FallenAngel97)
 - [x] [pip requirements](https://github.com/ObserverOfTime/tree-sitter-requirements) (maintained by @ObserverOfTime)
 - [x] [rnoweb](https://github.com/bamonroe/tree-sitter-rnoweb) (maintained by @bamonroe)
-- [x] [robot](https://github.com/Hubro/tree-sitter-robot) (experimental, maintained by @ema2159)
+- [x] [robot](https://github.com/Hubro/tree-sitter-robot) (maintained by @Hubro)
 - [x] [ron](https://github.com/amaanq/tree-sitter-ron) (maintained by @amaanq)
 - [x] [rst](https://github.com/stsewd/tree-sitter-rst) (maintained by @stsewd)
 - [x] [ruby](https://github.com/tree-sitter/tree-sitter-ruby) (maintained by @TravonteD)

--- a/lockfile.json
+++ b/lockfile.json
@@ -453,7 +453,7 @@
     "revision": "502c1126dc6777f09af5bef16e72a42f75bd081e"
   },
   "robot": {
-    "revision": "a7ea06e63669baf11e283891e8fed20f1ef4928d"
+    "revision": "8c9e8250b8395569c2d9af42bfc1d6de5ccb2b9a"
   },
   "ron": {
     "revision": "ce6086b2c9e8e71065b8129d6c2289c5f66d1879"

--- a/lockfile.json
+++ b/lockfile.json
@@ -453,7 +453,7 @@
     "revision": "502c1126dc6777f09af5bef16e72a42f75bd081e"
   },
   "robot": {
-    "revision": "8c9e8250b8395569c2d9af42bfc1d6de5ccb2b9a"
+    "revision": "322e4cc65754d2b3fdef4f2f8a71e0762e3d13af"
   },
   "ron": {
     "revision": "ce6086b2c9e8e71065b8129d6c2289c5f66d1879"

--- a/lockfile.json
+++ b/lockfile.json
@@ -453,7 +453,7 @@
     "revision": "502c1126dc6777f09af5bef16e72a42f75bd081e"
   },
   "robot": {
-    "revision": "f6f2eaf8bc711bcded4ede4e10859b06f73e191f"
+    "revision": "a7ea06e63669baf11e283891e8fed20f1ef4928d"
   },
   "ron": {
     "revision": "ce6086b2c9e8e71065b8129d6c2289c5f66d1879"

--- a/queries/robot/folds.scm
+++ b/queries/robot/folds.scm
@@ -1,0 +1,5 @@
+[
+ (section)
+ (keyword_definition)
+ (test_case_definition)
+] @fold

--- a/queries/robot/folds.scm
+++ b/queries/robot/folds.scm
@@ -1,5 +1,5 @@
 [
- (section)
- (keyword_definition)
- (test_case_definition)
+  (section)
+  (keyword_definition)
+  (test_case_definition)
 ] @fold

--- a/queries/robot/highlights.scm
+++ b/queries/robot/highlights.scm
@@ -1,21 +1,53 @@
-(argument (dictionary_variable) @string.special)
-(argument (list_variable) @string.special)
-(argument (scalar_variable) @string.special)
-(argument (text_chunk) @string)
+(comment) @comment
 
-(keyword_invocation (keyword) @function)
-
-(test_case_definition (name) @property)
-
-(keyword_definition (body (keyword_setting) @keyword))
-(keyword_definition (name) @function)
-
-(variable_definition (variable_name) @variable)
+(section_header) @keyword
+(extra_text) @comment
 
 (setting_statement) @keyword
 
-(extra_text) @comment
-(section_header) @keyword
+(variable_definition (variable_name) @variable)
+
+(keyword_definition (name) @function)
+(keyword_definition (body (keyword_setting) @keyword))
+
+(test_case_definition (name) @property)
+
+(keyword_invocation (keyword) @function.call)
+(ellipses) @punctuation.delimiter
+
+(argument (text_chunk) @string)
+(argument (scalar_variable) @variable)
+(argument (list_variable) @variable)
+(argument (dictionary_variable) @variable)
+(argument (inline_python_expression) @string.special)
 
 (ellipses) @punctuation.delimiter
-(comment) @comment
+
+; Control structures
+(for_statement
+  "FOR" @repeat
+  "END" @repeat)
+(for_statement (in "IN" @repeat))
+(for_statement (in_range "IN RANGE" @repeat))
+(for_statement (in_enumerate "IN ENUMERATE" @repeat))
+(for_statement (in_zip "IN ZIP" @repeat))
+
+(while_statement
+  "WHILE" @repeat
+  "END" @repeat)
+
+(break_statement) @repeat
+(continue_statement) @repeat
+
+(if_statement
+  "IF" @conditional
+  "END" @conditional)
+(if_statement (elseif_statement "ELSE IF" @conditional))
+(if_statement (else_statement "ELSE" @conditional))
+
+(try_statement
+  "TRY" @exception
+  "END" @exception)
+(try_statement (except_statement "EXCEPT" @exception))
+(try_statement (else_statement "ELSE" @exception))
+(try_statement (finally_statement "FINALLY" @exception))

--- a/queries/robot/highlights.scm
+++ b/queries/robot/highlights.scm
@@ -1,53 +1,57 @@
-(comment) @comment
+[
+  (comment)
+  (extra_text)
+] @comment
 
-(section_header) @keyword
-(extra_text) @comment
-
-(setting_statement) @keyword
+[
+  (section_header)
+  (setting_statement)
+  (keyword_setting)
+  (test_case_setting)
+] @keyword
 
 (variable_definition (variable_name) @variable)
-
 (keyword_definition (name) @function)
-(keyword_definition (body (keyword_setting) @keyword))
-
-(test_case_definition (name) @property)
+(test_case_definition (name) @function)
 
 (keyword_invocation (keyword) @function.call)
 (ellipses) @punctuation.delimiter
 
-(argument (text_chunk) @string)
-(argument (scalar_variable) @variable)
-(argument (list_variable) @variable)
-(argument (dictionary_variable) @variable)
-(argument (inline_python_expression) @string.special)
-
-(ellipses) @punctuation.delimiter
+(text_chunk) @string
+(inline_python_expression) @string.special
+[
+  (scalar_variable)
+  (list_variable)
+  (dictionary_variable)
+] @variable
 
 ; Control structures
-(for_statement
-  "FOR" @repeat
-  "END" @repeat)
-(for_statement (in "IN" @repeat))
-(for_statement (in_range "IN RANGE" @repeat))
-(for_statement (in_enumerate "IN ENUMERATE" @repeat))
-(for_statement (in_zip "IN ZIP" @repeat))
 
-(while_statement
-  "WHILE" @repeat
-  "END" @repeat)
+[
+  "FOR"
+  "IN"
+  "IN RANGE"
+  "IN ENUMERATE"
+  "IN ZIP"
+  (break_statement)
+  (continue_statement)
+] @repeat
+(for_statement "END" @repeat)
 
-(break_statement) @repeat
-(continue_statement) @repeat
+"WHILE" @repeat
+(while_statement "END" @repeat)
 
-(if_statement
-  "IF" @conditional
-  "END" @conditional)
-(if_statement (elseif_statement "ELSE IF" @conditional))
+[
+  "IF"
+  "ELSE IF"
+] @conditional
+(if_statement "END" @conditional)
 (if_statement (else_statement "ELSE" @conditional))
 
-(try_statement
-  "TRY" @exception
-  "END" @exception)
-(try_statement (except_statement "EXCEPT" @exception))
+[
+  "TRY"
+  "EXCEPT"
+  "FINALLY"
+] @exception
+(try_statement "END" @exception)
 (try_statement (else_statement "ELSE" @exception))
-(try_statement (finally_statement "FINALLY" @exception))

--- a/queries/robot/indents.scm
+++ b/queries/robot/indents.scm
@@ -1,0 +1,21 @@
+(keyword_definition) @indent.begin
+(test_case_definition) @indent.begin
+
+(for_statement) @indent.begin
+(for_statement "END" @indent.branch)
+(for_statement
+  right: (_ (arguments (continuation (ellipses) @indent.branch))))
+
+(while_statement) @indent.begin
+(while_statement "END" @indent.branch)
+
+(if_statement) @indent.begin
+(if_statement (elseif_statement) @indent.branch)
+(if_statement (else_statement) @indent.branch)
+(if_statement "END" @indent.branch)
+
+(try_statement) @indent.begin
+(try_statement (except_statement) @indent.branch)
+(try_statement (finally_statement) @indent.branch)
+(try_statement (else_statement) @indent.branch)
+(try_statement "END" @indent.branch)


### PR DESCRIPTION
I have completed and polished the tree-sitter parser for Robot files. This PR:

- Updates tree-sitter-robot to the latest ref
- Removes "experimental" and sets me as maintainer
- Improves syntax highlighting
- Adds queries for indents and folds