### PR TITLE
fix(angular): nullish coalescing operator in Angular templates

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "c21c3a0f996363ed17b8ac99d827fe5a4821f217"
   },
   "angular": {
-    "revision": "dfdce7ec26fb23f6f3fd83d4c79370759d5286b5"
+    "revision": "3946b1040b98a12458beef2763ce4780a523e3c6"
   },
   "apex": {
     "revision": "857077f9e6bb04df0f769c18d32bfe036911adc8"

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -113,7 +113,7 @@
 ] @punctuation.delimiter
 
 (nullish_coalescing_expression
-  (coalesing_operator) @operator)
+  (coalescing_operator) @operator)
 
 (concatination_expression
   "+" @operator)

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -112,6 +112,9 @@
   "?."
 ] @punctuation.delimiter
 
+(nullish_coalescing_expression
+  (coalesing_operator) @operator)
+
 (concatination_expression
   "+" @operator)
 


### PR DESCRIPTION
This PR updates the angular parser to the latest version and adds a highlight capture to mark the _nullish coalescing operator_ `??` as an operator.