### PR TITLE
fix(julia): highlight for `end` keyword

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -157,9 +157,6 @@
 [
   "global"
   "local"
-  "macro"
-  "struct"
-  "end"
 ] @keyword
 
 
@@ -208,8 +205,11 @@
 (export_statement
   "export" @include)
 
+(struct_definition
+  ["struct" "end"] @keyword)
+
 (macro_definition
-  ["macro" "end" @keyword])
+  ["macro" "end"] @keyword)
 
 (function_definition
   ["function" "end"] @keyword.function)


### PR DESCRIPTION
At present, the `end` is defined as `@keyword` globally, causing every instance of `end` to be recognized as a keyword, even in cases where it should not serve as one, as in `if foo; end`. In such cases, `end` should be categorized as `@conditional`.

Upon reviewing the `grammar.js` file of `tree-sitter-julia`, I noticed that the `end` keyword is never used in isolation, except within the keyword list. Furthermore, this keyword list is solely employed in the definition of the `quote_expression`, where keywords should be treated as regular identifiers. Based on this analysis, I have removed `macro`, `struct`, and `end` from the global `@keyword` and now match them within their specific scopes.

Here is a comparison between the highlight before this change (left) and after this change (right). It's worth noting that prior to this update, the `end` keywords were shown in italics, while the corresponding `if`, `for`, and `function` keywords were not.

<img width="786" alt="Screenshot 2023-09-09 at 00 57 40" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/40141251/f354cc35-bb6a-4cf2-a0cd-3c9b58475697">
