### PR TITLE
Modifies to work with gcc 4.8 for el7

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -106,6 +106,7 @@ function M.select_compiler_args(repo, compiler)
     }
   else
     local args = {
+      "--std=c99",
       "-o",
       "parser.so",
       "-I./src",


### PR DESCRIPTION
This change enables parsers/scanners to work on the version of `gcc` that comes with el7 (RHEL7/Oracle Linux 7), which is 4.8.  I assume later versions of `gcc` set c99 as the default standard and that's why it's not required.

The parser/scanners for most languages compile with `clang` 3.2.4.  I set it up with this added to my init function in Lazy's configuration for treesitter.

    require'nvim-treesitter.install'.compilers = { "clang" }

Unfortunately, the vim parser doesn't compile.  Instead of throwing an error, it never finishes compiling.  Strange; not going to investigate.  For me, the best option was to use `gcc` and add this argument.

Would adding this argument be detrimental to compilation on newer versions of `gcc`?  I don't know.  Please don't feel obligated to take this patch.  I'm just offering it and want to make it findable for anyone else having the same issue.