### PR TITLE
feat(python): `@string.regex` capture, injection improvements

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -352,5 +352,5 @@
 (call
   function: (attribute
               object: (identifier) @_re)
-  arguments: (argument_list (string) @string.regex)
+  arguments: (argument_list . (string) @string.regex)
   (#eq? @_re "re"))

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -346,3 +346,11 @@
               ;; https://docs.python.org/3/library/stdtypes.html
               "bool" "int" "float" "complex" "list" "tuple" "range" "str"
               "bytes" "bytearray" "memoryview" "set" "frozenset" "dict" "type" "object"))
+
+;; Regex from the `re` module
+
+(call
+  function: (attribute
+              object: (identifier) @_re)
+  arguments: (argument_list (string) @string.regex)
+  (#eq? @_re "re"))

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -352,5 +352,5 @@
 (call
   function: (attribute
               object: (identifier) @_re)
-  arguments: (argument_list . (string) @string.regex)
+  arguments: (argument_list . (string (string_content) @string.regex))
   (#eq? @_re "re"))

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -4,7 +4,6 @@
   arguments: (argument_list (string
                               (string_content) @injection.content) @_string)
   (#eq? @_re "re")
-  (#lua-match? @_string "^r.*")
   (#set! injection.language "regex"))
 
 ((comment) @injection.content

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -1,7 +1,7 @@
 (call
   function: (attribute
               object: (identifier) @_re)
-  arguments: (argument_list (string
+  arguments: (argument_list . (string
                               (string_content) @injection.content) @_string)
   (#eq? @_re "re")
   (#set! injection.language "regex"))

--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -2,7 +2,7 @@
   function: (attribute
               object: (identifier) @_re)
   arguments: (argument_list . (string
-                              (string_content) @injection.content) @_string)
+                              (string_content) @injection.content))
   (#eq? @_re "re")
   (#set! injection.language "regex"))
 


### PR DESCRIPTION
This PR removes the requirement that injected regex for Python must be a raw (`r'.*'`) string. For example, the following code is still valid, even though the first string is a regular Python string and not a raw one:
```python
txt = 'The rain in Spain'
x = re.search('^The.*Spain$', txt)
```
It also highlights this string as `@string.regex` for canonical purposes.