### PR TITLE
feat: add the hlsplaylist parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [heex](https://github.com/connorlay/tree-sitter-heex) (maintained by @connorlay)
 - [x] [hjson](https://github.com/winston0410/tree-sitter-hjson) (maintained by @winston0410)
 - [x] [hlsl](https://github.com/theHamsta/tree-sitter-hlsl) (maintained by @theHamsta)
+- [x] [hlsplaylist](https://github.com/Freed-Wu/tree-sitter-hlsplaylist) (maintained by @Freed-Wu)
 - [x] [hocon](https://github.com/antosha417/tree-sitter-hocon) (maintained by @antosha417)
 - [x] [hoon](https://github.com/urbit-pilled/tree-sitter-hoon) (experimental, maintained by @urbit-pilled)
 - [x] [html](https://github.com/tree-sitter/tree-sitter-html) (maintained by @TravonteD)

--- a/lockfile.json
+++ b/lockfile.json
@@ -272,6 +272,9 @@
   "hlsl": {
     "revision": "3ade6d065c69cd72c4da966d0c0af98bfb512f16"
   },
+  "hlsplaylist": {
+    "revision": "be3a18abfa9cef1f792324beb1f1e1c9ddba2748"
+  },
   "hocon": {
     "revision": "c390f10519ae69fdb03b3e5764f5592fb6924bcc"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1123,6 +1123,14 @@ list.luau = {
   maintainers = { "@amaanq" },
 }
 
+list.hlsplaylist = {
+  install_info = {
+    url = "https://github.com/Freed-Wu/tree-sitter-hlsplaylist",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@Freed-Wu" },
+}
+
 list.m68k = {
   install_info = {
     url = "https://github.com/grahambates/tree-sitter-m68k",

--- a/queries/hlsplaylist/highlights.scm
+++ b/queries/hlsplaylist/highlights.scm
@@ -1,0 +1,41 @@
+; Comments
+(comment) @comment @spell
+
+; General
+(uri) @string.special.url
+
+(tag_name) @keyword
+
+(attribute_name) @attribute
+
+[
+  (dec)
+  (hex)
+  (resolution)
+  (range)
+] @number
+
+(float) @number.float
+
+(string) @string
+
+[
+  (enum)
+  (date_time_msec)
+] @string.special
+
+(title) @markup.heading
+
+; Literals
+[
+  "="
+  "x"
+  "@"
+] @operator
+
+[
+  ":"
+  ","
+] @punctuation.delimiter
+
+"#" @punctuation.special

--- a/queries/hlsplaylist/injections.scm
+++ b/queries/hlsplaylist/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
m3u or m3u8 is the format used by Apple's [HLS](https://developer.apple.com/streaming/) (HTTP live streaming).

Its document is [RFC8216](https://datatracker.ietf.org/doc/html/rfc8216#page-10).

<https://github.com/iptv-org/iptv> provide m3u source in <https://iptv-org.github.io/>.

For example, <https://iptv-org.github.io/iptv/languages/zho.m3u> is the source for Chinese IPTV's m3u.

In Apple's website, [more examples](https://developer.apple.com/documentation/http-live-streaming/creating-a-multivariant-playlist) can be found.
