### PR TITLE
perf(comment): remove spell capture

### DIFF
--- a/queries/agda/highlights.scm
+++ b/queries/agda/highlights.scm
@@ -35,7 +35,7 @@
 
 (pragma) @preproc
 
-(comment) @comment
+(comment) @comment @spell
 
 ;; Keywords
 [

--- a/queries/bibtex/highlights.scm
+++ b/queries/bibtex/highlights.scm
@@ -11,6 +11,8 @@
   (comment)
 ] @comment
 
+(comment) @spell
+
 [
   "="
   "#"

--- a/queries/blueprint/highlights.scm
+++ b/queries/blueprint/highlights.scm
@@ -3,7 +3,7 @@
 (string) @string
 (escape_sequence) @string.escape
 
-(comment) @comment
+(comment) @comment @spell
 
 (constant) @constant.builtin
 

--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -1,5 +1,3 @@
-(_) @spell
-
 ((tag
   (name) @text.todo @nospell
   ("(" @punctuation.bracket (user) @constant ")" @punctuation.bracket)?

--- a/queries/corn/highlights.scm
+++ b/queries/corn/highlights.scm
@@ -11,7 +11,7 @@
 "." @punctuation.delimiter
 
 (input) @constant
-(comment) @comment
+(comment) @comment @spell
 
 (string) @string
 (integer) @number

--- a/queries/devicetree/highlights.scm
+++ b/queries/devicetree/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+(comment) @comment @spell
 
 [
   (preproc_include)

--- a/queries/ebnf/highlights.scm
+++ b/queries/ebnf/highlights.scm
@@ -5,7 +5,7 @@
 
 (integer) @number
 
-(comment) @comment
+(comment) @comment @spell
 
 ;;;; Identifiers ;;;;
 

--- a/queries/eex/highlights.scm
+++ b/queries/eex/highlights.scm
@@ -9,7 +9,7 @@
 ] @tag.delimiter
 
 ; EEx comments are highlighted as such
-(comment) @comment
+(comment) @comment @spell
 
 ; Tree-sitter parser errors
 (ERROR) @error

--- a/queries/elsa/highlights.scm
+++ b/queries/elsa/highlights.scm
@@ -38,4 +38,4 @@
 
 ; Comments
 
-(comment) @comment
+(comment) @comment @spell

--- a/queries/elvish/highlights.scm
+++ b/queries/elvish/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+(comment) @comment @spell
 
 ["if" "elif"] @conditional
 (if (else "else" @conditional))

--- a/queries/embedded_template/highlights.scm
+++ b/queries/embedded_template/highlights.scm
@@ -1,4 +1,4 @@
-(comment_directive) @comment
+(comment_directive) @comment @spell
 
 [
   "<%#"

--- a/queries/foam/highlights.scm
+++ b/queries/foam/highlights.scm
@@ -1,5 +1,5 @@
 ;; Comments
-(comment) @comment
+(comment) @comment @spell
 
 ;; Generic Key-value pairs and dictionary keywords
 (key_value

--- a/queries/forth/highlights.scm
+++ b/queries/forth/highlights.scm
@@ -16,6 +16,6 @@
   (end_definition)
 ] @punctuation.delimiter
 
-(comment) @comment
+(comment) @comment @spell
 
 (ERROR) @error

--- a/queries/fusion/highlights.scm
+++ b/queries/fusion/highlights.scm
@@ -1,5 +1,5 @@
-(comment) @comment
-(afx_comment) @comment
+(comment) @comment @spell
+(afx_comment) @comment @spell
 
 ; identifiers afx
 (afx_opening_element

--- a/queries/glimmer/highlights.scm
+++ b/queries/glimmer/highlights.scm
@@ -73,7 +73,7 @@
 
 (hash_pair key: (identifier) @property)
 
-(comment_statement) @comment
+(comment_statement) @comment @spell
 
 (attribute_node "=" @operator)
 

--- a/queries/gomod/highlights.scm
+++ b/queries/gomod/highlights.scm
@@ -9,7 +9,7 @@
 
 "=>" @operator
 
-(comment) @comment
+(comment) @comment @spell
 (module_path) @text.uri
 
 [

--- a/queries/gowork/highlights.scm
+++ b/queries/gowork/highlights.scm
@@ -6,7 +6,7 @@
 
 "=>" @operator
 
-(comment) @comment
+(comment) @comment @spell
 
 [
 (version)

--- a/queries/heex/highlights.scm
+++ b/queries/heex/highlights.scm
@@ -27,7 +27,7 @@
 (doctype) @constant
 
 ; HEEx comments are highlighted as such
-(comment) @comment
+(comment) @comment @spell
 
 ; HEEx text content is treated as markup
 (text) @text

--- a/queries/hjson/highlights.scm
+++ b/queries/hjson/highlights.scm
@@ -13,4 +13,4 @@
 "{" @punctuation.bracket
 "}" @punctuation.bracket
 
-(comment) @comment
+(comment) @comment @spell

--- a/queries/hocon/highlights.scm
+++ b/queries/hocon/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+(comment) @comment @spell
 
 (null) @constant.builtin
 [ (true) (false) ] @boolean

--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -1,6 +1,6 @@
 (tag_name) @tag
 (erroneous_end_tag_name) @error
-(comment) @comment
+(comment) @comment @spell
 (attribute_name) @tag.attribute
 (attribute
   (quoted_attribute_value) @string)

--- a/queries/ini/highlights.scm
+++ b/queries/ini/highlights.scm
@@ -1,6 +1,6 @@
 (section_name
   (text) @type) ; consistency with toml
-(comment) @comment
+(comment) @comment @spell
 
 [
  "["

--- a/queries/json5/highlights.scm
+++ b/queries/json5/highlights.scm
@@ -9,7 +9,7 @@
 
 (number) @number
 
-(comment) @comment
+(comment) @comment @spell
 
 (member
     name: (_) @keyword)

--- a/queries/jsonnet/highlights.scm
+++ b/queries/jsonnet/highlights.scm
@@ -1,5 +1,5 @@
 (id) @variable
-(comment) @comment
+(comment) @comment @spell
 
 ; Literals
 (null) @constant.builtin

--- a/queries/kconfig/highlights.scm
+++ b/queries/kconfig/highlights.scm
@@ -76,6 +76,6 @@
 
 (source (prompt) @text.uri @string.special)
 
-(comment) @comment
+(comment) @comment @spell
 
 (ERROR) @error

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -13,7 +13,7 @@
  (line_comment)
  (block_comment)
  (comment_environment)
-] @comment
+] @comment @spell
 
 ((line_comment) @preproc
   (#lua-match? @preproc "^%% !TeX"))

--- a/queries/ledger/highlights.scm
+++ b/queries/ledger/highlights.scm
@@ -3,7 +3,7 @@
     (comment)
     (note)
     (test)
-] @comment
+] @comment @spell
 
 [
     (quantity)

--- a/queries/llvm/highlights.scm
+++ b/queries/llvm/highlights.scm
@@ -112,7 +112,7 @@
   ] @keyword.function)
 
 (number) @number
-(comment) @comment
+(comment) @comment @spell
 (string) @string
 (cstring) @string
 (label) @label

--- a/queries/m68k/highlights.scm
+++ b/queries/m68k/highlights.scm
@@ -47,7 +47,7 @@
 (repeat (control_mnemonic) @repeat)
 (conditional (control_mnemonic) @conditional)
 
-(comment) @comment
+(comment) @comment @spell
 
 [
   (operator)

--- a/queries/menhir/highlights.scm
+++ b/queries/menhir/highlights.scm
@@ -25,5 +25,5 @@
 (ocaml_type) @type
 (ocaml) @none
 
-[(comment) (line_comment) (ocaml_comment)] @comment
+[(comment) (line_comment) (ocaml_comment)] @comment @spell
 (ERROR) @error

--- a/queries/meson/highlights.scm
+++ b/queries/meson/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+(comment) @comment @spell
 (number) @number
 (bool) @boolean
 

--- a/queries/mlir/highlights.scm
+++ b/queries/mlir/highlights.scm
@@ -332,4 +332,4 @@
 
 (caret_id) @tag
 (value_use) @variable
-(comment) @comment
+(comment) @comment @spell

--- a/queries/ninja/highlights.scm
+++ b/queries/ninja/highlights.scm
@@ -96,3 +96,5 @@
  (split)
  (comment)
 ] @comment
+
+(comment) @spell

--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -30,7 +30,7 @@
 "or" @keyword.operator
 
 ; comments
-(comment) @comment
+(comment) @comment @spell
 
 ; strings
 ([ (string_expression) (indented_string_expression) ]

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -172,6 +172,6 @@
 ; Comments
 ;---------
 
-[(comment) (line_number_directive) (directive) (shebang)] @comment
+[(comment) (line_number_directive) (directive) (shebang)] @comment @spell
 
 (ERROR) @error

--- a/queries/ocamllex/highlights.scm
+++ b/queries/ocamllex/highlights.scm
@@ -37,5 +37,5 @@
 
 ; Misc
 
-(comment) @comment
+(comment) @comment @spell
 (ERROR) @error

--- a/queries/pem/highlights.scm
+++ b/queries/pem/highlights.scm
@@ -6,6 +6,6 @@
 
 (data) @none
 
-(comment) @comment
+(comment) @comment @spell
 
 (ERROR) @error

--- a/queries/pioasm/highlights.scm
+++ b/queries/pioasm/highlights.scm
@@ -1,4 +1,4 @@
-[ (line_comment) (block_comment) ] @comment
+[ (line_comment) (block_comment) ] @comment @spell
 
 (label_decl) @label
 

--- a/queries/pymanifest/highlights.scm
+++ b/queries/pymanifest/highlights.scm
@@ -19,4 +19,4 @@
 
 (ERROR) @error
 
-(comment) @comment
+(comment) @comment @spell

--- a/queries/qmljs/highlights.scm
+++ b/queries/qmljs/highlights.scm
@@ -93,7 +93,7 @@
   (undefined)
 ] @constant.builtin
 
-(comment) @comment
+(comment) @comment @spell
 
 [
   (string)

--- a/queries/rasi/highlights.scm
+++ b/queries/rasi/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+(comment) @comment @spell
 
 "@media" @keyword
 "@import" @include

--- a/queries/rego/highlights.scm
+++ b/queries/rego/highlights.scm
@@ -37,7 +37,7 @@
 
 (term (ref (var))) @variable
 
-(comment) @comment
+(comment) @comment @spell
 
 (number) @number
 

--- a/queries/robot/highlights.scm
+++ b/queries/robot/highlights.scm
@@ -1,7 +1,7 @@
 [
   (comment)
   (extra_text)
-] @comment
+] @comment @spell
 
 [
   (section_header)

--- a/queries/scss/highlights.scm
+++ b/queries/scss/highlights.scm
@@ -26,7 +26,7 @@
   "in"
 ] @repeat
 
-(single_line_comment) @comment
+(single_line_comment) @comment @spell
 (function_name) @function
 
 

--- a/queries/slint/highlights.scm
+++ b/queries/slint/highlights.scm
@@ -1,6 +1,6 @@
 (identifier) @variable
 (type_identifier) @type
-(comment) @comment
+(comment) @comment @spell
 (int_literal) @number
 (float_literal) @float
 (string_literal) @string

--- a/queries/sparql/highlights.scm
+++ b/queries/sparql/highlights.scm
@@ -176,7 +176,7 @@
 ] @keyword.operator
 
 
-(comment) @comment
+(comment) @comment @spell
 
 
 ; Could this be summarized?

--- a/queries/strace/highlights.scm
+++ b/queries/strace/highlights.scm
@@ -49,6 +49,6 @@
   "=>"
 ] @punctuation.delimiter
 
-(comment) @comment
+(comment) @comment @spell
 
 (ERROR) @error

--- a/queries/supercollider/highlights.scm
+++ b/queries/supercollider/highlights.scm
@@ -2,8 +2,8 @@
 ; See this for full list: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md
 
 ; comments
-(line_comment) @comment
-(block_comment) @comment
+(line_comment) @comment @spell
+(block_comment) @comment @spell
 
 ; Argument definition
 (argument name: (identifier) @parameter)

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -2,7 +2,7 @@
 (text) @text
 
 ; Surface has two types of comments, both are highlighted as such
-(comment) @comment
+(comment) @comment @spell
 
 ; Surface attributes are highlighted as HTML attributes
 (attribute_name) @tag.attribute

--- a/queries/sxhkdrc/highlights.scm
+++ b/queries/sxhkdrc/highlights.scm
@@ -5,6 +5,6 @@
 (punctuation) @punctuation.bracket
 (delimiter) @punctuation.delimiter
 (keysym) @variable
-(comment) @comment
+(comment) @comment @spell
 (range) @number
 "\\\n" @punctuation.special

--- a/queries/tiger/highlights.scm
+++ b/queries/tiger/highlights.scm
@@ -111,7 +111,7 @@
 ; }}}
 
 ; Misc {{{
-(comment) @comment
+(comment) @comment @spell
 
 (type_identifier) @type
 (field_identifier) @property

--- a/queries/tlaplus/highlights.scm
+++ b/queries/tlaplus/highlights.scm
@@ -232,8 +232,8 @@
 ; Comments and tags
 (block_comment "(*" @comment)
 (block_comment "*)" @comment)
-(block_comment_text) @comment
-(comment) @comment
+(block_comment_text) @comment @spell
+(comment) @comment @spell
 (single_line) @comment
 (_ label: (identifier) @label)
 (label name: (_) @label)

--- a/queries/turtle/highlights.scm
+++ b/queries/turtle/highlights.scm
@@ -48,7 +48,7 @@
   (anon)
 ] @punctuation.bracket
 
-(comment) @comment
+(comment) @comment @spell
 
 (echar) @string.escape
 

--- a/queries/ungrammar/highlights.scm
+++ b/queries/ungrammar/highlights.scm
@@ -1,4 +1,4 @@
-(comment) @comment
+(comment) @comment @spell
 
 (definition) @keyword
 

--- a/queries/wgsl/highlights.scm
+++ b/queries/wgsl/highlights.scm
@@ -101,6 +101,6 @@
 (attribute
     (identifier) @attribute)
 
-[(line_comment) (block_comment)] @comment
+[(line_comment) (block_comment)] @comment @spell
 
 (ERROR) @error

--- a/queries/wing/highlights.scm
+++ b/queries/wing/highlights.scm
@@ -36,7 +36,7 @@
 
 ; Special
 
-(comment) @comment
+(comment) @comment @spell
 
 [
   "("

--- a/queries/yang/highlights.scm
+++ b/queries/yang/highlights.scm
@@ -1,5 +1,5 @@
 
-(comment) @comment
+(comment) @comment @spell
 
 ; Module / submodule
 ["module" "submodule"] @keyword


### PR DESCRIPTION
Problem:
Comment highlight query produces too many `@spell` captures.
https://github.com/neovim/neovim/issues/25113#issuecomment-1715548267

Solution:
Remove the query. This is fine because comment parser is only used in injection and the parent language has `@spell` for comment.