### PR TITLE
feat(bash): highlight commands called via keyword

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -144,6 +144,12 @@
              (concatenation (word) @parameter)
              ])
 
+(command
+  name: (command_name) @_name
+  .
+  argument: (word) @function.call
+  (#eq? @_name "command"))
+
 (number) @number
 ((word) @number
  (#lua-match? @number "^[0-9]+$"))


### PR DESCRIPTION
Highlights commands that are called with the `command` keyword as `@function.call`, as regular commands are highlighted.
Before:
![beforebashcommand](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/2773c418-ead3-4bc2-b23f-fc462dc231d6)
After:
![afterbashcommand](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/f7c72b48-37b9-4681-b6db-597f742afc3e)
