### PR TITLE
feat: add rbs parser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [r](https://github.com/r-lib/tree-sitter-r) (maintained by @echasnovski)
 - [ ] [racket](https://github.com/6cdh/tree-sitter-racket)
 - [x] [rasi](https://github.com/Fymyte/tree-sitter-rasi) (maintained by @Fymyte)
+- [x] [rbs](https://github.com/joker1007/tree-sitter-rbs) (maintained by @joker1007)
 - [x] [re2c](https://github.com/amaanq/tree-sitter-re2c) (maintained by @amaanq)
 - [x] [regex](https://github.com/tree-sitter/tree-sitter-regex) (maintained by @theHamsta)
 - [x] [rego](https://github.com/FallenAngel97/tree-sitter-rego) (maintained by @FallenAngel97)

--- a/lockfile.json
+++ b/lockfile.json
@@ -518,6 +518,9 @@
   "rasi": {
     "revision": "371dac6bcce0df5566c1cfebde69d90ecbeefd2d"
   },
+  "rbs": {
+    "revision": "192eda46774fd0281cdd41d372d5b4da86148780"
+  },
   "re2c": {
     "revision": "47aa19cf5f7aba2ed30e2b377f7172df76e819a6"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1536,6 +1536,14 @@ list.rasi = {
   maintainers = { "@Fymyte" },
 }
 
+list.rbs = {
+  install_info = {
+    url = "https://github.com/joker1007/tree-sitter-rbs",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@joker1007" },
+}
+
 list.re2c = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-re2c",

--- a/queries/rbs/folds.scm
+++ b/queries/rbs/folds.scm
@@ -1,0 +1,5 @@
+[
+  (class_decl)
+  (module_decl)
+  (interface_decl)
+] @fold

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -82,8 +82,6 @@
 
 (type (integer_literal) @number)
 
-(ERROR) @error
-
 [
  "="
  "->"

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -1,8 +1,3 @@
-(use_directive
- "use" @keyword)
-(use_clause
- "as" @keyword)
-
 (use_clause
   [
     (type_name)
@@ -19,6 +14,8 @@
 ] @constant.builtin
 
 [
+  "use"
+  "as"
   "class"
   "module"
   "interface"
@@ -35,9 +32,11 @@
  "def"
 ] @keyword.function
 
-(include_member "include" @function.method)  
-(extend_member "extend" @function.method)  
-(prepend_member "prepend" @function.method)  
+[
+ "include"
+ "extend"
+ "prepend"
+] @function.method
 
 (visibility) @type.qualifier
 
@@ -52,8 +51,7 @@
      (setter)
     ] @function.method))
 
-(ivar_member (ivar_name) @property)
-(ivar_member (cvar_name) @property)
+[(ivar_name) (cvar_name)] @property
 
 (alias_member (method_name) @function)
 

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -1,0 +1,111 @@
+(use_directive
+ "use" @keyword)
+(use_clause
+ "as" @keyword)
+
+(use_clause
+  [
+    (type_name)
+    (simple_type_name)
+  ] @type)
+
+[
+  "true"
+  "false"
+] @boolean
+
+[
+ "nil"
+] @constant.builtin
+
+[
+  "class"
+  "module"
+  "interface"
+  "type"
+  "def"
+  "attr_reader"
+  "attr_writer"
+  "attr_accessor"
+  "end"
+  "alias"
+] @keyword
+
+[
+ "def"
+] @keyword.function
+
+(include_member "include" @function.method)  
+(extend_member "extend" @function.method)  
+(prepend_member "prepend" @function.method)  
+
+(visibility) @type.qualifier
+
+(comment) @comment
+
+(method_member
+  (method_name
+    [
+     (identifier)
+     (constant)
+     (operator)
+     (setter)
+    ] @function.method))
+
+(ivar_member (ivar_name) @property)
+(ivar_member (cvar_name) @property)
+
+(alias_member (method_name) @function)
+
+(class_name (constant) @type)
+(module_name (constant) @type)
+(interface_name (interface) @type)
+(alias_name (identifier) @type)
+(type_variable) @constant
+(namespace (constant) @namespace)
+
+(builtin_type) @type.builtin
+
+(const_name (constant) @constant)
+(global_name) @property
+
+(parameter (var_name) @variable.parameter)
+
+(keyword) @variable.parameter
+
+(self) @variable.builtin
+
+(type (symbol_literal) @symbol)
+
+(type (string_literal (escape_sequence) @string.escape))
+(type (string_literal) @string)
+
+(type (integer_literal) @number)
+
+(ERROR) @error
+
+[
+ "="
+ "->"
+ "<"
+ "**"
+ "*"
+ "&"
+ "|"
+ "^"
+ ] @operator
+
+[
+ "("
+ ")"
+ "["
+ "]"
+ "{"
+ "}"
+ ] @punctuation.bracket
+
+
+[
+ ","
+ "."
+ ] @punctuation.delimiter

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -36,7 +36,7 @@
 
 (visibility) @type.qualifier
 
-(comment) @comment
+(comment) @comment @spell
 
 (method_member
   (method_name

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -9,9 +9,7 @@
   "false"
 ] @boolean
 
-[
- "nil"
-] @constant.builtin
+"nil" @constant.builtin
 
 [
   "use"
@@ -28,9 +26,7 @@
   "alias"
 ] @keyword
 
-[
- "def"
-] @keyword.function
+"def" @keyword.function
 
 [
  "include"
@@ -49,7 +45,7 @@
      (constant)
      (operator)
      (setter)
-    ] @function.method))
+    ] @method))
 
 [(ivar_name) (cvar_name)] @property
 
@@ -67,9 +63,9 @@
 (const_name (constant) @constant)
 (global_name) @property
 
-(parameter (var_name) @variable.parameter)
+(parameter (var_name) @parameter)
 
-(keyword) @variable.parameter
+(keyword) @parameter
 
 (self) @variable.builtin
 

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -1,8 +1,12 @@
+; Use directive
+
 (use_clause
   [
     (type_name)
     (simple_type_name)
   ] @type)
+
+; Buitin constants and Keywords
 
 [
   "true"
@@ -27,6 +31,8 @@
 ] @keyword
 
 "def" @keyword.function
+
+; Members of declaration
 
 [
  "include"
@@ -63,18 +69,24 @@
 (const_name (constant) @constant)
 (global_name) @property
 
+; Standard Arguments
 (parameter (var_name) @parameter)
 
+; Keyword Arguments
 (keyword) @parameter
 
+; Self
 (self) @variable.builtin
 
+; Literal
 (type (symbol_literal) @symbol)
 
 (type (string_literal (escape_sequence) @string.escape))
 (type (string_literal) @string)
 
 (type (integer_literal) @number)
+
+; Operators
 
 [
  "="
@@ -86,6 +98,8 @@
  "|"
  "^"
  ] @operator
+
+; Punctuation
 
 [
  "("

--- a/queries/rbs/indents.scm
+++ b/queries/rbs/indents.scm
@@ -21,4 +21,4 @@
   "]"
 ] @indent.branch
 
-(comment) @indent.ignore
+(comment) @indent.auto

--- a/queries/rbs/indents.scm
+++ b/queries/rbs/indents.scm
@@ -1,0 +1,24 @@
+[
+  (class_decl)
+  (module_decl)
+  (interface_decl)
+  (parameters)
+  (tuple_type)
+  (record_type)
+] @indent.begin
+
+[
+  "end"
+  ")"
+  "]"
+  "}"
+] @indent.end
+
+[
+  "end"
+  ")"
+  "}"
+  "]"
+] @indent.branch
+
+(comment) @indent.ignore

--- a/queries/rbs/injections.scm
+++ b/queries/rbs/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
I would like to add rbs (Ruby type signature) parser support.

I see that there was a pull request in the past to support rbs, but it wasn't merged.
Sorry, this pull request is for a different implementation by myself.