### PR TITLE
fix(bash): unordered concatenation highlights

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -68,10 +68,6 @@
   argument: "$" @string) ; bare dollar
 
 (concatenation
-  [
-    (simple_expansion)
-    (expansion)
-  ]
   (word) @string)
 
 [


### PR DESCRIPTION
Right now for something like `CDPATH=$HOME:.`, the `:.` will be highlighted as a string. But if the order is switched, in `CDPATH=.:$HOME`, `.:` will not be given a highlight. This PR makes it so any words in a concatenation are treated as strings. 

I'm not sure if this was done intentionally because only words next to an expansion should be considered strings, if so feel free to shoot this down.