### PR TITLE
fix(rust): Follow upstream injections

### DIFF
--- a/queries/rust/injections.scm
+++ b/queries/rust/injections.scm
@@ -1,6 +1,7 @@
 (macro_invocation
   (token_tree) @injection.content
-  (#set! injection.language "rust"))
+  (#set! injection.language "rust")
+  (#set! injection.include-children))
 
 (macro_definition
   (macro_rule


### PR DESCRIPTION
tree-sitter-rust and helix both have `injection.include-children` for the pattern in this PR. So it's best to changed to match the intended results

Fix #5958. 

Tested with the source code:
```rust
fn main() {
  println!("ok");
  println!("{}", returns_string_hello());
}
```
| Before:
```
(function_item ; [1:1 - 4:1]
  name: (identifier) ; [1:4 - 7]
  parameters: (parameters) ; [1:8 - 9]
  body: (block ; [1:11 - 4:1]
    (expression_statement ; [2:3 - 17]
      (macro_invocation ; [2:3 - 16]
        macro: (identifier) ; [2:3 - 9]
        (token_tree ; [2:11 - 16]
          (ERROR ; [2:11 - 16]
            (unit_expression)) ; [2:11 - 16]
          (string_literal)))) ; [2:12 - 15]
    (expression_statement ; [3:3 - 41]
      (macro_invocation ; [3:3 - 40]
        macro: (identifier) ; [3:3 - 9]
        (token_tree ; [3:11 - 40]
          (expression_statement ; [3:11 - 40]
            (unit_expression ; [3:11 - 40]
              (ERROR))) ; [3:16 - 16]
          (string_literal) ; [3:12 - 15]
          (identifier) ; [3:18 - 37]
          (token_tree)))))) ; [3:38 - 39]
```

After:
```
(function_item ; [1:1 - 4:1]
  name: (identifier) ; [1:4 - 7]
  parameters: (parameters) ; [1:8 - 9]
  body: (block ; [1:11 - 4:1]
    (expression_statement ; [2:3 - 17]
      (macro_invocation ; [2:3 - 16]
        macro: (identifier) ; [2:3 - 9]
        (token_tree ; [2:11 - 16]
          (ERROR ; [2:11 - 16]
            (parenthesized_expression ; [2:11 - 16]
              (string_literal))) ; [2:12 - 15]
          (string_literal)))) ; [2:12 - 15]
    (expression_statement ; [3:3 - 41]
      (macro_invocation ; [3:3 - 40]
        macro: (identifier) ; [3:3 - 9]
        (token_tree ; [3:11 - 40]
          (expression_statement ; [3:11 - 40]
            (tuple_expression ; [3:11 - 40]
              (string_literal) ; [3:12 - 15]
              (call_expression ; [3:18 - 39]
                function: (identifier) ; [3:18 - 37]
                arguments: (arguments)))) ; [3:38 - 39]
          (string_literal) ; [3:12 - 15]
          (identifier) ; [3:18 - 37]
          (token_tree)))))) ; [3:38 - 39]
```