### PR TITLE
chore(csv,psv,tsv): update parser to fix numbers

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -78,7 +78,7 @@
     "revision": "5f2c94b897601b4029fedcce7db4c6d76ce8a128"
   },
   "csv": {
-    "revision": "1f584470170b708880b024142d901b05b2b2b602"
+    "revision": "f1d35df780976721d3cd38f0b16538dd31f87a23"
   },
   "cuda": {
     "revision": "607851cc524d9f5b5a5cd31ad4044fd431cee54e"
@@ -417,7 +417,7 @@
     "revision": "09e158cd3650581c0af4c49c2e5b10c4834c8646"
   },
   "psv": {
-    "revision": "1f584470170b708880b024142d901b05b2b2b602"
+    "revision": "f1d35df780976721d3cd38f0b16538dd31f87a23"
   },
   "pug": {
     "revision": "a7ff31a38908df9b9f34828d21d6ca5e12413e18"
@@ -561,7 +561,7 @@
     "revision": "8bd2056818b21860e3d756b5a58c4f6e05fb744e"
   },
   "tsv": {
-    "revision": "1f584470170b708880b024142d901b05b2b2b602"
+    "revision": "f1d35df780976721d3cd38f0b16538dd31f87a23"
   },
   "tsx": {
     "revision": "b1bf4825d9eaa0f3bdeb1e52f099533328acfbdf"


### PR DESCRIPTION
I know the lockfile can update this, but I wasted 30m on what should've been a 2m fix because Javascript, and maybe someone someday will stumble upon this w/ the same issue. When using `new RegExp`, \n and \r are escaped automatically, but not others like \s and \d, so I had a token that looked something like this:

```json
{
  "type": "PATTERN",
  "value": "[^,ds\"][^, \\n\\r\"]+"
},
```

ideally d and s would be escaped too, but who knows why it isn't...

Here's the modified rule, which needs 2 backslashes for d and s to process properly (and I did so for \n and \r for consistency)

```js
  text: _ => token(choice(
    new RegExp(`[^${separator}\\d\\s"][^${separator} \\n\\r"]+`),
    seq('"', repeat(choice(/[^"]/, '""')), '"'),
  )),
```
