### PR TITLE
java(highlights): add missing import highlights

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -105,8 +105,8 @@
 ((field_access
   object: (identifier) @type)
   (#lua-match? @type "^[A-Z]"))
-((scoped_identifier
-  scope: (identifier) @type)
+(scoped_identifier
+  (identifier) @type
   (#lua-match? @type "^[A-Z]"))
 
 ; Fields


### PR DESCRIPTION
The pattern before does not occur if it's in import, leading to incorrect coloring

| Before | After |
| - | - |
| ![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/29790821/fe2059e4-7e10-4907-9240-5f54d066fa39)| ![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/29790821/4a504ea2-9ac7-47c4-be6c-5d8c9f717e40)|