### PR TITLE
feat: allow a custom revision in install_info

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -81,6 +81,11 @@ end
 ---@param lang string
 ---@return string?
 local function get_target_revision(lang)
+  local info = get_parser_install_info(lang)
+  if info and info.revision then
+    return info.revision
+  end
+
   if #lockfile == 0 then
     local filename = M.get_package_path('lockfile.json')
     lockfile = vim.json.decode(util.read_file(filename)) --[[@as table<string, LockfileInfo>]]

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1,6 +1,7 @@
 ---@class InstallInfo
 ---@field url string
 ---@field branch string|nil
+---@field revision string|nil Used to override lockfile revision
 ---@field files string[]
 ---@field generate_requires_npm boolean|nil
 ---@field requires_generate_from_grammar boolean|nil


### PR DESCRIPTION
Haven't put much thought into the API for this, but I need this so I can do:

```lua
local c_info = require "nvim-treesitter.parsers".configs.c.install_info
c_info.url = 'https://github.com/neovim/tree-sitter-c'
c_info.revision = 'nvimc'
```