### PR TITLE
feat(clojure): highlight Clojure's `#_` dispatch character.

### DIFF
--- a/queries/clojure/highlights.scm
+++ b/queries/clojure/highlights.scm
@@ -10,7 +10,9 @@
 ;; This can mean that sometimes things are highlighted weirdly because they
 ;; have multiple highlight groups applied to them.
 
-
+;; dispatch `discard` reader macro
+((dis_expr "#_" @preproc))
+ 
 ;; >> Literals
 
 (kwd_lit) @symbol


### PR DESCRIPTION
Closes issue #5599.
- Remove `@comment` highlight for s-expressions preceded by `#_`.
- Add `@preproc` highlight for `#_`, 
