### PR TITLE
ci: use `windows-latest` over `windows-2022`

### DIFF
--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2022, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-14]
         cc: [gcc, clang]
         nvim_tag: [stable]
         exclude:
@@ -34,12 +34,12 @@ jobs:
             cc: gcc
             nvim_tag: stable
 
-          - os: windows-2022
+          - os: windows-latest
             cc: clang
             nvim_tag: stable
 
         include:
-          - os: windows-2022
+          - os: windows-latest
             cc: cl
             nvim_tag: stable
 
@@ -51,8 +51,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.cc }}
-      NVIM: ${{ matrix.os == 'windows-2022' && 'nvim-win64\\bin\\nvim.exe' || 'nvim' }}
-      ALLOWED_INSTALLATION_FAILURES: ${{ matrix.os == 'windows-2022' && 'rnoweb' }}
+      NVIM: ${{ runner.os == 'Windows' && 'nvim-win64\\bin\\nvim.exe' || 'nvim' }}
+      ALLOWED_INSTALLATION_FAILURES: ${{ runner.os == 'Windows' && 'rnoweb' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
@@ -80,7 +80,7 @@ jobs:
         run: $NVIM --headless -c "lua require'nvim-treesitter.install'.prefer_git=false" -c "TSInstallSync all" -c "q"
 
       - name: Post compile Windows
-        if: matrix.os == 'windows-2022'
+        if: runner.os == 'Windows'
         run: cp -r ~/AppData/Local/nvim/pack/nvim-treesitter/start/nvim-treesitter/parser/* parser
 
       - name: Check query files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.cc }}-parsers-v1-${{ hashFiles('./lockfile.json', './lua/nvim-treesitter/parsers.lua', './lua/nvim-treesitter/install.lua', './lua/nvim-treesitter/shell_selectors.lua') }}
 
       - name: Compile parsers Unix like
-        if: ${{ matrix.os != 'windows-latest' && steps.parsers-cache.outputs.cache-hit != 'true' }}
+        if: ${{ runner.os != 'Windows' && steps.parsers-cache.outputs.cache-hit != 'true' }}
         run: |
           nvim --headless -c "TSInstallSync all" -c "q"
 


### PR DESCRIPTION
It's convenient to not need to manually update the runner version.
