### PR TITLE
fix(latex): highlight text functions

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -1,6 +1,7 @@
 ;; General syntax
 
 (command_name) @function
+(text_mode "\\text" @function)
 (caption
   command: _ @function)
 


### PR DESCRIPTION
Right now, basically every function of the form, e.g., `\funcname`, is highlighted as `@function`, except for `\text`, because it is not technically parsed as a `(command_name)`. This PR makes it so that `\text`, too, is highlighted as a `@function`.