### PR TITLE
fix(cpp): remove `@field` for identifiers with `_` prefix (#5731)

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -1,7 +1,7 @@
 ; inherits: c
 
 ((identifier) @field
-  (#lua-match? @field "^m?_.*$"))
+  (#lua-match? @field "^m_.*$"))
 
 (parameter_declaration
   declarator: (reference_declarator) @parameter)


### PR DESCRIPTION
This PR fixes #5731 by removing the `@field` highlight group for identifiers that start with `_`. Identifiers that start with `m_` will still be given the `@field` highlight.