### PR TITLE
fix(leo): minor coloring fixes constant highlight, finalize function highlights, affine_group highlights

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -327,7 +327,7 @@
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
   },
   "leo": {
-    "revision": "bf56a34745ee7a322442702f3aef2e633bb0b36c"
+    "revision": "91d7aa606f524cf4f5df7f4aacb45b4056fac704"
   },
   "liquidsoap": {
     "revision": "01df7d97af6210071f3f125e072d62305501bc50"

--- a/lockfile.json
+++ b/lockfile.json
@@ -327,7 +327,7 @@
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
   },
   "leo": {
-    "revision": "a3727051dd8e1d350667608190498f508c1cf6d6"
+    "revision": "bf56a34745ee7a322442702f3aef2e633bb0b36c"
   },
   "liquidsoap": {
     "revision": "01df7d97af6210071f3f125e072d62305501bc50"

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -143,6 +143,9 @@
 (transition_declaration
   name: (identifier) @function.builtin)
 
+(finalizer
+  name: (identifier) @function.builtin)
+
 (free_function_call
   (identifier) @function.call)
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -13,6 +13,7 @@
  "record"
  "self"
  "struct"
+ "then"
 ] @keyword
 
  "in" @keyword.operator
@@ -43,7 +44,6 @@
 [ 
   "else"
   "if"
-  "then"
 ] @conditional
 
 [

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -168,10 +168,12 @@
 
 [ 
   (address_literal)
-  (affine_group_literal) 
+  ((affine_group_literal) (#set! "priority" 101))
   (field_literal) 
   (product_group_literal) 
   (scalar_literal) 
   (signed_literal) 
   (unsigned_literal) 
 ] @number
+
+(annotation) @attribute

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -1,4 +1,5 @@
-(variable) @variable
+(variable_identifier) @variable
+(constant_identifier) @constant
 
 [
  "assert"


### PR DESCRIPTION
- make sure affine_group has priority, so parens and comma will not be miscolored; added `annotation` as `@attribute`
- `then` is not used as conditional, so moved to keywords
- finalize function highlight added
- differentiate between constant and variable variable identifiers
