### PR TITLE
Fix(julia): support broadcasting in piped function call

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -51,7 +51,7 @@
   (_)
   (operator) @_pipe
   (identifier) @function.call
-  (#eq? @_pipe "|>"))
+  (#lua-match? @_pipe "\.?|>"))
 
 ;; Builtins
 


### PR DESCRIPTION
When piping into a function call there was no capture when broadcasting, i.e. `println` is captured as `@function.call` in `x |> println` but not in `x .|> println`. This commit makes it captured in both cases.