### PR TITLE
Fix find_usages

### DIFF
--- a/lua/nvim-treesitter/locals.lua
+++ b/lua/nvim-treesitter/locals.lua
@@ -254,6 +254,7 @@ function M.find_usages(node, scope_node, bufnr)
   local usages = {}
 
   for match in M.iter_locals(bufnr, scope_node) do
+    match = match["local"]
     if match.reference and match.reference.node and ts.get_node_text(match.reference.node, bufnr) == node_text then
       local def_node, _, kind = M.find_definition(match.reference.node, bufnr)
 


### PR DESCRIPTION
Mostly I explained everything in my issue - https://github.com/nvim-treesitter/nvim-treesitter/issues/5980. 

Should close https://github.com/nvim-treesitter/nvim-treesitter/issues/5980 if merged.

Although, I haven't put `if` for checking whether that “local” exists, I don't think we should as per other lines: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/locals.lua#L44
