### PR TITLE
fix(luarocks): proper library and runtime path packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ build:
 
 install:
 	mkdir -p $(INST_LUADIR)
-	cp -r autoload plugin queries lua $(INST_LUADIR)
+	cp -r lua/* $(INST_LUADIR)

--- a/contrib/nvim-treesitter-luarocks.template
+++ b/contrib/nvim-treesitter-luarocks.template
@@ -37,9 +37,5 @@ build = {
     INST_LUADIR='$(LUADIR)',
     INST_CONFDIR='$(CONFDIR)',
   },
-  copy_directories = {
-    'autoload',
-    'plugin',
-    'queries'
-  }
+  copy_directories = $copy_directories,
 }


### PR DESCRIPTION
CC @teto @vhyrro 

This fixes two issues with the rockspec and rockspec template (for luarocks packaging).

## 1.  Makefile

### Before

The current makefile installs *all runtime directories* - the `lua/` directory to the `share/lua/<lua-version>/` directory.

![before](https://github.com/nvim-treesitter/nvim-treesitter/assets/12857160/38d42bc5-531a-434f-b552-ced0ae4a65f3)

### After

This PR corrects it, so that only the `lua` directory contents are installed to `share/lua/<lua-version>/` (by the `Makefile`) , and the runtime paths are installed to the appropriate place in `lib/luarocks/rocks-<lua-version>/<package-name>/<package-version>/` (specified by the `copy_directories` table in the rockspec).

This is in line with how luarocks would package a plugin with the `builtin` build type (which we don't use here because of test files containing deliberate syntax errors).

![01](https://github.com/nvim-treesitter/nvim-treesitter/assets/12857160/f807e017-35ba-43df-a8e4-b7e018980721)
![02](https://github.com/nvim-treesitter/nvim-treesitter/assets/12857160/2fae01f4-6a65-418f-b0ba-0bc119f9fb4b)
![03](https://github.com/nvim-treesitter/nvim-treesitter/assets/12857160/3522f163-46e2-4ccf-95d8-1c465337fe4f)


## 2. Rockspec template

I have modified to rockspec template (used by the `luarocks-tag-release` workflow) to use a placeholder for the `copy_directories` table. Since version 5, the workflow automatically detects Neovim runtime directories and adds them to the generated rockspec.