### PR TITLE
Readline fixups

### DIFF
--- a/queries/readline/highlights.scm
+++ b/queries/readline/highlights.scm
@@ -64,6 +64,6 @@
 
 (number_value) @number
 
-(version_number) @string.special
+(version_number) @number.float
 
 (bool_value) @boolean

--- a/queries/readline/indents.scm
+++ b/queries/readline/indents.scm
@@ -1,5 +1,8 @@
 (conditional_construct) @indent.begin
 
+(ERROR
+  "$if") @indent.begin
+
 [
   "$else"
   "$endif"


### PR DESCRIPTION
Improves indents to if statements before the full block can be parsed (basically while typing them on the fly), also changes the version number highlight after a parser update, see [this discussion about it](https://github.com/nvim-treesitter/nvim-treesitter/pull/6058#discussion_r1483418958)