### PR TITLE
feat(nix): Slightly improve injections

### DIFF
--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -1,6 +1,7 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
 
+; /**/-style comments
 ((comment) @injection.language
   . ; this is to make sure only adjacent comments are accounted for the injections
   [
@@ -8,6 +9,16 @@
     (indented_string_expression (string_fragment) @injection.content)
   ]
   (#gsub! @injection.language "/%*%s*([%w%p]+)%s*%*/" "%1")
+  (#set! injection.combined))
+
+; #-style Comments
+((comment) @injection.language
+  . ; this is to make sure only adjacent comments are accounted for the injections
+  [
+    (string_expression (string_fragment) @injection.content)
+    (indented_string_expression (string_fragment) @injection.content)
+  ]
+  (#gsub! @injection.language "#%s*([%w%p]+)%s*" "%1")
   (#set! injection.combined))
 
 (apply_expression
@@ -29,7 +40,8 @@
     (indented_string_expression 
       ((string_fragment) @injection.content (#set! injection.language "bash")))
   ]
-  (#match? @_path "(^\\w+(Phase|Hook)|(pre|post)[A-Z]\\w+|script)$"))
+  (#match? @_path "(^\\w+(Phase|Hook)|(pre|post)[A-Z]\\w+|script)$")
+  (#set! injection.combined))
 
 (apply_expression
   function: (_) @_func


### PR DESCRIPTION
This adds support for # comments, so one could do something like
```nix
{
  test = # bash
    ''
      rmdir $out
    '';

  test2 =
    # bash
    ''
      rmdir $out
    '';
}
```

This is both a useful feature in general but would also help with formatters that convert the `/**/` comments.

The second change adds injection.combined to scripts to make sure that interpolations in shell scripts don't break quoting.