### PR TITLE
fix(highlight): apply @error to nodes under error, instead of parent node

### DIFF
--- a/queries/ada/highlights.scm
+++ b/queries/ada/highlights.scm
@@ -192,5 +192,5 @@
 ;; Highlight errors in red. This is not very useful in practice, as text will
 ;; be highlighted as user types, and the error could be elsewhere in the code.
 ;; This also requires defining    :hi @error guifg=Red    for instance.
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node
 

--- a/queries/bitbake/highlights.scm
+++ b/queries/bitbake/highlights.scm
@@ -357,4 +357,4 @@
 
 (comment) @comment @spell
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -283,4 +283,4 @@
   (attribute_declaration)
 ] @attribute
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/cairo/highlights.scm
+++ b/queries/cairo/highlights.scm
@@ -335,4 +335,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/capnp/highlights.scm
+++ b/queries/capnp/highlights.scm
@@ -151,4 +151,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/chatito/highlights.scm
+++ b/queries/chatito/highlights.scm
@@ -51,4 +51,4 @@
 
 ;; Error
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/corn/highlights.scm
+++ b/queries/corn/highlights.scm
@@ -19,4 +19,4 @@
 (boolean) @boolean
 (null) @keyword
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/cpon/highlights.scm
+++ b/queries/cpon/highlights.scm
@@ -47,4 +47,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/css/highlights.scm
+++ b/queries/css/highlights.scm
@@ -88,4 +88,4 @@
  "}"
  ] @punctuation.bracket
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/cue/highlights.scm
+++ b/queries/cue/highlights.scm
@@ -161,4 +161,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -267,4 +267,4 @@
 ["do" "while" "continue" "for"] @repeat
 
 ; Error
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/dot/highlights.scm
+++ b/queries/dot/highlights.scm
@@ -52,4 +52,4 @@
 
 (comment) @spell
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/dtd/highlights.scm
+++ b/queries/dtd/highlights.scm
@@ -118,4 +118,4 @@
 
 (Comment) @comment @spell
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/eex/highlights.scm
+++ b/queries/eex/highlights.scm
@@ -12,4 +12,4 @@
 (comment) @comment @spell
 
 ; Tree-sitter parser errors
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -19,9 +19,6 @@
   "%"
 ] @punctuation.special
 
-; Parser Errors
-(ERROR) @error
-
 ; Identifiers
 (identifier) @variable
 
@@ -224,3 +221,6 @@
         (quoted_content) @comment.documentation
         quoted_end: _ @comment.documentation)
     ] @comment.documentation))) @comment.documentation
+
+; Parser Errors
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/firrtl/highlights.scm
+++ b/queries/firrtl/highlights.scm
@@ -186,4 +186,4 @@
 ["=>" "<=" "="] @operator
 
 ; Error
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -164,5 +164,5 @@
 
 ;; Error
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node
 

--- a/queries/forth/highlights.scm
+++ b/queries/forth/highlights.scm
@@ -18,4 +18,4 @@
 
 (comment) @comment @spell
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/fortran/highlights.scm
+++ b/queries/fortran/highlights.scm
@@ -329,4 +329,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -1,6 +1,4 @@
 ;; Basic
-(ERROR) @error
-
 (identifier) @variable
 (name) @variable
 (type) @type
@@ -342,3 +340,4 @@
   "OP_BIT_AND" "OP_BIT_OR" "OP_BIT_XOR" "OP_BIT_NEGATE" "OP_AND" "OP_OR" "OP_XOR" "OP_NOT" "OP_IN" "OP_MAX"
  ))
 
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gitattributes/highlights.scm
+++ b/queries/gitattributes/highlights.scm
@@ -48,6 +48,6 @@
   (trailing_slash)
 ] @error
 
-(ERROR) @error
-
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gitcommit/highlights.scm
+++ b/queries/gitcommit/highlights.scm
@@ -30,4 +30,4 @@
 
 (scissor) @comment
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gleam/highlights.scm
+++ b/queries/gleam/highlights.scm
@@ -169,4 +169,4 @@
 (binary_expression operator: "|>" right: (identifier) @function)
 
 ; Parser Errors
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -247,7 +247,7 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node
 
 ; Spell
 

--- a/queries/godot_resource/highlights.scm
+++ b/queries/godot_resource/highlights.scm
@@ -25,4 +25,4 @@
 
 "=" @operator
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gpg/highlights.scm
+++ b/queries/gpg/highlights.scm
@@ -46,4 +46,4 @@
 
 (comment) @comment @spell
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/hack/highlights.scm
+++ b/queries/hack/highlights.scm
@@ -314,4 +314,4 @@
  (xhp_close)
 ] @tag
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/hare/highlights.scm
+++ b/queries/hare/highlights.scm
@@ -252,4 +252,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -96,4 +96,4 @@
 ; first element in get_attr is a variable.builtin or a reference to a variable.builtin
 (expression (variable_expr (identifier) @variable.builtin) (get_attr (identifier) @field))
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/heex/highlights.scm
+++ b/queries/heex/highlights.scm
@@ -32,9 +32,6 @@
 ; HEEx text content is treated as markup
 (text) @text
 
