### PR TITLE
twig queries: add combined injections by default

### DIFF
--- a/queries/twig/injections.scm
+++ b/queries/twig/injections.scm
@@ -1,3 +1,4 @@
 ((content) @injection.content
- (#set! injection.language "html"))
+ (#set! injection.language "html")
+ (#set! injection.combined))
 


### PR DESCRIPTION
As it is in https://github.com/gbprod/tree-sitter-twig/blob/main/queries/injections.scm

What changes for the user?

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/22132993/d0c49b01-7a4f-4d63-a584-07a8c7004319)

instead of

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/22132993/19680f92-f671-4b08-8df3-b9c28a384746)


I didn't realise this was fixed after reading some issues in gbprod/tree-sitter-twig. Until I compared the injections.scm in both repositories and seeing a similar update was made for PHP which had the same issue.