### PR TITLE
feat: add tree-sitter-styled

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -606,7 +606,7 @@
     "revision": "d819cdd5dbe455bd3c859193633c8d91c0df7c36"
   },
   "styled": {
-    "revision" : "05b795ad742c3ad0dd212c5e601d824760a52a8f"
+    "revision": "e51e673efc860373167680b4bcbf418a11e4ed26"
   },
   "supercollider": {
     "revision": "3b35bd0fded4423c8fb30e9585c7bacbcd0e8095"

--- a/lockfile.json
+++ b/lockfile.json
@@ -606,7 +606,7 @@
     "revision": "d819cdd5dbe455bd3c859193633c8d91c0df7c36"
   },
   "styled": {
-    "revision" : "e51e673efc860373167680b4bcbf418a11e4ed26"
+    "revision" : "05b795ad742c3ad0dd212c5e601d824760a52a8f"
   },
   "supercollider": {
     "revision": "3b35bd0fded4423c8fb30e9585c7bacbcd0e8095"

--- a/lockfile.json
+++ b/lockfile.json
@@ -605,6 +605,9 @@
   "strace": {
     "revision": "d819cdd5dbe455bd3c859193633c8d91c0df7c36"
   },
+  "styled": {
+    "revision" : "e51e673efc860373167680b4bcbf418a11e4ed26"
+  },
   "supercollider": {
     "revision": "3b35bd0fded4423c8fb30e9585c7bacbcd0e8095"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1779,6 +1779,15 @@ list.strace = {
   maintainers = { "@amaanq" },
 }
 
+list.styled = {
+  install_info = {
+    url = "https://github.com/mskelton/tree-sitter-styled",
+    files = { "src/parser.c", "src/scanner.c" },
+    generate_requires_npm = true,
+  },
+  maintainers = { "@mskelton" },
+}
+
 list.supercollider = {
   install_info = {
     url = "https://github.com/madskjeldgaard/tree-sitter-supercollider",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1783,7 +1783,6 @@ list.styled = {
   install_info = {
     url = "https://github.com/mskelton/tree-sitter-styled",
     files = { "src/parser.c", "src/scanner.c" },
-    generate_requires_npm = true,
   },
   maintainers = { "@mskelton" },
 }

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -53,7 +53,7 @@
      (#eq? @_name "styled"))
  arguments: ((template_string) @injection.content
    (#offset! @injection.content 0 1 0 -1)
-   (#set! injection.language "css")))
+   (#set! injection.language "styled")))
 
 ; styled(Component)`<css>`
 (call_expression
@@ -62,7 +62,7 @@
      (#eq? @_name "styled"))
  arguments: ((template_string) @injection.content
    (#offset! @injection.content 0 1 0 -1)
-   (#set! injection.language "css")))
+   (#set! injection.language "styled")))
 
 ; styled.div.attrs({ prop: "foo" })`<css>`
 (call_expression
@@ -73,7 +73,7 @@
         (#eq? @_name "styled"))))
  arguments: ((template_string) @injection.content
    (#offset! @injection.content 0 1 0 -1)
-   (#set! injection.language "css")))
+   (#set! injection.language "styled")))
 
 
 ; styled(Component).attrs({ prop: "foo" })`<css>`
@@ -85,7 +85,7 @@
         (#eq? @_name "styled"))))
  arguments: ((template_string) @injection.content
    (#offset! @injection.content 0 1 0 -1)
-   (#set! injection.language "css")))
+   (#set! injection.language "styled")))
 
 ((regex_pattern) @injection.content
  (#set! injection.language "regex"))

--- a/queries/styled/folds.scm
+++ b/queries/styled/folds.scm
@@ -1,0 +1,1 @@
+; inherits: css

--- a/queries/styled/highlights.scm
+++ b/queries/styled/highlights.scm
@@ -1,0 +1,4 @@
+; inherits: css
+
+(plain_value) @identifier
+(js_expression) @identifier

--- a/queries/styled/highlights.scm
+++ b/queries/styled/highlights.scm
@@ -1,4 +1,4 @@
 ; inherits: css
 
-(plain_value) @identifier
-(js_expression) @identifier
+(plain_value) @variable
+(js_expression) @variable

--- a/queries/styled/highlights.scm
+++ b/queries/styled/highlights.scm
@@ -1,4 +1,1 @@
 ; inherits: css
-
-(plain_value) @variable
-(js_expression) @variable

--- a/queries/styled/indents.scm
+++ b/queries/styled/indents.scm
@@ -1,0 +1,1 @@
+; inherits: css

--- a/queries/styled/injections.scm
+++ b/queries/styled/injections.scm
@@ -1,0 +1,1 @@
+; inherits: css


### PR DESCRIPTION
I created a parser for styled-components or other CSS-in-JS languages to highlight CSS within `styled.div` type expressions.