### PR TITLE
feat(bash) Highlight concatenated words as strings

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -66,6 +66,13 @@
 (command
   argument: "$" @string) ; bare dollar
 
+(concatenation
+  [
+    (simple_expansion)
+    (expansion)
+  ]
+  (word) @string)
+
 [
   "if"
   "then"


### PR DESCRIPTION
In this shell snippet, it would be helpful for the `.y` parts to be a different color than the `foo` variable to clarify that the variable name is not `foo.y`. Only the second line `$foo.y` was originally misleading, but I edited the third line too for consistency. I think it's most correct to highlight as `@string`. The 5th line is a bit of an outlier because it's still highlighted as `@parameter`, which seems fine.

Before:
<img src="https://github.com/nvim-treesitter/nvim-treesitter/assets/3578681/361cb140-66f0-4727-ae97-dfa92dea4dad" width="200" />

After:
<img src="https://github.com/nvim-treesitter/nvim-treesitter/assets/3578681/c93c7418-b3d3-414b-97df-61fb8426be49" width="200" />

With `nvim --clean foo.sh` (no treesitter, for reference):
<img src="https://github.com/nvim-treesitter/nvim-treesitter/assets/3578681/110fe635-727d-4dbb-8892-66df7680a671" width="150" />