### PR TITLE
fix(markdown): fix a regression on `fenced_code_block` highlight

### DIFF
--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -50,14 +50,16 @@
 ; Code blocks (conceal backticks and language annotation)
 (indented_code_block) @markup.raw.block
 
+((fenced_code_block) @markup.raw.block
+  (#set! "priority" 90))
+
 (fenced_code_block
-  (fenced_code_block_delimiter) @markup.raw.block
-  (#set! "priority" 90)
+  (fenced_code_block_delimiter) @conceal
   (#set! conceal ""))
 
 (fenced_code_block
   (info_string
-    (language) @markup.raw.block
+    (language) @conceal
     (#set! conceal "")))
 
 (link_destination) @markup.link.url


### PR DESCRIPTION
Problem: fenced_code_block is not correcty highlighted; the content in
the code block is not highlighted, but only the fence backticks are
highlighted with `@markup.raw.block`. This is a regression
happened while updating to the upstream capture names.

Example: on a markdown file:

```txt
the content should be captured with `@markup.raw.block.markdown`
```

(previously it was `@text.literal.block`)

Solution: Fix the highlight query for `fenced_code_block`.