### PR TITLE
Highlight APKBUILD files as bash scripts

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -30,6 +30,7 @@ for ft, lang in pairs {
   ecma = "javascript",
   jsx = "javascript",
   sh = "bash",
+  apkbuild = "bash",
   PKGBUILD = "bash",
   html_tags = "html",
   ["typescript.tsx"] = "tsx",


### PR DESCRIPTION
APKBUILDs are technically shell scripts, so this highlighting fits perfectly. `filetype=apkbuild` is commonly used because bash-related tools (e.g.: language servers) provide bogus results for it, and dedicated linting tools (e.g.: ale+apkbuild_lint) expect this filetype.