### PR TITLE
feat(groovy)!: switch to more complete parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [gowork](https://github.com/omertuc/tree-sitter-go-work) (maintained by @omertuc)
 - [x] [gpg](https://github.com/ObserverOfTime/tree-sitter-gpg-config) (maintained by @ObserverOfTime)
 - [x] [graphql](https://github.com/bkegley/tree-sitter-graphql) (maintained by @bkegley)
-- [x] [groovy](https://github.com/Decodetalkers/tree-sitter-groovy) (maintained by @Decodetalkers)
+- [x] [groovy](https://github.com/murtaza64/tree-sitter-groovy) (maintained by @murtaza64)
 - [x] [gstlaunch](https://github.com/theHamsta/tree-sitter-gstlaunch) (maintained by @theHamsta)
 - [ ] [hack](https://github.com/slackhq/tree-sitter-hack)
 - [x] [hare](https://github.com/amaanq/tree-sitter-hare) (maintained by @amaanq)

--- a/lockfile.json
+++ b/lockfile.json
@@ -231,7 +231,7 @@
     "revision": "5e66e961eee421786bdda8495ed1db045e06b5fe"
   },
   "groovy": {
-    "revision": "7e023227f46fee428b16a0288eeb0f65ee2523ec"
+    "revision": "e20f616e6223b66defabc82c29f52431ee66e269"
   },
   "gstlaunch": {
     "revision": "2c0d9c94d35e37aa63fa5002163c8480985b3e5b"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -720,11 +720,10 @@ list.gpg = {
 
 list.groovy = {
   install_info = {
-    url = "https://github.com/Decodetalkers/tree-sitter-groovy",
+    url = "https://github.com/murtaza64/tree-sitter-groovy",
     files = { "src/parser.c" },
-    branch = "gh-pages",
   },
-  maintainers = { "@Decodetalkers" },
+  maintainers = { "@murtaza64" },
 }
 
 list.graphql = {

--- a/queries/groovy/folds.scm
+++ b/queries/groovy/folds.scm
@@ -1,4 +1,6 @@
 [
-  (closure)
   (argument_list)
+  (closure)
+  (list)
+  (map)
 ] @fold

--- a/queries/groovy/folds.scm
+++ b/queries/groovy/folds.scm
@@ -1,0 +1,4 @@
+[
+ (closure)
+ (argument_list)
+] @fold

--- a/queries/groovy/folds.scm
+++ b/queries/groovy/folds.scm
@@ -1,4 +1,4 @@
 [
- (closure)
- (argument_list)
+  (closure)
+  (argument_list)
 ] @fold

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -4,34 +4,45 @@
   "as"
   "assert"
   "case"
-  "catch"
   "class"
-  "def"
   "default"
-  "else"
   "extends"
-  "finally"
-  "for"
-  "if"
-  "import"
   "in"
   "instanceof"
   "package"
-  "pipeline"
-  "return"
   "switch"
+] @keyword
+
+[
+  "else"
+  "if"
+] @keyword.conditional
+
+[
+  "catch"
+  "finally"
   "try"
+] @keyword.exception
+
+"def" @keyword.function
+
+"import" @keyword.import
+
+[
+  "for"
   "while"
   (break)
   (continue)
-] @keyword
+] @keyword.repeat
+
+"return" @keyword.return
 
 [
   "true"
   "false"
 ] @boolean
 
-(null) @constant
+(null) @constant.builtin
 
 "this" @variable.builtin
 
@@ -55,9 +66,9 @@
   "synchronized"
 ] @type.qualifier
 
-(comment) @comment
+(comment) @comment @spell
 
-(shebang) @comment
+(shebang) @keyword.directive
 
 (string) @string
 
@@ -68,23 +79,20 @@
   (interpolation
     "$" @operator))
 
-"(" @punctuation.bracket
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
 
-")" @punctuation.bracket
-
-"[" @punctuation.bracket
-
-"]" @punctuation.bracket
-
-"{" @punctuation.bracket
-
-"}" @punctuation.bracket
-
-":" @punctuation.delimiter
-
-"," @punctuation.delimiter
-
-"." @punctuation.delimiter
+[
+  ":"
+  ","
+  "."
+] @punctuation.delimiter
 
 (number_literal) @number
 
@@ -150,9 +158,7 @@
     key: (identifier) @variable.parameter))
 
 (parameter
-  type: (identifier) @type)
-
-(parameter
+  type: (identifier) @type
   name: (identifier) @variable.parameter)
 
 (generic_param
@@ -241,21 +247,19 @@
 
 "@interface" @function.macro
 
-"pipeline" @keyword
-
-(groovy_doc) @comment.documentation
+(groovy_doc) @comment.documentation @spell
 
 (groovy_doc
   [
     (groovy_doc_param)
     (groovy_doc_throws)
     (groovy_doc_tag)
-  ] @string.special)
+  ] @string.special @nospell)
 
 (groovy_doc
   (groovy_doc_param
-    (identifier) @variable.parameter))
+    (identifier) @variable.parameter) @nospell)
 
 (groovy_doc
   (groovy_doc_throws
-    (identifier) @type))
+    (identifier) @type @nospell))

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -73,8 +73,8 @@
 
 (number_literal) @number
 (identifier) @variable
