### PR TITLE
fix(htmldjango): improve highlights

### DIFF
--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -2,8 +2,9 @@
 (erroneous_end_tag_name) @error
 (comment) @comment @spell
 (attribute_name) @tag.attribute
-(attribute
+((attribute
   (quoted_attribute_value) @string)
+ (#set! "priority" 99))
 (text) @text @spell
 
 ((element (start_tag (tag_name) @_tag) (text) @text.title)

--- a/queries/htmldjango/highlights.scm
+++ b/queries/htmldjango/highlights.scm
@@ -23,13 +23,26 @@
 
 (keyword) @keyword
 
-(operator) @operator
-(variable "|" @operator)
-(paired_statement "=" @operator)
+[
+ "|"
+ "="
+ (operator)
+] @operator
 (keyword_operator) @keyword.operator
 
+(string) @string
+(filter [ "'" "\"" ] . (filter_argument) @string)
+
 (number) @number
+((filter (filter_argument) @number)
+ (#lua-match? @number "^%d+$"))
 
 (boolean) @boolean
+((filter (filter_argument) @boolean)
+ (#any-of? @boolean "True" "False"))
 
-(string) @string
+[
+  ":"
+  "'"
+  "\""
+] @punctuation.delimiter


### PR DESCRIPTION
Instead of increasing all the priorities, I opted for reducing the string priority in html_tags instead.
This shouldn't cause an issue in html and it might even help other template languages as well.