### PR TITLE
feat: (java) Add "var" as part of keyword

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -95,6 +95,8 @@
 (constructor_declaration
   name: (identifier) @type)
 (type_identifier) @type
+((type_identifier) @type.builtin
+  (#eq? @type.builtin "var"))
 ((method_invocation
   object: (identifier) @type)
  (#lua-match? @type "^[A-Z]"))


### PR DESCRIPTION
Nothing much to say about this rather than 'var' ~~is a keyword~~ is highlighted as keyword in Intellij and should be treated as such for highlighting.