### PR TITLE
fix(latex): only highlight inner env text as math

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -111,17 +111,7 @@
 ] @text.math
 
 (math_environment
-  (begin
-   command: _ @text.math
-   name: (curly_group_text (text) @text.math)))
-
-(math_environment
   (text) @text.math)
-
-(math_environment
-  (end
-   command: _ @text.math
-   name: (curly_group_text (text) @text.math)))
 
 ;; Sectioning
 (title_declaration


### PR DESCRIPTION
Removes `@text.math` highlights from the actual math environment boundaries, preventing highlight overwriting.

Before:
![beforemathenv](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/36eecc67-8c2f-42ac-be32-764fa283522e)

After:
![aftermathenv](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/ec94a1d7-8d31-4d9c-9d21-e5b112916dd7)
