### PR TITLE
fix(injections): fix injection for hurl for new injection syntax

### DIFF
--- a/queries/hurl/injections.scm
+++ b/queries/hurl/injections.scm
@@ -8,4 +8,4 @@
 (multiline_string
   (multiline_string_type) @_lang
   (multiline_string_content) @injection.content
-  (#inject-language! @_lang))
+  (#set-lang-from-info-string! @_lang))


### PR DESCRIPTION
hurl injection currently throws an error of `No handler for inject-language` this fixes the injection to match new injection syntax. I pulled from the markdown injection as my example