### PR TITLE
fix!: backport `ac9e755` from `main`

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -124,7 +124,7 @@ function M.get_indent(lnum)
   -- some languages like Python will actually have worse results when re-parsing at opened new line
   if not M.avoid_force_reparsing[root_lang] then
     -- Reparse in case we got triggered by ":h indentkeys"
-    parser:parse()
+    parser:parse { vim.fn.line "w0" - 1, vim.fn.line "w$" - 1 }
   end
 
   -- Get language tree with smallest range around node that's not a comment parser

--- a/tests/query/highlights_spec.lua
+++ b/tests/query/highlights_spec.lua
@@ -1,5 +1,3 @@
-local highlighter = require "vim.treesitter.highlighter"
-local parsers = require "nvim-treesitter.parsers"
 local ts = vim.treesitter
 
 local COMMENT_NODES = {
@@ -7,15 +5,16 @@ local COMMENT_NODES = {
 }
 
 local function check_assertions(file)
-  local buf = vim.fn.bufadd(file)
-  vim.fn.bufload(file)
-  local lang = parsers.get_buf_lang(buf)
   assert.same(
     1,
     vim.fn.executable "highlight-assertions",
     '"highlight-assertions" not executable!'
       .. ' Get it via "cargo install --git https://github.com/theHamsta/highlight-assertions"'
   )
+  local buf = vim.fn.bufadd(file)
+  vim.fn.bufload(file)
+  local ft = vim.bo[buf].filetype
+  local lang = vim.treesitter.language.get_lang(ft) or ft
   local comment_node = COMMENT_NODES[lang] or "comment"
   local assertions = vim.fn.json_decode(
     vim.fn.system(
@@ -27,18 +26,20 @@ local function check_assertions(file)
         .. comment_node
     )
   )
-  local parser = parsers.get_parser(buf, lang)
-
-  local self = highlighter.new(parser, {})
-
   assert.True(#assertions > 0, "No assertions detected!")
+
+  local parser = ts.get_parser(buf)
+
+  parser:parse(true)
+
   for _, assertion in ipairs(assertions) do
     local row = assertion.position.row
     local col = assertion.position.column
+    assert.is.number(row)
+    assert.is.number(col)
 
     local captures = {}
-    local highlights = {}
-    self.tree:for_each_tree(function(tstree, tree)
+    parser:for_each_tree(function(tstree, tree)
       if not tstree then
         return
       end
@@ -51,35 +52,24 @@ local function check_assertions(file)
         return
       end
 
-      local query = self:get_query(tree:lang())
-
-      -- Some injected languages may not have highlight queries.
-      if not query:query() then
+      local query = ts.query.get(tree:lang(), "highlights")
+      if not query then
         return
       end
 
-      local iter = query:query():iter_captures(root, self.bufnr, row, row + 1)
-
-      for capture, node, _ in iter do
-        local hl = query.hl_cache[capture]
-        assert.is.truthy(hl)
-
-        assert.Truthy(node)
-        assert.is.number(row)
-        assert.is.number(col)
-        if hl and ts.is_in_node_range(node, row, col) then
-          local c = query._query.captures[capture] -- name of the capture in the query
-          if c ~= nil and c ~= "spell" and c ~= "conceal" then
-            captures[c] = true
-            highlights[c] = true
+      for id, node, _ in query:iter_captures(root, buf, row, row + 1) do
+        if ts.is_in_node_range(node, row, col) then
+          local capture = query.captures[id]
+          if capture ~= nil and capture ~= "conceal" and capture ~= "spell" then
+            captures[capture] = true
           end
         end
       end
     end, true)
     if assertion.expected_capture_name:match "^!" then
       assert.Falsy(
-        captures[assertion.expected_capture_name:sub(2)] or highlights[assertion.expected_capture_name:sub(2)],
-        "Error in at "
+        captures[assertion.expected_capture_name:sub(2)],
+        "Error in "
           .. file
           .. ":"
           .. (row + 1)
@@ -89,13 +79,11 @@ local function check_assertions(file)
           .. assertion.expected_capture_name
           .. '", captures: '
           .. vim.inspect(vim.tbl_keys(captures))
-          .. '", highlights: '
-          .. vim.inspect(vim.tbl_keys(highlights))
       )
     else
       assert.True(
-        captures[assertion.expected_capture_name] or highlights[assertion.expected_capture_name],
-        "Error in at "
+        captures[assertion.expected_capture_name],
+        "Error in "
           .. file
           .. ":"
           .. (row + 1)
@@ -105,8 +93,6 @@ local function check_assertions(file)
           .. assertion.expected_capture_name
           .. '", captures: '
           .. vim.inspect(vim.tbl_keys(captures))
-          .. '", highlights: '
-          .. vim.inspect(vim.tbl_keys(highlights))
       )
     end
   end

--- a/tests/query/injection_spec.lua
+++ b/tests/query/injection_spec.lua
@@ -1,5 +1,4 @@
 require "nvim-treesitter.highlight" -- yes, this is necessary to set the hlmap
-local highlighter = require "vim.treesitter.highlighter"
 local configs = require "nvim-treesitter.configs"
 local parsers = require "nvim-treesitter.parsers"
 local ts = vim.treesitter
@@ -19,10 +18,8 @@ local function check_assertions(file)
       "highlight-assertions -p '" .. configs.get_parser_install_dir() .. "/" .. lang .. ".so'" .. " -s '" .. file .. "'"
     )
   )
-  local parser = parsers.get_parser(buf, lang)
-
-  local self = highlighter.new(parser, {})
-  local top_level_root = parser:parse()[1]:root()
+  local parser = ts.get_parser(buf, lang)
+  local top_level_root = parser:parse(true)[1]:root()
 
   for _, assertion in ipairs(assertions) do
     local row = assertion.position.row
@@ -32,7 +29,7 @@ local function check_assertions(file)
     assertion.expected_capture_name = neg_assert and assertion.expected_capture_name:sub(2)
       or assertion.expected_capture_name
     local found = false
-    self.tree:for_each_tree(function(tstree, tree)
+    parser:for_each_tree(function(tstree, tree)
       if not tstree then
         return
       end
@@ -45,11 +42,11 @@ local function check_assertions(file)
       if assertion.expected_capture_name == tree:lang() then
         found = true
       end
-    end, true)
+    end)
     if neg_assert then
       assert.False(
         found,
-        "Error in at "
+        "Error in "
           .. file
           .. ":"
           .. (row + 1)
@@ -62,7 +59,7 @@ local function check_assertions(file)
     else
       assert.True(
         found,
-        "Error in at "
+        "Error in "
           .. file
           .. ":"
           .. (row + 1)


### PR DESCRIPTION
reference: https://github.com/nvim-treesitter/nvim-treesitter/commit/ac9e75594208e9c348417240df05afd826c78f59

Co-authored-by: Pham Huy Hoang <hoangtun0810@gmail.com>
Closes: neovim/neovim#25088