### PR TITLE
feat(markdown): conceals for bullets, block quotes

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -39,9 +39,17 @@
   @punctuation.special
   (#offset! @punctuation.special 0 0 0 -1)
   (#set! conceal "•"))
+([(list_marker_plus) (list_marker_star)]
+  @punctuation.special
+  (#any-of? @punctuation.special "+" "*")
+  (#set! conceal "•"))
 ((list_marker_minus)
   @punctuation.special
   (#offset! @punctuation.special 0 0 0 -1)
+  (#set! conceal "—"))
+((list_marker_minus)
+  @punctuation.special
+  (#eq? @punctuation.special "-")
   (#set! conceal "—"))
 
 (code_fence_content) @none

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -34,28 +34,15 @@
   (info_string (language) @conceal
   (#set! conceal "")))
 
-;; Conceal blockquote markers
-((block_quote_marker) @punctuation.special
-  (#offset! @punctuation.special 0 0 0 -1)
-  (#set! conceal "▐"))
-((block_continuation) @punctuation.special
-  (#eq? @punctuation.special ">")
-  (#set! conceal "▐"))
-((block_continuation) @punctuation.special
-  (#eq? @punctuation.special "> ")
-  (#offset! @punctuation.special 0 0 0 -1)
-  (#set! conceal "▐"))
-((block_continuation) @punctuation.special
-  ; for indented code blocks
-  (#eq? @punctuation.special ">     ")
-  (#offset! @punctuation.special 0 0 0 -5)
-  (#set! conceal "▐"))
-
 ;; Conceal bullet points
-([(list_marker_minus) (list_marker_plus) (list_marker_star)]
+([(list_marker_plus) (list_marker_star)]
   @punctuation.special
   (#offset! @punctuation.special 0 0 0 -1)
   (#set! conceal "•"))
+((list_marker_minus)
+  @punctuation.special
+  (#offset! @punctuation.special 0 0 0 -1)
+  (#set! conceal "—"))
 
 (code_fence_content) @none
 

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -34,6 +34,29 @@
   (info_string (language) @conceal
   (#set! conceal "")))
 
+;; Conceal blockquote markers
+((block_quote_marker) @punctuation.special
+  (#offset! @punctuation.special 0 0 0 -1)
+  (#set! conceal "▐"))
+((block_continuation) @punctuation.special
+  (#eq? @punctuation.special ">")
+  (#set! conceal "▐"))
+((block_continuation) @punctuation.special
+  (#eq? @punctuation.special "> ")
+  (#offset! @punctuation.special 0 0 0 -1)
+  (#set! conceal "▐"))
+((block_continuation) @punctuation.special
+  ; for indented code blocks
+  (#eq? @punctuation.special ">     ")
+  (#offset! @punctuation.special 0 0 0 -5)
+  (#set! conceal "▐"))
+
+;; Conceal bullet points
+([(list_marker_minus) (list_marker_plus) (list_marker_star)]
+  @punctuation.special
+  (#offset! @punctuation.special 0 0 0 -1)
+  (#set! conceal "•"))
+
 (code_fence_content) @none
 
 [


### PR DESCRIPTION
Adds conceals for Markdown bullets and block quotes. Preview:

![moremdconceals](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/2373fb5f-125e-4dea-9490-14dcf243fb2e)

**KNOWN LIMITATION:** When using a bullet with an immediate indented code block, e.g.:

```md
-     print('code here')
```

the conceals will display this as:

```md
- print('code here')
```

As far as I know there is no (easy?) way to fix this, as (unlike with the block quote markers) the bullet point capture fills whitespace until the first non-whitespace content is reached. However I think little to no users will be affected by this, and even so, indented blocks still display all preceding whitespace on a new line in a bullet. E.g.:

```md
- This works
  
      print('code here')
```