### PR TITLE
queries/gomod: add the toolchain keyboard

### DIFF
--- a/queries/gomod/highlights.scm
+++ b/queries/gomod/highlights.scm
@@ -2,6 +2,7 @@
   "require"
   "replace"
   "go"
+  "toolchain"
   "exclude"
   "retract"
   "module"


### PR DESCRIPTION
Update the highlights file to handle the `toolchain` directive added in tree-sitter-gomod since [this commit](https://github.com/camdencheek/tree-sitter-go-mod/commit/af4270aed18500af1d24e6de5f6e7d243e2c8b05).