### PR TITLE
fix(lua): use include-children instead

### DIFF
--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -33,10 +33,11 @@
  (#lua-match? @injection.content "^%s*;+%s?query")
  (#set! injection.language "query"))
 
-(comment content: (_) @injection.content
-  (#lua-match? @injection.content "^[-][%s]*@")
+((comment) @injection.content
+  (#lua-match? @injection.content "^[-][-][-][%s]*@")
   (#set! injection.language "luadoc")
-  (#offset! @injection.content 0 1 0 0))
+  (#set! injection.include-children)
+  (#offset! @injection.content 0 3 0 0))
 
 ; string.match("123", "%d+")
 
@@ -86,5 +87,6 @@
                  (#set! injection.language "luap")
                  (#set! injection.include-children))))
 
-(comment content: (_) @injection.content
-  (#set! injection.language "comment"))
+((comment) @injection.content
+  (#set! injection.language "comment")
+  (#set! injection.include-children))


### PR DESCRIPTION
Fixes #5294, #5291.

This partially reverts #5263.

The root issue is fixed with neovim 0.9.2 (neovim/neovim#24595). But the current stable version is neovim 0.9.1, so partially reverts the commit to make it compatible with the current stable version.

Todo: Reapply #5263 once 0.9.2 becomes the stable version