### PR TITLE
fix(make): highlight order-only prerequisite pipe

### DIFF
--- a/queries/make/highlights.scm
+++ b/queries/make/highlights.scm
@@ -31,6 +31,7 @@
     "&:"
     ":"
     "::"
+    "|"
   ] @operator)
 
 (export_directive


### PR DESCRIPTION
Highlights order-only prerequisite separator pipe as `@operator`. Specified in [the manual](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html)