### PR TITLE
fix(kotlin): temporary fix for treesitter bug that causes delay in file opening

### DIFF
--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -27,9 +27,11 @@
 (class_parameter
   (simple_identifier) @variable.member)
 
-((simple_identifier) @property
-  (#has-parent? @property variable_declaration))
-
+; NOTE: temporary fix for treesitter bug that causes delay in file opening
+;(class_body
+;  (property_declaration
+;    (variable_declaration
+;      (simple_identifier) @variable.member)))
 ; id_1.id_2.id_3: `id_2` and `id_3` are assumed as object properties
 (_
   (navigation_suffix

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -27,10 +27,8 @@
 (class_parameter
   (simple_identifier) @variable.member)
 
-(class_body
-  (property_declaration
-    (variable_declaration
-      (simple_identifier) @variable.member)))
+((simple_identifier) @property
+  (#has-parent? @property variable_declaration))
 
 ; id_1.id_2.id_3: `id_2` and `id_3` are assumed as object properties
 (_

--- a/queries/kotlin/locals.scm
+++ b/queries/kotlin/locals.scm
@@ -32,11 +32,11 @@
     (variable_declaration
       (simple_identifier) @local.definition.parameter)))
 
-(class_body
-  (property_declaration
-    (variable_declaration
-      (simple_identifier) @local.definition.field)))
-
+; NOTE: temporary fix for treesitter bug that causes delay in file opening
+;(class_body
+;  (property_declaration
+;    (variable_declaration
+;      (simple_identifier) @local.definition.field)))
 (class_declaration
   (primary_constructor
     (class_parameter


### PR DESCRIPTION
Fixes #5810 

The following query inside `query/kotlin/highlights.scm` leads to noticeable delay in the opening of kotlin files.
```
(class_body
	(property_declaration
		(variable_declaration
			(simple_identifier) @property)))
```