### PR TITLE
fix(query): stricter match for `extends` directive

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -31,4 +31,4 @@
  (#lua-match? @include "^;+ *inherits *:"))
 
 ((program . (comment)* . (comment) @preproc)
- (#lua-match? @preproc "^;+ *extends"))
+ (#lua-match? @preproc "^;+ *extends *$"))


### PR DESCRIPTION
Without this any word starting with "extends" was highlighted as `@preproc`.