### PR TITLE
Highlight HTML character references (a.k.a. entities)

### DIFF
--- a/queries/html/highlights.scm
+++ b/queries/html/highlights.scm
@@ -3,3 +3,5 @@
 (doctype) @constant
 
 "<!" @tag.delimiter
+
+(entity) @character.special


### PR DESCRIPTION
HTML entities, e.g. `&nbsp;`, are detected by the HTML parser, but not currently highlighted. It's not totally clear to me what highlight group they should get – I can see an argument for `@string.escape`, `@escape`, `@character.special`, `@constant`, the list goes on – and I'm open to input on that, but they should get _something_.