### PR TITLE
feat(gitcommit): add highlight group for subject_prefix

### DIFF
--- a/queries/gitcommit/highlights.scm
+++ b/queries/gitcommit/highlights.scm
@@ -9,6 +9,7 @@
 
 (subject) @text.title @spell
 (subject (overflow) @text @spell)
+(subject (subject_prefix) @function @nospell)
 (prefix (type) @keyword @nospell)
 (prefix (scope) @parameter @nospell)
 (prefix [


### PR DESCRIPTION
After introducing a new token in gitcommit tree-sitter grammar, I think we should add a highlight group.

Ref: https://github.com/gbprod/tree-sitter-gitcommit/pull/48