### PR TITLE
fix(config)!: always install parsers bundled with nvim

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -20,7 +20,7 @@ local M = {}
 local config = {
   modules = {},
   sync_install = false,
-  ensure_installed = {},
+  ensure_installed = { "lua", "query", "vimdoc", "vim", "c", "python", "bash", "markdown", "markdown_inline" },
   auto_install = false,
   ignore_install = {},
   parser_install_dir = nil,
@@ -421,6 +421,7 @@ function M.setup(user_data)
   end
 
   local ensure_installed = user_data.ensure_installed or {}
+  vim.list_extend(ensure_installed, config.ensure_installed)
   if #ensure_installed > 0 then
     if user_data.sync_install then
       require("nvim-treesitter.install").ensure_installed_sync(ensure_installed)


### PR DESCRIPTION
Problem: Nvim-treesitter ships with queries that may be incompatible with parsers bundled by Neovim and used by default (in particular `vimdoc`, whence the recent flood of issues).

Solution: Force installation of bundled parsers that may be used by Neovim.

This is a bandaid fix to tide us over until 1.0, which addresses this issue more cleanly.
