### PR TITLE
fix(julia): add missing capture of ":" in selected import

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -398,6 +398,8 @@
   "as" @include)
 (export_statement
   "export" @include)
+(selected_import
+  ":" @punctuation.delimiter)
 
 (struct_definition
   ["struct" "end"] @keyword)


### PR DESCRIPTION
If writing a selected import, e.g. `using BSON: @load`, the colon isn't currently captured. This change captures it as `@punctuation.delimiter`.