### PR TITLE
feat(latex): more text func highlights

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -2,7 +2,11 @@
 (command_name) @function
 
 (text_mode
-  "\\text" @function)
+  [
+    "\\text"
+    "\\intertext"
+    "\\shortintertext"
+  ] @function)
 
 (caption
   command: _ @function)


### PR DESCRIPTION
Highlights all possible functions that invoke `text_mode`, following a parser update.