### PR TITLE
astro: add custom component highlighting

### DIFF
--- a/queries/astro/highlights.scm
+++ b/queries/astro/highlights.scm
@@ -3,3 +3,11 @@
 [ "---" ] @punctuation.delimiter
 
 [ "{" "}" ] @punctuation.special
+
+; custom components get `@type` highlighting
+((start_tag (tag_name) @type)
+ (#lua-match? @type "^[A-Z]"))
+((end_tag (tag_name) @type)
+ (#lua-match? @type "^[A-Z]"))
+((erroneous_end_tag (erroneous_end_tag_name) @type)
+ (#lua-match? @type "^[A-Z]"))


### PR DESCRIPTION
Adds custom `@type` captures for custom components ala JSX to Astro's highlights.

Closes https://github.com/virchau13/tree-sitter-astro/issues/17.