-; Tree-sitter parser errors
-(ERROR) @error
-
 ; HEEx tags and slots are highlighted as HTML
 [
  (tag_name) 
@@ -54,3 +51,6 @@
   (function) @function
   "." @punctuation.delimiter
 ])
+
+; Tree-sitter parser errors
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/hjson/highlights.scm
+++ b/queries/hjson/highlights.scm
@@ -6,7 +6,6 @@
 (pair value: (string) @string)
 (array (string) @string)
 ;  (string_content (escape_sequence) @string.escape)
-(ERROR) @error
 ;  "," @punctuation.delimiter
 "[" @punctuation.bracket
 "]" @punctuation.bracket
@@ -14,3 +13,5 @@
 "}" @punctuation.bracket
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/http/highlights.scm
+++ b/queries/http/highlights.scm
@@ -57,4 +57,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/json/highlights.scm
+++ b/queries/json/highlights.scm
@@ -12,8 +12,6 @@
 
 (array (string) @string)
 
-(ERROR) @error
-
 ["," ":"] @punctuation.delimiter
 
 [
@@ -28,3 +26,5 @@
 ((escape_sequence) @conceal
  (#eq? @conceal "\\\"")
  (#set! conceal "\""))
+
+(ERROR _ @error)  ; up the specificity to nodes under error, instead of parent node

--- a/queries/json5/highlights.scm
+++ b/queries/json5/highlights.scm
@@ -14,4 +14,4 @@
 (member
     name: (_) @keyword)
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/jsonnet/highlights.scm
+++ b/queries/jsonnet/highlights.scm
@@ -118,4 +118,4 @@
   ")")
 
 ; ERROR
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/kconfig/highlights.scm
+++ b/queries/kconfig/highlights.scm
@@ -78,4 +78,4 @@
 
 (comment) @comment @spell
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -1,6 +1,4 @@
 ;; General syntax
-(ERROR) @error
-
 (command_name) @function
 (caption
   command: _ @function)
@@ -247,3 +245,5 @@
 (citation
   keys: _ @nospell)
 (command_name) @nospell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/llvm/highlights.scm
+++ b/queries/llvm/highlights.scm
@@ -163,4 +163,4 @@
   "zeroinitializer"
 ] @constant.builtin
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -247,4 +247,4 @@
 (escape_sequence) @string.escape
 
 ;; Error
-(ERROR) @error
+(ERROR _ @error)  ; up the specificity to nodes under error, instead of parent node

--- a/queries/luau/highlights.scm
+++ b/queries/luau/highlights.scm
@@ -249,4 +249,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/matlab/highlights.scm
+++ b/queries/matlab/highlights.scm
@@ -151,4 +151,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/menhir/highlights.scm
+++ b/queries/menhir/highlights.scm
@@ -26,4 +26,4 @@
 (ocaml) @none
 
 [(comment) (line_comment) (ocaml_comment)] @comment @spell
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -174,4 +174,4 @@
 
 [(comment) (line_number_directive) (directive) (shebang)] @comment @spell
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ocamllex/highlights.scm
+++ b/queries/ocamllex/highlights.scm
@@ -38,4 +38,4 @@
 ; Misc
 
 (comment) @comment @spell
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/odin/highlights.scm
+++ b/queries/odin/highlights.scm
@@ -290,4 +290,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/pem/highlights.scm
+++ b/queries/pem/highlights.scm
@@ -8,4 +8,4 @@
 
 (comment) @comment @spell
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -319,4 +319,4 @@
   "::"
 ] @operator
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/po/highlights.scm
+++ b/queries/po/highlights.scm
@@ -30,4 +30,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/pony/highlights.scm
+++ b/queries/pony/highlights.scm
@@ -289,4 +289,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/promql/highlights.scm
+++ b/queries/promql/highlights.scm
@@ -38,5 +38,5 @@
 (function_name) @function.call
 
 (comment) @comment @spell
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node
 

--- a/queries/puppet/highlights.scm
+++ b/queries/puppet/highlights.scm
@@ -192,4 +192,4 @@
 
 ; Errors
 
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/pymanifest/highlights.scm
+++ b/queries/pymanifest/highlights.scm
@@ -17,6 +17,6 @@
 
 (escaped_char) @string.escape
 
-(ERROR) @error
-
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -348,4 +348,4 @@
               "bytes" "bytearray" "memoryview" "set" "frozenset" "dict" "type" "object"))
 
 ;; Error
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -141,4 +141,4 @@
   function: ((dollar _ (identifier) @method.call)))
 
 ; Error
-(ERROR) @error
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -256,4 +256,4 @@
   "#{" @punctuation.special
   "}" @punctuation.special) @none
 
-(ERROR) @error
+(ERROR _ @error)  ; up the specificity to nodes under error, instead of parent node


### PR DESCRIPTION
feat: apply @error to nodes under error, instead of parent node

per @lucario387,
> When in error nodes, the tree is like (ERROR ","), so what's happening
> here is nvim is applying highlights onto ERROR node, but also having a
> separate highlight for ",", leading to it also getting applied. And
> because "," capture is more specific, it's taking priority

https://github.com/nvim-treesitter/nvim-treesitter/pull/5421#issuecomment-1724707540

Related: https://github.com/folke/tokyonight.nvim/issues/283