### PR TITLE
Fix unused TSX highlight in markdown_inline

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -15,7 +15,15 @@ local non_filetype_match_injection_language_aliases = {
   ts = "typescript",
 }
 
+local ignore_filetype_match_injection_language_aliases = {
+  tsx = true,
+}
+
 local function get_parser_from_markdown_info_string(injection_alias)
+  if ignore_filetype_match_injection_language_aliases[injection_alias] then
+    return injection_alias
+  end
+
   local match = vim.filetype.match { filename = "a." .. injection_alias }
   return match or non_filetype_match_injection_language_aliases[injection_alias] or injection_alias
 end


### PR DESCRIPTION
In the current implementation, there is a bug where the tsx parser does not work when `markdown_inline` is used. This Pull Request makes a modification to properly execute the highlight of TSX.

Currently, when a `tsx` is passed across to `injection_alias`, the value of `match` is converted to `typescriptreact` and does not return the `tsx` that should be specified in the treesitter.

Specifically, a new table, `ignore_filetype_match_injection_language_aliases`, is created. When TSX is specified, a special process is performed in `get_parser_from_markdown_info_string`. This table prevents the highlight of TSX from being erroneously ignored. Specifically, this newly created table is referred to, and if TSX is specified, the matching process is skipped and the TSX parser is directly returned.

As a result, the TSX highlight used in any Markdown snippet will be displayed correctly.

Also, although not part of this change, perhaps we should fix it so that the `tsx` parser is also applied when `typescriptreact` is specified.