### PR TITLE
feat(vim): highlight keycodes

### DIFF
--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -132,6 +132,8 @@
 (map_statement
   cmd: _ @keyword)
 
+(keycode) @character.special
+
 (command_name) @function.macro
 
 ; Filetype command


### PR DESCRIPTION
Incidentally, I found an issue in the parser. :thinking: 
The `<CR>` in `<Cmd>...<CR>` is parsed as `(command_argument)`, leaving a `MISSING` `(keycode)` node in the tree.
```vim
nnoremap <C-q> <Cmd>quit<CR>
```
```clojure
(script_file [0, 0] - [1, 0]
  (map_statement [0, 0] - [0, 28]
    lhs: (map_side [0, 9] - [0, 14]
      (keycode [0, 9] - [0, 14]))
    rhs: (map_side [0, 15] - [0, 28]
      (keycode [0, 15] - [0, 20])
      (unknown_builtin_statement [0, 20] - [0, 28]
        (unknown_command_name [0, 20] - [0, 24])
        (arguments [0, 24] - [0, 28]
          (command_argument [0, 24] - [0, 28])))
      (keycode [0, 28] - [0, 28]))))
test.vim        0 ms    (MISSING keycode [0, 28] - [0, 28])
```