### PR TITLE
fix(wgsl_bevy): Correct formatter mistake

### DIFF
--- a/queries/wgsl_bevy/highlights.scm
+++ b/queries/wgsl_bevy/highlights.scm
@@ -14,7 +14,7 @@
 
 (function_declaration
   (import_path
-    (identifier) @function.))
+    (identifier) @function .))
 
 (import_path
   (identifier) @module


### PR DESCRIPTION
Old version of `format-queries` incorrectly took away a space, creating a wrong capture.

This is a fixup for that.