### PR TITLE
Fix indent. of curly expressions and of ],} in BOL

### DIFF
--- a/queries/julia/indents.scm
+++ b/queries/julia/indents.scm
@@ -22,16 +22,21 @@
   (comprehension_expression)
   (matrix_expression)
   (vector_expression)
+  (curly_expression)
 ] @indent.begin
 
 [
   "end"
+  ")"
+  "]"
+  "}"
 ] @indent.end
 
 [
   "end"
   ")"
   "]"
+  "}"
   (else_clause)
   (elseif_clause)
   (catch_clause)


### PR DESCRIPTION
Hi!

This second PR fixes two remaining problems with the Julia indentation (sorry, I decided to break up into two PR instead of making every change in one).

The first is the indentation of the curly expressions. Currently, the code:

```julia
function teste(
    a::Union{
        Number,
        String
    },
)
    return a
end
```

is indent to:

```julia
function teste(
    a::Union{
    Number,
    String
    },
)
    return a
end
```

After the PR, the original version is not changed after the indentation.

The second problem was related to the cursor position when we have `)`, `]`, `}` as the only character in a line. When a new line is entered, the indentation is wrongly increased. For example, if the cursor is here:

```julia
function teste()
    a = [
        1,
        2,
    ]|
end
```

it goes to this scenario after a new line:

```julia
function teste()
    a = [
        1,
        2,
    ]
        |
end
```

This PR also fixes it.
