### PR TITLE
feat(query): highlight parameters as `@parameter`

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -24,6 +24,7 @@
 ["@" "#"] @punctuation.special
 "_" @constant
 
+(parameters (identifier) @parameter)
 ((parameters (identifier) @number)
  (#match? @number "^[-+]?[0-9]+(.[0-9]+)?$"))
 


### PR DESCRIPTION
I feel like this just makes sense, and it's something that was missing.