### PR TITLE
Backport rust changes from `main`

### DIFF
--- a/queries/rust/folds.scm
+++ b/queries/rust/folds.scm
@@ -8,6 +8,7 @@
   (impl_item)
   (type_item)
   (union_item)
+  (const_item)
   (use_declaration)
   (let_declaration)
   (loop_expression)

--- a/queries/rust/indents.scm
+++ b/queries/rust/indents.scm
@@ -24,6 +24,16 @@
   (macro_definition)
 ] @indent.begin
 
+; Typing in "(" inside macro definitions breaks the tree entirely
+; Making macro_definition becoming errors
+; Offset this by adding back one indent for start of macro rules
+(ERROR
+  .
+  "macro_rules!"
+  "(" @indent.begin
+  (#set! indent.immediate)
+  (#set! indent.start_at_same_line))
+
 (trait_item
   body: (_) @indent.begin)
 


### PR DESCRIPTION
The rust indents commit from `main` duplicated the `indent.end` queries as well. This also remove that