### PR TITLE
feat(make): give targets the function highlight

### DIFF
--- a/queries/make/highlights.scm
+++ b/queries/make/highlights.scm
@@ -10,6 +10,8 @@
  ] @conditional)
  "endif" @conditional)
 
+(rule (targets (word) @function))
+
 (rule (targets
        (word) @function.builtin
        (#any-of? @function.builtin


### PR DESCRIPTION
Highlights target words as `@function` to match up with builtin target words being `@function.builtin`
Before:
![beforemakefile](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/4e665f3d-2b6e-4703-a55e-4d5cff9c890d)
After:
![aftermakefile](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/c68013df-68f8-43e9-8c74-ad8f3cfce9c2)
