### PR TITLE
feat(latex): more comprehensive highlights

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -156,6 +156,12 @@
     (curly_group_text
       (_) @markup.link))
 
+; Formatting
+(text_mode
+  content:
+    (curly_group
+      (_) @none @spell))
+
 ; Math
 [
   (displayed_equation)
@@ -167,17 +173,17 @@
     command: _ @markup.math
     name:
       (curly_group_text
-        (text) @markup.math)))
+        (_) @markup.math)))
 
 (math_environment
-  (text) @markup.math)
+  (_) @markup.math)
 
 (math_environment
   (end
     command: _ @markup.math
     name:
       (curly_group_text
-        (text) @markup.math)))
+        (_) @markup.math)))
 
 ; Sectioning
 (title_declaration
@@ -275,12 +281,6 @@
     (curly_group
       (text) @markup.heading))
   (#eq? @_name "\\frametitle"))
-
-; Formatting
-(text_mode
-  content:
-    (curly_group
-      (_) @none @spell))
 
 ((generic_command
   command: (command_name) @_name

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -28,6 +28,8 @@
 [
   (operator)
   "="
+  "_"
+  "^"
 ] @operator
 
 "\\item" @punctuation.special


### PR DESCRIPTION
Better precedence for highlighting environments (supporting different nesting levels), and operator highlights for super- and subscripts. Some examples below.

Before:
![beforelatex](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/5622acfc-6150-434a-abb6-ff1726c576b0)

After:
![afterlatex](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/21ebb816-b91b-4ade-8cbd-571edf328352)

A lot of the changes are simply from query reordering which applies highlights with different precedence. Other than that, this PR makes it so all nodes (not just `text`) in a math environment are highlighted as such, and the aforementioned operator highlights.