### PR TITLE
fix(cpp): add back comment injection

### DIFF
--- a/queries/cpp/injections.scm
+++ b/queries/cpp/injections.scm
@@ -2,6 +2,9 @@
   (#set! injection.language "cpp"))
 
 ((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((comment) @injection.content
   (#lua-match? @injection.content "/[*][!<*][^a-zA-Z]")
   (#set! injection.language "doxygen"))
 


### PR DESCRIPTION
accidentally removed in https://github.com/nvim-treesitter/nvim-treesitter/commit/57a8acf0c4ed5e7f6dda83c3f9b073f8a99a70f9#diff-7e47e0991335c05bf503d5603c5c047b7648299bb0f6fe6d2f08230827cece77