### PR TITLE
fix(latex): add `@nospell` to labels

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -249,3 +249,6 @@
 (citation
   keys: _ @nospell)
 (command_name) @nospell
+(label_definition) @nospell
+(label_reference) @nospell
+(label_reference_range) @nospell


### PR DESCRIPTION
In TeX files, enabling the spell checker results in label definitions and references being flagged as spelling errors. These labels often contain things like abbreviations and should not be flagged as spelling errors. See the screenshot below. This pull request fixes this phenomenon by adding @nospell annotations to the highlights.scm file corresponding to LaTeX.

![Screenshot 2023-12-20 at 16 28 51](https://github.com/nvim-treesitter/nvim-treesitter/assets/20092027/f29e0f7c-b4c6-476c-a746-e74a4ca65e23)