-((identifier) @parameter
-  (#is? @parameter "parameter"))
+((identifier) @variable.parameter
+  (#is? @variable.parameter "local.parameter"))
 
 ((identifier) @constant
   (#match? @constant "^[A-Z][A-Z_]+"))
@@ -89,10 +89,10 @@
 
 (ternary_op ([ "?" ":" ]) @operator)
 
-(map (map_item key: (identifier) @parameter))
+(map (map_item key: (identifier) @variable.parameter))
 
-(parameter type: (identifier) @type name: (identifier) @parameter)
-(generic_param name: (identifier) @parameter)
+(parameter type: (identifier) @type name: (identifier) @variable.parameter)
+(generic_param name: (identifier) @variable.parameter)
 
 (declaration type: (identifier) @type)
 (function_definition type: (identifier) @type)
@@ -117,14 +117,14 @@
   function: (dotted_identifier
 	  (identifier) @function . ))
 (function_call (argument_list
-		 (map_item key: (identifier) @parameter)))
+		 (map_item key: (identifier) @variable.parameter)))
 (juxt_function_call 
   function: (identifier) @function)
 (juxt_function_call
   function: (dotted_identifier
 	  (identifier) @function . ))
 (juxt_function_call (argument_list 
-		      (map_item key: (identifier) @parameter)))
+		      (map_item key: (identifier) @variable.parameter)))
 
 (function_definition 
   function: (identifier) @function)
@@ -144,6 +144,5 @@
     (groovy_doc_throws)
     (groovy_doc_tag)
   ] @string.special)
-(groovy_doc (groovy_doc_param (identifier) @parameter))
+(groovy_doc (groovy_doc_param (identifier) @variable.parameter))
 (groovy_doc (groovy_doc_throws (identifier) @type))
