### PR TITLE
feat(python): allow comments before module docstring

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -200,6 +200,8 @@
 ; doc-strings
 (module
   .
+  (comment)*
+  .
   (expression_statement
     (string) @string.documentation @spell))
 


### PR DESCRIPTION
Example:

  ```python
  #!/usr/bin/env/python
  # some comment before module docstring
  # Copyright (c) LICENSE foo bar

  """module docstring."""
  ```

Python indeed recognizes it:

  ```
  $ python -c 'import testfile; print(testfile.__doc__)'
  module docstring.
  ```
