### PR TITLE
Update parsers: devicetree

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -102,7 +102,7 @@
     "revision": "f71e310a93010863f4b17a2a501ea8e2032c345b"
   },
   "devicetree": {
-    "revision": "53b4137bd37e726116ea918139767f982a1584d8"
+    "revision": "6b53bfdb20a54727bfe344aa40907351a298f75c"
   },
   "dhall": {
     "revision": "affb6ee38d629c9296749767ab832d69bb0d9ea8"

--- a/queries/devicetree/highlights.scm
+++ b/queries/devicetree/highlights.scm
@@ -30,8 +30,8 @@
 (property
   (identifier) @property)
 
-(labeled_item
-  (identifier) @label)
+(node
+  label: (_) @label)
 
 (call_expression
   (identifier) @function.macro)


### PR DESCRIPTION
Bumps devicetree parser to 0.9. Related to https://github.com/nvim-treesitter/nvim-treesitter/pull/5959#issuecomment-1905410470.

@lucario387 is this what you meant or something else breaks?
