### PR TITLE
fix!: use win line range to re parse indents

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -123,7 +123,7 @@ function M.get_indent(lnum)
   -- some languages like Python will actually have worse results when re-parsing at opened new line
   if not M.avoid_force_reparsing[root_lang] then
     -- Reparse in case we got triggered by ":h indentkeys"
-    parser:parse()
+    parser:parse({ vim.fn.line('w0') - 1, vim.fn.line('w$') - 1 })
   end
 
   -- Get language tree with smallest range around node that's not a comment parser

--- a/tests/query/injection_spec.lua
+++ b/tests/query/injection_spec.lua
@@ -25,9 +25,7 @@ local function check_assertions(file)
     )
   )
   local parser = ts.get_parser(buf, lang)
-
-  local self = ts.highlighter.new(parser, {})
-  local top_level_root = parser:parse()[1]:root()
+  local top_level_root = parser:parse(true)[1]:root()
 
   for _, assertion in ipairs(assertions) do
     local row = assertion.position.row
@@ -37,7 +35,7 @@ local function check_assertions(file)
     assertion.expected_capture_name = neg_assert and assertion.expected_capture_name:sub(2)
       or assertion.expected_capture_name
     local found = false
-    self.tree:for_each_tree(function(tstree, tree)
+    parser:for_each_tree(function(tstree, tree)
       if not tstree then
         return
       end
@@ -50,11 +48,11 @@ local function check_assertions(file)
       if assertion.expected_capture_name == tree:lang() then
         found = true
       end
-    end, true)
+    end)
     if neg_assert then
       assert.False(
         found,
-        'Error in at '
+        'Error in '
           .. file
           .. ':'
           .. (row + 1)
@@ -67,7 +65,7 @@ local function check_assertions(file)
     else
       assert.True(
         found,
-        'Error in at '
+        'Error in '
           .. file
           .. ':'
           .. (row + 1)


### PR DESCRIPTION
- [x] Apply suggestion from @lewis6991 for indents
  - I've been using it for the past week and have yet to see downsides of it, under the scenario that treesitter highlights will carry the parsing the rest of the tree 
- [x] Fix injection_spec
- [x] Highlights tests (That one test ...)