### PR TITLE
highlight(jsx,tsx): character references (a.k.a. entities)

### DIFF
--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -63,3 +63,5 @@
     (property_identifier) @constructor))
 
 (jsx_text) @none
+
+(html_character_reference) @character.special


### PR DESCRIPTION
Followup to tree-sitter/tree-sitter-javascript#284 now that it's merged – add highlight groups for HTML character references (entities) in JSX & TSX:

<img width="261" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/9437625/3198fdad-a71b-47c9-b1ec-45ef3f415d17">
