### PR TITLE
fix(t32): update indent queries & test

### DIFF
--- a/queries/t32/indents.scm
+++ b/queries/t32/indents.scm
@@ -1,34 +1,20 @@
-; Subroutines & scoping
 (block
   ")" @indent.branch .) @indent.begin
 
+(if_block) @indent.begin
 
-; Control flow statements
-(
-  (if_block
-    condition: (_)
-    . (_) @_then) @indent.begin
-  (#not-has-type? @_then block)
-)
+(if_block
+  (block)) @indent.dedent
 
 (else_block) @indent.branch
 
 (else_block
-  (if_block) @indent.dedent) @indent.branch
-
-(
-  (else_block
-    (if_block
-      condition: (_)
-      . (_) @_then)) @indent.branch
-  (#not-has-type? @_then block)
-)
+  (if_block) @indent.dedent)
 
 (while_block
   (command_expression)) @indent.auto
 
 (repeat_block
   (command_expression)) @indent.auto
-
 
 (comment) @indent.auto

--- a/tests/indent/t32/if_block.cmm
+++ b/tests/indent/t32/if_block.cmm
@@ -43,7 +43,7 @@ IF &f
     stop
   ELSE
     IF &h
-  (
-    continue
-  )
+    (
+      continue
+    )
 

--- a/tests/indent/t32_spec.lua
+++ b/tests/indent/t32_spec.lua
@@ -35,7 +35,22 @@ describe("indent t32:", function()
       )
     end
 
-    runner:new_line("if_block.cmm", { on_line = 45, text = "&x=1.", indent = 2 }, "command in IF then")
+    -- Insertion of a command right before the existing block results in
+    -- incorrect syntax. The parse either detect an error or incorrectly
+    -- assumes "ELSE IF" is a command.
+    for ii, test in ipairs {
+      { 26, 2 },
+      { 30, 2 },
+    } do
+      runner:new_line(
+        "if_block.cmm",
+        { on_line = test[1], text = 'PRINT ""', indent = test[2] },
+        "displace block in IF then[" .. ii .. "]",
+        XFAIL
+      )
+    end
+
+    runner:new_line("if_block.cmm", { on_line = 45, text = "&x=1.", indent = 6 }, "command in IF then", XFAIL)
 
     for ii, test in ipairs {
       { 16, 2 },
@@ -45,7 +60,7 @@ describe("indent t32:", function()
     } do
       runner:new_line(
         "if_block.cmm",
-        { on_line = test[1], text = "(\n", indent = test[2] },
+        { on_line = test[1], text = "CONTinue\n", indent = test[2] },
         "command in IF else[" .. ii .. "]"
       )
     end
@@ -68,8 +83,8 @@ describe("indent t32:", function()
     end
 
     for ii, test in ipairs {
-      { 1, 0, nil },
-      { 4, 2, XFAIL },
+      { 1, 0 },
+      { 4, 2 },
     } do
       runner:new_line(
         "repeat_block.cmm",
@@ -81,9 +96,9 @@ describe("indent t32:", function()
     runner:new_line("repeat_block.cmm", { on_line = 3, text = "(\n", indent = 0 }, "block in RePeaT then")
 
     for ii, test in ipairs {
-      { 7, 2, XFAIL },
-      { 18, 2, nil },
-      { 24, 2, XFAIL },
+      { 7, 2 },
+      { 18, 2 },
+      { 24, 2 },
     } do
       runner:new_line(
         "repeat_block.cmm",
@@ -95,11 +110,11 @@ describe("indent t32:", function()
     runner:new_line("subroutine_block.cmm", { on_line = 1, text = "(\n", indent = 0 }, "block after call label")
 
     for ii, test in ipairs {
-      { 2, 2, XFAIL },
-      { 3, 2, nil },
-      { 8, 2, XFAIL },
-      { 12, 2, nil },
-      { 19, 2, XFAIL },
+      { 2, 2 },
+      { 3, 2 },
+      { 8, 2 },
+      { 12, 2 },
+      { 19, 2 },
     } do
       runner:new_line(
         "subroutine_block.cmm",


### PR DESCRIPTION
In the latest version of the grammar, handling of consecutive line breaks has changed. Tests inserting single lines will now fail (after next parser update). I am not quite sure why this is happening.

The updated queries are a bit simpler than before and seem to do the job.