### PR TITLE
fix(julia): pipe function highlight

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -47,6 +47,12 @@
 (broadcast_call_expression
   (field_expression (identifier) @function.call .))
 
+(binary_expression
+  (_)
+  (operator) @pipe
+  (identifier) @function.call
+  (#lua-match? @pipe "|>"))
+
 ;; Builtins
 
 ((identifier) @function.builtin

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -49,9 +49,9 @@
 
 (binary_expression
   (_)
-  (operator) @pipe
+  (operator) @_pipe
   (identifier) @function.call
-  (#lua-match? @pipe "|>"))
+  (#eq? @_pipe "|>"))
 
 ;; Builtins
 


### PR DESCRIPTION
In Julia when piping into a function the function should be highlighted as a function call, and not a variable.
This change adds `@function.call` to any identifier that are piped into by matching the operator in a binary_expression against the string "|>". It also annotates the operator with `@pipe`, as a side-effect.