### PR TITLE
feat(tests): allow check-queries to take list of parsers

### DIFF
--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -46,8 +46,8 @@ end
 
 local function do_check()
   local timings = {}
-  local parsers = require("nvim-treesitter.info").installed_parsers()
   local queries = require "nvim-treesitter.query"
+  local parsers = #_G.arg > 0 and { unpack(_G.arg) } or require("nvim-treesitter.info").installed_parsers()
   local query_types = queries.built_in_query_groups
 
   local captures = extract_captures()


### PR DESCRIPTION
This allows contributors to run the tests on some languages only via

`./scripts/check-queries.lua foo bar baz`

Makes it more feasible to ask them for before/after timings on PRs that might have a performance impact.
