### PR TITLE
feat: register aliases defined for set-lang-from-info-string

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -33,6 +33,8 @@ for ft, lang in pairs {
   py = "python",
   erl = "erlang",
   typ = "typst",
+  pl = "perl",
+  uxn = "uxntal",
 } do
   ts.language.register(lang, ft)
 end


### PR DESCRIPTION
~~There are several [Chart.js](https://github.com/chartjs/Chart.js) Markdown previewing plugins, and they all (or all I have seen) take JSON data passed to a `chart` codeblock to generate the graphs. Since the chart info string isn't recognized in any way, it would be nice to alias it to JSON to get nice injections still.~~