### PR TITLE
fix: allow merge config with 'all'

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -421,6 +421,9 @@ function M.setup(user_data)
   end
 
   local ensure_installed = user_data.ensure_installed or {}
+  if type(config.ensure_installed) ~= "table" then
+    ensure_installed = config.ensure_installed
+  end
   if type(ensure_installed) == "table" then
     vim.list_extend(ensure_installed, config.ensure_installed)
   end


### PR DESCRIPTION
There's a special case, if users set `ensure_installed` to `"all"` in their config, and every other call of `setup` will try to merge a table with a string.