### PR TITLE
feat: improve queries/muttrc/highlights.scm

### DIFF
--- a/queries/muttrc/highlights.scm
+++ b/queries/muttrc/highlights.scm
@@ -20,10 +20,12 @@
 
 (regex) @string.regexp
 
-[
-  (option)
-  (command_line_option)
-] @variable.builtin
+(option) @variable
+
+(command_line_option) @variable.builtin
+
+((option) @variable.builtin
+  (#not-lua-match? @variable.builtin "^my_"))
 
 (command) @keyword
 


### PR DESCRIPTION
I found almost colorscheme doesn't distinguish `@variable` and `@variable.builtin` .
So I am not sure is this PR useful.
