### PR TITLE
fix(latex): update bibstyle queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -348,7 +348,7 @@
     "revision": "456dec2990ed7e9595eca82f85db14a1db46e126"
   },
   "latex": {
-    "revision": "2ae2021d7b224fb6aa57b760e0d146059f943bb8"
+    "revision": "841f89ffbba9650529a40fb867f3456bf92bf9b1"
   },
   "ledger": {
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -316,9 +316,13 @@
   directory: (curly_group_path) @string
   file: (curly_group_path) @string)
 
-(bibtex_include
+(bibstyle_include
   command: _ @keyword.import
   path: (curly_group_path) @string)
+
+(bibtex_include
+  command: _ @keyword.import
+  paths: (curly_group_path_list) @string)
 
 (biblatex_include
   "\\addbibresource" @keyword.import


### PR DESCRIPTION
Match grammar.js from commit 0d598bb95ffe3ba63403979d0d32158210974ca5 in latex-lsp/tree-sitter-latex