### PR TITLE
fix(c_sharp): link type in pattern matching correctly

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -13,6 +13,9 @@
 (method_declaration
   type: (identifier) @type)
 
+(declaration_pattern
+  type: (identifier) @type)
+
 (local_function_statement
   type: (identifier) @type)
 


### PR DESCRIPTION

![before](https://github.com/nvim-treesitter/nvim-treesitter/assets/72729880/3e115f7d-519b-4398-bd27-aecce29c77db)

![after](https://github.com/nvim-treesitter/nvim-treesitter/assets/72729880/c43517ba-ba1e-4b10-942c-c3d6eaabe251)
