### PR TITLE
feat(html): inject comment

### DIFF
--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -1,3 +1,5 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
 ; <style>...</style>
 ; <style blocking> ...</style>
 ; Add "lang" to predicate check so that vue/svelte can inherit this


### PR DESCRIPTION
Allows TODO comments and comment URIs, etc. to be recognized by comments in html, markdown, etc.