### PR TITLE
fix(markdown): give code blocks higher priority than block quotes

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -57,7 +57,7 @@
 (task_list_marker_unchecked) @text.todo.unchecked
 (task_list_marker_checked) @text.todo.checked
 
-((block_quote) @text.quote (#set! "priority" 89))
+((block_quote) @text.quote (#set! "priority" 90))
 
 [
   (block_continuation)

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -57,7 +57,7 @@
 (task_list_marker_unchecked) @text.todo.unchecked
 (task_list_marker_checked) @text.todo.checked
 
-(block_quote) @text.quote
+((block_quote) @text.quote (#set! "priority" 89))
 
 [
   (block_continuation)


### PR DESCRIPTION
Before: 
![beforeprioritychangets](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/144c6c49-e3c9-4f04-b727-a5bfb578df5d)

After:
![afterprioritychangets](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/70fe946f-6eb8-480e-82a9-44fa6f4792ed)
