### PR TITLE
feat: more `@string.regex` highlights

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -247,3 +247,23 @@
 (string) @string
 
 (escape_sequence) @string.escape
+
+; string.match("123", "%d+")
+(function_call
+  (dot_index_expression
+    field: (identifier) @_method
+    (#any-of? @_method "find" "match" "gmatch" "gsub"))
+  arguments: (arguments
+               . (_)
+               .
+               (string
+                 content: (string_content) @string.regex)))
+
+;("123"):match("%d+")
+(function_call
+  (method_index_expression
+    method: (identifier) @_method
+    (#any-of? @_method "find" "match" "gmatch" "gsub"))
+  arguments: (arguments
+               . (string
+                   content: (string_content) @string.regex)))

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -114,19 +114,7 @@
 (function_call
   (dot_index_expression
     field: (identifier) @_method
-    (#any-of? @_method "find" "match"))
-  arguments: (arguments
-               . (_)
-               .
-               (string
-                 content: (string_content) @injection.content
-                 (#set! injection.language "luap")
-                 (#set! injection.include-children))))
-
-(function_call
-  (dot_index_expression
-    field: (identifier) @_method
-    (#any-of? @_method "gmatch" "gsub"))
+    (#any-of? @_method "find" "match" "gmatch" "gsub"))
   arguments: (arguments
                . (_)
                .
@@ -140,22 +128,12 @@
 (function_call
   (method_index_expression
     method: (identifier) @_method
-    (#any-of? @_method "find" "match"))
+    (#any-of? @_method "find" "match" "gmatch" "gsub"))
   arguments: (arguments
                . (string
                    content: (string_content) @injection.content
                    (#set! injection.language "luap")
                    (#set! injection.include-children))))
-
-(function_call
-  (method_index_expression
-    method: (identifier) @_method
-    (#any-of? @_method "gmatch" "gsub"))
-  arguments: (arguments
-               . (string
-                 content: (string_content) @injection.content
-                 (#set! injection.language "luap")
-                 (#set! injection.include-children))))
 
 (comment
    content: (_) @injection.content

--- a/queries/luau/highlights.scm
+++ b/queries/luau/highlights.scm
@@ -246,3 +246,29 @@
 
 ((comment) @comment.documentation
   (#lua-match? @comment.documentation "^[-][-](%s?)@"))
+
+; string.match("123", "%d+")
+(function_call
+  (dot_index_expression
+    field: (identifier) @_method
+    (#any-of? @_method "find" "format" "match"))
+  arguments: (arguments (_) . (string content: _ @string.regex)))
+
+(function_call
+  (dot_index_expression
+    field: (identifier) @_method
+    (#any-of? @_method "gmatch" "gsub"))
+  arguments: (arguments (_) (string content: _ @string.regex)))
+
+; ("123"):match("%d+")
+(function_call
+  (method_index_expression
+    method: (identifier) @_method
+    (#any-of? @_method "find" "format" "match"))
+    arguments: (arguments . (string content: _ @string.regex)))
+
+(function_call
+  (method_index_expression
+    method: (identifier) @_method
+    (#any-of? @_method "gmatch" "gsub"))
+    arguments: (arguments (string content: _ @string.regex)))

--- a/queries/luau/injections.scm
+++ b/queries/luau/injections.scm
@@ -16,30 +16,16 @@
 (function_call
   (dot_index_expression
     field: (identifier) @_method
-    (#any-of? @_method "find" "format" "match"))
-  arguments: (arguments (_) . (string content: _ @injection.content))
-    (#set! injection.language "luap"))
-
-(function_call
-  (dot_index_expression
-    field: (identifier) @_method
-    (#any-of? @_method "gmatch" "gsub"))
-  arguments: (arguments (_) (string content: _ @injection.content))
+    (#any-of? @_method "find" "format" "match" "gmatch" "gsub"))
+  arguments: (arguments . (_) . (string content: _ @injection.content))
     (#set! injection.language "luap"))
 
 ; ("123"):match("%d+")
 (function_call
   (method_index_expression
     method: (identifier) @_method
-    (#any-of? @_method "find" "format" "match"))
+    (#any-of? @_method "find" "format" "match" "gmatch" "gsub"))
     arguments: (arguments . (string content: _ @injection.content))
-    (#set! injection.language "luap"))
-
-(function_call
-  (method_index_expression
-    method: (identifier) @_method
-    (#any-of? @_method "gmatch" "gsub"))
-    arguments: (arguments (string content: _ @injection.content))
     (#set! injection.language "luap"))
 
 ((comment) @injection.content

--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -32,3 +32,19 @@
 
 ((program . (comment)* . (comment) @preproc)
  (#lua-match? @preproc "^;+ *extends *$"))
+
+((predicate
+  name: (identifier) @_name
+  parameters: (parameters (string "\"" @string "\"" @string) @string.regex))
+ (#any-of? @_name
+   "match"
+   "not-match"
+   "vim-match"
+   "not-vim-match"
+   "lua-match"
+   "not-lua-match"))
+
+((predicate
+  name: (identifier) @_name
+  parameters: (parameters (string "\"" @string "\"" @string) @string.regex . (string) .))
+ (#any-of? @_name "gsub" "not-gsub"))


### PR DESCRIPTION
Applies `@string.regex` highlights to places where `luap` is injected. Also applies it where `regex` is injected in `query` files.

**NOTE:** For the query used in the `query` files, I didn't have any success using the `#offset!` directive for some reason (maybe due to https://github.com/neovim/neovim/issues/23664? I really have no clue), even though it seemed to be working in the `injections` file... hence the hacky workaround by highlighting the actual `"` nodes