### PR TITLE
ci: use token for automated PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,9 @@
 name: Linting and style checking
 
 on:
-  push:
   pull_request:
+    branches:
+      - "master"
 
 jobs:
   luacheck:

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           ref: master
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.TOKEN_ID }}
+          private-key: ${{ secrets.TOKEN_PRIVATE_KEY }}
+
       - name: Prepare
         env:
           NVIM_TAG: stable
@@ -32,21 +38,20 @@ jobs:
           # Pretty print
           cp lockfile.json /tmp/lockfile.json
           cat /tmp/lockfile.json | jq --sort-keys > lockfile.json
-
-      - name: Commit changes
-        run: |
-          git config user.name 'GitHub'
-          git config user.email 'noreply@github.com'
-          git add lockfile.json
           UPDATED_PARSERS=$(/tmp/jd -f merge /tmp/old_lockfile.json lockfile.json | jq -r 'keys | join(", ")')
           echo "UPDATED_PARSERS=$UPDATED_PARSERS" >> $GITHUB_ENV
-          git commit -m "Update parsers: $UPDATED_PARSERS" || echo 'No commit necessary!'
-          git clean -xf
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "Update parsers: ${{ env.UPDATED_PARSERS }}"
           title: "Update lockfile.json: ${{ env.UPDATED_PARSERS }}"
+          body: "[beep boop](https://github.com/peter-evans/create-pull-request)"
           branch: update-lockfile-pr
           base: ${{ github.head_ref }}
-          draft: true
+
+      - name: Enable Pull Request Automerge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge --rebase --auto update-lockfile-pr

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.TOKEN_ID }}
+          private-key: ${{ secrets.TOKEN_PRIVATE_KEY }}
+
       - name: Prepare
         env:
           NVIM_TAG: stable
@@ -21,18 +27,19 @@ jobs:
 
       - name: Check README
         run: |
-          git config user.email 'actions@github'
-          git config user.name 'Github Actions'
           nvim -l scripts/update-readme.lua || echo 'Needs update'
-          git add README.md
-          git commit -m 'Update README' || echo 'No commit necessary!'
-          git clean -xf
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: Update README
           title: Update README
+          body: "[beep boop](https://github.com/peter-evans/create-pull-request)"
           branch: update-readme-pr
           base: ${{ github.head_ref }}
-          draft: true
+
+      - name: Enable Pull Request Automerge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge --rebase --auto update-readme-pr


### PR DESCRIPTION
This should allow automated `update-lockfile` and  `update-readme` PRs to run CI automatically (following https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens, but using the new official Github token action). 

It's possible to exempt the bot from the branch protection rule; this would allow fully automated (non-breaking) lockfile updates. In this case, the update-readme workflow could also push straight to master so we don't have to deal with the noise of a PR.
