### PR TITLE
fix(css): tweak operator keyword highlights

### DIFF
--- a/queries/css/highlights.scm
+++ b/queries/css/highlights.scm
@@ -34,11 +34,14 @@
  "~="
  "$="
  "*="
+ ] @operator
+
+[
  "and"
  "or"
  "not"
  "only"
- ] @operator
+ ] @keyword.operator
 
 (important) @type.qualifier
 


### PR DESCRIPTION
Moves `and`, `or`, `not`, and `only` from `@operator` to `@keyword.operator`