### PR TITLE
fix(query): apply `parsers.ft_to_lang` to `vim.filetype.match`

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -1,4 +1,5 @@
 local query = require "vim.treesitter.query"
+local parsers = require "nvim-treesitter.parsers"
 
 local html_script_type_languages = {
   ["importmap"] = "json",
@@ -16,8 +17,9 @@ local non_filetype_match_injection_language_aliases = {
 }
 
 local function get_parser_from_markdown_info_string(injection_alias)
-  local match = vim.filetype.match { filename = "a." .. injection_alias }
-  return match or non_filetype_match_injection_language_aliases[injection_alias] or injection_alias
+  local ft = vim.filetype.match { filename = "a." .. injection_alias }
+  local lang = parsers.ft_to_lang(ft)
+  return lang or non_filetype_match_injection_language_aliases[injection_alias] or injection_alias
 end
 
 local function error(str)


### PR DESCRIPTION
This fixes an issue where `jsx` code blocks resolve to `javascriptreact` filetype, but there is no `javascriptreact` lang. So markdown JSX code blocks are not highlighted.

Tangential question regarding an edge case (will we ever hit this?):
- What if `lang` and `injection_alias` both exist? Currently, `lang` of the injection alias interpreted as a file extension is preferred regardless of whether a parser exists for it. Should we check nvim core `has_parser` API? And what if both `lang` and `injection_alias` have parsers? Which should be preferred?

Fixes: #4918