### PR TITLE
fix(markdown): remove @none from code fences

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -98,8 +98,6 @@
 ;   @punctuation.special
 ;   (#eq? @punctuation.special "-")
 ;   (#set! conceal "—"))
-(code_fence_content) @none
-
 (thematic_break) @punctuation.special
 
 (task_list_marker_unchecked) @markup.list.unchecked


### PR DESCRIPTION
With #5895, `@none` is the new `@text`. This is great but if none is to be highlighted as text was, probably as a generic foreground color, then it will remove highlighting from code fence blocks which have a none capture for some reason. This PR removes it.