### PR TITLE
feat: highlight regular latex text…

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -185,6 +185,9 @@
  (#eq? @_name "\\frametitle"))
 
 ;; Formatting
+(text_mode
+  content: (curly_group (_) @text))
+
 ((generic_command
   command: (command_name) @_name
   arg: (curly_group (_) @text.emphasis))


### PR DESCRIPTION
…to maintain consistency with boldfaced and italic text.
Before:
![beforelatex](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/d9f1c958-b24a-46a9-955a-a49d70342233)
After:
![afterlatex](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/f3523d8a-7ac7-4e98-902c-c0e8177fbcc0)
