### PR TITLE
fix(scala): Add (for_expression) locals

### DIFF
--- a/queries/scala/locals.scm
+++ b/queries/scala/locals.scm
@@ -5,6 +5,7 @@
   (lambda_expression)
   (function_definition)
   (block)
+  (for_expression)
 ] @scope
 
 ; References
@@ -40,3 +41,8 @@
 (var_declaration
   name: (identifier) @definition.var)
 
+(for_expression
+  enumerators: (enumerators
+    (enumerator
+      (tuple_pattern
+        (identifier) @definition.var))))


### PR DESCRIPTION
This change does two main things:

1. Indicate that `(for_expression)`'s introduce a `@scope` (this is the scope for the enumerators to be used within the loop).
2. Indicate that the `(identifiers)` within the `(enumerators)` are `@definition.var`s.

---

For the following example snippet:

```scala
val fruits = List("apple", "banana", "avocado", "papaya")

val countsToFruits = fruits.groupBy(fruit => fruit.count(_ == 'a'))

for ((count, fruits) <- countsToFruits) {
  println(s"with (fruits) 'a' × $count = $fruits")
}
```

The `count` and `fruits` identifiers are new definitions introduced by the `for` expressions scope.
