### PR TITLE
Add tree-sitter-disassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [devicetree](https://github.com/joelspadin/tree-sitter-devicetree) (maintained by @jedrzejboczar)
 - [x] [dhall](https://github.com/jbellerb/tree-sitter-dhall) (maintained by @amaanq)
 - [x] [diff](https://github.com/the-mikedavis/tree-sitter-diff) (maintained by @gbprod)
+- [x] [disassembly](https://github.com/ColinKennedy/tree-sitter-disassembly) (maintained by @ColinKennedy)
 - [x] [dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) (maintained by @camdencheek)
 - [x] [dot](https://github.com/rydesun/tree-sitter-dot) (maintained by @rydesun)
 - [x] [doxygen](https://github.com/amaanq/tree-sitter-doxygen) (maintained by @amaanq)

--- a/lockfile.json
+++ b/lockfile.json
@@ -110,6 +110,9 @@
   "diff": {
     "revision": "c165725c28e69b36c5799ff0e458713a844f1aaf"
   },
+  "disassembly": {
+    "revision": "e48ebe20581145b381204cf21adf305e29329b5d"
+  },
   "dockerfile": {
     "revision": "33e22c33bcdbfc33d42806ee84cfd0b1248cc392"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -388,6 +388,14 @@ list.diff = {
   maintainers = { "@gbprod" },
 }
 
+list.disassembly = {
+  install_info = {
+    url = "https://github.com/ColinKennedy/tree-sitter-disassembly",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@ColinKennedy" },
+}
+
 list.dockerfile = {
   install_info = {
     url = "https://github.com/camdencheek/tree-sitter-dockerfile",

--- a/queries/disassembly/highlights.scm
+++ b/queries/disassembly/highlights.scm
@@ -1,0 +1,18 @@
+(byte) @constant
+
+[
+  (address)
+  (hexadecimal)
+  (integer)
+] @number
+
+(identifier) @variable
+
+(bad_instruction) @text.warning
+(code_location (identifier) @function.call)
+(comment) @comment
+(instruction) @function
+(memory_dump) @string
+
+["<" ">"] @punctuation.special
+["+" ":"] @punctuation.delimiter

--- a/queries/disassembly/injections.scm
+++ b/queries/disassembly/injections.scm
@@ -1,0 +1,6 @@
+; TODO: https://github.com/nvim-treesitter/nvim-treesitter/pull/5548#issuecomment-1773707396
+;
+; To be added once a compatible Assembly parser is merged into nvim-treesitter
+;
+; ((instruction) @injection.content
+;  (#set! injection.language "asm"))


### PR DESCRIPTION
A couple months ago I made added tree-sitter-objdump (https://github.com/nvim-treesitter/nvim-treesitter/pull/5548). One oversight of that repository is that you cannot parse just disassembly on its own, nor memory dumps. So I pulled that portion out and made a separate parser for it.Thanks @amaanq for bringing that to my attention.

Since then, I've started adding a disassembly view to nvim-dap-ui which is working really well. You can see a demo of the parser in action, here. 

https://github.com/nvim-treesitter/nvim-treesitter/assets/10103049/52a66458-ae0c-4f68-81d0-f1fbed43252b

And adding this parser should pave the way for viewing raw memory with nvim-dap-ui, too. I also took a different approach for parsing disassembly in tree-sitter-disassembly than I had in tree-sitter-objdump so it should future proof it better.


### About Maintaining tree-sitter-objdump
Since most of the hard stuff about disassembly parsing is solved in tree-sitter-disassembly and both tree-sitter-objdump and tree-sitter-disassembly will benefit from an eventual Assembly parser, I wonder if it makes sense to convert tree-sitter-objdump into a "don't parse anything, use inject to disassembly and have it parse everything instead", rather than maintain two separate parsers. I maintain both repositories in this case but was hoping to get some advice on that point (e.g. is it worth it, is nested injections `objdump -> disassembly -> asm` advisable, etc)