### PR TITLE
feat(lalrpop): highlight annotation macros

### DIFF
--- a/queries/lalrpop/highlights.scm
+++ b/queries/lalrpop/highlights.scm
@@ -77,3 +77,6 @@
 (string_literal) @string
 
 (regex_literal) @string
+
+(annotation
+  (id) @function.macro)


### PR DESCRIPTION
Lalrpop support putting annotation like `#[precedence(level = "1")]`. This commit aims to highlight `precedence` with the `function.macro` highlight group, like rust does with its proc macros.