### PR TITLE
Fix incremental selection omitting last character if vim selection=exclusive

### DIFF
--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -15,7 +15,7 @@ function M.init_selection()
   local buf = api.nvim_get_current_buf()
   local node = ts_utils.get_node_at_cursor()
   selections[buf] = { [1] = node }
-  ts_utils.update_selection(buf, node)
+  ts_utils.update_selection(buf, node, nil, ts_utils.is_selecton_end_exclusive())
 end
 
 -- Get the range of the current visual selection.
@@ -38,6 +38,10 @@ local function visual_selection_range()
     start_col = cecol
     end_row = csrow
     end_col = cscol
+  end
+
+  if ts_utils.is_selecton_end_exclusive() then
+    end_col = end_col - 1
   end
 
   return start_row, start_col, end_row, end_col
@@ -63,7 +67,7 @@ local function select_incremental(get_parent)
     if not nodes or #nodes == 0 or not range_matches(nodes[#nodes]) then
       local root = parsers.get_parser():parse()[1]:root()
       local node = root:named_descendant_for_range(csrow - 1, cscol - 1, cerow - 1, cecol)
-      ts_utils.update_selection(buf, node)
+      ts_utils.update_selection(buf, node, nil, ts_utils.is_selecton_end_exclusive())
       if nodes and #nodes > 0 then
         table.insert(selections[buf], node)
       else
@@ -82,7 +86,7 @@ local function select_incremental(get_parent)
         local root = parsers.get_parser():parse()[1]:root()
         parent = root:named_descendant_for_range(csrow - 1, cscol - 1, cerow - 1, cecol)
         if not parent or root == node or parent == node then
-          ts_utils.update_selection(buf, node)
+          ts_utils.update_selection(buf, node, nil, ts_utils.is_selecton_end_exclusive())
           return
         end
       end
@@ -94,7 +98,7 @@ local function select_incremental(get_parent)
         if node ~= nodes[#nodes] then
           table.insert(nodes, node)
         end
-        ts_utils.update_selection(buf, node)
+        ts_utils.update_selection(buf, node, nil, ts_utils.is_selecton_end_exclusive())
         return
       end
     end
@@ -123,7 +127,7 @@ function M.node_decremental()
 
   table.remove(selections[buf])
   local node = nodes[#nodes] ---@type TSNode
-  ts_utils.update_selection(buf, node)
+  ts_utils.update_selection(buf, node, nil, ts_utils.is_selecton_end_exclusive())
 end
 
 local FUNCTION_DESCRIPTIONS = {


### PR DESCRIPTION
As described in #3488, incremental selection doesn't include the last character if vim's `selection` option is set to `exclusive`. This happens because [`ts_utils.update_selection`](https://github.com/nvim-treesitter/nvim-treesitter/blob/b056e4227b1c5d3ecfe96941352364c0c10668df/lua/nvim-treesitter/ts_utils.lua#L278C55-L278C55) converts treesitter node range to an inclusive range, and then sets the start and end markers to the boundaries of that range.
Updating this function to consider `selection` could break other scripts as they might expect both selection ends to be inclusive (as it is the case with incremental selection), so whether the end is exclusive is now controlled by an additional parameter. 
Incremental selection script is changed to take `selection` into account and call `update_selection` with the correct new parameter.

The `end_col = end_col - 1` part is not guaranteed to work with multibyte characters for arbitrary position, as `end_col` can be on the second+ byte of the character and subtracting 1 will leave position the same, but from my tests '< and '> marks of the last visual selection always stay on the first byte of the character, even if the cursor in visual mode was set to the second byte of that character. I couldn't find any vim function that would give starting position of a multibyte character from a byte offset. Besides, two other plugins I know work with `selection=exclusive` both do it the same way ([nvim-surround](https://github.com/kylechui/nvim-surround/blob/0855a89e00a5822c3a482a82e5223fcf2e9ede13/lua/nvim-surround/init.lua#L130) and [targets](https://github.com/wellle/targets.vim/blob/642d3a4ce306264b05ea3219920b13ea80931767/autoload/targets/target.vim#L47)).