### PR TITLE
queries/templ: add the spread_attributes node

### DIFF
--- a/queries/templ/highlights.scm
+++ b/queries/templ/highlights.scm
@@ -15,6 +15,9 @@
 (attribute
   value: (quoted_attribute_value) @string)
 
+(spread_attributes
+  name: (identifier) @variable)
+
 [
   (element_text)
   (style_element_text)


### PR DESCRIPTION
I recently added a new `spread_attributes` node in the `tree-sitter-templ` parser that requires specific highlighting, this PR adds it.