### PR TITLE
fix(slint)!: Change slint tree-sitter to official slint repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [ ] [scheme](https://github.com/6cdh/tree-sitter-scheme)
 - [x] [scss](https://github.com/serenadeai/tree-sitter-scss) (maintained by @elianiva)
 - [x] [slang](https://github.com/theHamsta/tree-sitter-slang) (experimental, maintained by @theHamsta)
-- [x] [slint](https://github.com/jrmoulton/tree-sitter-slint) (experimental, maintained by @jrmoulton)
+- [x] [slint](https://github.com/slint-ui/slint) (experimental, maintained by @hunger)
 - [x] [smali](https://git.sr.ht/~yotam/tree-sitter-smali) (maintained by @amaanq)
 - [x] [smithy](https://github.com/indoorvivants/tree-sitter-smithy) (maintained by @amaanq, @keynmol)
 - [ ] [snakemake](https://github.com/osthomas/tree-sitter-snakemake) (experimental)

--- a/lockfile.json
+++ b/lockfile.json
@@ -576,7 +576,7 @@
     "revision": "ac07aa2c875ef6ada2ec468d8a4d0c7c5efd96d7"
   },
   "slint": {
-    "revision": "00c8a2d3645766f68c0d0460086c0a994e5b0d85"
+    "revision": "ea81f6b5e5d4e6dbe2b2fce24e47f379a432a824"
   },
   "smali": {
     "revision": "72e334b2630f5852825ba5ff9dfd872447175eb5"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1697,7 +1697,8 @@ list.slang = {
 list.slint = {
   install_info = {
     url = "https://github.com/slint-ui/slint",
-    files = { "editors/tree-sitter-slint/src/parser.c" },
+    files = { "src/parser.c" },
+    location = "editors/tree-sitter-slint",
   },
   maintainers = { "@hunger" },
   experimental = true,

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1696,10 +1696,10 @@ list.slang = {
 
 list.slint = {
   install_info = {
-    url = "https://github.com/jrmoulton/tree-sitter-slint",
-    files = { "src/parser.c" },
+    url = "https://github.com/slint-ui/slint",
+    files = { "editors/tree-sitter-slint/src/parser.c" },
   },
-  maintainers = { "@jrmoulton" },
+  maintainers = { "@hunger" },
   experimental = true,
 }
 

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1699,6 +1699,7 @@ list.slint = {
     url = "https://github.com/slint-ui/slint",
     files = { "src/parser.c" },
     location = "editors/tree-sitter-slint",
+    requires_generate_from_grammar = true,
   },
   maintainers = { "@hunger" },
   experimental = true,


### PR DESCRIPTION
Points slint to the official repository as I haven't maintained the other one in a while. 

Marking as a draft for now because I believe that slint needs to add the generated c source files first. 

@hunger I've marked you as the maintainer. Does that work?