### PR TITLE
feat(tcl): add parser and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [t32](https://gitlab.com/xasc/tree-sitter-t32.git) (maintained by @xasc)
 - [x] [tablegen](https://github.com/amaanq/tree-sitter-tablegen) (maintained by @amaanq)
 - [x] [teal](https://github.com/euclidianAce/tree-sitter-teal) (maintained by @euclidianAce)
+- [x] [tcl](https://github.com/tree-sitter-grammars/tree-sitter-tcl) (maintained by @lewis6991)
 - [x] [templ](https://github.com/vrischmann/tree-sitter-templ) (maintained by @vrischmann)
 - [x] [terraform](https://github.com/MichaHoffmann/tree-sitter-hcl) (maintained by @MichaHoffmann)
 - [x] [textproto](https://github.com/PorterAtGoogle/tree-sitter-textproto) (maintained by @Porter)

--- a/lockfile.json
+++ b/lockfile.json
@@ -662,6 +662,9 @@
   "teal": {
     "revision": "33482c92a0dfa694491d34e167a1d2f52b0dccb1"
   },
+  "tcl": {
+    "revision": "ca2643e3cd818771635a152899fb70b6b37d648a"
+  },
   "templ": {
     "revision": "592faa3186ef857c92e4bd1c31d73c07a4a334db"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1934,6 +1934,14 @@ list.teal = {
   maintainers = { "@euclidianAce" },
 }
 
+list.tcl = {
+  install_info = {
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-tcl",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@lewis6991" },
+}
+
 list.terraform = {
   install_info = {
     url = "https://github.com/MichaHoffmann/tree-sitter-hcl",

--- a/queries/tcl/folds.scm
+++ b/queries/tcl/folds.scm
@@ -1,0 +1,1 @@
+(braced_word) @fold

--- a/queries/tcl/highlights.scm
+++ b/queries/tcl/highlights.scm
@@ -1,0 +1,105 @@
+(comment) @comment @spell
+
+(command
+  name: (simple_word) @function)
+
+"proc" @keyword.function
+
+(procedure
+  name: (_) @variable)
+
+(set
+  (simple_word) @variable)
+
+(argument
+  name: (_) @variable.parameter)
+
+((simple_word) @variable.builtin
+  (#any-of? @variable.builtin "argc" "argv" "argv0" "auto_path" "env" "errorCode" "errorInfo" "tcl_interactive" "tcl_library" "tcl_nonwordchars" "tcl_patchLevel" "tcl_pkgPath" "tcl_platform" "tcl_precision" "tcl_rcFileName" "tcl_traceCompile" "tcl_traceExec" "tcl_wordchars" "tcl_version"))
+
+"expr" @function.builtin
+
+(command
+  name: (simple_word) @function.builtin
+  (#any-of? @function.builtin "cd" "exec" "exit" "incr" "info" "join" "puts" "regexp" "regsub" "split" "subst" "trace" "source"))
+
+(command
+  name: (simple_word) @keyword
+  (#any-of? @keyword "append" "break" "catch" "continue" "default" "dict" "error" "eval" "global" "lappend" "lassign" "lindex" "linsert" "list" "llength" "lmap" "lrange" "lrepeat" "lreplace" "lreverse" "lsearch" "lset" "lsort" "package" "return" "switch" "throw" "unset" "variable"))
+
+[
+  "error"
+  "namespace"
+  "on"
+  "set"
+  "try"
+] @keyword
+
+(unpack) @operator
+
+[
+  "while"
+  "foreach"
+] @keyword.repeat
+
+[
+  "if"
+  "else"
+  "elseif"
+] @keyword.conditional
+
+[
+  "**"
+  "/"
+  "*"
+  "%"
+  "+"
+  "-"
+  "<<"
+  ">>"
+  ">"
+  "<"
+  ">="
+  "<="
+  "=="
+  "!="
+  "eq"
+  "ne"
+  "in"
+  "ni"
+  "&"
+  "^"
+  "|"
+  "&&"
+  "||"
+] @operator
+
+(variable_substitution) @variable
+
+(quoted_word) @string
+
+(escaped_character) @string.escape
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+  ";"
+] @punctuation.delimiter
+
+((simple_word) @number
+  (#lua-match? @number "^[0-9]+$"))
+
+((simple_word) @boolean
+  (#any-of? @boolean "true" "false"))
+
+; after apply array auto_execok auto_import auto_load auto_mkindex auto_qualify
+; auto_reset bgerror binary chan clock close coroutine dde encoding eof fblocked
+; fconfigure fcopy file fileevent filename flush format gets glob history http
+; interp load mathfunc mathop memory msgcat my next nextto open parray pid
+; pkg::create pkg_mkIndex platform platform::shell pwd re_syntax read refchan
+; registry rename safe scan seek self socket source string tailcall tcl::prefix
+; tcl_endOfWord tcl_findLibrary tcl_startOfNextWord tcl_startOfPreviousWord
+; tcl_wordBreakAfter tcl_wordBreakBefore tcltest tell time timerate tm
+; transchan unknown unload update uplevel upvar vwait yield yieldto zlib

--- a/queries/tcl/indents.scm
+++ b/queries/tcl/indents.scm
@@ -1,0 +1,25 @@
+[
+  (braced_word_simple)
+  (namespace)
+  (command)
+  (conditional)
+  (foreach)
+  (while)
+  (try)
+  (procedure)
+  (command_substitution)
+] @indent.begin
+
+(quoted_word) @indent.align
+
+([
+  (expr)
+  (arguments)
+] @indent.align
+  (#set! "indent.open_delimiter" "{")
+  (#set! "indent.close_delimiter" "}"))
+
+[
+  "}"
+  "]"
+] @indent.branch @indent.end


### PR DESCRIPTION
Taken from https://github.com/tree-sitter-grammars/tree-sitter-tcl/tree/main/queries/tcl so people _can_ install it with nvim-treesitter (if they want).

Upstream for the queries remains them, so improvements should always go there first. (I did run the formatter on them, though.)

@lewis6991 