### PR TITLE
highlights(haskell): add `fail` to exception highlights

### DIFF
--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -417,6 +417,7 @@
    "bracket_"
    "bracketOnErrorSource"
    "finally"
+   "fail"
    "onException"
    "expectationFailure"))
 


### PR DESCRIPTION
See [`Control.Monad.Fail`](https://hackage.haskell.org/package/base-4.19.0.0/docs/Control-Monad-Fail.html).