### PR TITLE
fix(lua): luap injection

### DIFF
--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -39,30 +39,50 @@
   (#offset! @injection.content 0 1 0 0))
 
 ; string.match("123", "%d+")
+
 (function_call
   (dot_index_expression
     field: (identifier) @_method
     (#any-of? @_method "find" "match"))
-  arguments: (arguments (_) . (string content: _ @injection.content (#set! injection.language "luap"))))
+  arguments: (arguments
+               . (_)
+               . (string
+                   content: (string_content) @injection.content
+                   (#set! injection.language "luap")
+                   (#set! injection.include-children))))
 
 (function_call
   (dot_index_expression
     field: (identifier) @_method
     (#any-of? @_method "gmatch" "gsub"))
-  arguments: (arguments (_) (string content: _ @injection.content (#set! injection.language "luap"))))
+  arguments: (arguments
+               . (_)
+               . (string
+                 content: (string_content) @injection.content
+                 (#set! injection.language "luap")
+                 (#set! injection.include-children))))
 
-; ("123"):match("%d+")
+;("123"):match("%d+")
+
 (function_call
   (method_index_expression
     method: (identifier) @_method
     (#any-of? @_method "find" "match"))
-    arguments: (arguments . (string content: _ @injection.content (#set! injection.language "luap"))))
+  arguments: (arguments
+               . (string
+                   content: (string_content) @injection.content
+                   (#set! injection.language "luap")
+                   (#set! injection.include-children))))
 
 (function_call
   (method_index_expression
     method: (identifier) @_method
     (#any-of? @_method "gmatch" "gsub"))
-    arguments: (arguments (string content: _ @injection.content (#set! injection.language "luap"))))
+  arguments: (arguments
+               . (string
+                 content: (string_content) @injection.content
+                 (#set! injection.language "luap")
+                 (#set! injection.include-children))))
 
 (comment content: (_) @injection.content
   (#set! injection.language "comment"))

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -46,10 +46,11 @@
     (#any-of? @_method "find" "match"))
   arguments: (arguments
                . (_)
-               . (string
-                   content: (string_content) @injection.content
-                   (#set! injection.language "luap")
-                   (#set! injection.include-children))))
+               .
+               (string
+                 content: (string_content) @injection.content
+                 (#set! injection.language "luap")
+                 (#set! injection.include-children))))
 
 (function_call
   (dot_index_expression
@@ -57,7 +58,8 @@
     (#any-of? @_method "gmatch" "gsub"))
   arguments: (arguments
                . (_)
-               . (string
+               .
+               (string
                  content: (string_content) @injection.content
                  (#set! injection.language "luap")
                  (#set! injection.include-children))))

--- a/tests/query/highlights/lua/test.lua
+++ b/tests/query/highlights/lua/test.lua
@@ -1,3 +1,4 @@
+-- luacheck: ignore
 local a = { 1, 2, 3, 4, 5 }
 --          ^ number      ^ punctuation.bracket
 --    ^ variable

--- a/tests/query/highlights/lua/test.lua
+++ b/tests/query/highlights/lua/test.lua
@@ -11,3 +11,7 @@ _ = next(a)
 
 next(a)
 -- ^ function.builtin
+
+-- Checking for incorrect hlgroup of injected luap
+string.match(s, "\0%d[^\n]+")
+--                       ^ !constant


### PR DESCRIPTION
This fixes a problem similar to #5244, but for lua.

In the following code, the injection of `luap` causes errors outside of the string because the string content node has children that are not being parsed in the injection (in this case, the `escape_sequence` node).

```lua
--- this isn't a lua pattern
string.match("123", "\0%d+")
```

To solve this, `(#set! injection.include-children)` was added to the captures.

Also, I made the captrues slightly more specific. If something is wrong with this logic, it can be reverted.