### PR TITLE
fix(lua): add `vim` back to `namespace.builtin`

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -134,7 +134,7 @@
   (#eq? @variable.builtin "self"))
 
 ((identifier) @namespace.builtin
-  (#any-of? @namespace.builtin "_G" "debug" "io" "jit" "math" "os" "package" "string" "table" "utf8"))
+  (#any-of? @namespace.builtin "_G" "debug" "io" "jit" "math" "os" "package" "string" "table" "utf8" "vim"))
 
 ((identifier) @keyword.coroutine
   (#eq? @keyword.coroutine "coroutine"))


### PR DESCRIPTION
add `vim` back to `namespace.builtin`.

It was probably accidentally removed in https://github.com/nvim-treesitter/nvim-treesitter/commit/581fc14cea6e85c710ece75f89f17dffd816fbc4

This is annoying, since highlights change as soon as semantic tokens load