### PR TITLE
feat: add some ft, lang pairs

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -30,14 +30,10 @@ for ft, lang in pairs {
   ecma = "javascript",
   jsx = "javascript",
   sh = "bash",
-  apkbuild = "bash",
-  PKGBUILD = "bash",
   html_tags = "html",
   ["typescript.tsx"] = "tsx",
   ["html.handlebars"] = "glimmer",
   systemverilog = "verilog",
-  cls = "latex",
-  sty = "latex",
   pandoc = "markdown",
   rmd = "markdown",
   quarto = "markdown",
@@ -46,6 +42,8 @@ for ft, lang in pairs {
   svg = "xml",
   xsd = "xml",
   xslt = "xml",
+  expect = "tcl",
+  mysql = "sql",
   sbt = "scala",
 } do
   register_lang(lang, ft)


### PR DESCRIPTION
ebuild comes from https://github.com/gentoo/gentoo-syntax which is installed by Gentoo/Linux
tutor comes from $VIMRUNTIME/syntax/tutor.vim
mysql comes from $VIMRUNTIME/syntax/mysql.vim
text comes from $VIMRUNTIME/ftplugin/text.vim
expect comes from $VIMRUNTIME/syntax/expect.vim

I am not sure should we add

brewfile => ruby, comes from https://github.com/bfontaine/Brewfile.vim
altera => tcl, comes from https://github.com/vim-scripts/altera.vim
xdc => tcl, comes from https://github.com/amal-khailtash/vim-xdc-syntax

Because they don't come from $VIMRUNTIME
or preinstalled by any GNU/Linux distributions.