-(groovy_doc (first_line) @text)

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -73,11 +73,11 @@
 (string) @string
 
 (string
-  (escape_sequence) @operator)
+  (escape_sequence) @string.escape)
 
 (string
   (interpolation
-    "$" @operator))
+    "$" @punctuation.special))
 
 [
   "("
@@ -151,7 +151,7 @@
   ([
     "?"
     ":"
-  ]) @operator)
+  ]) @keyword.conditional.ternary)
 
 (map
   (map_item

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -1,70 +1,149 @@
-(unit
-  (identifier) @variable)
+[
+  "!in"
+  "!instanceof"
+  "as"
+  "assert"
+  "case"
+  "catch"
+  "class"
+  "def"
+  "default"
+  "else"
+  "extends"
+  "finally"
+  "for"
+  "if"
+  "import"
+  "in"
+  "instanceof"
+  "package"
+  "pipeline"
+  "return"
+  "switch"
+  "try"
+  "while"
+  (break)
+  (continue)
+] @keyword
 
-(string
-  (identifier) @variable)
+[
+  "true"
+  "false"
+] @boolean
 
-(escape_sequence) @string.escape
+(null) @constant
+"this" @variable.builtin
 
-(block
-  (unit
-    (identifier) @module))
+[ 
+  "int"
+  "char"
+  "short"
+  "long"
+  "boolean"
+  "float"
+  "double"
+  "void"
+] @type.builtin
 
-(func
-  (identifier) @function)
+[ 
+  "final"
+  "private"
+  "protected"
+  "public"
+  "static"
+  "synchronized"
+] @type.qualifier
 
-(number) @number
-
-((identifier) @boolean
-  (#any-of? @boolean "true" "false" "True" "False"))
-
-((identifier) @constant
-  (#lua-match? @constant "^[A-Z][A-Z%d_]*$"))
-
-((identifier) @constant.builtin
-  (#eq? @constant.builtin "null"))
-
-((identifier) @type
-  (#any-of? @type "String" "Map" "Object" "Boolean" "Integer" "List"))
-
-((identifier) @function.builtin
-  (#any-of? @function.builtin "void" "id" "version" "apply" "implementation" "testImplementation" "androidTestImplementation" "debugImplementation"))
-
-((identifier) @keyword
-  (#any-of? @keyword "static" "class" "def" "import" "package" "assert" "extends" "implements" "instanceof" "interface" "new"))
-
-((identifier) @type.qualifier
-  (#any-of? @type.qualifier "abstract" "protected" "private" "public"))
-
-((identifier) @keyword.exception
-  (#any-of? @keyword.exception "throw" "finally" "try" "catch"))
+(comment) @comment
+(shebang) @comment
 
 (string) @string
+(string (escape_sequence) @operator)
+(string (interpolation ([ "$" ]) @operator))
 
-[
-  (line_comment)
-  (block_comment)
-] @comment @spell
+("(") @punctuation.bracket
+(")") @punctuation.bracket
+("[") @punctuation.bracket
+("]") @punctuation.bracket
+("{") @punctuation.bracket
+("}") @punctuation.bracket
+(":") @punctuation.delimiter
+(",") @punctuation.delimiter
+(".") @punctuation.delimiter
 
-((block_comment) @comment.documentation
-  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
+(number_literal) @number
+(identifier) @variable
+((identifier) @parameter
+  (#is? @parameter "parameter"))
 
-((line_comment) @comment.documentation
-  (#lua-match? @comment.documentation "^///[^/]"))
+((identifier) @constant
+  (#match? @constant "^[A-Z][A-Z_]+"))
 
-((line_comment) @comment.documentation
-  (#lua-match? @comment.documentation "^///$"))
-
-[
-  (operators)
-  (leading_key)
+[ 
+  "%" "*" "/" "+" "-" "<<" ">>" ">>>" ".." "..<" "<..<" "<.." "<"
+  "<=" ">" ">=" "==" "!=" "<=>" "===" "!==" "=~" "==~" "&" "^" "|"
+  "&&" "||" "?:" "+" "*" ".&" ".@" "?." "*." "*" "*:" "++" "--" "!"
 ] @operator
 
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
+(string ("/") @string)
+
+(ternary_op ([ "?" ":" ]) @operator)
+
+(map (map_item key: (identifier) @parameter))
+
+(parameter type: (identifier) @type name: (identifier) @parameter)
+(generic_param name: (identifier) @parameter)
+
+(declaration type: (identifier) @type)
+(function_definition type: (identifier) @type)
+(function_declaration type: (identifier) @type)
+(class_definition name: (identifier) @type)
+(class_definition superclass: (identifier) @type)
+(generic_param superclass: (identifier) @type)
+
+(type_with_generics (identifier) @type)
+(type_with_generics (generics (identifier) @type))
+(generics [ "<" ">" ] @punctuation.bracket)
+(generic_parameters [ "<" ">" ] @punctuation.bracket)
+; TODO: Class literals with PascalCase
+
+(declaration ("=") @operator)
+(assignment ("=") @operator)
+
+
+(function_call 
+  function: (identifier) @function)
+(function_call
+  function: (dotted_identifier
+	  (identifier) @function . ))
+(function_call (argument_list
+		 (map_item key: (identifier) @parameter)))
+(juxt_function_call 
+  function: (identifier) @function)
+(juxt_function_call
+  function: (dotted_identifier
+	  (identifier) @function . ))
+(juxt_function_call (argument_list 
+		      (map_item key: (identifier) @parameter)))
+
+(function_definition 
+  function: (identifier) @function)
+(function_declaration 
+  function: (identifier) @function)
+
+(annotation) @function.macro
+(annotation (identifier) @function.macro)
+"@interface" @function.macro
+
+"pipeline" @keyword
+
+(groovy_doc) @comment.documentation
+(groovy_doc 
+  [
+    (groovy_doc_param)
+    (groovy_doc_throws)
+    (groovy_doc_tag)
+  ] @string.special)
+(groovy_doc (groovy_doc_param (identifier) @parameter))
+(groovy_doc (groovy_doc_throws (identifier) @type))
+(groovy_doc (first_line) @text)

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -66,7 +66,7 @@
 
 (string
   (interpolation
-    ("$") @operator))
+    "$" @operator))
 
 "(" @punctuation.bracket
 

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -1,21 +1,24 @@
 [
-  "!in"
   "!instanceof"
-  "as"
   "assert"
-  "case"
   "class"
-  "default"
   "extends"
-  "in"
   "instanceof"
   "package"
-  "switch"
 ] @keyword
 
 [
+  "!in"
+  "as"
+  "in"
+] @keyword.operator
+
+[
+  "case"
+  "default"
   "else"
   "if"
+  "switch"
 ] @keyword.conditional
 
 [

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -32,9 +32,10 @@
 ] @boolean
 
 (null) @constant
+
 "this" @variable.builtin
 
-[ 
+[
   "int"
   "char"
   "short"
@@ -45,7 +46,7 @@
   "void"
 ] @type.builtin
 
-[ 
+[
   "final"
   "private"
   "protected"
@@ -55,94 +56,207 @@
 ] @type.qualifier
 
 (comment) @comment
+
 (shebang) @comment
 
 (string) @string
-(string (escape_sequence) @operator)
-(string (interpolation ([ "$" ]) @operator))
 
-("(") @punctuation.bracket
-(")") @punctuation.bracket
-("[") @punctuation.bracket
-("]") @punctuation.bracket
-("{") @punctuation.bracket
-("}") @punctuation.bracket
-(":") @punctuation.delimiter
-(",") @punctuation.delimiter
-(".") @punctuation.delimiter
+(string
+  (escape_sequence) @operator)
+
+(string
+  (interpolation
+    ("$") @operator))
+
+"(" @punctuation.bracket
+
+")" @punctuation.bracket
+
+"[" @punctuation.bracket
+
+"]" @punctuation.bracket
+
+"{" @punctuation.bracket
+
+"}" @punctuation.bracket
+
+":" @punctuation.delimiter
+
+"," @punctuation.delimiter
+
+"." @punctuation.delimiter
 
 (number_literal) @number
+
 (identifier) @variable
+
 ((identifier) @variable.parameter
   (#is? @variable.parameter "local.parameter"))
 
 ((identifier) @constant
   (#match? @constant "^[A-Z][A-Z_]+"))
 
-[ 
-  "%" "*" "/" "+" "-" "<<" ">>" ">>>" ".." "..<" "<..<" "<.." "<"
-  "<=" ">" ">=" "==" "!=" "<=>" "===" "!==" "=~" "==~" "&" "^" "|"
-  "&&" "||" "?:" "+" "*" ".&" ".@" "?." "*." "*" "*:" "++" "--" "!"
+[
+  "%"
+  "*"
+  "/"
+  "+"
+  "-"
+  "<<"
+  ">>"
+  ">>>"
+  ".."
+  "..<"
+  "<..<"
+  "<.."
+  "<"
+  "<="
+  ">"
+  ">="
+  "=="
+  "!="
+  "<=>"
+  "==="
+  "!=="
+  "=~"
+  "==~"
+  "&"
+  "^"
+  "|"
+  "&&"
+  "||"
+  "?:"
+  "+"
+  "*"
+  ".&"
+  ".@"
+  "?."
+  "*."
+  "*"
+  "*:"
+  "++"
+  "--"
+  "!"
 ] @operator
 
-(string ("/") @string)
+(string
+  "/" @string)
 
-(ternary_op ([ "?" ":" ]) @operator)
+(ternary_op
+  ([
+    "?"
+    ":"
+  ]) @operator)
 
-(map (map_item key: (identifier) @variable.parameter))
+(map
+  (map_item
+    key: (identifier) @variable.parameter))
 
-(parameter type: (identifier) @type name: (identifier) @variable.parameter)
-(generic_param name: (identifier) @variable.parameter)
+(parameter
+  type: (identifier) @type
+  name: (identifier) @variable.parameter)
 
-(declaration type: (identifier) @type)
-(function_definition type: (identifier) @type)
-(function_declaration type: (identifier) @type)
-(class_definition name: (identifier) @type)
-(class_definition superclass: (identifier) @type)
-(generic_param superclass: (identifier) @type)
+(generic_param
+  name: (identifier) @variable.parameter)
 
-(type_with_generics (identifier) @type)
-(type_with_generics (generics (identifier) @type))
-(generics [ "<" ">" ] @punctuation.bracket)
-(generic_parameters [ "<" ">" ] @punctuation.bracket)
+(declaration
+  type: (identifier) @type)
+
+(function_definition
+  type: (identifier) @type)
+
+(function_declaration
+  type: (identifier) @type)
+
+(class_definition
+  name: (identifier) @type)
+
+(class_definition
+  superclass: (identifier) @type)
+
+(generic_param
+  superclass: (identifier) @type)
+
+(type_with_generics
+  (identifier) @type)
+
+(type_with_generics
+  (generics
+    (identifier) @type))
+
+(generics
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(generic_parameters
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
 ; TODO: Class literals with PascalCase
+(declaration
+  "=" @operator)
 
-(declaration ("=") @operator)
-(assignment ("=") @operator)
+(assignment
+  "=" @operator)
 
-
-(function_call 
-  function: (identifier) @function)
 (function_call
-  function: (dotted_identifier
-	  (identifier) @function . ))
-(function_call (argument_list
-		 (map_item key: (identifier) @variable.parameter)))
-(juxt_function_call 
   function: (identifier) @function)
-(juxt_function_call
-  function: (dotted_identifier
-	  (identifier) @function . ))
-(juxt_function_call (argument_list 
-		      (map_item key: (identifier) @variable.parameter)))
 
-(function_definition 
+(function_call
+  function:
+    (dotted_identifier
+      (identifier) @function .))
+
+(function_call
+  (argument_list
+    (map_item
+      key: (identifier) @variable.parameter)))
+
+(juxt_function_call
   function: (identifier) @function)
-(function_declaration 
+
+(juxt_function_call
+  function:
+    (dotted_identifier
+      (identifier) @function .))
+
+(juxt_function_call
+  (argument_list
+    (map_item
+      key: (identifier) @variable.parameter)))
+
+(function_definition
+  function: (identifier) @function)
+
+(function_declaration
   function: (identifier) @function)
 
 (annotation) @function.macro
-(annotation (identifier) @function.macro)
+
+(annotation
+  (identifier) @function.macro)
+
 "@interface" @function.macro
 
 "pipeline" @keyword
 
 (groovy_doc) @comment.documentation
-(groovy_doc 
+
+(groovy_doc
   [
     (groovy_doc_param)
     (groovy_doc_throws)
     (groovy_doc_tag)
   ] @string.special)
-(groovy_doc (groovy_doc_param (identifier) @variable.parameter))
-(groovy_doc (groovy_doc_throws (identifier) @type))
+
+(groovy_doc
+  (groovy_doc_param
+    (identifier) @variable.parameter))
+
+(groovy_doc
+  (groovy_doc_throws
+    (identifier) @type))

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -90,9 +90,6 @@
 
 (identifier) @variable
 
-((identifier) @variable.parameter
-  (#is? @variable.parameter "local.parameter"))
-
 ((identifier) @constant
   (#match? @constant "^[A-Z][A-Z_]+"))
 
@@ -153,7 +150,9 @@
     key: (identifier) @variable.parameter))
 
 (parameter
-  type: (identifier) @type
+  type: (identifier) @type)
+
+(parameter
   name: (identifier) @variable.parameter)
 
 (generic_param

--- a/queries/groovy/indents.scm
+++ b/queries/groovy/indents.scm
@@ -1,0 +1,23 @@
+[
+  (closure)
+  (map)
+  (list)
+  (argument_list)
+  (parameter_list)
+  (for_parameters)
+] @indent.begin
+
+; (function_definition "(" @indent.begin)
+
+(closure "}" @indent.end)
+(argument_list ")" @indent.end)
+(for_parameters ")" @indent.end)
+((for_loop
+  body: (_) @_body) @indent.begin
+  (#not-has-type? @_body closure))
+; TODO: while, try
+
+(list "]" @indent.end)
+(map "]" @indent.end)
+
+[ "}" ")" "]" ] @indent.branch

--- a/queries/groovy/indents.scm
+++ b/queries/groovy/indents.scm
@@ -8,16 +8,28 @@
 ] @indent.begin
 
 ; (function_definition "(" @indent.begin)
+(closure
+  "}" @indent.end)
 
-(closure "}" @indent.end)
-(argument_list ")" @indent.end)
-(for_parameters ")" @indent.end)
+(argument_list
+  ")" @indent.end)
+
+(for_parameters
+  ")" @indent.end)
+
 ((for_loop
   body: (_) @_body) @indent.begin
   (#not-has-type? @_body closure))
+
 ; TODO: while, try
+(list
+  "]" @indent.end)
 
-(list "]" @indent.end)
-(map "]" @indent.end)
+(map
+  "]" @indent.end)
 
-[ "}" ")" "]" ] @indent.branch
+[
+  "}"
+  ")"
+  "]"
+] @indent.branch

--- a/queries/groovy/injections.scm
+++ b/queries/groovy/injections.scm
@@ -1,0 +1,5 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((groovy_doc) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/groovy/injections.scm
+++ b/queries/groovy/injections.scm
@@ -1,5 +1,0 @@
-((block_comment) @injection.content
-  (#set! injection.language "comment"))
-
-((line_comment) @injection.content
-  (#set! injection.language "comment"))

--- a/queries/groovy/locals.scm
+++ b/queries/groovy/locals.scm
@@ -1,6 +1,6 @@
-[
-  (function_definition)
-] @local.scope
-(parameter name: (identifier) @local.definition.parameter)
+(function_definition) @local.scope
+
+(parameter
+  name: (identifier) @local.definition.parameter)
 
 (identifier) @local.reference

--- a/queries/groovy/locals.scm
+++ b/queries/groovy/locals.scm
@@ -1,0 +1,6 @@
+[
+  (function_definition)
+] @scope
+(parameter name: (identifier) @definition.parameter)
+
+(identifier) @reference

--- a/queries/groovy/locals.scm
+++ b/queries/groovy/locals.scm
@@ -1,6 +1,6 @@
 [
   (function_definition)
-] @scope
-(parameter name: (identifier) @definition.parameter)
+] @local.scope
+(parameter name: (identifier) @local.definition.parameter)
 
-(identifier) @reference
+(identifier) @local.reference


### PR DESCRIPTION
I've been actively building a new parser for groovy because I was dissatisfied with the included one. The [README of my project](https://github.com/murtaza64/tree-sitter-groovy/blob/main/README.md) includes a screenshot showing some of the superficial improvements, but this new parser much more accurately and richly parses groovy code based on the groovy language spec, and supports features including annotations, closures, the various string types in groovy and more. It also includes a pretty extensive test suite to aid in future improvement.

I've been daily driving it for a few months now, and I work on Jenkins pipelines a lot and have been pretty happy with it.

Willing to change or add stuff if other people find issues with it. Also willing to go into more detail about the improvements, but wanted to put this PR up to start the discussion.

I've been [discussing](https://github.com/Decodetalkers/tree-sitter-groovy/issues/5) with @Decodetalkers about their interest in adopting my parser--they wanted me to submit a PR to their repo, but since this was a full rewrite of the parser, I'm waiting for confirmation that they're ok with replacing the upstream parser here.

Thanks @WillLillis for your help here too!