### PR TITLE
fix(elixir): highlight functions without parenthesis

### DIFF
--- a/queries/elixir/highlights.scm
+++ b/queries/elixir/highlights.scm
@@ -112,6 +112,7 @@
   ))
   (arguments [
     (call (identifier) @function)
+    (identifier) @function
     (binary_operator left: (call target: (identifier) @function) operator: "when")])?)
 
 ; Kernel Keywords & Special Forms


### PR DESCRIPTION
Elixir does not require parenthesis after the function name for a valid function definition.