### PR TITLE
fix(git_config): highlight parent relative path

### DIFF
--- a/queries/git_config/highlights.scm
+++ b/queries/git_config/highlights.scm
@@ -26,7 +26,7 @@
 (string) @string
 
 ((string) @string.special.path
-  (#lua-match? @string.special.path "^[.]?[/]"))
+  (#lua-match? @string.special.path "^[.]?[.]?[/]"))
 
 ((string) @string.special.path
   (#lua-match? @string.special.path "^[~]"))


### PR DESCRIPTION
Highlights values starting with `../` (relative to parent directory) as file paths as well