### PR TITLE
feat(regex): any_character, start end assertion hl differentiation

### DIFF
--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -25,10 +25,14 @@
  (control_letter_escape)
  (character_class_escape)
  (control_escape)
- (start_assertion)
- (end_assertion)
  (boundary_assertion)
  (non_boundary_assertion)
 ] @string.escape
 
-[ "*" "+" "?" "|" "=" "!" ] @operator
+[ "*" "+" "?" "|" "=" "!" "-"] @operator
+
+[
+ (any_character)
+ (start_assertion)
+ (end_assertion)
+] @variable.builtin


### PR DESCRIPTION
This PR highlights the `class_range` operator (`-`) as `@operator`. It also moves `start_assertion` and `end_assertion` (and adds `any_character` (`.`)) to the `@variable.builtin` highlight. Hopefully this change isn't too controversial but I understand if it gets shot down. I figured this made more sense than the escape highlight group since (unlike the other nodes in the highlight group) these nodes do not begin with an actual escape character (`\`). If the start and end assertion changes get shot down I still think it would be beneficial to highlight `.` as either `@string.escape` or `@variable.builtin`.
Before:
![beforeregex](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/9f79aadb-a131-492a-bf78-860b72204eab)

After:
![afterregex](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/7ddbbde5-a5d1-4c2b-8321-564d068393a5)
