### PR TITLE
fix!: backport `ac9e755` from `main`

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -124,7 +124,7 @@ function M.get_indent(lnum)
   -- some languages like Python will actually have worse results when re-parsing at opened new line
   if not M.avoid_force_reparsing[root_lang] then
     -- Reparse in case we got triggered by ":h indentkeys"
-    parser:parse()
+    parser:parse { vim.fn.line "w0" - 1, vim.fn.line "w$" - 1 }
   end
 
   -- Get language tree with smallest range around node that's not a comment parser


### PR DESCRIPTION
The signature for `LanguageTree:parse()` changed to `LanguageTree:parse(range)` in https://github.com/neovim/neovim/pull/24647. Lua ignores extra arguments. That means if we pass in the right `range`, we get unchanged behavior for pre- patch users, and the correct behavior for post- patch users.

Closes: neovim/neovim#25088