### PR TITLE
Leo language fix: highlights program_id and this_program_id correctly

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -330,7 +330,7 @@
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"
   },
   "leo": {
-    "revision": "91d7aa606f524cf4f5df7f4aacb45b4056fac704"
+    "revision": "23a9534d09d523d0dcee7dbf89e7c819e6835f6f"
   },
   "liquidsoap": {
     "revision": "b35882f2e1460867ddddcbe8af586e6807d4676f"


### PR DESCRIPTION
Minor fix for Leo language: now filenames are highlighted correctly. 