### PR TITLE
feat(angular)!: switch to parser supporting v17

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "c21c3a0f996363ed17b8ac99d827fe5a4821f217"
   },
   "angular": {
-    "revision": "624ff108fe949727217cddb302f20e4f16997b1c"
+    "revision": "28119b4dc813d3f8267d451c44548e99124fbf9a"
   },
   "apex": {
     "revision": "ca70b2347a79615cd749517f6c6c2352e50a7ce9"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -95,10 +95,11 @@ list.agda = {
 
 list.angular = {
   install_info = {
-    url = "https://github.com/steelsojka/tree-sitter-angular",
-    files = { "src/parser.c" },
-    requires_generate_from_grammar = true,
+    url = "https://github.com/dlvandenberg/tree-sitter-angular",
+    files = { "src/parser.c", "src/scanner.c" },
+    generate_requires_npm = true,
   },
+  maintainers = { "@dlvandenberg" },
   experimental = true,
 }
 

--- a/queries/angular/folds.scm
+++ b/queries/angular/folds.scm
@@ -1,0 +1,1 @@
+; inherits: html

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -1,7 +1,7 @@
+; inherits: html_tags
 (identifier) @variable
 
-(pipe_sequence
-  "|" @operator)
+(pipe_operator) @operator
 
 (string) @string
 
@@ -13,7 +13,28 @@
 (pipe_call
   arguments:
     (pipe_arguments
-      (identifier) @variable.parameter))
+      (identifier) @parameter))
+
+(structural_directive
+  "*" @keyword
+  (identifier) @keyword)
+
+(attribute
+  (attribute_name) @variable.template
+  (#lua-match? @variable.template "#.*"))
+
+(binding_name
+  (identifier) @keyword)
+
+(event_binding
+  (binding_name
+    (identifier) @keyword.event))
+
+(event_binding
+  "\"" @punctuation.delimiter)
+
+(property_binding
+  "\"" @punctuation.delimiter)
 
 (structural_assignment
   operator: (identifier) @keyword)
@@ -29,10 +50,35 @@
     ((identifier) @function.builtin
       (#eq? @function.builtin "$any")))
 
+(pair
+  key:
+    ((identifier) @variable.builtin
+      (#eq? @variable.builtin "$implicit")))
+
+((control_keyword) @repeat
+  (#any-of? @repeat "for" "empty"))
+
+((control_keyword) @conditional
+  (#any-of? @conditional "if" "else" "switch" "case" "default"))
+
+((control_keyword) @keyword.coroutine
+  (#any-of? @keyword.coroutine "defer" "placeholder" "loading"))
+
+((control_keyword) @exception
+  (#eq? @exception "error"))
+
+(special_keyword) @keyword
+
+((identifier) @boolean
+  (#any-of? @boolean "true" "false"))
+
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin "this" "$event" "null"))
+
 [
-  "let"
-  "as"
-] @keyword
+  (ternary_operator)
+  (conditional_operator)
+] @conditional.ternary
 
 [
   "("
@@ -41,6 +87,16 @@
   "]"
   "{"
   "}"
+  "{{"
+  "}}"
+  "@"
+  "} @"
+  (if_end_expression)
+  (for_end_expression)
+  (switch_end_expression)
+  (case_end_expression)
+  (default_end_expression)
+  (defer_end_expression)
 ] @punctuation.bracket
 
 [
@@ -50,27 +106,25 @@
   "?."
 ] @punctuation.delimiter
 
-((identifier) @boolean
-  (#any-of? @boolean "true" "false"))
+(concatination_expression
+  "+" @operator)
 
-((identifier) @variable.builtin
-  (#any-of? @variable.builtin "this" "\$event" "null"))
-
-[
-  "-"
-  "&&"
-  "+"
-  "<"
-  "<="
-  "="
-  "=="
-  "==="
-  "!="
-  "!=="
-  ">"
-  ">="
-  "*"
-  "/"
-  "||"
-  "%"
-] @operator
+(binary_expression
+  [
+    "-"
+    "&&"
+    "+"
+    "<"
+    "<="
+    "="
+    "=="
+    "==="
+    "!="
+    "!=="
+    ">"
+    ">="
+    "*"
+    "/"
+    "||"
+    "%"
+  ] @operator)

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -73,7 +73,10 @@
   (#any-of? @boolean "true" "false"))
 
 ((identifier) @variable.builtin
-  (#any-of? @variable.builtin "this" "$event" "null"))
+  (#any-of? @variable.builtin "this" "$event"))
+
+((identifier) @constant.builtin
+  (#eq? @constant.builtin "null"))
 
 [
   (ternary_operator)

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -13,22 +13,22 @@
 (pipe_call
   arguments:
     (pipe_arguments
-      (identifier) @parameter))
+      (identifier) @variable.parameter))
 
 (structural_directive
   "*" @keyword
   (identifier) @keyword)
 
 (attribute
-  (attribute_name) @variable.template
-  (#lua-match? @variable.template "#.*"))
+  (attribute_name) @variable.member
+  (#lua-match? @variable.member "#.*"))
 
 (binding_name
   (identifier) @keyword)
 
 (event_binding
   (binding_name
-    (identifier) @keyword.event))
+    (identifier) @keyword))
 
 (event_binding
   "\"" @punctuation.delimiter)
@@ -55,17 +55,17 @@
     ((identifier) @variable.builtin
       (#eq? @variable.builtin "$implicit")))
 
-((control_keyword) @repeat
-  (#any-of? @repeat "for" "empty"))
+((control_keyword) @keyword.repeat
+  (#any-of? @keyword.repeat "for" "empty"))
 
-((control_keyword) @conditional
-  (#any-of? @conditional "if" "else" "switch" "case" "default"))
+((control_keyword) @keyword.conditional
+  (#any-of? @keyword.conditional "if" "else" "switch" "case" "default"))
 
 ((control_keyword) @keyword.coroutine
   (#any-of? @keyword.coroutine "defer" "placeholder" "loading"))
 
-((control_keyword) @exception
-  (#eq? @exception "error"))
+((control_keyword) @keyword.exception
+  (#eq? @keyword.exception "error"))
 
 (special_keyword) @keyword
 
@@ -78,7 +78,7 @@
 [
   (ternary_operator)
   (conditional_operator)
-] @conditional.ternary
+] @keyword.conditional.ternary
 
 [
   "("
@@ -87,8 +87,6 @@
   "]"
   "{"
   "}"
-  "{{"
-  "}}"
   "@"
   "} @"
   (if_end_expression)
@@ -98,6 +96,11 @@
   (default_end_expression)
   (defer_end_expression)
 ] @punctuation.bracket
+
+[
+  "{{"
+  "}}"
+] @punctuation.special
 
 [
   ";"

--- a/queries/angular/indents.scm
+++ b/queries/angular/indents.scm
@@ -1,0 +1,1 @@
+; inherits: html_tags

--- a/queries/angular/injections.scm
+++ b/queries/angular/injections.scm
@@ -1,0 +1,1 @@
+; inherits: html_tags

--- a/queries/angular/locals.scm
+++ b/queries/angular/locals.scm
@@ -1,0 +1,1 @@
+; inherits: html

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -137,3 +137,65 @@
     (string
       (string_fragment) @injection.content)
   (#set! injection.language "html"))
+
+;---- Angular injections -----
+; @Component({
+;   template: `<html>`
+; })
+(decorator
+  (call_expression
+    function:
+      ((identifier) @_name
+        (#eq? @_name "Component"))
+    arguments:
+      (arguments
+        (object
+          (pair
+            key:
+              ((property_identifier) @_prop
+                (#eq? @_prop "template"))
+            value:
+              ((template_string) @injection.content
+                (#offset! @injection.content 0 1 0 -1)
+                (#set! injection.language "angular")))))))
+
+; @Component({
+;   styles: [`<css>`]
+; })
+(decorator
+  (call_expression
+    function:
+      ((identifier) @_name
+        (#eq? @_name "Component"))
+    arguments:
+      (arguments
+        (object
+          (pair
+            key:
+              ((property_identifier) @_prop
+                (#eq? @_prop "styles"))
+            value:
+              (array
+                ((template_string) @injection.content
+                  (#offset! @injection.content 0 1 0 -1)
+                  (#set! injection.language "css"))))))))
+
+; @Component({
+;   styles: `<css>`
+; })
+(decorator
+  (call_expression
+    function:
+      ((identifier) @_name
+        (#eq? @_name "Component"))
+    arguments:
+      (arguments
+        (object
+          (pair
+            key:
+              ((property_identifier) @_prop
+                (#eq? @_prop "styles"))
+            value:
+              ((template_string) @injection.content
+                (#offset! @injection.content 0 1 0 -1)
+                (#set! injection.language "css")))))))

--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -89,23 +89,3 @@
   (quoted_attribute_value
     (attribute_value) @injection.content)
   (#set! injection.language "javascript"))
-
-(attribute
-  ((attribute_name) @_name
-    (#lua-match? @_name "[%[%(].*[%)%]]"))
-  (quoted_attribute_value
-    (attribute_value) @injection.content)
-  (#set! injection.language "angular"))
-
-(attribute
-  ((attribute_name) @_name
-    (#lua-match? @_name "^%*"))
-  (quoted_attribute_value
-    (attribute_value) @injection.content)
-  (#set! injection.language "angular"))
-
-(element
-  ((text) @injection.content
-    (#lua-match? @injection.content "%{%{.*%}%}")
-    (#offset! @injection.content 0 2 0 -2))
-  (#set! injection.language "angular"))


### PR DESCRIPTION
This PR adds a new Angular parser, which is built from scratch, extending the HTML parser so it works better with the new Angular syntax. No injections in HTML are required (only in ecma for inline templates/styles).

This PR replaces #5734

EDIT: FYI I have added in the README of [tree-sitter-angular](https://github.com/dlvandenberg/tree-sitter-angular) that filetype must be set (manually or via autocmd) in order for this parser to work. 