### PR TITLE
feat(c_sharp): Add missing highlights

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -223,6 +223,7 @@
  "switch"
  "break"
  "case"
+ "when"
  (if_directive)
  (elif_directive)
  (else_directive)
@@ -289,6 +290,8 @@
  ">>="
  ">>>="
  "=>"
+ "??"
+ "??="
 ] @operator
 
 [
@@ -364,6 +367,7 @@
  "checked"
  "unchecked"
  "fixed"
+ "alias"
 ] @keyword
 
 [


### PR DESCRIPTION
I noticed Null Coalescing operator (`??`) is not highlighted, so I searched the c# tree-sitter grammar and found out that their [highlights file](https://github.com/tree-sitter/tree-sitter-c-sharp/blob/master/queries/highlights.scm) already had the `??` and `??=` operator, `alias` and `when` keyword.

Added:
* `??` and `??=` as operators
* `alias` as keyword
* `when` as conditional

I don't know if this was the correct move. Please let me know if I made some kind of mistake, or if I missed something.
<details>
<summary>
Before/After
</summary>

**Before**
![before](https://github.com/nvim-treesitter/nvim-treesitter/assets/48023091/dfc1b672-3229-42f5-89e8-8120b12e3b81)

**After**
![after](https://github.com/nvim-treesitter/nvim-treesitter/assets/48023091/d56ddf38-b11a-4bea-91bc-096aa20048bf)
</details>


