### PR TITLE
fix(jsx): proper tag and builtin tag distinction

### DIFF
--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -24,42 +24,42 @@
   (property_identifier) @tag.attribute)
 
 (jsx_opening_element
-  name: (identifier) @tag)
+  name: (identifier) @tag.builtin)
 
 (jsx_closing_element
-  name: (identifier) @tag)
+  name: (identifier) @tag.builtin)
 
 (jsx_self_closing_element
-  name: (identifier) @tag)
+  name: (identifier) @tag.builtin)
 
 (jsx_opening_element
-  ((identifier) @constructor
-    (#lua-match? @constructor "^[A-Z]")))
+  ((identifier) @tag
+    (#lua-match? @tag "^[A-Z]")))
 
 ; Handle the dot operator effectively - <My.Component>
 (jsx_opening_element
   (member_expression
-    (identifier) @tag
-    (property_identifier) @constructor))
+    (identifier) @tag.builtin
+    (property_identifier) @tag))
 
 (jsx_closing_element
-  ((identifier) @constructor
-    (#lua-match? @constructor "^[A-Z]")))
+  ((identifier) @tag
+    (#lua-match? @tag "^[A-Z]")))
 
 ; Handle the dot operator effectively - </My.Component>
 (jsx_closing_element
   (member_expression
-    (identifier) @tag
-    (property_identifier) @constructor))
+    (identifier) @tag.builtin
+    (property_identifier) @tag))
 
 (jsx_self_closing_element
-  ((identifier) @constructor
-    (#lua-match? @constructor "^[A-Z]")))
+  ((identifier) @tag
+    (#lua-match? @tag "^[A-Z]")))
 
 ; Handle the dot operator effectively - <My.Component />
 (jsx_self_closing_element
   (member_expression
-    (identifier) @tag
-    (property_identifier) @constructor))
+    (identifier) @tag.builtin
+    (property_identifier) @tag))
 
 (jsx_text) @none


### PR DESCRIPTION
This PR changes the uppercase JSX tag highlights from `@constructor` to `@tag`. There was discussion about this before and it was decided to keep it this way so that they were differentiated from builtin tags, but now we have `@tag.builtin` so I figured this would be OK. This PR changes existing highlights of `@tag` to the builtin variant, so users and colorscheme authors can still have proper differentiation. Using constructor is especially annoying for colorschemes like [onedark](https://github.com/navarasu/onedark.nvim) that use bolded constructors or other styles that cascade through just color highlights.