### PR TITLE
fix(incremental_selection): mute deleting possibly non-existent keymaps

### DIFF
--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -162,12 +162,18 @@ end
 
 function M.detach(bufnr)
   local config = configs.get_module "incremental_selection"
+  ---@type string
+  local mode
   for f, mapping in pairs(config.keymaps) do
     if mapping then
       if f == "init_selection" then
-        vim.keymap.del("n", mapping, { buffer = bufnr })
+        mode = "n"
       else
-        vim.keymap.del("x", mapping, { buffer = bufnr })
+        mode = "x"
+      end
+      local ok, err = pcall(vim.keymap.del, mode, mapping, { buffer = bufnr })
+      if not ok then
+        vim.notify(('%s "%s" for mode "%s"'):format(err, mapping, mode), vim.log.levels.DEBUG, {title = "nvim-treesitter"})
       end
     end
   end

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -176,7 +176,7 @@ function M.detach(bufnr)
         vim.notify(
           ('%s "%s" for mode "%s"'):format(err, mapping, mode),
           vim.log.levels.DEBUG,
-          {title = "nvim-treesitter"}
+          { title = "nvim-treesitter" }
         )
       end
     end

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -173,7 +173,11 @@ function M.detach(bufnr)
       end
       local ok, err = pcall(vim.keymap.del, mode, mapping, { buffer = bufnr })
       if not ok then
-        vim.notify(('%s "%s" for mode "%s"'):format(err, mapping, mode), vim.log.levels.DEBUG, {title = "nvim-treesitter"})
+        vim.notify(
+          ('%s "%s" for mode "%s"'):format(err, mapping, mode),
+          vim.log.levels.DEBUG,
+          {title = "nvim-treesitter"}
+        )
       end
     end
   end


### PR DESCRIPTION
It can happen when the buffer gets some change from outside e.g. `git stash`.