### PR TITLE
refactor: replace some match & vim-match usages

### DIFF
--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -101,9 +101,9 @@
 
 ; Interop
 ((sym_lit) @method
- (#match? @method "^\\.[^-]"))
+ (#lua-match? @method "^[.][^-]"))
 ((sym_lit) @field
- (#match? @field "^\\.-"))
+ (#lua-match? @field "^[.]-"))
 ((sym_lit) @field
  (#lua-match? @field "^[%u].*/.+"))
 (list_lit
@@ -133,7 +133,7 @@
  (#any-of? @keyword.coroutine
   "alts!" "alts!!" "await" "await-for" "await1" "chan" "close!" "future" "go" "sync" "thread" "timeout" "<!" "<!!" ">!" ">!!"))
 ((sym_lit) @keyword.function
- (#match? @keyword.function "^(defn|defn-|fn|fn[*])$"))
+ (#any-of? @keyword.function "defn" "defn-" "fn" "fn*"))
 
 ; Comment
 ((sym_lit) @comment

--- a/queries/dhall/highlights.scm
+++ b/queries/dhall/highlights.scm
@@ -25,7 +25,7 @@
 ((primitive_expression
   (identifier (label) @type)
   (selector (label) @type)) @variable
-  (#vim-match? @variable "^[A-Z][^.]*$"))
+  (#lua-match? @variable "^[A-Z][^.]*$"))
 
 ;; Parameters
 

--- a/queries/glsl/highlights.scm
+++ b/queries/glsl/highlights.scm
@@ -31,7 +31,5 @@
 
 (extension_storage_class) @storageclass
 
-(
-  (identifier) @variable.builtin
-  (#match? @variable.builtin "^gl_")
-)
+((identifier) @variable.builtin
+ (#lua-match? @variable.builtin "^gl_"))

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -193,18 +193,18 @@
 ((generic_command
   command: (command_name) @_name
   arg: (curly_group (_) @text.emphasis))
-  (#match? @_name "^(\\\\textit|\\\\mathit)$"))
+ (#any-of? @_name "\\textit" "\\mathit"))
 
 ((generic_command
   command: (command_name) @_name
   arg: (curly_group (_) @text.strong))
-  (#match? @_name "^(\\\\textbf|\\\\mathbf)$"))
+ (#any-of? @_name "\\textbf" "\\mathbf"))
 
 ((generic_command
   command: (command_name) @_name
   .
   arg: (curly_group (_) @text.uri))
- (#match? @_name "^(\\\\url|\\\\href)$"))
+ (#any-of? @_name "\\url" "\\href"))
 
 ;; File inclusion commands
 (class_include

--- a/queries/query/injections.scm
+++ b/queries/query/injections.scm
@@ -1,14 +1,14 @@
 ((predicate 
   name: (identifier) @_name
   parameters: (parameters (string) @injection.content))
- (#match? @_name "^#?(not-)?(match|vim-match)$")
+ (#any-of? @_name "match" "not-match" "vim-match" "not-vim-match")
  (#set! injection.language "regex")
  (#offset! @injection.content 0 1 0 -1))
 
 ((predicate
   name: (identifier) @_name
   parameters: (parameters (string) @injection.content))
- (#match? @_name "^#?(not-)?lua-match$")
+ (#any-of? @_name "lua-match" "not-lua-match")
  (#set! injection.language "luap")
  (#offset! @injection.content 0 1 0 -1))
 

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -60,7 +60,7 @@
  "next"
  ] @repeat
 
-(constant) @type
+(constant) @constant
 
 ((identifier) @type.qualifier
  (#any-of? @type.qualifier "private" "protected" "public"))
@@ -116,10 +116,10 @@
  ] @label
 
 ((identifier) @constant.builtin
- (#vim-match? @constant.builtin "^__(callee|dir|id|method|send|ENCODING|FILE|LINE)__$"))
+ (#match? @constant.builtin "^__(callee|dir|id|method|send|ENCODING|FILE|LINE)__$"))
 
 ((constant) @type
- (#vim-match? @type "^[A-Z\\d_]+$"))
+ (#not-lua-match? @type "^[A-Z0-9_]+$"))
 
 [
  (self)

--- a/queries/tlaplus/locals.scm
+++ b/queries/tlaplus/locals.scm
@@ -75,8 +75,7 @@
     (_ (_ (_ (_ (identifier_ref) @definition.var))))
     (_ (_ (_ (_ (_ (identifier_ref) @definition.var)))))
   ]
-  (#vim-match? @definition.var "^(self|pc|stack)$")
-)
+  (#any-of? @definition.var "self" "pc" "stack"))
 
 ; References
 (identifier_ref) @reference


### PR DESCRIPTION
Also, Ruby currently highlights all `(constant)` nodes as `@type`.
I made it default to `@constant` and have `@type` *not* match `^[A-Z0-9_]+$`.