### PR TITLE
fix: leo language highlight 

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -323,6 +323,9 @@
   "ledger": {
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
   },
+  "leo": {
+    "revision": "f194fb3ed9fb7aa40d519169c11f4630b9f93bcd"
+  },
   "liquidsoap": {
     "revision": "bbef4df4dc5b324455ad1ea4770bbed0df5130ea"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -200,6 +200,9 @@
   "glsl": {
     "revision": "952739a25a7c014882aa777f1a32da8950f31f58"
   },
+  "gn": {
+    "revision": "bc06955bc1e3c9ff8e9b2b2a55b38b94da923c05"
+  },
   "go": {
     "revision": "bbaa67a180cfe0c943e50c55130918be8efb20bd"
   },
@@ -234,7 +237,7 @@
     "revision": "3d4af179414525a35dd069ba0208c9b71093d8b3"
   },
   "haskell": {
-    "revision": "d7ac98f49e3ed7e17541256fe3881a967d7ffdd3"
+    "revision": "ca10c43a4c9bfe588c480d2941726c2fadcae699"
   },
   "haskell_persistent": {
     "revision": "577259b4068b2c281c9ebf94c109bd50a74d5857"
@@ -324,10 +327,10 @@
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
   },
   "leo": {
-    "revision": "bf56a34745ee7a322442702f3aef2e633bb0b36c"
+    "revision": "91d7aa606f524cf4f5df7f4aacb45b4056fac704"
   },
   "liquidsoap": {
-    "revision": "bbef4df4dc5b324455ad1ea4770bbed0df5130ea"
+    "revision": "01df7d97af6210071f3f125e072d62305501bc50"
   },
   "llvm": {
     "revision": "1b96e58faf558ce057d4dc664b904528aee743cb"
@@ -392,6 +395,9 @@
   "objc": {
     "revision": "62e61b6f5c0289c376d61a8c91faf6435cde9012"
   },
+  "objdump": {
+    "revision": "64e4741d58345c36ded639f5a3bcd7811be7f8f8"
+  },
   "ocaml": {
     "revision": "694c57718fd85d514f8b81176038e7a4cfabcaaf"
   },
@@ -417,10 +423,10 @@
     "revision": "e01767921df18142055d97407595329d7629e643"
   },
   "perl": {
-    "revision": "79e88f64681660f3961939bf764d8f3b4bbb0d27"
+    "revision": "99bbcb0faddfc79db3fd2996cb56689a4685e78c"
   },
   "php": {
-    "revision": "92a98adaa534957b9a70b03e9acb9ccf9345033a"
+    "revision": "0e02e7fab7913a0e77343edb347c8f17cac1f0ba"
   },
   "phpdoc": {
     "revision": "915a527d5aafa81b31acf67fab31b0ac6b6319c0"
@@ -430,6 +436,9 @@
   },
   "po": {
     "revision": "d6aed225290bc71a15ab6f06305cb11419360c56"
+  },
+  "pod": {
+    "revision": "ea5d557cbd185cdcb5efcfdb6bc846fe909d86ae"
   },
   "poe_filter": {
     "revision": "d7b43b51f92fb19efe8af45c2246087c611c8f63"
@@ -552,7 +561,7 @@
     "revision": "05f949d3c1c15e3261473a244d3ce87777374dec"
   },
   "sql": {
-    "revision": "36c4de35f76dfa732493aae606feb69dce4b1daa"
+    "revision": "caf2938f1bc6b174e5bf5b6f3b5522cb723ee55b"
   },
   "squirrel": {
     "revision": "e8b5835296f931bcaa1477d3c5a68a0c5c2ba034"
@@ -669,7 +678,7 @@
     "revision": "a041228ae64632f59b9bd37346a0dbcb7817f36b"
   },
   "wing": {
-    "revision": "6a7b21b322a347cda6076fe14dbe0bb592c5a041"
+    "revision": "2b00ad4c06f1f49257f1310b01f23a98dc117f77"
   },
   "xml": {
     "revision": "9deacbfb79cb3527a0396255beb17e1bba3f2052"

--- a/lockfile.json
+++ b/lockfile.json
@@ -324,7 +324,7 @@
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
   },
   "leo": {
-    "revision": "f194fb3ed9fb7aa40d519169c11f4630b9f93bcd"
+    "revision": "288de83cd71b9ef6218249a3bded1539c76f0c58"
   },
   "liquidsoap": {
     "revision": "bbef4df4dc5b324455ad1ea4770bbed0df5130ea"

--- a/lockfile.json
+++ b/lockfile.json
@@ -324,7 +324,7 @@
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
   },
   "leo": {
-    "revision": "288de83cd71b9ef6218249a3bded1539c76f0c58"
+    "revision": "412ae4808c0794204fbdba669b2024c39b8eccf2"
   },
   "liquidsoap": {
     "revision": "bbef4df4dc5b324455ad1ea4770bbed0df5130ea"

--- a/lockfile.json
+++ b/lockfile.json
@@ -324,7 +324,7 @@
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
   },
   "leo": {
-    "revision": "412ae4808c0794204fbdba669b2024c39b8eccf2"
+    "revision": "bf56a34745ee7a322442702f3aef2e633bb0b36c"
   },
   "liquidsoap": {
     "revision": "bbef4df4dc5b324455ad1ea4770bbed0df5130ea"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -983,7 +983,7 @@ list.ledger = {
   maintainers = { "@cbarrete" },
 }
 
-list.ledger = {
+list.leo = {
   install_info = {
     url = "https://github.com/r001/tree-sitter-leo",
     files = { "src/parser.c" },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -983,6 +983,14 @@ list.ledger = {
   maintainers = { "@cbarrete" },
 }
 
+list.ledger = {
+  install_info = {
+    url = "https://github.com/r001/tree-sitter-leo",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@r001" },
+}
+
 list.llvm = {
   install_info = {
     url = "https://github.com/benwilliamgraham/tree-sitter-llvm",

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -6,7 +6,6 @@
  "assert_neq"
  "block"
  "console"
- "in"
  "let"
  "mapping"
  "program"

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -145,8 +145,7 @@
 (transition_declaration
   name: (identifier) @function.builtin)
 
-;external transition call
-;will be wrong for internal function calls!
+(free_function_call
   (identifier) @function.call)
 
 (function_declaration

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -1,0 +1,264 @@
+((identifier) @variable (#set! "priority" 95))
+
+[
+ "assert"
+ "assert_eq"
+ "assert_neq"
+ "block"
+ "console"
+ "const"
+ "constant"
+ "finalize"
+ "in"
+ "let"
+ "mapping"
+ "private"
+ "program"
+ "public"
+ "record"
+ "self"
+ "struct"
+] @keyword
+
+[
+ "transition"
+ "function"
+ "inline"
+] @keyword.function
+
+"import" @include
+
+"return" @keyword.return
+
+"for" @repeat
+
+[ 
+  "if"
+  "then"
+  "else"
+] @conditional
+
+[ ";" "," "::"] @punctuation.delimiter
+
+[
+"!"
+
+"&&"
+"||"
+
+"=="
+"!="
+
+"<"
+"<="
+">"
+">="
+
+"&"
+"|"
+"^"
+
+"<<"
+">>"
+
+"+"
+"-"
+"*"
+"/"
+"%"
+"**"
+
+"="
+
+"+="
+"-="
+"*="
+"/="
+"%="
+"**="
+
+"<<="
+">>="
+
+"&="
+"|="
+"^="
+
+"&&="
+"||="
+
+] @operator
+
+(comment) @comment
+
+(boolean_literal) @boolean
+
+(ternary_expression
+  (_)
+  (ternary_if) @conditional
+  (_)
+  (ternary_else) @conditional
+  (_))
+
+(constant_declaration 
+  (identifier) @constant
+)
+
+;program name if with right extension "aleo" -> okay
+(program_declaration
+  (program_id 
+    name: (identifier) 
+    extension: (identifier) @ext (#eq? @ext "aleo")) @string
+)
+
+;program name if with not with extension "aleo" -> error
+(program_declaration
+  (program_id 
+    name: (identifier) 
+    extension: (identifier) @ext (#not-eq? @ext "aleo")) @punctuation.delimiter
+)
+
+;record declaration
+(record_declaration (identifier) @structure) 
+
+;struct component 
+(struct_component_declaration 
+  (identifier) @parameter
+  (type)       @type
+) 
+
+(type) @type
+
+(associated_constant) @constant
+
+(self_caller) @constant
+
+(block_height) @constant
+
+(transition_declaration
+  .
+  name: (identifier) @function.bultin
+  .
+  (function_parameters)*
+  .
+  (return_arrow) @keyword.return
+  .
+  (type)
+  .
+  (block)
+  .
+)
+
+;external transition call
+;will be wrong for internal function calls!
+(free_function_call
+  (identifier)  @function ) 
+
+(function_declaration
+  .
+  name: (identifier) @function
+  .
+  (function_parameters)*
+  .
+  (return_arrow) @keyword.return
+  .
+  (type)
+  .
+  (block)
+  .
+)
+
+(inline_declaration
+  .
+  name: (identifier) @function
+  .
+  (function_parameters)*
+  .
+  (return_arrow) @keyword.return
+  .
+  (type)
+  .
+  (block)
+  .
+)
+
+(method_call
+  (_)
+  (identifier) @method
+)
+
+(function_parameter
+ (identifier) @parameter
+) 
+
+(struct_declaration
+  name: (identifier) @structure)
+
+(unsigned_literal) @number
+
+(signed_literal) @number
+
+(field_literal) @number
+
+(product_group_literal) @number
+
+(affine_group_literal) @number
+
+(scalar_literal) @number
+
+(boolean_literal) @boolean
+
+(address_literal) @number
+
+
+;address with wrong length or characters -> error
+((identifier) @address
+ (#match? @address "^aleo1.*$")
+ (#not-match? @address "aleo1[a-z0-9]{58}"
+ )) @punctuation.delimiter 
+
+
+;external transition call locator if "leo" extension used -> okay
+(struct_component_expression
+  (_)
+  (identifier) @leo 
+  (#eq? @leo "leo")
+) @string
+
+;external transition call locator if "leo" is used as extension -> okay
+(locator
+  (program_id
+    name: (identifier)
+    extension: (identifier) @ext
+    (#eq? @ext "leo")
+  ) @string
+) 
+
+;external transition call locator if NOT "leo" is used as extension -> error
+(locator
+  (program_id
+    name: (identifier)
+    extension: (identifier) @ext
+    (#not-eq? @ext "leo")
+  ) @punctuation.delimiter
+) 
+
+;import declaration filename if "leo" is used as extension -> okay
+(import_declaration
+  (program_id
+    name: (identifier)
+    extension: (identifier) @ext
+    (#eq? @ext "leo")
+  ) @string
+)
+
+;import declaration filename if NOT "leo" used as extension -> error
+(import_declaration
+  (program_id
+    name: (identifier)
+    extension: (identifier) @ext
+    (#not-eq? @ext "leo")
+  ) @punctuation.delimiter
+) 
+
+

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -178,5 +178,3 @@
   (scalar_literal) 
   (address_literal)
 ] @number
-
-(ERROR) @error

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -38,9 +38,10 @@
   "else"
 ] @conditional
 
-(ternary_if) @conditional.ternary
-
-(ternary_else) @conditional.ternary
+[
+ (ternary_if)
+ (ternary_else)
+] @conditional.ternary
 
 
 [ ";" "," "::"] @punctuation.delimiter
@@ -128,9 +129,10 @@
 
 (associated_constant) @constant
 
-(self_caller) @constant.builtin
-
-(block_height) @constant.builtin
+[
+ (self_caller)
+ (block_height)
+] @constant.builtin
 
 (transition_declaration
   .
@@ -180,7 +182,9 @@
 )
 
 (method_call
+  .
   (_)
+  .
   (identifier) @method
 )
 
@@ -206,9 +210,6 @@
 
   (address_literal)
 ] @number
-
-(boolean_literal) @boolean
-
 
 ;address with wrong length or characters -> error
 ((identifier) @_address

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -1,4 +1,4 @@
-(identifier) @variable 
+(variable) @variable
 
 [
  "assert"
@@ -21,6 +21,14 @@
 ] @keyword
 
 [
+	"constant"
+	"public"
+	"private"
+] @type.qualifier
+
+"self" @variable.builtin
+
+[
  "transition"
  "function"
  "inline"
@@ -29,6 +37,8 @@
 "import" @include
 
 "return" @keyword.return
+
+ (return_arrow) @punctuation.delimiter
 
 "for" @repeat
 
@@ -102,8 +112,10 @@
 (constant_declaration 
   (identifier) @constant)
 
-(program_declaration
-  (program_id) @string.special)
+[
+ (this_program_id)
+ (program_id)
+] @string.special
 
 ;record declaration
 (record_declaration (identifier) @field) 
@@ -121,10 +133,16 @@
  (block_height)
 ] @constant.builtin
 
-(return_arrow) @punctuation.delimiter
+(free_function_call
+ (locator
+	(identifier) @function))
+
+(record_type
+ (locator
+	(identifier) @field))
 
 (transition_declaration
-  . name: (identifier) @function.bultin)
+  name: (identifier) @function.builtin)
 
 ;external transition call
 ;will be wrong for internal function calls!
@@ -132,10 +150,10 @@
   (identifier) @function)
 
 (function_declaration
-  . name: (identifier) @function)
+  name: (identifier) @function)
 
 (inline_declaration
-  . name: (identifier) @function)
+  name: (identifier) @function.macro)
 
 (method_call
   . (_)
@@ -147,31 +165,18 @@
 (struct_declaration
   name: (identifier) @field)
 
+(variable_declaration
+	(identifier_or_identifiers
+		(identifier) @variable))
+
 [ 
   (unsigned_literal) 
-
   (signed_literal) 
-
   (field_literal) 
-
   (product_group_literal) 
-
   (affine_group_literal) 
-
   (scalar_literal) 
-
   (address_literal)
 ] @number
 
-;external transition call locator if "leo" extension used -> okay
-(struct_component_expression
-  (_)
-  (identifier) @_leo 
-  (#eq? @_leo "leo")
-) @string
-
-(locator
-  (program_id) @string.special)
-
-(import_declaration
-  (program_id) @string.special)
+(ERROR) @error

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -145,8 +145,7 @@
 )
 
 (function_parameter
- (identifier) @parameter
-) 
+ (identifier) @parameter)
 
 (struct_declaration
   name: (identifier) @field)

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -135,18 +135,7 @@
   . name: (identifier) @function)
 
 (inline_declaration
-  .
-  name: (identifier) @function
-  .
-  (function_parameters)*
-  .
-  (return_arrow) @keyword.return
-  .
-  (type)
-  .
-  (block)
-  .
-)
+  . name: (identifier) @function)
 
 (method_call
   .

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -6,7 +6,6 @@
  "assert_neq"
  "block"
  "console"
- "const"
  "finalize"
  "in"
  "let"
@@ -16,6 +15,11 @@
  "self"
  "struct"
 ] @keyword
+
+[
+ "const"
+ "in"
+] @keyword.operator
 
 [
  "constant"

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -143,6 +143,9 @@
 (transition_declaration
   name: (identifier) @function.builtin)
 
+(finalizer
+  name: (identifier) @function.builtin)
+
 (free_function_call
   (identifier) @function.call)
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -153,7 +153,7 @@
 
 (method_call
   . (_)
-  . (identifier) @method)
+  . (identifier) @method.call)
 
 (function_parameter
  (identifier) @parameter)

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -7,24 +7,21 @@
  "block"
  "console"
  "const"
- "constant"
  "finalize"
  "in"
  "let"
  "mapping"
- "private"
  "program"
- "public"
  "record"
  "self"
  "struct"
 ] @keyword
 
 [
-	"constant"
-	"public"
-	"private"
-] @type.qualifier
+ "constant"
+ "public"
+ "private"
+ ] @type.qualifier
 
 "self" @variable.builtin
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -138,11 +138,8 @@
   . name: (identifier) @function)
 
 (method_call
-  .
-  (_)
-  .
-  (identifier) @method
-)
+  . (_)
+  . (identifier) @method)
 
 (function_parameter
  (identifier) @parameter)

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -22,31 +22,31 @@
 
 [
  "constant"
- "public"
  "private"
+ "public"
  ] @type.qualifier
 
 "self" @variable.builtin
 
 [
- "transition"
- "function"
  "finalize"
+ "function"
  "inline"
+ "transition"
 ] @keyword.function
 
 "import" @include
 
 "return" @keyword.return
 
- (return_arrow) @punctuation.delimiter
+(return_arrow) @punctuation.delimiter
 
 "for" @repeat
 
 [ 
+  "else"
   "if"
   "then"
-  "else"
 ] @conditional
 
 [
@@ -114,8 +114,8 @@
   (identifier) @constant)
 
 [
- (this_program_id)
  (program_id)
+ (this_program_id)
 ] @string.special
 
 ;record declaration
@@ -130,8 +130,8 @@
 (associated_constant) @constant
 
 [
- (self_caller)
  (block_height)
+ (self_caller)
 ] @constant.builtin
 
 (free_function_call
@@ -170,11 +170,11 @@
 		(identifier) @variable))
 
 [ 
-  (unsigned_literal) 
-  (signed_literal) 
+  (address_literal)
+  (affine_group_literal) 
   (field_literal) 
   (product_group_literal) 
-  (affine_group_literal) 
   (scalar_literal) 
-  (address_literal)
+  (signed_literal) 
+  (unsigned_literal) 
 ] @number

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -218,12 +218,3 @@
     (#eq? @_ext "leo")
   ) @string
 )
-
-;import declaration filename if NOT "leo" used as extension -> error
-(import_declaration
-  (program_id
-    name: (identifier)
-    extension: (identifier) @_ext
-    (#not-eq? @_ext "leo")
-  ) @punctuation.delimiter
-) 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -38,6 +38,11 @@
   "else"
 ] @conditional
 
+(ternary_if) @conditional.ternary
+
+(ternary_else) @conditional.ternary
+
+
 [ ";" "," "::"] @punctuation.delimiter
 
 [
@@ -93,10 +98,6 @@
 
 (boolean_literal) @boolean
 
-(ternary_if) @conditional
-
-(ternary_else) @conditional
-
 (constant_declaration 
   (identifier) @constant
 )
@@ -116,21 +117,20 @@
 )
 
 ;record declaration
-(record_declaration (identifier) @structure) 
+(record_declaration (identifier) @field) 
 
 ;struct component 
 (struct_component_declaration 
-  (identifier) @parameter
-  (type)       @type
+  (identifier) @field
 ) 
 
 (type) @type
 
 (associated_constant) @constant
 
-(self_caller) @constant
+(self_caller) @constant.builtin
 
-(block_height) @constant
+(block_height) @constant.builtin
 
 (transition_declaration
   .
@@ -189,7 +189,7 @@
 ) 
 
 (struct_declaration
-  name: (identifier) @structure)
+  name: (identifier) @field)
 
 [ 
   (unsigned_literal) 
@@ -211,17 +211,17 @@
 
 
 ;address with wrong length or characters -> error
-((identifier) @address
- (#match? @address "^aleo1.*$")
- (#not-match? @address "aleo1[a-z0-9]{58}"
+((identifier) @_address
+ (#match? @_address "^aleo1.*$")
+ (#not-match? @_address "aleo1[a-z0-9]{58}"
  )) @punctuation.delimiter 
 
 
 ;external transition call locator if "leo" extension used -> okay
 (struct_component_expression
   (_)
-  (identifier) @leo 
-  (#eq? @leo "leo")
+  (identifier) @_leo 
+  (#eq? @_leo "leo")
 ) @string
 
 ;external transition call locator if "leo" is used as extension -> okay
@@ -259,5 +259,3 @@
     (#not-eq? @_ext "leo")
   ) @punctuation.delimiter
 ) 
-
-

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -132,18 +132,7 @@
   (identifier) @function)
 
 (function_declaration
-  .
-  name: (identifier) @function
-  .
-  (function_parameters)*
-  .
-  (return_arrow) @keyword.return
-  .
-  (type)
-  .
-  (block)
-  .
-)
+  . name: (identifier) @function)
 
 (inline_declaration
   .

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -170,14 +170,8 @@
   (#eq? @_leo "leo")
 ) @string
 
-;external transition call locator if "leo" is used as extension -> okay
 (locator
-  (program_id
-    name: (identifier)
-    extension: (identifier) @_ext
-    (#eq? @_ext "leo")
-  ) @string
-) 
+  (program_id) @string.special)
 
 ;external transition call locator if NOT "leo" is used as extension -> error
 (locator

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -188,11 +188,5 @@
   ) @punctuation.delimiter
 ) 
 
-;import declaration filename if "leo" is used as extension -> okay
 (import_declaration
-  (program_id
-    name: (identifier)
-    extension: (identifier) @_ext
-    (#eq? @_ext "leo")
-  ) @string
-)
+  (program_id) @string.special)

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -13,6 +13,7 @@
  "record"
  "self"
  "struct"
+ "then"
 ] @keyword
 
  "in" @keyword.operator
@@ -43,7 +44,6 @@
 [ 
   "else"
   "if"
-  "then"
 ] @conditional
 
 [

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -51,6 +51,7 @@
  (ternary_else)
 ] @conditional.ternary
 
+[ "(" ")" "{" "}" "[" "]" ] @punctuation.bracket
 
 [ ";" "," "::"] @punctuation.delimiter
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -143,8 +143,7 @@
 
 ;external transition call
 ;will be wrong for internal function calls!
-(free_function_call
-  (identifier) @function)
+  (identifier) @function.call)
 
 (function_declaration
   name: (identifier) @function)

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -6,7 +6,6 @@
  "assert_neq"
  "block"
  "console"
- "finalize"
  "in"
  "let"
  "mapping"
@@ -32,6 +31,7 @@
 [
  "transition"
  "function"
+ "finalize"
  "inline"
 ] @keyword.function
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -50,11 +50,12 @@
  (ternary_if)
  (ternary_else)
 ] @conditional.ternary
+(
+ [ "(" ")" "{" "}" "[" "]" ] @punctuation.bracket
+ (#set! "priority" 90))
 
-[ "(" ")" "{" "}" "[" "]" ] @punctuation.bracket
-
-[ ";" "," "::"] @punctuation.delimiter
-
+ ([ ";" "," "::"] @punctuation.delimiter
+ (#set! "priority" 90))
 [
 "!"
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -163,13 +163,6 @@
   (address_literal)
 ] @number
 
-;address with wrong length or characters -> error
-((identifier) @_address
- (#match? @_address "^aleo1.*$")
- (#not-match? @_address "aleo1[a-z0-9]{58}"
- )) @punctuation.delimiter 
-
-
 ;external transition call locator if "leo" extension used -> okay
 (struct_component_expression
   (_)

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -173,14 +173,5 @@
 (locator
   (program_id) @string.special)
 
-;external transition call locator if NOT "leo" is used as extension -> error
-(locator
-  (program_id
-    name: (identifier)
-    extension: (identifier) @_ext
-    (#not-eq? @_ext "leo")
-  ) @punctuation.delimiter
-) 
-
 (import_declaration
   (program_id) @string.special)

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -95,7 +95,7 @@
 
 ] @operator
 
-(comment) @comment
+(comment) @comment @spell
 
 (boolean_literal) @boolean
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -191,21 +191,23 @@
 (struct_declaration
   name: (identifier) @structure)
 
-(unsigned_literal) @number
+[ 
+  (unsigned_literal) 
 
-(signed_literal) @number
+  (signed_literal) 
 
-(field_literal) @number
+  (field_literal) 
 
-(product_group_literal) @number
+  (product_group_literal) 
 
-(affine_group_literal) @number
+  (affine_group_literal) 
 
-(scalar_literal) @number
+  (scalar_literal) 
+
+  (address_literal)
+] @number
 
 (boolean_literal) @boolean
-
-(address_literal) @number
 
 
 ;address with wrong length or characters -> error

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -93,12 +93,9 @@
 
 (boolean_literal) @boolean
 
-(ternary_expression
-  (_)
-  (ternary_if) @conditional
-  (_)
-  (ternary_else) @conditional
-  (_))
+(ternary_if) @conditional
+
+(ternary_else) @conditional
 
 (constant_declaration 
   (identifier) @constant

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -102,19 +102,8 @@
 (constant_declaration 
   (identifier) @constant)
 
-;program name if with right extension "aleo" -> okay
 (program_declaration
-  (program_id 
-    name: (identifier) 
-    extension: (identifier) @_ext (#eq? @_ext "aleo")) @string
-)
-
-;program name if with not with extension "aleo" -> error
-(program_declaration
-  (program_id 
-    name: (identifier) 
-    extension: (identifier) @_ext (#not-eq? @_ext "aleo")) @punctuation.delimiter
-)
+  (program_id) @string.special)
 
 ;record declaration
 (record_declaration (identifier) @field) 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -105,14 +105,14 @@
 (program_declaration
   (program_id 
     name: (identifier) 
-    extension: (identifier) @ext (#eq? @ext "aleo")) @string
+    extension: (identifier) @_ext (#eq? @_ext "aleo")) @string
 )
 
 ;program name if with not with extension "aleo" -> error
 (program_declaration
   (program_id 
     name: (identifier) 
-    extension: (identifier) @ext (#not-eq? @ext "aleo")) @punctuation.delimiter
+    extension: (identifier) @_ext (#not-eq? @_ext "aleo")) @punctuation.delimiter
 )
 
 ;record declaration
@@ -226,8 +226,8 @@
 (locator
   (program_id
     name: (identifier)
-    extension: (identifier) @ext
-    (#eq? @ext "leo")
+    extension: (identifier) @_ext
+    (#eq? @_ext "leo")
   ) @string
 ) 
 
@@ -235,8 +235,8 @@
 (locator
   (program_id
     name: (identifier)
-    extension: (identifier) @ext
-    (#not-eq? @ext "leo")
+    extension: (identifier) @_ext
+    (#not-eq? @_ext "leo")
   ) @punctuation.delimiter
 ) 
 
@@ -244,8 +244,8 @@
 (import_declaration
   (program_id
     name: (identifier)
-    extension: (identifier) @ext
-    (#eq? @ext "leo")
+    extension: (identifier) @_ext
+    (#eq? @_ext "leo")
   ) @string
 )
 
@@ -253,8 +253,8 @@
 (import_declaration
   (program_id
     name: (identifier)
-    extension: (identifier) @ext
-    (#not-eq? @ext "leo")
+    extension: (identifier) @_ext
+    (#not-eq? @_ext "leo")
   ) @punctuation.delimiter
 ) 
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -6,6 +6,7 @@
  "assert_neq"
  "block"
  "console"
+ "const"
  "let"
  "mapping"
  "program"
@@ -14,10 +15,7 @@
  "struct"
 ] @keyword
 
-[
- "const"
- "in"
-] @keyword.operator
+ "in" @keyword.operator
 
 [
  "constant"

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -129,7 +129,7 @@
 ;external transition call
 ;will be wrong for internal function calls!
 (free_function_call
-  (identifier)  @function ) 
+  (identifier) @function)
 
 (function_declaration
   .

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -50,12 +50,11 @@
  (ternary_if)
  (ternary_else)
 ] @conditional.ternary
-(
- [ "(" ")" "{" "}" "[" "]" ] @punctuation.bracket
- (#set! "priority" 90))
 
- ([ ";" "," "::"] @punctuation.delimiter
- (#set! "priority" 90))
+[ "(" ")" "{" "}" "[" "]" ] @punctuation.bracket
+
+[ ";" "," "::"] @punctuation.delimiter
+
 [
 "!"
 
@@ -169,10 +168,12 @@
 
 [ 
   (address_literal)
-  (affine_group_literal) 
+  ((affine_group_literal) (#set! "priority" 101))
   (field_literal) 
   (product_group_literal) 
   (scalar_literal) 
   (signed_literal) 
   (unsigned_literal) 
 ] @number
+
+(annotation) @attribute

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -110,8 +110,7 @@
 
 ;struct component 
 (struct_component_declaration 
-  (identifier) @field
-) 
+  (identifier) @field)
 
 (type) @type
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -100,8 +100,7 @@
 (boolean_literal) @boolean
 
 (constant_declaration 
-  (identifier) @constant
-)
+  (identifier) @constant)
 
 ;program name if with right extension "aleo" -> okay
 (program_declaration

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -121,19 +121,10 @@
  (block_height)
 ] @constant.builtin
 
+(return_arrow) @punctuation.delimiter
+
 (transition_declaration
-  .
-  name: (identifier) @function.bultin
-  .
-  (function_parameters)*
-  .
-  (return_arrow) @keyword.return
-  .
-  (type)
-  .
-  (block)
-  .
-)
+  . name: (identifier) @function.bultin)
 
 ;external transition call
 ;will be wrong for internal function calls!

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -1,4 +1,4 @@
-((identifier) @variable (#set! "priority" 95))
+(identifier) @variable 
 
 [
  "assert"

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -1,4 +1,5 @@
-(variable) @variable
+(variable_identifier) @variable
+(constant_identifier) @constant
 
 [
  "assert"

--- a/queries/leo/injections.scm
+++ b/queries/leo/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
A few changes added to leo highlights and grammar:
- make sure affine_group has priority, so parens and comma will not be miscolored
- added `annotation` as @attribute
- `then` is not used as conditional, so moved to keywords
- finalize function highlight added
- differentiate between constant and variable variable identifiers
