### PR TITLE
fix(markdown_inline): prioritize link URI

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -7,20 +7,8 @@
 
 (strikethrough) @markup.strikethrough
 
-[
-  (link_destination)
-  (uri_autolink)
-] @markup.link.url @nospell
-
 (shortcut_link
   (link_text) @nospell)
-
-[
-  (link_label)
-  (link_text)
-  (link_title)
-  (image_description)
-] @markup.link.label
 
 [
   (backslash_escape)
@@ -81,6 +69,18 @@
     "]"
   ] @markup.link
   (#set! conceal ""))
+
+[
+  (link_destination)
+  (uri_autolink)
+] @markup.link.url @nospell
+
+[
+  (link_label)
+  (link_text)
+  (link_title)
+  (image_description)
+] @markup.link.label
 
 ; Replace common HTML entities.
 ((entity_reference) @character.special


### PR DESCRIPTION
Right now the conceal code is overriding the `@markup.link.url` highlight for link URIs with `@markup.link`. This PR applies the more specific, non-conceal queries _after_ the conceal ones so they are given higher precedence.

**NOTE:** This is not necessary right now for the link label query, but I moved them both so they are near each other still.
