### PR TITLE
Add :TSEnsure command

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -347,6 +347,17 @@ Perform the |:TSInstall| operation synchronously.
 
 List information about currently installed parsers
 
+								   *:TSEnsure*
+:TSEnsure {language} ...~
+
+Install {language} like with |:TSInstall|, but without need for confirmation.
+If the parser is already installed it will be skipped.
+
+							       *:TSEnsureSync*
+:TSEnsureSync {language} ...~
+
+Perform the |:TSEnsure| operation synchronously.
+
 								   *:TSUpdate*
 :TSUpdate {language} ...~
 

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -747,6 +747,22 @@ M.commands = {
       "-complete=custom,nvim_treesitter#installable_parsers",
     },
   },
+  TSEnsure = {
+    run = install { ask_reinstall = false },
+    args = {
+      "-nargs=+",
+      "-bang",
+      "-complete=custom,nvim_treesitter#installable_parsers",
+    },
+  },
+  TSEnsureSync = {
+    run = install { with_sync = true, ask_reinstall = false },
+    args = {
+      "-nargs=+",
+      "-bang",
+      "-complete=custom,nvim_treesitter#installable_parsers",
+    },
+  },
   TSUpdate = {
     run = M.update {},
     args = {


### PR DESCRIPTION
I have a testing setup where an embedded headless Neovim (`nvim --embed --headless`) runs inside an isolated environment (by setting the XDG environment variables). Aside from the plugin under test there is also nvim-treesitter in this environment because I need it to download parsers. But I want to download each parser at most once, synchronously, without need for confirmation.

None of the existing commands meet all of these criteria, so I have added the commands `:TSEnsure` (asynchronous) and `:TSEnsureSync` (synchronous). I use the synchronous command in my tests.