### PR TITLE
ci: fix invalid workflow

### DIFF
--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -51,8 +51,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.cc }}
-      NVIM: ${{ runner.os == 'Windows' && 'nvim-win64\\bin\\nvim.exe' || 'nvim' }}
-      ALLOWED_INSTALLATION_FAILURES: ${{ runner.os == 'Windows' && 'rnoweb' }}
+      NVIM: ${{ matrix.os == 'windows-latest' && 'nvim-win64\\bin\\nvim.exe' || 'nvim' }}
+      ALLOWED_INSTALLATION_FAILURES: ${{ matrix.os == 'windows-latest' && 'rnoweb' }}
     steps:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
@@ -65,7 +65,7 @@ jobs:
         env:
           NVIM_TAG: ${{ matrix.nvim_tag }}
         run: |
-          bash ./scripts/ci-install-${{ matrix.os }}.sh
+          bash ./scripts/ci-install.sh
 
       - name: Setup Parsers Cache
         id: parsers-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           NVIM_TAG: stable
         run: |
-          bash ./scripts/ci-install-${{ matrix.os }}.sh
+          bash ./scripts/ci-install.sh
 
       - name: Setup Parsers Cache
         id: parsers-cache

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -27,7 +27,7 @@ jobs:
           wget https://github.com/josephburnett/jd/releases/download/v1.7.1/jd-amd64-linux
           mv jd-amd64-linux /tmp/jd
           chmod +x /tmp/jd
-          bash scripts/ci-install-ubuntu-latest.sh
+          bash scripts/ci-install.sh
 
       - name: Update parsers
         env:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           NVIM_TAG: stable
         run: |
-          bash ./scripts/ci-install-ubuntu-latest.sh
+          bash ./scripts/ci-install.sh
 
       - name: Check README
         run: |

--- a/scripts/ci-install-macos-14.sh
+++ b/scripts/ci-install-macos-14.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-curl -L https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-macos.tar.gz | tar -xz
-sudo ln -s "$PWD"/nvim-macos/bin/nvim /usr/local/bin
-rm -rf "$PWD"/nvim-macos/lib/nvim/parser
-mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
-ln -s "$PWD" ~/.local/share/nvim/site/pack/nvim-treesitter/start

--- a/scripts/ci-install-ubuntu-latest.sh
+++ b/scripts/ci-install-ubuntu-latest.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux64.tar.gz
-tar -zxf nvim-linux64.tar.gz
-sudo ln -s "$PWD"/nvim-linux64/bin/nvim /usr/local/bin
-rm -rf "$PWD"/nvim-linux64/lib/nvim/parser
-mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
-ln -s "$PWD" ~/.local/share/nvim/site/pack/nvim-treesitter/start

--- a/scripts/ci-install-windows-2022.sh
+++ b/scripts/ci-install-windows-2022.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-curl -L https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-win64.zip -o nvim-win64.zip
-unzip nvim-win64
-mkdir -p ~/AppData/Local/nvim/pack/nvim-treesitter/start
-mkdir -p ~/AppData/Local/nvim-data
-cp -r "$PWD" ~/AppData/Local/nvim/pack/nvim-treesitter/start

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+os=$(uname -s)
+if [[ $os == Linux ]]; then
+  wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux64.tar.gz
+  tar -zxf nvim-linux64.tar.gz
+  sudo ln -s "$PWD"/nvim-linux64/bin/nvim /usr/local/bin
+  rm -rf "$PWD"/nvim-linux64/lib/nvim/parser
+  mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
+  ln -s "$PWD" ~/.local/share/nvim/site/pack/nvim-treesitter/start
+elif [[ $os == Darwin ]]; then
+  curl -L https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-macos.tar.gz | tar -xz
+  sudo ln -s "$PWD"/nvim-macos/bin/nvim /usr/local/bin
+  rm -rf "$PWD"/nvim-macos/lib/nvim/parser
+  mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
+  ln -s "$PWD" ~/.local/share/nvim/site/pack/nvim-treesitter/start
+else
+  curl -L https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-win64.zip -o nvim-win64.zip
+  unzip nvim-win64
+  mkdir -p ~/AppData/Local/nvim/pack/nvim-treesitter/start
+  mkdir -p ~/AppData/Local/nvim-data
+  cp -r "$PWD" ~/AppData/Local/nvim/pack/nvim-treesitter/start
+fi


### PR DESCRIPTION
Context variables aren't always available, so we can't rely on them for
e.g. environment variables.

Also merge all install scripts into `script/ci-install.sh`, that way it
can be called the same way regardless of system.