### PR TITLE
feat: Another try adding asynchronous module attachment

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -506,7 +506,14 @@ function M.attach_module(mod_name, bufnr, lang)
 
   if resolved_mod and not attached_buffers_by_module.has(mod_name, bufnr) and M.is_enabled(mod_name, lang, bufnr) then
     attached_buffers_by_module.set(mod_name, bufnr, true)
-    resolved_mod.attach(bufnr, lang)
+    local handle
+    handle = vim.loop.new_async(vim.schedule_wrap(function()
+      if not handle:is_closing() then
+        resolved_mod.attach(bufnr, lang)
+        handle:close()
+      end
+    end))
+    handle:send()
   end
 end
 


### PR DESCRIPTION
This PR attempts to revive the asynchronous module attachment feature initially added in #824 and reverted in #845.
It's motivated by the very slow initial load times of some complex grammars (e.g., `latex`), which can block the first screen update.
For me, this PR reduces time to first update on `latex` files by ~200ms - a very noticeable difference.

I believe that I've addressed at least some of the issues with the original implementation by (1) moving the async handle creation to inside the existing attach logic as much as possible, (2) explicitly closing the async handle, and (3) adding two-stage tracking of module attachment status.
I cannot reproduce #838 with this PR. However, further testing is absolutely called for before merging this work - at this point, I have "works for me"-level confidence, but my `treesitter` setup isn't very advanced.

Additionally, I think that this should be made opt-in, potentially on a per-language basis - there is a visible "flicker" when `treesitter` highlights load for the first time, and not all users will prefer this to the existing blocking load.

If there's interest in trying this feature again, I'll look into how to set this up with the config system in `nvim-treesitter`, as well as figuring out a less hacky design for the two-stage attachment tracking.
