### PR TITLE
feat(angular): switch to parser supporting v17

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "c21c3a0f996363ed17b8ac99d827fe5a4821f217"
   },
   "angular": {
-    "revision": "46a5b1d51cce407f7b311d949baf4aa04a545ddd"
+    "revision": "b19982a98bb889e45f33b3ef3134c19bfb537bb8"
   },
   "apex": {
     "revision": "82ee140f4ee7652a4915ac9e9f60c4d66f7637d7"

--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "c21c3a0f996363ed17b8ac99d827fe5a4821f217"
   },
   "angular": {
-    "revision": "624ff108fe949727217cddb302f20e4f16997b1c"
+    "revision": "6c0b1dfc63352c6be608c807e05e5a892c4b49b3"
   },
   "apex": {
     "revision": "82ee140f4ee7652a4915ac9e9f60c4d66f7637d7"

--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "c21c3a0f996363ed17b8ac99d827fe5a4821f217"
   },
   "angular": {
-    "revision": "6c0b1dfc63352c6be608c807e05e5a892c4b49b3"
+    "revision": "46a5b1d51cce407f7b311d949baf4aa04a545ddd"
   },
   "apex": {
     "revision": "82ee140f4ee7652a4915ac9e9f60c4d66f7637d7"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -95,10 +95,11 @@ list.agda = {
 
 list.angular = {
   install_info = {
-    url = "https://github.com/steelsojka/tree-sitter-angular",
+    url = "https://github.com/dlvandenberg/tree-sitter-angular",
     files = { "src/parser.c" },
     requires_generate_from_grammar = true,
   },
+  maintainers = { "@dlvandenberg" },
   experimental = true,
 }
 

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -21,10 +21,14 @@
   function: ((identifier) @function.builtin
     (#eq? @function.builtin "$any")))
 
+(annotation) @punctuation.special
+
 [
-"let"
-"as"
+  (control_flow_keyword)
+  "let"
 ] @keyword
+
+(special_block_keyword) @type
 
 [
 "("
@@ -43,9 +47,9 @@
 ] @punctuation.delimiter
 
 ((identifier) @boolean
-  (#any-of? @boolean "true" "false"))
+  (#vim-match? @boolean "^(true|false)$"))
 ((identifier) @variable.builtin
-  (#any-of? @variable.builtin "this" "\$event" "null"))
+  (#vim-match? @variable.builtin "^(this|\$event|null)$"))
 
 [
   "-"
@@ -65,3 +69,5 @@
   "||"
   "%"
 ] @operator
+
+(ternary_operator) @conditional.ternary

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -21,7 +21,7 @@
   function: ((identifier) @function.builtin
     (#eq? @function.builtin "$any")))
 
-(annotation) @punctuation.special
+(annotation) @type
 
 [
   (control_flow_keyword)
@@ -31,25 +31,26 @@
 (special_block_keyword) @type
 
 [
-"("
-")"
-"["
-"]"
-"{"
-"}"
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
 ] @punctuation.bracket
 
 [
-";"
-"."
-","
-"?."
+  ";"
+  "."
+  ","
+  "?."
 ] @punctuation.delimiter
 
 ((identifier) @boolean
   (#vim-match? @boolean "^(true|false)$"))
 ((identifier) @variable.builtin
   (#vim-match? @variable.builtin "^(this|\$event|null)$"))
+
 
 [
   "-"
@@ -70,4 +71,7 @@
   "%"
 ] @operator
 
-(ternary_operator) @conditional.ternary
+[
+ (ternary_operator)
+ (conditional_operator)
+] @conditional.ternary

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -47,9 +47,9 @@
 ] @punctuation.delimiter
 
 ((identifier) @boolean
-  (#vim-match? @boolean "^(true|false)$"))
+  (#any-of? @boolean "true" "false"))
 ((identifier) @variable.builtin
-  (#vim-match? @variable.builtin "^(this|\$event|null)$"))
+  (#any-of? @variable.builtin "this" "\$event" "null"))
 
 
 [

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -119,3 +119,69 @@
   right: 
     (string (string_fragment) @injection.content)
     (#set! injection.language "html"))
+
+;---- Angular injections -----
+; @Component({
+;   template: `<html>`
+; })
+((decorator
+  (call_expression
+    function: ((identifier) @_name
+               (#eq? @_name "Component"))
+    arguments: (arguments
+                 (object
+                   (pair
+                     key: ((property_identifier) @_prop
+                           (#eq? @_prop "template"))
+                     value: ((template_string) @injection.content
+                              (#offset! @injection.content 0 1 0 -1)
+                              (#set! injection.language "html")
+                            ) 
+                   )
+               ))
+  )
+))
+
+; @Component({
+;   styles: [`<css>`]
+; })
+((decorator
+  (call_expression
+    function: ((identifier) @_name
+               (#eq? @_name "Component"))
+    arguments: (arguments
+                 (object
+                   (pair
+                     key: ((property_identifier) @_prop
+                           (#eq? @_prop "styles"))
+                     value: (array
+                              ((template_string) @injection.content 
+                                  (#offset! @injection.content 0 1 0 -1)
+                                  (#set! injection.language "css")
+                              )
+                            )
+                   )
+               ))
+  )
+))
+
+; @Component({
+;   styles: `<css>`
+; })
+((decorator
+  (call_expression
+    function: ((identifier) @_name
+               (#eq? @_name "Component"))
+    arguments: (arguments
+                 (object
+                   (pair
+                     key: ((property_identifier) @_prop
+                           (#eq? @_prop "styles"))
+                     value: ((template_string) @injection.content 
+                              (#offset! @injection.content 0 1 0 -1)
+                              (#set! injection.language "css")
+                            )
+                   )
+               ))
+  )
+))

--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -25,3 +25,112 @@
   (text) @injection.content
   (#eq? @_py_config "py-config")
   (#set! injection.language "toml"))
+
+;------ Angular queries ------
+
+; {{ someBinding }}
+((text) @injection.content 
+  (#lua-match? @injection.content "%{%{.+%}%}")
+  (#set! injection.language "angular")
+)
+
+; }
+((text) @injection.content 
+  (#lua-match? @injection.content "%}.*")
+  (#set! injection.language "angular")
+)
+
+; Angular control flow statements
+; @if (condition) {
+((text) @injection.content 
+  (#lua-match? @injection.content "%@if%s+%(.+%)%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; @for (item of items) {
+((text) @injection.content 
+  (#lua-match? @injection.content "%@for%s+%(.+%)%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; @switch (condition) {
+((text) @injection.content 
+  (#lua-match? @injection.content "%@switch%s+%(.+%)%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; @case (value) {
+((text) @injection.content 
+  (#lua-match? @injection.content "%@case%s+%(.+%)%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; @default {
+((text) @injection.content 
+  (#lua-match? @injection.content "%@default%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; @defer {
+((text) @injection.content 
+  (#lua-match? @injection.content "%@defer%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; @defer (conditions) {
+((text) @injection.content 
+  (#lua-match? @injection.content "%@defer%s+%(.+%)%{$")
+  (#set! injection.language "angular")
+)
+
+; Angular continuation blocks
+; } @else {
+((text) @injection.content
+  (#lua-match? @injection.content "%}%s+%@else%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; } @else if (condition) {
+((text) @injection.content
+  (#lua-match? @injection.content "%}%s+%@else%s+if%s+%(.+%)%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; } @empty {
+((text) @injection.content 
+  (#lua-match? @injection.content "%}%s+%@empty%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; } @placeholder {
+((text) @injection.content
+  (#lua-match? @injection.content "%}%s+%@placeholder%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; @placeholder (minumum) {
+((text) @injection.content
+  (#lua-match? @injection.content "%}%s+%@placeholder%s+%(.+%)%{$")
+  (#set! injection.language "angular")
+)
+
+; } @loading {
+((text) @injection.content
+  (#lua-match? @injection.content "%}%s+%@loading%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; } @loading (conditions) {
+((text) @injection.content
+  (#lua-match? @injection.content "%}%s+%@loading%s+%(.+%)%s+%{$")
+  (#set! injection.language "angular")
+)
+
+; } @error {
+((text) @injection.content
+  (#lua-match? @injection.content "%}%s+%@error%s+%{$")
+  (#set! injection.language "angular")
+)
+
+
+

--- a/queries/html/injections.scm
+++ b/queries/html/injections.scm
@@ -36,7 +36,7 @@
 
 ; }
 ((text) @injection.content 
-  (#lua-match? @injection.content "%}.*")
+  (#lua-match? @injection.content "%}")
   (#set! injection.language "angular")
 )
 

--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -59,3 +59,16 @@
 ] @tag.delimiter
 
 "=" @operator
+
+(attribute
+  ((attribute_name) @_name
+   (#lua-match? @_name "%[.*%]")) @keyword)
+
+(attribute
+  ((attribute_name) @_name
+   (#lua-match? @_name "%(.*%)")) @keyword)
+
+(attribute
+  ((attribute_name) @_name
+   (#lua-match? @_name "^%*.*")) @keyword)
+

--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -75,6 +75,7 @@
   (quoted_attribute_value (attribute_value) @injection.content)
   (#set! injection.language "javascript"))
 
+; <element [attr]="value"> | <element [(value)]="value">
 (attribute
   ((attribute_name) @_name
    (#lua-match? @_name "[%[%(].*[%)%]]"))
@@ -82,16 +83,11 @@
     (attribute_value) @injection.content)
   (#set! injection.language "angular"))
 
+; <element *ngIf="value"> | <element *ngFor="value">
 (attribute
   ((attribute_name) @_name
    (#lua-match? @_name "^%*"))
   (quoted_attribute_value
     ((attribute_value) @injection.content))
-  (#set! injection.language "angular"))
-
-(element
-  ((text) @injection.content
-   (#lua-match? @injection.content "%{%{.*%}%}")
-   (#offset! @injection.content 0 2 0 -2))
   (#set! injection.language "angular"))
 


### PR DESCRIPTION
Updated the parser for Angular which has support for v17.
Added injections and highlights for both HTML and TypeScript files (for inline templates)