### PR TITLE
fix: use augroup for auto_install autocmds

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -555,6 +555,7 @@ end
 function M.setup_auto_install()
   vim.api.nvim_create_autocmd("FileType", {
     pattern = { "*" },
+    group = vim.api.nvim_create_augroup("NvimTreesitter-auto_install", { clear = true }),
     callback = function()
       local lang = parsers.get_buf_lang()
       if parsers.get_parser_configs()[lang] and not is_installed(lang) and not is_ignored_parser(lang) then


### PR DESCRIPTION
Problem: The FileType autocmd to automatically install parsers on a new
filetype (introduced in #3130) did not have augroup. As a result, when
`ts_configs.setup{ }` is called multiple times (for some reason),
duplicated installation requests will be made.

Solution: Use augroup with `clear = true`.
