### PR TITLE
fix(comments)!: consolidate note captures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,11 +193,10 @@ As languages differ quite a lot, here is a set of captures available to you when
 @comment               ; line and block comments
 @comment.documentation ; comments documenting code
 
-@comment.error         ; error-type comments (e.g., `DEPRECATED:`)
-@comment.warning       ; warning-type comments (e.g., `WARNING:`, `FIX:`)
-@comment.hint          ; note-type comments (e.g., `NOTE:`)
-@comment.info          ; info-type comments
-@comment.todo          ; todo-type comments (e.g-, `TODO:`, `WIP:`)
+@comment.error         ; error-type comments (e.g. `ERROR`, `FIXME`, `DEPRECATED:`)
+@comment.warning       ; warning-type comments (e.g. `WARNING:`, `FIX:`, `HACK:`)
+@comment.todo          ; todo-type comments (e.g. `TODO:`, `WIP:`, `FIXME:`)
+@comment.note          ; note-type comments (e.g. `NOTE:`, `INFO:`, `XXX`)
 ```
 
 #### Markup

--- a/queries/comment/highlights.scm
+++ b/queries/comment/highlights.scm
@@ -4,10 +4,10 @@
     (user) @constant
     ")" @punctuation.bracket)?
   ":" @punctuation.delimiter)
-  (#any-of? @comment.todo "TODO" "WIP"))
+  (#any-of? @comment.todo "TODO" "WIP" "FIXME"))
 
 ("text" @comment.todo @nospell
-  (#any-of? @comment.todo "TODO" "WIP"))
+  (#any-of? @comment.todo "TODO" "WIP" "FIXME"))
 
 ((tag
   (name) @comment.note @nospell

--- a/queries/gitcommit/highlights.scm
+++ b/queries/gitcommit/highlights.scm
@@ -44,7 +44,7 @@
 
 ; (trailer (value) @none)
 (breaking_change
-  (token) @comment.warning)
+  (token) @comment.error)
 
 (breaking_change
   (value) @none @spell)

--- a/queries/vimdoc/highlights.scm
+++ b/queries/vimdoc/highlights.scm
@@ -48,8 +48,8 @@
 
 (url) @string.special.url
 
-((note) @comment.hint
-  (#any-of? @comment.hint "Note:" "NOTE:" "Notes:"))
+((note) @comment.note
+  (#any-of? @comment.note "Note:" "NOTE:" "Notes:"))
 
 ((note) @comment.warning
   (#any-of? @comment.warning "Warning:" "WARNING:"))


### PR DESCRIPTION
Distinguishing `hint` and `info` is too confusing; it's enough to have `error`, `warning`, `todo`, and `note`.

Alternative to #5929 

(@ribru17 thanks for pointing this out!)