### PR TITLE
feat: add the muttrc parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [ ] [mermaid](https://github.com/monaqa/tree-sitter-mermaid) (experimental)
 - [x] [meson](https://github.com/Decodetalkers/tree-sitter-meson) (maintained by @Decodetalkers)
 - [x] [mlir](https://github.com/artagnon/tree-sitter-mlir) (experimental, maintained by @artagnon)
+- [x] [muttrc](https://github.com/neomutt/tree-sitter-muttrc) (maintained by @Freed-Wu)
 - [x] [nasm](https://github.com/naclsn/tree-sitter-nasm) (maintained by @ObserverOfTime)
 - [ ] [nickel](https://github.com/nickel-lang/tree-sitter-nickel)
 - [x] [nim](https://github.com/alaviss/tree-sitter-nim) (maintained by @aMOPel)

--- a/lockfile.json
+++ b/lockfile.json
@@ -404,6 +404,9 @@
   "mlir": {
     "revision": "650a8fb72013ba8d169bdb458e480d640fc545c9"
   },
+  "muttrc": {
+    "revision": "9d4e1774e754f55a867638ab6a81335cf1078c23"
+  },
   "nasm": {
     "revision": "3bc691d2cfba44bea339a775ad496c8bc552c60d"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -47,6 +47,7 @@ for ft, lang in pairs {
   xsd = "xml",
   xslt = "xml",
   sbt = "scala",
+  neomuttrc = "muttrc",
 } do
   register_lang(lang, ft)
 end
@@ -1210,6 +1211,14 @@ list.mlir = {
   },
   experimental = true,
   maintainers = { "@artagnon" },
+}
+
+list.muttrc = {
+  install_info = {
+    url = "https://github.com/neomutt/tree-sitter-muttrc",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@Freed-Wu" },
 }
 
 list.nasm = {

--- a/queries/muttrc/highlights.scm
+++ b/queries/muttrc/highlights.scm
@@ -1,0 +1,53 @@
+; Comments
+(comment) @comment @spell
+
+; General
+(int) @number
+
+(string) @string
+
+[
+  (map)
+  (object)
+  (composeobject)
+  (color)
+  (attribute)
+] @string.special
+
+(quadoption) @boolean
+
+(path) @string.special.path
+
+(regex) @string.regexp
+
+[
+  (option)
+  (command_line_option)
+] @variable.builtin
+
+(command) @keyword
+
+(source_directive
+  (command) @keyword.import)
+
+(uri) @string.special.url
+
+(key_name) @constant.builtin
+
+(escape) @string.escape
+
+(function) @function.call
+
+; Literals
+[
+  "<"
+  ">"
+] @punctuation.bracket
+
+"," @punctuation.delimiter
+
+[
+  "&"
+  "?"
+  "*"
+] @character.special

--- a/queries/muttrc/injections.scm
+++ b/queries/muttrc/injections.scm
@@ -1,0 +1,8 @@
+((regex) @injection.content
+  (#set! injection.language "regex"))
+
+((shell) @injection.content
+  (#set! injection.language "bash"))
+
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
![Screenshot from 2024-02-14 09-50-29](https://github.com/neomutt/mutt-language-server/assets/32936898/51b084c0-e1b3-4e62-be68-f94981853de7)

The above is tree-sitter, the below is vim syn.
