### PR TITLE
feat(lua): highlight variadic expressions as builtin parameters

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -181,6 +181,8 @@
 
 (parameters (identifier) @parameter)
 
+(vararg_expression) @parameter.builtin
+
 (function_declaration
   name: [
     (identifier) @function


### PR DESCRIPTION
Highlights the `...` parameter in Lua as a builtin parameter, similar to [other languages](https://github.com/search?q=repo%3Anvim-treesitter%2Fnvim-treesitter%20parameter.builtin&type=code).

Example:
```lua
local function test(...)
  print(...)
end
```
In this case both instances of `...` would be highlighted.