### PR TITLE
Use scala parser for sbt filetype

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -45,6 +45,7 @@ for ft, lang in pairs {
   svg = "xml",
   xsd = "xml",
   xslt = "xml",
+  sbt = "scala",
 } do
   register_lang(lang, ft)
 end


### PR DESCRIPTION
Scala parser is now capable of parsing sbt files. The sbt filetype is also added in the `package.json` - https://github.com/tree-sitter/tree-sitter-scala/blob/master/package.json#L29

