### PR TITLE
feat(luap): highlights more consistent with regex

### DIFF
--- a/queries/luap/highlights.scm
+++ b/queries/luap/highlights.scm
@@ -4,8 +4,10 @@
   "."
 ] @variable.builtin
 
-((character "." @constant) @_
- (#has-parent? @_ set negated_set))
+(set
+  (character "." @constant))
+(negated_set
+  (character "." @constant)) 
 
 [
   "[" "]"

--- a/queries/luap/highlights.scm
+++ b/queries/luap/highlights.scm
@@ -1,7 +1,7 @@
 [
   (anchor_begin)
   (anchor_end)
-] @variable.builtin
+] @punctuation.delimiter
 
 (pattern
   (character "." @variable.builtin))

--- a/queries/luap/highlights.scm
+++ b/queries/luap/highlights.scm
@@ -8,6 +8,8 @@
   (character "." @constant))
 (negated_set
   (character "." @constant)) 
+(range
+  (character "." @constant))
 
 [
   "[" "]"
@@ -28,12 +30,12 @@
 
 (set
   (character) @constant)
+(negated_set
+  (character) @constant)
 
 (class) @keyword
 
-(negated_set
-  "^" @operator
-  (character) @constant)
+(negated_set "^" @operator)
 
 (balanced_match
   (character) @parameter)

--- a/queries/luap/highlights.scm
+++ b/queries/luap/highlights.scm
@@ -1,9 +1,11 @@
-"." @character
-
 [
   (anchor_begin)
   (anchor_end)
-] @string.escape
+  "."
+] @variable.builtin
+
+(character "." @constant
+ (#has-ancestor? @constant set negated_set))
 
 [
   "[" "]"
@@ -19,7 +21,7 @@
 
 (range
   from: (character) @constant
-  "-" @punctuation.delimiter
+  "-" @operator
   to: (character) @constant)
 
 (set

--- a/queries/luap/highlights.scm
+++ b/queries/luap/highlights.scm
@@ -1,15 +1,10 @@
 [
   (anchor_begin)
   (anchor_end)
-  "."
 ] @variable.builtin
 
-(set
-  (character "." @constant))
-(negated_set
-  (character "." @constant)) 
-(range
-  (character "." @constant))
+(pattern
+  (character "." @variable.builtin))
 
 [
   "[" "]"

--- a/queries/luap/highlights.scm
+++ b/queries/luap/highlights.scm
@@ -4,8 +4,8 @@
   "."
 ] @variable.builtin
 
-(character "." @constant
- (#has-ancestor? @constant set negated_set))
+((character "." @constant) @_
+ (#has-parent? @_ set negated_set))
 
 [
   "[" "]"

--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -32,7 +32,8 @@
 [ "*" "+" "?" "|" "=" "!" "-"] @operator
 
 [
- (any_character)
  (start_assertion)
  (end_assertion)
-] @variable.builtin
+] @punctuation.delimiter
+
+(any_character) @variable.builtin


### PR DESCRIPTION
This PR adds some highlights similar to #5698 to be a bit more consistent. It also adds logic to make sure that any instances of `.` that are to be matched as a literal full stop will be highlighted as `@constant`, as other characters in a set should be.
Before:
![beforeluapreg](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/ec5d57a5-5af0-4f86-b224-9295f1a5dd32)
After:
![afterluapreg](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/242c96eb-e78c-4dcb-8f07-19de90759d56)
