### PR TITLE
fix(utils): use pairs to iterate trees like upstream

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -173,7 +173,7 @@ function M.get_node_at_cursor(winnr, ignore_injected_langs)
 
   local root ---@type TSNode|nil
   if ignore_injected_langs then
-    for _, tree in ipairs(root_lang_tree:trees()) do
+    for _, tree in pairs(root_lang_tree:trees()) do
       local tree_root = tree:root()
       if tree_root and ts.is_in_node_range(tree_root, cursor_range[1], cursor_range[2]) then
         root = tree_root
@@ -202,7 +202,7 @@ function M.get_root_for_position(line, col, root_lang_tree)
 
   local lang_tree = root_lang_tree:language_for_range { line, col, line, col }
 
-  for _, tree in ipairs(lang_tree:trees()) do
+  for _, tree in pairs(lang_tree:trees()) do
     local root = tree:root()
 
     if root and ts.is_in_node_range(root, line, col) then


### PR DESCRIPTION
not sure if it needs commit [feat(treesitter)!: incremental injection parsing ](https://github.com/neovim/neovim/commit/2ca076e45fb3f1c08f6a1a374834df0701b8d778) to work.