### PR TITLE
fix(kotlin): avoid capturing jump_expression as @keyword.return

### DIFF
--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -309,14 +309,16 @@
 ] @keyword
 
 [
+  "return"
+] @keyword.return
+
+[
   "suspend"
 ] @keyword.coroutine
 
 [
   "fun"
 ] @keyword.function
-
-(jump_expression) @keyword.return
 
 [
 	"if"


### PR DESCRIPTION
Without this PR, everything that comes after the `return` keyword will also be treated as a keyword, which is incorrect. As in: 

![unfixed](https://github.com/nvim-treesitter/nvim-treesitter/assets/69449791/073d1755-956d-4336-81c7-a4f1af005400)

This is due to the fact that the entire `jump_expression` node is captured as the `keyword.return`. This PR eliminates that and captures only the `return` keyword. 