### PR TITLE
fix(markdown_inline): latex highlight injection (#5397)

### DIFF
--- a/queries/markdown_inline/injections.scm
+++ b/queries/markdown_inline/injections.scm
@@ -3,4 +3,5 @@
  (#set! injection.combined))
 
 ((latex_block) @injection.content
- (#set! injection.language "latex"))
+ (#set! injection.language "latex")
+ (#set! injection.include-children))


### PR DESCRIPTION
Fix https://github.com/nvim-treesitter/nvim-treesitter/issues/5397 

The `injection.include-children` is needed in markdown_inline parser.

See https://github.com/MDeiml/tree-sitter-markdown/issues/117#issuecomment-1793717965 , it is neccessary to pass the `$` delimiter to latex parser to let the latex parser know the content is a math content.