### PR TITLE
fix(latex): give comments higher precedence

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -298,15 +298,6 @@
       (_) @markup.link.url))
   (#any-of? @_name "\\url" "\\href"))
 
-[
-  (line_comment)
-  (block_comment)
-  (comment_environment)
-] @comment @spell
-
-((line_comment) @keyword.directive
-  (#lua-match? @keyword.directive "^%% !TeX"))
-
 ; File inclusion commands
 (class_include
   command: _ @keyword.import
@@ -369,3 +360,15 @@
   (displayed_equation)
   (inline_formula)
 ] @markup.math
+
+[
+  (line_comment)
+  (block_comment)
+  (comment_environment)
+] @comment @spell
+
+((line_comment) @keyword.directive
+  (#lua-match? @keyword.directive "^%% !TeX"))
+
+((line_comment) @keyword.directive
+  (#lua-match? @keyword.directive "^%%&"))

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -12,15 +12,6 @@
   value: (_))
 
 [
-  (line_comment)
-  (block_comment)
-  (comment_environment)
-] @comment @spell
-
-((line_comment) @keyword.directive
-  (#lua-match? @keyword.directive "^%% !TeX"))
-
-[
   (brack_group)
   (brack_group_argc)
 ] @variable.parameter
@@ -163,12 +154,6 @@
   content:
     (curly_group
       (_) @none @spell))
-
-; Math
-[
-  (displayed_equation)
-  (inline_formula)
-] @markup.math
 
 (math_environment
   (begin
@@ -313,6 +298,15 @@
       (_) @markup.link.url))
   (#any-of? @_name "\\url" "\\href"))
 
+[
+  (line_comment)
+  (block_comment)
+  (comment_environment)
+] @comment @spell
+
+((line_comment) @keyword.directive
+  (#lua-match? @keyword.directive "^%% !TeX"))
+
 ; File inclusion commands
 (class_include
   command: _ @keyword.import
@@ -369,3 +363,9 @@
 (label_reference) @nospell
 
 (label_reference_range) @nospell
+
+; Math
+[
+  (displayed_equation)
+  (inline_formula)
+] @markup.math

--- a/tests/query/highlights/latex/test.tex
+++ b/tests/query/highlights/latex/test.tex
@@ -1,0 +1,33 @@
+% vim:ft=latex
+% !TeX
+% ^ @keyword.directive
+%& filename
+%  ^ @keyword.directive
+      \begin{equation} \frac{4}{2} + 128 \text{hello} \sum_{n=1}^{\text{hi\_hi\^hi}} n \end{equation}
+%                            ^ @markup.math    ^ @none             ^ @function
+
+\begin{equation} 
+  a = b % Comment here
+%         ^ @comment
+% ^ @markup.math
+\end{equation}
+\begin{equation} 
+  a = b % Comment here
+%         ^ @comment
+  b = c
+\end{equation}
+\text{
+hi $here$ is some text % with a comment
+%                        ^ @comment
+%   ^ @markup.math
+}
+\textbf{
+here is some text $5 + 2$ % with a comment
+%                           ^ @comment
+%                  ^ @markup.math
+}
+\textit{
+here is some text $5 + 2$ % with a comment
+%                           ^ @comment
+%                  ^ @markup.math
+}


### PR DESCRIPTION
This commit also moves things around to give text better precedence in the case of `textit` and `textbf`.

Fixes #6047 

I created a comprehensive example file to show some differences. Before:
![latexfixupsbefore](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/345e11bc-c5f5-4cf1-ac12-e64c7a9e5bf1)

After:
![latexfixupsafter](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/ced0cad8-c5ec-470f-8fc6-6ed249175999)

Note that this was tested in Markdown only but I did a few tests in a `.tex` file and the same results were noticed. Hopefully this fixes the last of this weirdness, but I am not certain that every edge case is caught.