### PR TITLE
fix(ecma): label delimiter highlight

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -206,23 +206,12 @@
 
 ; Punctuation
 ;------------
-";" @punctuation.delimiter
-
-"." @punctuation.delimiter
-
-"," @punctuation.delimiter
-
-(pair
-  ":" @punctuation.delimiter)
-
-(pair_pattern
-  ":" @punctuation.delimiter)
-
-(switch_case
-  ":" @punctuation.delimiter)
-
-(switch_default
-  ":" @punctuation.delimiter)
+[
+  ";"
+  "."
+  ","
+  ":"
+] @punctuation.delimiter
 
 [
   "--"


### PR DESCRIPTION
Highlights the colon following a loop label indentifier (when present). Sorry, this should've been added in #6112... lol