### PR TITLE
fix(typescript): do not highlight undefined as variable

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -98,10 +98,6 @@
 
 (conditional_type ["?" ":"] @conditional.ternary)
 
-; Variables
-
-(undefined) @variable.builtin
-
 ;;; Parameters
 (required_parameter (identifier) @parameter)
 (optional_parameter (identifier) @parameter)


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined