### PR TITLE
fix(rust): Add back 1 indent for macro rules

### DIFF
--- a/runtime/queries/rust/indents.scm
+++ b/runtime/queries/rust/indents.scm
@@ -26,6 +26,16 @@
 (trait_item body: (_) @indent.begin)
 (string_literal (escape_sequence)) @indent.begin
 
+;; Typing in "(" inside macro definitions breaks the tree entirely
+;; Making macro_definition becoming errors
+;; Offset this by adding back one indent for start of macro rules
+(ERROR
+  .
+  "macro_rules!"
+  "(" @indent.begin
+  (#set! indent.immediate)
+  (#set! indent.start_at_same_line))
+
 (block "}" @indent.end)
 (enum_item
   body: (enum_variant_list "}" @indent.end))


### PR DESCRIPTION
@clason 

Not really a regression, but an oversight that was not caught