### PR TITLE
chore(v): update repository url

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [unison](https://github.com/kylegoetz/tree-sitter-unison) (maintained by @tapegram)
 - [x] [usd](https://github.com/ColinKennedy/tree-sitter-usd) (maintained by @ColinKennedy)
 - [x] [uxn tal](https://github.com/amaanq/tree-sitter-uxntal) (maintained by @amaanq)
-- [x] [v](https://github.com/v-analyzer/v-analyzer) (maintained by @kkharji, @amaanq)
+- [x] [v](https://github.com/vlang/v-analyzer) (maintained by @kkharji, @amaanq)
 - [x] [vala](https://github.com/vala-lang/tree-sitter-vala) (maintained by @Prince781)
 - [x] [verilog](https://github.com/tree-sitter/tree-sitter-verilog) (maintained by @zegervdv)
 - [x] [vhs](https://github.com/charmbracelet/tree-sitter-vhs) (maintained by @caarlos0)

--- a/lockfile.json
+++ b/lockfile.json
@@ -723,7 +723,7 @@
     "revision": "4c5ecd6326ebd61f6f9a22a370cbd100e0d601da"
   },
   "v": {
-    "revision": "9ac84e62396bb13c8f1d11f967f0c0f2dec1a448"
+    "revision": "56d7905f423b82dff4b23c86e2869ddc06f6e419"
   },
   "vala": {
     "revision": "8f690bfa639f2b83d1fb938ed3dd98a7ba453e8b"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2102,7 +2102,7 @@ list.uxntal = {
 
 list.v = {
   install_info = {
-    url = "https://github.com/v-analyzer/v-analyzer",
+    url = "https://github.com/vlang/v-analyzer",
     files = { "src/parser.c" },
     location = "tree_sitter_v",
   },


### PR DESCRIPTION
The development source for `v-analyzer` has moved, therefore the PR updates it's URL.