### PR TITLE
fix(rust): highlight inline attributes properly

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -172,6 +172,7 @@
 ; Attribute macros
 
 (attribute_item (attribute (identifier) @function.macro))
+(inner_attribute_item (attribute (identifier) @function.macro))
 
 (attribute (scoped_identifier (identifier) @function.macro .))
 


### PR DESCRIPTION
Matches inline attribute highlights (e.g. `#![crate_name = "rust"]`) to the regular attribute highlights. Preview (with semantic highlights disabled):
Before:
![beforerustinat](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/a8fa38d2-36ab-4b7f-b70b-c513f02c9ae7)
After:
![afterrustinat](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/8f0f0005-e26d-406c-a5ca-448a47cdf821)
