### PR TITLE
feat: folds for git config files

### DIFF
--- a/queries/git_config/folds.scm
+++ b/queries/git_config/folds.scm
@@ -1,1 +1,2 @@
-
+((section) @fold
+  (#trim! @fold))


### PR DESCRIPTION
Defines folds for sections of `.gitconfig` files, like the following:
```.gitconfig
# this is its own fold section
[core]
	editor = nvim
	pager = delta

# and here
[credential]
	helper = libsecret

# and here
[delta]
	navigate = true
	syntax-theme = Dracula
	side-by-side = false
	line-numbers = true
```