### PR TITLE
feat: make `ERROR` node capture consistent across all langs

### DIFF
--- a/queries/agda/highlights.scm
+++ b/queries/agda/highlights.scm
@@ -79,3 +79,5 @@
 [
   "="
 ] @operator
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/arduino/highlights.scm
+++ b/queries/arduino/highlights.scm
@@ -109,3 +109,5 @@
   (function_declarator
     declarator: (identifier) @constructor)
   (#eq? @type.builtin "SPISettings"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/astro/highlights.scm
+++ b/queries/astro/highlights.scm
@@ -3,3 +3,5 @@
 [ "---" ] @punctuation.delimiter
 
 [ "{" "}" ] @punctuation.special
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/awk/highlights.scm
+++ b/queries/awk/highlights.scm
@@ -193,3 +193,5 @@
   "{"
   "}"
 ] @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -184,3 +184,5 @@
 
 ((program . (comment) @preproc)
  (#lua-match? @preproc "^#!/"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/bass/highlights.scm
+++ b/queries/bass/highlights.scm
@@ -107,3 +107,5 @@
 ;; Comments
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/beancount/highlights.scm
+++ b/queries/beancount/highlights.scm
@@ -22,3 +22,5 @@
     (custom) (pushtag) (poptag) (pushmeta)
     (popmeta) (option) (include) (plugin)
 ] @keyword
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/bibtex/highlights.scm
+++ b/queries/bibtex/highlights.scm
@@ -49,3 +49,5 @@
 ] @punctuation.bracket
 
 "," @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/bicep/highlights.scm
+++ b/queries/bicep/highlights.scm
@@ -228,3 +228,5 @@
   (comment)
   (diagnostic_comment)
 ] @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/blueprint/highlights.scm
+++ b/queries/blueprint/highlights.scm
@@ -55,3 +55,5 @@
   "{"
   "}"
 ] @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -414,3 +414,5 @@
   "return"
   "yield"
 ] @keyword.return
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -379,3 +379,5 @@
  (#eq? @_include "ns")
  .
  (sym_lit) @namespace)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/cmake/highlights.scm
+++ b/queries/cmake/highlights.scm
@@ -215,3 +215,5 @@
 
 ((source_file . (line_comment) @preproc)
   (#lua-match? @preproc "^#!/"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/commonlisp/highlights.scm
+++ b/queries/commonlisp/highlights.scm
@@ -143,3 +143,5 @@
 [(array_dimension) "#0A" "#0a"] @number
 
 (char_lit) @character
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/cooklang/highlights.scm
+++ b/queries/cooklang/highlights.scm
@@ -20,3 +20,5 @@
 	(amount
 	  (quantity)? @number
 		(units)? @tag.attribute)?)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -238,3 +238,5 @@
   ["<" ">"] @punctuation.bracket)
 
 (literal_suffix) @operator
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/csv/highlights.scm
+++ b/queries/csv/highlights.scm
@@ -1,3 +1,5 @@
 ; inherits: tsv
 
 "," @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/cuda/highlights.scm
+++ b/queries/cuda/highlights.scm
@@ -11,3 +11,5 @@
 ] @storageclass
 
 "__launch_bounds__" @type.qualifier
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/d/highlights.scm
+++ b/queries/d/highlights.scm
@@ -286,3 +286,5 @@
 (primary_expression
   "this" @variable.builtin
 )
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/devicetree/highlights.scm
+++ b/queries/devicetree/highlights.scm
@@ -33,3 +33,5 @@
 [ "=" ] @operator
 [ "(" ")" "[" "]" "{" "}" "<" ">" ] @punctuation.bracket
 [ ";" ":" "," "@" ] @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/dhall/highlights.scm
+++ b/queries/dhall/highlights.scm
@@ -169,3 +169,5 @@
   (line_comment)
   (block_comment)
 ] @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/diff/highlights.scm
+++ b/queries/diff/highlights.scm
@@ -4,3 +4,5 @@
 (commit) @constant
 (location) @attribute
 (command) @function
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/dockerfile/highlights.scm
+++ b/queries/dockerfile/highlights.scm
@@ -55,3 +55,5 @@
 
 (expose_instruction
   (expose_port) @number)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/doxygen/highlights.scm
