### PR TITLE
fix(php): highlight `never` as `@type.builtin`

### DIFF
--- a/queries/php/highlights.scm
+++ b/queries/php/highlights.scm
@@ -16,6 +16,7 @@
 [
  (primitive_type)
  (cast_type)
+ (bottom_type)
  ] @type.builtin
 (named_type
   [(name) @type


### PR DESCRIPTION
# Problem

[`never` type](https://www.php.net/manual/en/language.types.never.php) is not highlighted. The parser, [tree-sitter-php](https://github.com/tree-sitter/tree-sitter-php), can parse it as `bottom_type` node, but there is no highlight for it.

<img width="719" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/54318333/7e3ca8db-250b-400b-89ab-9d40c87006df">

# Solution

Highlight `bottom_type` node as `@type.builtin`.
