### PR TITLE
Try to fix indentation for <template> ... </template>

### DIFF
--- a/queries/ecma/indents.scm
+++ b/queries/ecma/indents.scm
@@ -16,6 +16,7 @@
   (switch_statement)
   (template_substitution)
   (ternary_expression)
+  (glimmer_opening_tag)
 ] @indent.begin
 
 (arguments
@@ -68,6 +69,8 @@
   "}"
   "]"
 ] @indent.end
+
+(glimmer_closing_tag) @indent.end
 
 (template_string) @indent.ignore
 


### PR DESCRIPTION
Currently, when I press `Enter` in a 
```gjs
// test.gjs
<template>

</template>
```
block, 
the cursor goes all the way to the left, rather than being indented.

I'm still trying to figure out how to test things locally, so this isn't ready for review or merge.