### PR TITLE
fix(locals): index matches with split capture names

### DIFF
--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -41,8 +41,8 @@ function M.get_definitions(bufnr)
   local defs = {}
 
   for _, loc in ipairs(locals) do
-    if loc["local.definition"] then
-      table.insert(defs, loc["local.definition"])
+    if loc["local"]["definition"] then
+      table.insert(defs, loc["local"]["definition"])
     end
   end
 
@@ -55,8 +55,8 @@ function M.get_scopes(bufnr)
   local scopes = {}
 
   for _, loc in ipairs(locals) do
-    if loc["local.scope"] and loc["local.scope"].node then
-      table.insert(scopes, loc["local.scope"].node)
+    if loc["local"]["scope"] and loc["local"]["scope"].node then
+      table.insert(scopes, loc["local"]["scope"].node)
     end
   end
 
@@ -69,8 +69,8 @@ function M.get_references(bufnr)
   local refs = {}
 
   for _, loc in ipairs(locals) do
-    if loc["local.reference"] and loc["local.reference"].node then
-      table.insert(refs, loc["local.reference"].node)
+    if loc["local"]["reference"] and loc["local"]["reference"].node then
+      table.insert(refs, loc["local"]["reference"].node)
     end
   end
 


### PR DESCRIPTION
Bad indexing is leading to no results using the `get_definitions`, `get_scopes` and `get_references` API.

related commit: https://github.com/nvim-treesitter/nvim-treesitter/pull/5895/commits/d1b59d4e28406bcc77c04d4dbaced4447227fc1e

related downstream issue: https://github.com/nvim-telescope/telescope.nvim/issues/2883