### PR TITLE
feat:  support injection with incremental selection

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -191,6 +191,8 @@ Supported options:
     (as defined in `locals.scm`). Defaults to `grc`.
   - node_decremental: in visual mode, decrement to the previous named node.
     Defaults to `grm`.
+- ignore_injections: a function that takes bufnr and returns boolean. Defaults
+  to `true`.
 
 >
   require'nvim-treesitter.configs'.setup {

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -37,6 +37,7 @@ local is_initialized = false
 ---@field enable boolean|string[]|function(string): boolean
 ---@field disable boolean|string[]|function(string): boolean
 ---@field keymaps table<string, string>
+---@field ignore_injections function(bufnr): boolean
 ---@field is_supported function(string): boolean
 ---@field attach function(string)
 ---@field detach function(string)
@@ -64,6 +65,9 @@ local builtin_modules = {
       scope_incremental = "grc",
       node_decremental = "grm",
     },
+    ignore_injections = function()
+      return true
+    end,
     is_supported = function()
       return true
     end,

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -160,7 +160,11 @@ function M.attach(bufnr)
         mode = "x"
         -- We need to move to command mode to access marks '< (visual area start) and '> (visual area end) which are not
         -- properly accessible in visual mode.
-        rhs = string.format(":lua require'nvim-treesitter.incremental_selection'.%s()<CR>", funcname)
+        rhs = string.format(
+          ":lua require'nvim-treesitter.incremental_selection'.%s(%s)<CR>",
+          funcname,
+          config.ignore_injections(bufnr)
+        )
       end
       vim.keymap.set(
         mode,


### PR DESCRIPTION
This PR adds the `ignore_injections` option to support injections with incremental selection.
By default, injections are ignored for the backword-compatibility.

``` lua
require'nvim-treesitter.configs'.setup {
  incremental_selection = {
    enable = true,
    keymaps = {
      init_selection = "gnn", -- set to `false` to disable one of the mappings
      node_incremental = "grn",
      scope_incremental = "grc",
      node_decremental = "grm",
      ignore_injections = function(bufnr)
        return false
      end
    },
  },
}
```