### PR TITLE
fix(lua): inject luadoc into comments immediately beginning with a `|`

### DIFF
--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -131,7 +131,7 @@
 
 (comment
   content: (_) @injection.content
-  (#lua-match? @injection.content "^[-][%s]*@")
+  (#lua-match? @injection.content "^[-][%s]*[@|]")
   (#set! injection.language "luadoc")
   (#offset! @injection.content 0 1 0 0))
 


### PR DESCRIPTION
context - https://github.com/amaanq/tree-sitter-luadoc/issues/8#issuecomment-1911045824

I can understand this being rejected for false positives with normal comments just happening to start w/ a `|`, but I'd assume that'd be rare