### PR TITLE
fix(scala): Ensure (function_definition) is in parent scope

### DIFF
--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -17,7 +17,8 @@
   name: (identifier) @definition.function)
 
 (function_definition
-  name: (identifier) @definition.function)
+  name: ((identifier) @definition.function)
+  (#set! definition.var.scope parent))
 
 (parameter
   name: (identifier) @definition.parameter)


### PR DESCRIPTION
Prior to this change, a defined function was not seen as being in scope for the parent scope. This mirrors a similar change done to a number of other languages (python, javascript, etc).
