### PR TITLE
feat(java): add highlights to string interpolation

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -264,6 +264,8 @@
 (type_arguments [ "<" ">" ] @punctuation.bracket)
 (type_parameters [ "<" ">" ] @punctuation.bracket)
 
+(string_interpolation [ "\\{" "}" ] @punctuation.special)
+
 ; Exceptions
 
 [


### PR DESCRIPTION
Introduced in tree-sitter/tree-sitter-java#157

`@punctuation.bracket` might not be the most fitting for this