### PR TITLE
feat(lua): folds for parameter, argument lists

### DIFF
--- a/queries/lua/folds.scm
+++ b/queries/lua/folds.scm
@@ -6,5 +6,7 @@
  (for_statement)
  (function_declaration)
  (function_definition)
+ (parameters)
+ (arguments)
  (table_constructor)
 ] @fold


### PR DESCRIPTION
Allows folding of the following
```lua
function(
  lots_of_parameters,
  lots_of_parameters,
  lots_of_parameters,
  lots_of_parameters
)
  print('function')
end

print(
  'lots of arguments',
  'lots of arguments',
  'lots of arguments',
  'lots of arguments',
  'lots of arguments'
)
```