### PR TITLE
fix(php): fix indentation for in between braces

### DIFF
--- a/queries/php/indents.scm
+++ b/queries/php/indents.scm
@@ -10,7 +10,6 @@
   (switch_block)
   (match_block)
   (case_statement)
-  "["
 ] @indent.begin
 
 [
@@ -25,4 +24,5 @@
 
 (compound_statement "}" @indent.end)
 
-(ERROR) @indent.auto
+(ERROR "(" @indent.align (#set! indent.open_delimiter "(") (#set! indent.close_delimiter ")") . (_))
+(ERROR "[" @indent.align (#set! indent.open_delimiter "[") (#set! indent.close_delimiter "]") . (_))

--- a/queries/php/indents.scm
+++ b/queries/php/indents.scm
@@ -24,5 +24,13 @@
 
 (compound_statement "}" @indent.end)
 
-(ERROR "(" @indent.align (#set! indent.open_delimiter "(") (#set! indent.close_delimiter ")") . (_))
-(ERROR "[" @indent.align (#set! indent.open_delimiter "[") (#set! indent.close_delimiter "]") . (_))
+(ERROR
+  "(" @indent.align
+  . (_)
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+(ERROR
+  "[" @indent.align
+  . (_)
+  (#set! indent.open_delimiter "[")
+  (#set! indent.close_delimiter "]"))

--- a/tests/indent/php/issue-3591.php
+++ b/tests/indent/php/issue-3591.php
@@ -2,4 +2,5 @@
 
 function test() {
     $array = [
+    ]
 }

--- a/tests/indent/php_spec.lua
+++ b/tests/indent/php_spec.lua
@@ -21,7 +21,7 @@ describe("indent PHP:", function()
       { on_line = 5, text = "indentation with `enter` in insert mode is not correct", indent = 4 }
     )
     run:new_line("issue-2497.php", { on_line = 5, text = "$a =", indent = 4 })
-    run:new_line("unfinished-call.php", { on_line = 6, text = "$a =", indent = 0 })
+    run:new_line("unfinished-call.php", { on_line = 6, text = "$a =", indent = 4 })
     run:new_line("issue-3591.php", { on_line = 4, text = "$a =", indent = 8 })
     run:new_line("enum-indent.php", { on_line = 4, text = "case", indent = 4 })
   end)


### PR DESCRIPTION
This is an improvement fix on top of the #3591 so indentation also works properly in cases like:

```php
<?php

function test() {
    $array = [|] // insert new line in between braces
}
```