### PR TITLE
fix(cpp): incorrect indent of class with opening { on new line

### DIFF
--- a/queries/cpp/indents.scm
+++ b/queries/cpp/indents.scm
@@ -1,11 +1,9 @@
 ; inherits: c
 
 [
-  (class_specifier)
   (condition_clause)
 ] @indent.begin
 
 ((field_initializer_list) @indent.begin
   (#set! indent.start_at_same_line 1))
 (access_specifier) @indent.branch
-

--- a/tests/indent/cpp/class_newline.cpp
+++ b/tests/indent/cpp/class_newline.cpp
@@ -1,0 +1,9 @@
+class Foo
+{
+    int x;
+    class Bar
+    {
+        int y;
+    };
+    Bar z;
+};


### PR DESCRIPTION
Removed `@indent.begin` from `(class_specifier)`, otherwise it indents as:
```cpp
class Foo
    {
        int x;
        class Bar {
            int y;
        };
        Bar z;
    };
```
Added a test for this.

I also removed  `@indent.begin`  from `(condition_clause)` as I couldn't find why this is there. No tests fail due to removing it and I tried some variants of `if (x) ...` and indenting still seems to work correctly, so maybe this was some legacy code that is no longer needed due to changes in `c/indents.scm`?