### PR TITLE
fix(scala): Mark `(lambda_expression)` without bindings as `@defintition.parameters`

### DIFF
--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -25,6 +25,9 @@
 (class_parameter
   name: (identifier) @definition.parameter)
 
+(lambda_expression
+  parameters: (identifier) @definition.var)
+
 (binding
   name: (identifier) @definition.var)
 


### PR DESCRIPTION
When you have a lambda expression like:

```scala
val fruits = List("apple", "banana", "avocado", "papaya")

val countsToFruits = fruits.groupBy(fruit => fruit.count(_ == 'a'))

for ((count, fruits) <- countsToFruits) {
  println(s"with (fruits) 'a' × $count = $fruits")
}
```

The `fruit => fruit.count(_ == 'a')` lambda expression (note: without wrapping parenthesis) does not create a `(binding)` node. Its syntax tree is:

```
    (lambda_expression) ; [5:18 - 47]
     parameters: (identifier) ; [5:18 - 22]
     (call_expression) ; [5:27 - 47]
      function: (field_expression) ; [5:27 - 37]
       value: (identifier) ; [5:27 - 31]
       field: (identifier) ; [5:33 - 37]
      arguments: (arguments) ; [5:38 - 47]
       (infix_expression) ; [5:39 - 46]
        left: (wildcard) ; [5:39 - 39]
        operator: (operator_identifier) ; [5:41 - 42]
        right: (character_literal) ; [5:44 - 46]
```

That example just _happens_ to be **exactly** one of the example from https://www.scala-lang.org/ ([see playground](https://scastie.scala-lang.org/S0bkCiXkQiuOMXnlhWn46g)) 😁.
