### PR TITLE
Update README.md for better folding settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,9 +474,9 @@ set foldlevelstart = 99
 or if you prefer lua:
 
 ```lua
-vim.wo.foldmethod = "expr"
-vim.wo.foldexpr = "nvim_treesitter#foldexpr()"
-vim.go.foldlevelstart = 99
+vim.o.foldmethod = "expr"
+vim.o.foldexpr = "nvim_treesitter#foldexpr()"
+vim.o.foldlevelstart = 99
 ```
 
 This will respect your `foldminlines` and `foldnestmax` settings.

--- a/README.md
+++ b/README.md
@@ -462,24 +462,29 @@ require'nvim-treesitter.configs'.setup {
 
 Tree-sitter based folding. _(Technically not a module because it's per windows and not per buffer.)_
 
-```vim
-set foldmethod=expr
-set foldexpr=nvim_treesitter#foldexpr()
-" With the above settings applied, vim will fold everything by default when
-" opening a file... setting foldlevelstart to a high value allows you to
-" start with no folds and then toggle them as desired with the za keymap.
-set foldlevelstart = 99
-```
-
-or if you prefer lua:
-
 ```lua
 vim.o.foldmethod = "expr"
-vim.o.foldexpr = "nvim_treesitter#foldexpr()"
+vim.o.foldexpr = "v:lua.vim.treesitter.foldexpr()"
+-- With the above settings applied, vim will fold everything by default when
+-- opening a file... setting foldlevelstart to a high value allows you to
+-- start with no folds and then toggle them as desired with the za keymap.
 vim.o.foldlevelstart = 99
 ```
 
-This will respect your `foldminlines` and `foldnestmax` settings.
+or if you prefer vimscript:
+
+```vim
+set foldmethod=expr
+set foldexpr=v:lua.vim.treesitter.foldexpr()
+set foldlevelstart=99
+```
+
+This will respect your `foldminlines` and `foldnestmax` settings. Once inside 
+a buffer, you could use `:set foldlevel=2` to collapse all folds above level 2.
+
+Note that this applies these options globally. If you want these settings to
+only be set for certain filetypes, then apply the above as window options using
+`vim.wo` in a `ftplugin/<filetype>.lua` file or in a `FileType` autocommand.
 
 # Advanced setup
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,18 @@ Tree-sitter based folding. _(Technically not a module because it's per windows a
 ```vim
 set foldmethod=expr
 set foldexpr=nvim_treesitter#foldexpr()
-set nofoldenable                     " Disable folding at startup.
+" With the above settings applied, vim will fold everything by default when
+" opening a file... setting foldlevelstart to a high value allows you to
+" start with no folds and then toggle them as desired with the za keymap.
+set foldlevelstart = 99
+```
+
+or if you prefer lua:
+
+```lua
+vim.wo.foldmethod = "expr"
+vim.wo.foldexpr = "nvim_treesitter#foldexpr()"
+vim.go.foldlevelstart = 99
 ```
 
 This will respect your `foldminlines` and `foldnestmax` settings.


### PR DESCRIPTION
I think that the README's recommended settings for enabling treesitter's folding capabilities do not reflect how most people probably want their folds to behave. The current settings make it so that when a single section of code is folded, everything folds (due to how `foldlevel` works)... most people probably want the folds to be created for them automatically, sit in the background invisibly, and then only activate when they manually toggle them. By setting `foldlevelstart`, this is achieved, and the user can still use `:set foldlevel` to batch fold if desired. Most people probably do not already have this option set, so including it in the README rather than `nofoldenable` seems like it would be a desirable change to me.