### PR TITLE
Add parser for "Just"

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -309,7 +309,7 @@
     "revision": "0c088d1ad270f02c4e84189247ac7001e86fe342"
   },
   "just": {
-    "revision": "4e5f5f3ff37b12a1bbf664eb3966b3019e924594"
+    "revision": "4a348161a7f3c9df304a9789b54c1964fb81f9e7"
   },
   "kconfig": {
     "revision": "aaba009ba9d7881f0f81742da588ae70b572316d"

--- a/lockfile.json
+++ b/lockfile.json
@@ -308,6 +308,9 @@
   "julia": {
     "revision": "0c088d1ad270f02c4e84189247ac7001e86fe342"
   },
+  "just": {
+    "revision": "4e5f5f3ff37b12a1bbf664eb3966b3019e924594"
+  },
   "kconfig": {
     "revision": "aaba009ba9d7881f0f81742da588ae70b572316d"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -944,6 +944,16 @@ list.julia = {
   maintainers = { "@theHamsta" },
 }
 
+list.just = {
+  install_info = {
+    url = "https://github.com/IndianBoy42/tree-sitter-just",
+    files = { "src/parser.c", "src/scanner.cc" },
+    branch = "main",
+  },
+  filetype = "just",
+  maintainers = { "@Hubro" }
+}
+
 list.kconfig = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-kconfig",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -951,7 +951,7 @@ list.just = {
     branch = "main",
   },
   filetype = "just",
-  maintainers = { "@Hubro" }
+  maintainers = { "@Hubro" },
 }
 
 list.kconfig = {

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -952,6 +952,7 @@ list.just = {
   },
   filetype = "just",
   maintainers = { "@Hubro" },
+  experimental = true,
 }
 
 list.kconfig = {

--- a/queries/just/highlights.scm
+++ b/queries/just/highlights.scm
@@ -1,39 +1,102 @@
 
-(assignment (NAME) @variable)
-(alias (NAME) @variable)
-(value (NAME) @variable)
-(parameter (NAME) @variable)
-(setting (NAME) @keyword)
-(setting "shell" @keyword)
-
-(call (NAME) @function)
-(dependency (NAME) @function)
-(depcall (NAME) @function)
-(recipeheader (NAME) @function)
-
-(depcall (expression) @parameter)
-(parameter) @parameter
-(variadic_parameters) @parameter
-
-["if" "else"] @conditional
-
-(string) @string
-
-(boolean ["true" "false"]) @boolean
-
 (comment) @comment
+(string) @string
+(boolean ["true" "false"]) @boolean
+["if" "else"] @conditional
+["export" "alias" "set"] @keyword
+["@" "==" "!=" "+" ":="] @operator
+[ "(" ")" "[" "]" "{{" "}}" "{" "}"] @punctuation.bracket
 
+[
+  (assignment (NAME))
+  (alias (NAME))
+  (value (NAME))
+  (parameter (NAME))
+] @variable
+
+; Recipe definitions
+[
+  (recipeheader (NAME))
+  (dependency (NAME))
+  (dependency (depcall (NAME)))
+] @function
+(parameter) @parameter
+(depcall (expression (value (NAME) @parameter)))
+
+; Fallback highlighting for recipe bodies
 (recipe
   (body) @text.literal.block (#set! "priority" 90))
-
 (shebang_recipe
   (shebang interpreter: (TEXT) @keyword) @comment
   (shebang_body) @text.literal.block (#set! "priority" 90))
 
-["export" "alias" "set"] @keyword
+; Ref: https://just.systems/man/en/chapter_26.html
+(setting (NAME) @error)
+(setting (NAME) @constant.builtin
+  (#any-of? @constant.builtin 
+    "allow-duplicate-recipes"
+    "dotenv-filename"
+    "dotenv-load"
+    "dotenv-path"
+    "export"
+    "fallback"
+    "ignore-comments"
+    "positional-arguments"
+    "shell"
+    "tempdir"
+    "windows-powershell"
+    "windows-shell"))
+; Special handling for the shell setting
+(setting "shell" @constant.builtin)
+(setting lang: (NAME) @string.special)
 
-["@" "==" "!=" "+" ":="] @operator
-
-[ "(" ")" "[" "]" "{{" "}}" "{" "}"] @punctuation.bracket
-
-(ERROR) @error
+; Ref: https://just.systems/man/en/chapter_31.html
+(call (NAME) @error)
+(call (NAME) @function
+  (#any-of? @function 
+    "arch"
+    "num_cpus"
+    "os"
+    "os_family"
+    "env_var"
+    "env_var_or_default"
+    "env"
+    "invocation_directory"
+    "invocation_directory_native"
+    "justfile"
+    "justfile_directory"
+    "just_executable"
+    "quote"
+    "replace"
+    "replace_regex"
+    "trim"
+    "trim_end"
+    "trim_end_match"
+    "trim_end_matches"
+    "trim_start"
+    "trim_start_match"
+    "trim_start_matches"
+    "capitalize"
+    "kebabcase"
+    "lowercamelcase"
+    "lowercase"
+    "shoutykebabcase"
+    "shoutysnakecase"
+    "snakecase"
+    "titlecase"
+    "uppercamelcase"
+    "uppercase"
+    "absolute_path"
+    "extension"
+    "file_name"
+    "file_stem"
+    "parent_directory"
+    "without_extension"
+    "clean"
+    "join"
+    "path_exists"
+    "error"
+    "sha256"
+    "sha256_file"
+    "uuid"
+    "semver_matches"))

--- a/queries/just/highlights.scm
+++ b/queries/just/highlights.scm
@@ -27,7 +27,6 @@
   (shebang_body) @text.literal.block (#set! "priority" 90))
 
 ; Ref: https://just.systems/man/en/chapter_26.html
-(setting (NAME) @error)
 (setting (NAME) @constant.builtin
   (#any-of? @constant.builtin 
     "allow-duplicate-recipes"
@@ -47,7 +46,6 @@
 (setting lang: (NAME) @string.special)
 
 ; Ref: https://just.systems/man/en/chapter_31.html
-(call (NAME) @error)
 (call (NAME) @function
   (#any-of? @function 
     "arch"

--- a/queries/just/highlights.scm
+++ b/queries/just/highlights.scm
@@ -7,19 +7,15 @@
 ["@" "==" "!=" "+" ":="] @operator
 [ "(" ")" "[" "]" "{{" "}}" "{" "}"] @punctuation.bracket
 
-[
-  (assignment (NAME))
-  (alias (NAME))
-  (value (NAME))
-  (parameter (NAME))
-] @variable
+(assignment (NAME) @variable)
+(alias (NAME) @variable)
+(value (NAME) @variable)
+(parameter (NAME) @variable)
 
 ; Recipe definitions
-[
-  (recipeheader (NAME))
-  (dependency (NAME))
-  (dependency (depcall (NAME)))
-] @function
+(recipeheader (NAME) @function)
+(dependency (NAME) @function)
+(dependency (depcall (NAME) @function))
 (parameter) @parameter
 (depcall (expression (value (NAME) @parameter)))
 

--- a/queries/just/highlights.scm
+++ b/queries/just/highlights.scm
@@ -1,7 +1,7 @@
 
 (comment) @comment
 (string) @string
-(boolean ["true" "false"]) @boolean
+[ "true" "false" ] @boolean
 ["if" "else"] @conditional
 ["export" "alias" "set"] @keyword
 ["@" "==" "!=" "+" ":="] @operator

--- a/queries/just/highlights.scm
+++ b/queries/just/highlights.scm
@@ -1,0 +1,39 @@
+
+(assignment (NAME) @variable)
+(alias (NAME) @variable)
+(value (NAME) @variable)
+(parameter (NAME) @variable)
+(setting (NAME) @keyword)
+(setting "shell" @keyword)
+
+(call (NAME) @function)
+(dependency (NAME) @function)
+(depcall (NAME) @function)
+(recipeheader (NAME) @function)
+
+(depcall (expression) @parameter)
+(parameter) @parameter
+(variadic_parameters) @parameter
+
+["if" "else"] @conditional
+
+(string) @string
+
+(boolean ["true" "false"]) @boolean
+
+(comment) @comment
+
+(recipe
+  (body) @text.literal.block (#set! "priority" 90))
+
+(shebang_recipe
+  (shebang interpreter: (TEXT) @keyword) @comment
+  (shebang_body) @text.literal.block (#set! "priority" 90))
+
+["export" "alias" "set"] @keyword
+
+["@" "==" "!=" "+" ":="] @operator
+
+[ "(" ")" "[" "]" "{{" "}}" "{" "}"] @punctuation.bracket
+
+(ERROR) @error

--- a/queries/just/injections.scm
+++ b/queries/just/injections.scm
@@ -1,12 +1,28 @@
 
-(shebang_recipe 
-  (shebang_body) @injection.content (#set! injection.language "sh")) 
+; If no shell is explicitly set, let's default to bash for recipe bodies
+(source_file 
+  (item (recipe (body (recipe_body) @injection.content
+    (#set! injection.include-children)
+    (#set! injection.language "bash"))))) 
 
-;(shebang_recipe 
-;  (shebang 
-;    interpreter:(TEXT) @injection.language)
-;  (shebang_body) @injection.content) 
+; Sets the injection language of a recipe to the executable of the shebang line
 ;
+; This works well in most cases, since it's probably "bash" or "python", but
+; will break in cases where the executable doesn't match the language name,
+; such as "python3"
+;
+(shebang_recipe
+  (shebang interpreter: (TEXT) @injection.language)
+  (shebang_body) @injection.content
+  (#set! injection.include-children))
+
+; If a shell is set (set shell := ["zsh"]) then use that
 ;(source_file 
-;  (item (setting lang:(NAME) @injection.language))
-;  (item (recipe (body (recipe_body) @injection.content)))) 
+;  (item (setting lang: (NAME) @injection.language))
+;  (item (recipe (body (recipe_body) @injection.content
+;    (#set! injection.include-children))))) 
+;
+; This works if the shell is set to something that matches a language name,
+; like "bash", "zsh", "python" etc. However, since it can be set to any
+; executable, including a full path, this can easily break. This needs some
+; kind of post processing to be usable.

--- a/queries/just/injections.scm
+++ b/queries/just/injections.scm
@@ -1,28 +1,30 @@
 
 ; If no shell is explicitly set, let's default to bash for recipe bodies
 (source_file 
-  (item (recipe (body (recipe_body) @injection.content
-    (#set! injection.include-children)
-    (#set! injection.language "bash"))))) 
+  (item (recipe (body (recipe_body) @injection.content))) 
+  (#set! injection.include-children)
+  (#set! injection.language "bash"))
 
-; Sets the injection language of a recipe to the executable of the shebang line
-;
-; This works well in most cases, since it's probably "bash" or "python", but
-; will break in cases where the executable doesn't match the language name,
-; such as "python3"
-;
+; If a default shell is explicitly set, use the executable name for normal recipes
+(source_file 
+  (item (setting lang: (NAME) @_lang))
+  (item (recipe (body (recipe_body) @injection.content))) 
+  (#eq? @_lang "python3")
+  (#set! injection.language "python")
+  (#set! injection.include-children))
+(source_file 
+  (item (setting lang: (NAME) @injection.language))
+  (item (recipe (body (recipe_body) @injection.content))) 
+  (#set! injection.include-children))
+
+; For shebang recipes, use the shebang executable name as the language
+(shebang_recipe
+  (shebang interpreter: (TEXT) @_lang)
+  (shebang_body) @injection.content
+  (#eq? @_lang "python3")
+  (#set! injection.language "python")
+  (#set! injection.include-children))
 (shebang_recipe
   (shebang interpreter: (TEXT) @injection.language)
   (shebang_body) @injection.content
   (#set! injection.include-children))
-
-; If a shell is set (set shell := ["zsh"]) then use that
-;(source_file 
-;  (item (setting lang: (NAME) @injection.language))
-;  (item (recipe (body (recipe_body) @injection.content
-;    (#set! injection.include-children))))) 
-;
-; This works if the shell is set to something that matches a language name,
-; like "bash", "zsh", "python" etc. However, since it can be set to any
-; executable, including a full path, this can easily break. This needs some
-; kind of post processing to be usable.

--- a/queries/just/injections.scm
+++ b/queries/just/injections.scm
@@ -1,0 +1,12 @@
+
+(shebang_recipe 
+  (shebang_body) @injection.content (#set! injection.language "sh")) 
+
+;(shebang_recipe 
+;  (shebang 
+;    interpreter:(TEXT) @injection.language)
+;  (shebang_body) @injection.content) 
+;
+;(source_file 
+;  (item (setting lang:(NAME) @injection.language))
+;  (item (recipe (body (recipe_body) @injection.content)))) 

--- a/queries/just/injections.scm
+++ b/queries/just/injections.scm
@@ -15,6 +15,7 @@
 (source_file 
   (item (setting lang: (NAME) @injection.language))
   (item (recipe (body (recipe_body) @injection.content))) 
+  (#not-eq? @injection.language "python3")
   (#set! injection.include-children))
 
 ; For shebang recipes, use the shebang executable name as the language
@@ -27,4 +28,5 @@
 (shebang_recipe
   (shebang interpreter: (TEXT) @injection.language)
   (shebang_body) @injection.content
+  (#not-eq? @injection.language "python3")
   (#set! injection.include-children))


### PR DESCRIPTION
**Edit:** Currently blocked by the upstream custom scanner, which is written in C++ and fails to compile on MacOS. See issue: https://github.com/IndianBoy42/tree-sitter-just/issues/23. Unfortunately I don't know C or C++ so I can't fix the issue myself, and the original author is not active.

---

I did not make this parser, but I use it constantly and it would be nice to have it in nvim-treesitter.

I wrote the injections and added a couple of highlight queries, otherwise this is all @IndianBoy42's work.

I have listed myself as maintainer, as I'm not sure if it refers to the maintainer of the parser or the maintainer of the associated configuration in this repository, and I guessed the latter.

The injections could be improved, but I'm not sure how.

To very roughly explain, a justfile can look like this:

```just
deploy: deploy-foo deploy-bar
    echo "This is a regular recipe and defaults to Bash"

deploy-foo:
    #!/usr/bin/env bash
    echo "This is a shebang recipe and can be set to any language"

deploy-bar:
    #!/usr/bin/env python
    print("Including Python!")
```

The injections currently capture the executable name in the shebang line ("bash" and "python" in these examples) and sets that to the injection language, which works phenomenally!

The only issue is that the executable name doesn't necessarily match the language, such as with "python3" and probably many others. Are there any good ways to deal with that currently, or do I just have to add a whole bunch of extra queries to capture most error scenarios?

The same is also true for the injection used for normal recipes when a shell is explicitly set:

```just
set shell := ["python"]
```