### PR TITLE
Use main branch for HCL parser installation

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -779,6 +779,7 @@ list.hcl = {
   install_info = {
     url = "https://github.com/MichaHoffmann/tree-sitter-hcl",
     files = { "src/parser.c", "src/scanner.c" },
+    branch = "main",
   },
   maintainers = { "@MichaHoffmann" },
 }


### PR DESCRIPTION
https://github.com/MichaHoffmann/tree-sitter-hcl uses `main` instead of `master`.

Without this change, I get an error similar to #1741 when `:TSInstall hcl`:

```
nvim-treesitter[jsonc]: Failed to execute the following command:
{
  cmd = "mv",
  opts = {
    args = { "tree-sitter-hcl-tmp/tree-sitter-hcl-master", "tree-sitter-hcl" },
    cwd = "/home/user/.local/share/nvim",
    stdio = {
      [2] = <userdata 1>,
      [3] = <userdata 2>
    }
  }
}
mv: cannot stat 'tree-sitter-hcl-tmp/tree-sitter-hcl-master': No such file or directory
```

I lost the error message, so I adapted from the linked issue.