### PR TITLE
Added objdump to the supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [norg](https://github.com/nvim-neorg/tree-sitter-norg) (maintained by @JoeyGrajciar, @vhyrro)
 - [x] [nqc](https://github.com/amaanq/tree-sitter-nqc) (maintained by @amaanq)
 - [x] [objc](https://github.com/amaanq/tree-sitter-objc) (maintained by @amaanq)
+- [x] [objdump](https://github.com/ColinKennedy/tree-sitter-objdump) (maintained by @ColinKennedy)
 - [x] [ocaml](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
 - [x] [ocaml_interface](https://github.com/tree-sitter/tree-sitter-ocaml) (maintained by @undu)
 - [x] [ocamllex](https://github.com/atom-ocaml/tree-sitter-ocamllex) (maintained by @undu)

--- a/lockfile.json
+++ b/lockfile.json
@@ -389,6 +389,9 @@
   "objc": {
     "revision": "62e61b6f5c0289c376d61a8c91faf6435cde9012"
   },
+  "objdump": {
+    "revision": "f002f632821d8006444d681abef0f024a9ef5cfe"
+  },
   "ocaml": {
     "revision": "694c57718fd85d514f8b81176038e7a4cfabcaaf"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -390,7 +390,7 @@
     "revision": "62e61b6f5c0289c376d61a8c91faf6435cde9012"
   },
   "objdump": {
-    "revision": "f002f632821d8006444d681abef0f024a9ef5cfe"
+    "revision": "64e4741d58345c36ded639f5a3bcd7811be7f8f8"
   },
   "ocaml": {
     "revision": "694c57718fd85d514f8b81176038e7a4cfabcaaf"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1174,7 +1174,7 @@ list.objc = {
 list.objdump = {
   install_info = {
     url = "https://github.com/ColinKennedy/tree-sitter-objdump",
-    files = { "src/parser.c", "src/scanner.cc" },
+    files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@ColinKennedy" },
 }

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1171,6 +1171,14 @@ list.objc = {
   maintainers = { "@amaanq" },
 }
 
+list.objdump = {
+  install_info = {
+    url = "https://github.com/ColinKennedy/tree-sitter-objdump",
+    files = { "src/parser.c", "src/scanner.cc" },
+  },
+  maintainers = { "@ColinKennedy" },
+}
+
 list.ocaml = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-ocaml",

--- a/queries/objdump/highlights.scm
+++ b/queries/objdump/highlights.scm
@@ -1,0 +1,29 @@
+(byte) @constant
+
+[
+  (hexadecimal)
+  (integer)
+  (address)
+] @number
+
+(section_address) @number @text.underline
+
+(identifier) @variable
+(code_location (identifier) @function.call)
+(header (identifier) @keyword)
+(disassembly_section_label (identifier) @namespace)
+(disassembly_section (identifier) @namespace)
+
+[(file_offset) (discriminator)] @field
+
+(file_path) @string
+(instruction) @function
+(bad_instruction) @text.warning
+(label) @label
+(machine_code_bytes) @field
+
+["<" ">"] @punctuation.special
+["(" ")"] @punctuation.bracket
+["+" ":"] @punctuation.delimiter
+
+(comment) @comment.documentation

--- a/queries/objdump/highlights.scm
+++ b/queries/objdump/highlights.scm
@@ -6,6 +6,13 @@
   (address)
 ] @number
 
+[
+  "file" "format"
+  "File" "Offset:"
+  "discriminator"
+] @text
+"Disassembly of section " @text.title
+
 (section_address) @number @text.underline
 
 (identifier) @variable
@@ -20,7 +27,6 @@
 (instruction) @function
 (bad_instruction) @text.warning
 (label) @label
-(machine_code_bytes) @field
 
 ["<" ">"] @punctuation.special
 ["(" ")"] @punctuation.bracket

--- a/queries/objdump/injections.scm
+++ b/queries/objdump/injections.scm
@@ -1,7 +1,3 @@
-((comment) @injection.content
- (#set! injection.language "objdump"))
-
-
 ; TODO: https://github.com/nvim-treesitter/nvim-treesitter/pull/5548#issuecomment-1773707396
 ;
 ; To be added once a compatible Assembly parser is merged into nvim-treesitter

--- a/queries/objdump/injections.scm
+++ b/queries/objdump/injections.scm
@@ -7,4 +7,4 @@
 ; To be added once a compatible Assembly parser is merged into nvim-treesitter
 ;
 ; ((instruction) @injection.content
-;  (#set! injection.language "assembly"))
+;  (#set! injection.language "asm"))

--- a/queries/objdump/injections.scm
+++ b/queries/objdump/injections.scm
@@ -1,0 +1,10 @@
+((comment) @injection.content
+ (#set! injection.language "objdump"))
+
+
+; TODO: https://github.com/nvim-treesitter/nvim-treesitter/pull/5548#issuecomment-1773707396
+;
+; To be added once a compatible Assembly parser is merged into nvim-treesitter
+;
+; ((instruction) @injection.content
+;  (#set! injection.language "assembly"))


### PR DESCRIPTION
[tree-sitter-objdump](https://github.com/ColinKennedy/tree-sitter-objdump) parses [objdump](https://man7.org/linux/man-pages/man1/objdump.1.html) disassembly so users can quickly and easily parse / highlight / query the objdump text separately from the raw, generated Assembly code.

I've got some unittests / highlight tests which I can copy over to here if the maintainers are interested. The setup for running tests in nvim-treesitter changed I think since the last time I contributed a language though so if I could be directed to any documentation on how to run it now, that'd be helpful.

In a future PR, hopefully to github.com/vim/vim, I'd like to recognize .objdump / .cppobjdump etc files but I'll omit that from this PR since I hear maintainers prefer to receive those changes as downstreamed patches.