+++ b/queries/doxygen/highlights.scm
@@ -51,3 +51,5 @@
 [ "(" ")" "{" "}" "[" "]" ] @punctuation.bracket
 
 (code_block_content) @none
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ebnf/highlights.scm
+++ b/queries/ebnf/highlights.scm
@@ -41,3 +41,5 @@
  "{"
  "}"
 ] @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -355,3 +355,5 @@
   "default" @keyword)
 (switch_default
   "default" @conditional)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/eds/highlights.scm
+++ b/queries/eds/highlights.scm
@@ -47,3 +47,5 @@
    (statement (key) @_key) @number
    (#match? @_key "\\c^(DefaultValue|LowLimit|HighLimit|SubNumber)$")
    (#not-match? @_name "\\c^Comments$"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/elm/highlights.scm
+++ b/queries/elm/highlights.scm
@@ -203,3 +203,5 @@
   (string_escape) @character)
 (char_constant_expr
   (regular_string_part) @character)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/elsa/highlights.scm
+++ b/queries/elsa/highlights.scm
@@ -39,3 +39,5 @@
 ; Comments
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/elvish/highlights.scm
+++ b/queries/elvish/highlights.scm
@@ -68,3 +68,5 @@
 ["$" "@"] @punctuation.special
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 ";" @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/embedded_template/highlights.scm
+++ b/queries/embedded_template/highlights.scm
@@ -10,3 +10,5 @@
   "-%>"
   "_%>"
 ] @keyword
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/erlang/highlights.scm
+++ b/queries/erlang/highlights.scm
@@ -127,3 +127,5 @@
 (function_clause name: (atom) @function)
 (fa fun: (atom) @function)
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/fennel/highlights.scm
+++ b/queries/fennel/highlights.scm
@@ -119,3 +119,5 @@
 ((symbol) @function.builtin
  (#any-of? @function.builtin
   "loadstring" "module" "setfenv" "unpack"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/foam/highlights.scm
+++ b/queries/foam/highlights.scm
@@ -59,3 +59,5 @@
 
 ((identifier) @constant.builtin
   (#any-of? @constant.builtin "uniform" "non-uniform" "and" "or"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/fsh/highlights.scm
+++ b/queries/fsh/highlights.scm
@@ -89,3 +89,5 @@
 
 ; Extras
 (fsh_comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/func/highlights.scm
+++ b/queries/func/highlights.scm
@@ -173,3 +173,5 @@
 ; Comments
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/fusion/highlights.scm
+++ b/queries/fusion/highlights.scm
@@ -118,3 +118,5 @@
 
 (eel_ternary_expression
   ["?" ":"] @conditional.ternary)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/git_config/highlights.scm
+++ b/queries/git_config/highlights.scm
@@ -47,3 +47,5 @@
 ; Comments
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/git_rebase/highlights.scm
+++ b/queries/git_rebase/highlights.scm
@@ -6,3 +6,5 @@
 
 (comment) @comment
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gitignore/highlights.scm
+++ b/queries/gitignore/highlights.scm
@@ -29,3 +29,5 @@
 (bracket_range 
   "-" @operator)
 (bracket_char_class) @constant.builtin
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/glimmer/highlights.scm
+++ b/queries/glimmer/highlights.scm
@@ -86,3 +86,5 @@
   "</"
   "/>"
 ] @tag.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/glsl/highlights.scm
+++ b/queries/glsl/highlights.scm
@@ -33,3 +33,5 @@
 
 ((identifier) @variable.builtin
  (#lua-match? @variable.builtin "^gl_"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gomod/highlights.scm
+++ b/queries/gomod/highlights.scm
@@ -16,3 +16,5 @@
 (version)
 (go_version)
 ] @string
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gosum/highlights.scm
+++ b/queries/gosum/highlights.scm
@@ -29,3 +29,5 @@
   "-"
   "/"
 ] @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/gowork/highlights.scm
+++ b/queries/gowork/highlights.scm
@@ -12,3 +12,5 @@
 (version)
 (go_version)
 ] @string
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/graphql/highlights.scm
+++ b/queries/graphql/highlights.scm
@@ -163,3 +163,5 @@
 
 "..." @punctuation.special
 "!" @punctuation.special
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -93,3 +93,5 @@
 ] @operator
 
 ["(" ")" "[" "]" "{" "}"]  @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -158,3 +158,5 @@
 
 (comment) @spell
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/haskell_persistent/highlights.scm
+++ b/queries/haskell_persistent/highlights.scm
@@ -36,3 +36,5 @@
 (type) @type
 
 (constructor) @constructor
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/hlsl/highlights.scm
+++ b/queries/hlsl/highlights.scm
@@ -33,3 +33,5 @@
 
 (hlsl_attribute) @attribute
 (hlsl_attribute ["[" "]"] @attribute)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/hocon/highlights.scm
+++ b/queries/hocon/highlights.scm
@@ -35,3 +35,5 @@
 [ "," ] @punctuation.delimiter
 (unquoted_path "." @punctuation.delimiter)
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/hoon/highlights.scm
+++ b/queries/hoon/highlights.scm
@@ -31,3 +31,5 @@
 (specialIndex) @number.builtin
 (lark) @operator
 (fullContext) @symbol
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/html/highlights.scm
+++ b/queries/html/highlights.scm
@@ -3,3 +3,5 @@
 (doctype) @constant
 
 "<!" @tag.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/htmldjango/highlights.scm
+++ b/queries/htmldjango/highlights.scm
@@ -33,3 +33,5 @@
 (boolean) @boolean
 
 (string) @string
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/hurl/highlights.scm
+++ b/queries/hurl/highlights.scm
@@ -131,3 +131,5 @@
 
 (method) @type.builtin
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ispc/highlights.scm
+++ b/queries/ispc/highlights.scm
@@ -223,3 +223,5 @@
    "tan"
    "trunc"
    ))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/janet_simple/highlights.scm
