### PR TITLE
fix(python): highlight variadic lambda parameters

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -137,6 +137,12 @@
 (parameters
   (dictionary_splat_pattern ; **kwargs
     (identifier) @parameter))
+(lambda_parameters
+  (list_splat_pattern
+    (identifier) @parameter))
+(lambda_parameters
+  (dictionary_splat_pattern
+    (identifier) @parameter))
 
 
 ;; Literals

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -129,7 +129,7 @@
 (typed_parameter
   (identifier) @parameter)
 (typed_default_parameter
-  (identifier) @parameter)
+  name: (identifier) @parameter)
 ; Variadic parameters *args, **kwargs
 (parameters
   (list_splat_pattern ; *args


### PR DESCRIPTION
The `args` / `**kwargs` in `lambda *args, **kwargs: ...`