### PR TITLE
fix(luadoc): Assign `@field.lua`, not `@field`, in member_type

### DIFF
--- a/queries/luadoc/highlights.scm
+++ b/queries/luadoc/highlights.scm
@@ -85,7 +85,7 @@
 
 (table_literal_type field: (identifier) @field)
 
-(member_type ["#" "."] . (identifier) @field)
+(member_type ["#" "."] . (identifier) @field.lua)
 
 ; Types
 


### PR DESCRIPTION
TL;DR) This patch makes the `@field.luadoc` highlight group more usable,
in distinction with `@field.lua.luadoc`.

Problem: Previously, there is no way to distinguish "field name" and
"fields" in lua type nodes with a nested namespace (both captured as
`@field.luadoc`).

For example,

```lua
---@class MyClass
---@field opts? lsp.ClientConfig | { buffer: integer? } an option table.
---       ^^^^      ^^^^^^^^^^^^     ^^^^^^
---        (1)           (2)           (3)
```

- First, (1) (field_annotation) should be captured as `@field.luadoc`.
- But (2) should not. `lsp.ClientConfig` (member_type) is a type with
  some namespaces; this is captured `@type` but we are not
  interested in the most significant segment (e.g. `ClientConfig`).
- Also, (3) is (table_literal_type) another example that is correctly
  captured as `@field.luadoc`.

So if one highlights `@field.luadoc`, all of (1), (2), and (3) will be
highlighted. Instead, we want (1) and (3) only.

Solution: Capture the cases like (2) in (member_type) nodes as
`@field.lua.luadoc`. This will allow users to have two separate
highlight groups for (1) and (3) v.s. (2).