+++ b/queries/janet_simple/highlights.scm
@@ -299,3 +299,5 @@
   "yield"
   "zero?" "zipcoll"))
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -296,3 +296,5 @@
 
 ((line_comment) @comment.documentation
   (#lua-match? @comment.documentation "^///$"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -53,3 +53,5 @@
 
 ;; punctuation
 (optional_chain) @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/jq/highlights.scm
+++ b/queries/jq/highlights.scm
@@ -328,3 +328,5 @@
 ; Comments
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/jsdoc/highlights.scm
+++ b/queries/jsdoc/highlights.scm
@@ -1,2 +1,4 @@
 (tag_name) @keyword
 (type) @type
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/jsonc/highlights.scm
+++ b/queries/jsonc/highlights.scm
@@ -1,3 +1,5 @@
 ; inherits: json
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -33,3 +33,5 @@
 (jsx_self_closing_element ((member_expression (identifier) @tag (property_identifier) @constructor)))
 
 (jsx_text) @none
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -298,3 +298,5 @@
   (block_comment)
 ] @comment @spell
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/kdl/highlights.scm
+++ b/queries/kdl/highlights.scm
@@ -56,3 +56,5 @@
 (node (node_comment) (#set! "priority" 105)) @comment
 (node (node_field (node_field_comment) (#set! "priority" 105)) @comment)
 (node_children (node_children_comment) (#set! "priority" 105)) @comment
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -420,3 +420,5 @@
 	"${" @punctuation.special
 	(interpolated_expression) @none
 	"}" @punctuation.special)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/lalrpop/highlights.scm
+++ b/queries/lalrpop/highlights.scm
@@ -58,3 +58,5 @@
 
 (string_literal) @string
 (regex_literal) @string
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ledger/highlights.scm
+++ b/queries/ledger/highlights.scm
@@ -52,3 +52,5 @@
     "C"
     "P"
 ] @keyword
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/luadoc/highlights.scm
+++ b/queries/luadoc/highlights.scm
@@ -150,3 +150,5 @@
   (identifier) @type
   ("extends"? (identifier)? @type)
   (_) @comment @spell)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/luap/highlights.scm
+++ b/queries/luap/highlights.scm
@@ -33,3 +33,5 @@
 
 (balanced_match
   (character) @parameter)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/m68k/highlights.scm
+++ b/queries/m68k/highlights.scm
@@ -69,3 +69,5 @@
 ] @punctuation.bracket
 
 (section) @namespace
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/make/highlights.scm
+++ b/queries/make/highlights.scm
@@ -129,3 +129,5 @@
  "file"
  "value"
  ] @function.builtin)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -69,3 +69,5 @@
 ] @string.escape
 
 (inline) @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -100,3 +100,5 @@
 ((entity_reference) @conceal (#eq? @conceal "&amp;") (#set! conceal "&"))
 ((entity_reference) @conceal (#eq? @conceal "&quot;") (#set! conceal "\""))
 ((entity_reference) @conceal (#any-of? @conceal "&ensp;" "&emsp;") (#set! conceal " "))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/mermaid/highlights.scm
+++ b/queries/mermaid/highlights.scm
@@ -175,3 +175,5 @@
  ] @type.qualifier
 
 (er_attribute_comment) @string @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/meson/highlights.scm
+++ b/queries/meson/highlights.scm
@@ -74,3 +74,5 @@
     "build_machine"
     "target_machine"
    ))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/mlir/highlights.scm
+++ b/queries/mlir/highlights.scm
@@ -333,3 +333,5 @@
 (caret_id) @tag
 (value_use) @variable
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/nickel/highlights.scm
+++ b/queries/nickel/highlights.scm
@@ -59,3 +59,5 @@
 (applicative t1:
   (applicative (record_operand) @function)
 )
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ninja/highlights.scm
+++ b/queries/ninja/highlights.scm
@@ -98,3 +98,5 @@
 ] @comment
 
 (comment) @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -131,3 +131,5 @@
   (unary_expression "-" (float_expression))
   (float_expression)
 ] @float
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/nqc/highlights.scm
+++ b/queries/nqc/highlights.scm
@@ -16,3 +16,5 @@
   "start"
   "stop"
 ] @keyword.coroutine
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/objc/highlights.scm
+++ b/queries/objc/highlights.scm
@@ -214,3 +214,5 @@
 "@" @punctuation.special
 
 [ "<" ">" ] @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ocaml_interface/highlights.scm
+++ b/queries/ocaml_interface/highlights.scm
@@ -1,1 +1,3 @@
 ; inherits: ocaml
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/pascal/highlights.scm
+++ b/queries/pascal/highlights.scm
@@ -422,3 +422,5 @@
  (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
 (defaultValue ((identifier) @constant
  (#match? @constant "^[A-Z][A-Z0-9_]+$|^[a-z]{2,3}[A-Z].+$")))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/passwd/highlights.scm
+++ b/queries/passwd/highlights.scm
@@ -14,3 +14,5 @@
 ] @number
 
 (separator) @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -196,3 +196,5 @@
 (function_attribute) @field
 
 (function_signature) @type
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/phpdoc/highlights.scm
+++ b/queries/phpdoc/highlights.scm
@@ -43,3 +43,5 @@
   (#eq? @_tag_name "@author"))
 
 (text) @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/pioasm/highlights.scm
+++ b/queries/pioasm/highlights.scm
@@ -32,3 +32,5 @@
 (value (identifier) @variable)
 
 (directive directive: _ @preproc)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/poe_filter/highlights.scm
+++ b/queries/poe_filter/highlights.scm
@@ -36,3 +36,5 @@
 ("\"" @conceal
   (#not-has-parent? @conceal string file)
   (#set! conceal ""))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/prisma/highlights.scm
+++ b/queries/prisma/highlights.scm
@@ -37,3 +37,5 @@
   "="
   "@"
 ] @operator
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/proto/highlights.scm
+++ b/queries/proto/highlights.scm
@@ -80,3 +80,5 @@
 ] @punctuation.delimiter
 
 "=" @operator
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/prql/highlights.scm
+++ b/queries/prql/highlights.scm
@@ -149,3 +149,5 @@ alias: (identifier) @field
  (keyword_null) @constant.builtin
 
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/psv/highlights.scm
+++ b/queries/psv/highlights.scm
@@ -1,3 +1,5 @@
 ; inherits: tsv
 
 "|" @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/pug/highlights.scm
+++ b/queries/pug/highlights.scm
@@ -78,3 +78,5 @@
 (buffered_code "=" @punctuation.delimiter)
 (unbuffered_code "-" @punctuation.delimiter)
 (unescaped_buffered_code "!=" @punctuation.delimiter)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/ql/highlights.scm
+++ b/queries/ql/highlights.scm
@@ -133,3 +133,5 @@
 ] @comment @spell
 
 (qldoc) @comment.documentation
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/qmldir/highlights.scm
+++ b/queries/qmldir/highlights.scm
@@ -22,3 +22,5 @@
 ; Comments
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/qmljs/highlights.scm
+++ b/queries/qmljs/highlights.scm
@@ -151,3 +151,5 @@
   "type"
   "override"
 ] @keyword
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -32,3 +32,5 @@
 
 ((program . (comment)* . (comment) @preproc)
  (#lua-match? @preproc "^;+ *extends"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -32,3 +32,5 @@
 ] @string.escape
 
 [ "*" "+" "?" "|" "=" "!" ] @operator
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/rego/highlights.scm
+++ b/queries/rego/highlights.scm
@@ -62,3 +62,5 @@
   (rule_head (term (ref (var) @namespace)))
   (rule_body (query (literal (expr (expr_infix (expr (term (ref (var)) @_output)))))) (#eq? @_output @namespace))
 )
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/robot/highlights.scm
+++ b/queries/robot/highlights.scm
@@ -55,3 +55,5 @@
 ] @exception
 (try_statement "END" @exception)
 (try_statement (else_statement "ELSE" @exception))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -382,3 +382,5 @@
   macro: (identifier) @debug
   "!" @debug
   (#eq? @debug "dbg"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -262,3 +262,5 @@
 ;; Scala CLI using directives
 (using_directive_key) @parameter
 (using_directive_value) @string
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/scfg/highlights.scm
+++ b/queries/scfg/highlights.scm
@@ -6,3 +6,5 @@
 (comment) @comment @spell
 (directive_name) @type
 (directive_params) @parameter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/scheme/highlights.scm
+++ b/queries/scheme/highlights.scm
@@ -180,3 +180,5 @@
   ;; system
   "load" "transcript-on" "transcript-off"))
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/scss/highlights.scm
+++ b/queries/scss/highlights.scm
@@ -63,3 +63,5 @@
 ] @punctuation.bracket
 
 (include_statement (identifier) @function)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/slint/highlights.scm
+++ b/queries/slint/highlights.scm
@@ -152,3 +152,5 @@
  ] @operator
 
 (ternary_expression [":" "?"] @conditional.ternary)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/smithy/highlights.scm
+++ b/queries/smithy/highlights.scm
@@ -111,3 +111,5 @@
 (comment) @comment @spell
 
 (documentation_comment) @comment.documentation @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/snakemake/highlights.scm
+++ b/queries/snakemake/highlights.scm
@@ -62,3 +62,5 @@
   (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards")
   (#has-ancestor? @label "directive")
   (#has-ancestor? @label "block"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/sparql/highlights.scm
+++ b/queries/sparql/highlights.scm
@@ -209,3 +209,5 @@
   (iri_reference)
   (prefixed_name)
 ] @variable
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -386,3 +386,5 @@
   ","
   "."
 ] @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/squirrel/highlights.scm
+++ b/queries/squirrel/highlights.scm
@@ -305,3 +305,5 @@
 
 ((comment) @comment.documentation
   (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/supercollider/highlights.scm
+++ b/queries/supercollider/highlights.scm
@@ -95,3 +95,5 @@
 
 ; SinOsc.ar()!2
 (duplicated_statement) @repeat
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/surface/highlights.scm
+++ b/queries/surface/highlights.scm
@@ -42,3 +42,5 @@
 
 ; Surface operators
 ["="] @operator
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/svelte/highlights.scm
+++ b/queries/svelte/highlights.scm
@@ -28,3 +28,5 @@
   "/"
   "@"
 ] @tag.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -187,3 +187,5 @@
   (bang)
 ] @operator
 
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/sxhkdrc/highlights.scm
+++ b/queries/sxhkdrc/highlights.scm
@@ -8,3 +8,5 @@
 (comment) @comment @spell
 (range) @number
 "\\\n" @punctuation.special
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -151,3 +151,5 @@
 
 "private" @type.qualifier
 "global" @storageclass
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/t32/highlights.scm
+++ b/queries/t32/highlights.scm
@@ -230,3 +230,5 @@
 
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/terraform/highlights.scm
+++ b/queries/terraform/highlights.scm
@@ -19,3 +19,5 @@
 (object_elem val: (expression
   (variable_expr
     (identifier) @type.builtin (#any-of? @type.builtin "bool" "string" "number" "object" "tuple" "list" "map" "set" "any"))))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/textproto/highlights.scm
+++ b/queries/textproto/highlights.scm
@@ -16,3 +16,5 @@
   (open_arrow)
   (close_arrow)
 ] @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/tiger/highlights.scm
+++ b/queries/tiger/highlights.scm
@@ -119,3 +119,5 @@
 ; }}}
 
 ; vim: sw=2 foldmethod=marker
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/tlaplus/highlights.scm
+++ b/queries/tlaplus/highlights.scm
@@ -268,3 +268,5 @@
 (bound_nonfix_op symbol: (_) @constant (#is? @constant constant))
 (bound_nonfix_op symbol: (_) @function.macro (#is? @function.macro macro))
 (bound_nonfix_op symbol: (_) @parameter (#is? @parameter parameter))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/todotxt/highlights.scm
+++ b/queries/todotxt/highlights.scm
@@ -4,3 +4,5 @@
 (task (kv) @comment)
 (task (project) @string)
 (task (context) @type)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/tsv/highlights.scm
+++ b/queries/tsv/highlights.scm
@@ -2,3 +2,5 @@
 (number) @number
 (float) @float
 (boolean) @boolean
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/tsx/highlights.scm
+++ b/queries/tsx/highlights.scm
@@ -1,1 +1,3 @@
 ; inherits: typescript,jsx
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/turtle/highlights.scm
+++ b/queries/turtle/highlights.scm
@@ -56,3 +56,5 @@
 (rdf_literal 
   "^^" @type
 	datatype: (_ ["<" ">" (namespace)] @type) @type)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/twig/highlights.scm
+++ b/queries/twig/highlights.scm
@@ -53,3 +53,5 @@
 ] @punctuation.bracket
 
 (hash ["{" "}"] @punctuation.bracket)
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -155,3 +155,5 @@
             (union_type (parenthesized_type (function_type)))
             (function_type)
           ]))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/unison/highlights.scm
+++ b/queries/unison/highlights.scm
@@ -71,3 +71,5 @@
   "["
   "]"
 ] @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/usd/highlights.scm
+++ b/queries/usd/highlights.scm
@@ -179,3 +179,5 @@
  (comment)*
  (string) @comment.documentation
 )
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/uxntal/highlights.scm
+++ b/queries/uxntal/highlights.scm
@@ -82,3 +82,5 @@
 ; Comments
 
 (comment) @comment @spell
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/vala/highlights.scm
+++ b/queries/vala/highlights.scm
@@ -248,3 +248,5 @@
  "["
  "]"
 ] @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/vhs/highlights.scm
+++ b/queries/vhs/highlights.scm
@@ -36,3 +36,5 @@
 (comment) @comment @spell
 [(path) (string) (json)] @string
 (time) @symbol
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -289,3 +289,5 @@
     "completefunc" "cfu"
     "omnifunc" "ofu"
     "operatorfunc" "opfunc"))
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/vimdoc/highlights.scm
+++ b/queries/vimdoc/highlights.scm
@@ -23,3 +23,5 @@
 (argument) @parameter
 (keycode) @string.special
 (url) @text.uri
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/vue/highlights.scm
+++ b/queries/vue/highlights.scm
@@ -21,3 +21,5 @@
   (directive_modifier)
   (directive_argument)
 ] @method
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/wgsl_bevy/highlights.scm
+++ b/queries/wgsl_bevy/highlights.scm
@@ -34,3 +34,5 @@
  "#endif"
  "#else"
 ] @preproc
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/wing/highlights.scm
+++ b/queries/wing/highlights.scm
@@ -84,3 +84,5 @@
   "return"
   (inflight_specifier)
 ] @keyword
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/xml/highlights.scm
+++ b/queries/xml/highlights.scm
@@ -51,3 +51,5 @@
 [ "<" "</" "/>" ] @tag.delimiter
 
 "]" @punctuation.bracket
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node

--- a/queries/yang/highlights.scm
+++ b/queries/yang/highlights.scm
@@ -41,3 +41,5 @@
 (plus_symbol) @operator
 ["{" "}"] @punctuation.bracket
 [";"] @punctuation.delimiter
+
+(ERROR _ @error) ; up the specificity to nodes under error, instead of parent node


### PR DESCRIPTION
`ERROR` nodes are a concept fundamental to Tree-sitter. We capture them as `@error` in about a third of languages currently, which suggests that `@error` is an intended standard.

This patch extends it to all languages. Impact on users:

- Only certain Tree-sitter aware color schemes actually assign any visuals to parse errors; for example, catppuccin has it but tokyonight does not.
- Users of these themes already see errors prior to this PR; this just makes it consistent across all languages. I imagine if users found visual syntax errors annoying, they would've already experienced and disabled it.
- The color can be overwritten by users.

Note: whether we use `(ERROR) @error` or `(ERROR _ @error)` depends on the outcome of #5421. This can easily be find+replaced.