### PR TITLE
injections(vue): inject typescript instead of js

### DIFF
--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -57,12 +57,12 @@
 
 ((interpolation
   (raw_text) @injection.content)
-  (#set! injection.language "javascript"))
+  (#set! injection.language "typescript"))
 
 (directive_attribute
   (quoted_attribute_value
     (attribute_value) @injection.content
-    (#set! injection.language "javascript")))
+    (#set! injection.language "typescript")))
 
 (template_element
     (start_tag

--- a/tests/query/injections/vue/test-vue-injections.vue
+++ b/tests/query/injections/vue/test-vue-injections.vue
@@ -1,12 +1,12 @@
 <template>
   <span>{{"Text inside interpolation"}}</span>
-  <!--      ^ javascript -->
+  <!--      ^ typescript -->
 
   <template lang="pug"> a(:href="url") some link title in pug: </template>
   <!--                                       ^ pug -->
 
   <template v-if="'text inside directives'"></template>
-<!--              ^ javascript -->
+<!--              ^ typescript -->
 </template>
 <script> const foo = "1" </script>
 <!--      ^ javascript -->


### PR DESCRIPTION
Interpolations (`{{valid js code}}`) and directive attributes (`<element :directive="valid js code"`) can also be typescript code, hence we can inject typescript instead of javascript here and still ok with highlights (bar some changes between ts and js)