### PR TITLE
rnoweb: add highlights query

### DIFF
--- a/queries/rnoweb/highlights.scm
+++ b/queries/rnoweb/highlights.scm
@@ -1,0 +1,1 @@
+;; This file is a placeholder to enable the highlighting of injected languages.


### PR DESCRIPTION
Add an empty highlights query to rnoweb. Without the empty query, the highlighting for injected languages is disabled.