### PR TITLE
feat(fennel)! change parser and update queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -162,7 +162,7 @@
     "revision": "9e514af33bfe061d0ccf1999dbcc93fca91f133c"
   },
   "fennel": {
-    "revision": "15e4f8c417281768db17080c4447297f8ff5343a"
+    "revision": "389e9ec34d9a56ecf3dd74232de8675b3c4b5487"
   },
   "firrtl": {
     "revision": "2b5adae629c8cba528c7b1e4aa67a8ae28934ea5"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -529,10 +529,10 @@ list.faust = {
 
 list.fennel = {
   install_info = {
-    url = "https://github.com/travonted/tree-sitter-fennel",
+    url = "https://github.com/alexmozaidze/tree-sitter-fennel",
     files = { "src/parser.c" },
   },
-  maintainers = { "@TravonteD" },
+  maintainers = { "@alexmozaidze" },
 }
 
 list.firrtl = {

--- a/queries/fennel/folds.scm
+++ b/queries/fennel/folds.scm
@@ -1,11 +1,35 @@
 [
   (list)
   (table)
-  (sequential_table)
-  (let)
-  (fn)
-  (let_clause)
-  (quoted_list)
-  (local)
-  (global)
+  (sequence)
 ] @fold
+
+(list
+  .
+  (symbol) @_let
+  (#eq? @_let "let")
+  .
+  (sequence) @fold) @fold
+
+(list
+  .
+  (symbol) @_local
+  (#eq? @_local "local")) @fold
+
+(list
+  .
+  (symbol) @_global
+  (#eq? @_global "global")) @fold
+
+(list
+  .
+  (symbol) @_fn
+  (#any-of? @_fn "fn" "lambda" "λ" "hashfn")) @fold
+
+(reader_macro
+  macro:
+    [
+      "'"
+      "`"
+    ]
+  expression: (_) @fold)

--- a/queries/fennel/highlights.scm
+++ b/queries/fennel/highlights.scm
@@ -46,11 +46,14 @@
 ((symbol) @punctuation.special
   (#eq? @punctuation.special "&"))
 
-; BUG: It should only be valid if inside hashfn of any depth, but
+; BUG: $ arguments should only be valid inside hashfn of any depth, but
 ; it's impossible to express such query at the moment of writing.
 ; See tree-sitter/tree-sitter#880
 ((symbol) @variable.parameter
-  (#vim-match? @variable.parameter "^\\$(...|[1-9])$"))
+  (#eq? @variable.parameter "$..."))
+
+((symbol) @variable.parameter
+  (#lua-match? @variable.parameter "^%$[1-9]$"))
 
 ((symbol) @operator
   ; format-ignore

--- a/queries/fennel/highlights.scm
+++ b/queries/fennel/highlights.scm
@@ -12,8 +12,6 @@
   "]"
 ] @punctuation.bracket
 
-"." @punctuation.delimiter
-
 (nil) @constant.builtin
 
 (boolean) @boolean
@@ -27,6 +25,7 @@
 (symbol) @variable
 
 (multi_symbol
+  "." @punctuation.delimiter
   member: (symbol_fragment) @variable.member)
 
 (list
@@ -59,20 +58,11 @@
   ; format-ignore
   (#any-of? @operator
     ; arithmetic
-    "+"
-    "-"
-    "*"
-    "/"
-    "//"
-    "%"
-    "^"
+    "+" "-" "*" "/" "//" "%" "^"
     ; comparison
-    ">"
-    "<"
-    ">="
-    "<="
-    "="
-    "~="))
+    ">" "<" ">=" "<=" "=" "~="
+    ; other
+    "#" "." "?." ".."))
 
 ((symbol) @keyword.operator
   ; format-ignore
@@ -80,9 +70,11 @@
     ; comparison
     "not="
     ; boolean
-    "length" "and" "or" "not"
+    "and" "or" "not"
     ; bitwise
-    "lshift" "rshift" "band" "bor" "bxor" "bnot"))
+    "lshift" "rshift" "band" "bor" "bxor" "bnot"
+    ; other
+    "length"))
 
 ((symbol) @keyword.function
   (#any-of? @keyword.function "fn" "lambda" "λ" "hashfn"))
@@ -109,7 +101,8 @@
     "macros"
     "quote"
     "tset"
-    "values"))
+    "values"
+    "tail!"))
 
 ((symbol) @keyword.import
   (#any-of? @keyword.import "require" "require-macros" "import-macros" "include"))

--- a/queries/fennel/highlights.scm
+++ b/queries/fennel/highlights.scm
@@ -1,3 +1,6 @@
+; Most primitive nodes
+(shebang) @keyword.directive
+
 (comment) @comment @spell
 
 [
@@ -9,17 +12,9 @@
   "]"
 ] @punctuation.bracket
 
-[
-  ":"
-  ":until"
-  "&"
-  "&as"
-  "?"
-] @punctuation.special
+"." @punctuation.delimiter
 
 (nil) @constant.builtin
-
-(vararg) @punctuation.special
 
 (boolean) @boolean
 
@@ -32,12 +27,7 @@
 (symbol) @variable
 
 (multi_symbol
-  "." @punctuation.delimiter
-  (symbol) @variable.member)
-
-(multi_symbol_method
-  ":" @punctuation.delimiter
-  (symbol) @function.method.call .)
+  member: (symbol_fragment) @variable.member)
 
 (list
   .
@@ -46,80 +36,217 @@
 (list
   .
   (multi_symbol
-    (symbol) @function.call .))
+    member: (symbol_fragment) @function.call .))
 
-((symbol) @variable.builtin
-  (#lua-match? @variable.builtin "^[$]"))
+(multi_symbol_method
+  ":" @punctuation.delimiter
+  method: (symbol_fragment) @function.method.call .)
 
-(binding) @string.special.symbol
+; Just `&` is only used in destructuring
+((symbol) @punctuation.special
+  (#eq? @punctuation.special "&"))
 
-[
-  "fn"
-  "lambda"
-  "hashfn"
-  "#"
-] @keyword.function
+; BUG: It should only be valid if inside hashfn of any depth, but
+; it's impossible to express such query at the moment of writing.
+; See tree-sitter/tree-sitter#880
+((symbol) @variable.parameter
+  (#vim-match? @variable.parameter "^\\$(...|[1-9])$"))
 
-(fn
-  name:
-    [
-      (symbol) @function
-      (multi_symbol
-        (symbol) @function .)
-    ])
+((symbol) @operator
+  ; format-ignore
+  (#any-of? @operator
+    ; arithmetic
+    "+"
+    "-"
+    "*"
+    "/"
+    "//"
+    "%"
+    "^"
+    ; comparison
+    ">"
+    "<"
+    ">="
+    "<="
+    "="
+    "~="))
 
-(lambda
-  name:
-    [
-      (symbol) @function
-      (multi_symbol
-        (symbol) @function .)
-    ])
+((symbol) @keyword.operator
+  ; format-ignore
+  (#any-of? @keyword.operator
+    ; comparison
+    "not="
+    ; boolean
+    "length" "and" "or" "not"
+    ; bitwise
+    "lshift" "rshift" "band" "bor" "bxor" "bnot"))
 
-[
-  "for"
-  "each"
-] @keyword.repeat
+((symbol) @keyword.function
+  (#any-of? @keyword.function "fn" "lambda" "λ" "hashfn"))
 
 ((symbol) @keyword.repeat
-  (#any-of? @keyword.repeat "while"))
-
-"match" @keyword.conditional
+  (#any-of? @keyword.repeat "for" "each" "while"))
 
 ((symbol) @keyword.conditional
-  (#any-of? @keyword.conditional "if" "when"))
-
-[
-  "global"
-  "local"
-  "let"
-  "set"
-  "var"
-  "where"
-  "or"
-] @keyword
+  (#any-of? @keyword.conditional "if" "when" "match" "case"))
 
 ((symbol) @keyword
-  (#any-of? @keyword "comment" "do" "doc" "eval-compiler" "lua" "macros" "quote" "tset" "values"))
+  ; format-ignore
+  (#any-of? @keyword
+    "global"
+    "local"
+    "let"
+    "set"
+    "var"
+    "comment"
+    "do"
+    "doc"
+    "eval-compiler"
+    "lua"
+    "macros"
+    "quote"
+    "tset"
+    "values"))
 
 ((symbol) @keyword.import
   (#any-of? @keyword.import "require" "require-macros" "import-macros" "include"))
 
-[
-  "collect"
-  "icollect"
-  "accumulate"
-] @function.macro
-
 ((symbol) @function.macro
-  (#any-of? @function.macro "->" "->>" "-?>" "-?>>" "?." "doto" "macro" "macrodebug" "partial" "pick-args" "pick-values" "with-open"))
+  ; format-ignore
+  (#any-of? @function.macro
+    "collect"
+    "icollect"
+    "fcollect"
+    "accumulate"
+    "faccumulate"
+    "->"
+    "->>"
+    "-?>"
+    "-?>>"
+    "?."
+    "doto"
+    "macro"
+    "macrodebug"
+    "partial"
+    "pick-args"
+    "pick-values"
+    "with-open"))
 
-; Lua builtins
+; TODO: Highlight builtin methods (`table.unpack`, etc) as @function.builtin
+([
+  (symbol) @module.builtin
+  (multi_symbol
+    base: (symbol_fragment) @module.builtin)
+]
+  (#any-of? @module.builtin "vim" "_G" "debug" "io" "jit" "math" "os" "package" "string" "table" "utf8"))
+
+([
+  (symbol) @variable.builtin
+  (multi_symbol
+    .
+    (symbol_fragment) @variable.builtin)
+]
+  (#eq? @variable.builtin "arg"))
+
+((symbol) @variable.builtin
+  (#eq? @variable.builtin "..."))
+
 ((symbol) @constant.builtin
-  (#any-of? @constant.builtin "arg" "_ENV" "_G" "_VERSION"))
+  (#eq? @constant.builtin "_VERSION"))
 
 ((symbol) @function.builtin
-  (#any-of? @function.builtin "assert" "collectgarbage" "dofile" "error" "getmetatable" "ipairs" "load" "loadfile" "next" "pairs" "pcall" "print" "rawequal" "rawget" "rawlen" "rawset" "require" "select" "setmetatable" "tonumber" "tostring" "type" "warn" "xpcall"))
+  ; format-ignore
+  (#any-of? @function.builtin
+    "assert"
+    "collectgarbage"
+    "dofile"
+    "error"
+    "getmetatable"
+    "ipairs"
+    "load"
+    "loadfile"
+    "next"
+    "pairs"
+    "pcall"
+    "print"
+    "rawequal"
+    "rawget"
+    "rawlen"
+    "rawset"
+    "require"
+    "select"
+    "setmetatable"
+    "tonumber"
+    "tostring"
+    "type"
+    "warn"
+    "xpcall"
+    "module"
+    "setfenv"
+    "loadstring"
+    "unpack"))
 
-((symbol) @function.builtin
-  (#any-of? @function.builtin "loadstring" "module" "setfenv" "unpack"))
+(table
+  (table_pair
+    key: (symbol) @keyword.directive
+    (#eq? @keyword.directive "&as")))
+
+(list
+  .
+  (symbol) @keyword.function
+  (#any-of? @keyword.function "fn" "lambda" "λ")
+  .
+  [
+    (symbol) @function
+    (multi_symbol
+      (symbol_fragment) @function .)
+  ]
+  .
+  (sequence
+    ((symbol) @variable.parameter
+      (#not-any-of? @variable.parameter "&" "..."))))
+
+(list
+  .
+  (symbol) @function.macro
+  (#any-of? @function.macro "collect" "icollect" "fcollect")
+  .
+  (sequence
+    [
+      (symbol)
+      (string)
+    ] @keyword.directive
+    (#any-of? @keyword.directive "&into" ":into")))
+
+(list
+  .
+  (symbol) @function.macro
+  (#any-of? @function.macro "for" "each" "collect" "icollect" "fcollect" "accumulate" "faccumulate")
+  .
+  (sequence
+    [
+      (symbol)
+      (string)
+    ] @keyword.directive
+    (#any-of? @keyword.directive "&until" ":until")))
+
+(list
+  .
+  (symbol) @keyword.conditional
+  (#any-of? @keyword.conditional "match" "case")
+  .
+  (_)
+  .
+  ((list
+    .
+    (symbol) @keyword
+    (#eq? @keyword "where"))
+    .
+    (_))*
+  .
+  (list
+    .
+    (symbol) @keyword
+    (#eq? @keyword "where"))
+  .
+  (_)? .)

--- a/queries/fennel/highlights.scm
+++ b/queries/fennel/highlights.scm
@@ -76,6 +76,9 @@
     ; other
     "length"))
 
+(reader_macro
+  macro: "#" @keyword.function)
+
 ((symbol) @keyword.function
   (#any-of? @keyword.function "fn" "lambda" "λ" "hashfn"))
 
@@ -99,6 +102,7 @@
     "eval-compiler"
     "lua"
     "macros"
+    "unquote"
     "quote"
     "tset"
     "values"

--- a/queries/fennel/injections.scm
+++ b/queries/fennel/injections.scm
@@ -1,2 +1,148 @@
 ((comment) @injection.content
   (#set! injection.language "comment"))
+
+(list
+  .
+  (multi_symbol) @_vimcmd_identifier
+  (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec2")
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "vim")))
+
+; NOTE: Matches *exactly* `ffi.cdef`
+(list
+  .
+  (multi_symbol) @_cdef_identifier
+  (#eq? @_cdef_identifier "ffi.cdef")
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "c")))
+
+(list
+  .
+  (multi_symbol) @_ts_query_identifier
+  (#any-of? @_ts_query_identifier "vim.treesitter.query.set" "vim.treesitter.query.parse")
+  .
+  (_)
+  .
+  (_)
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "query")))
+
+(list
+  .
+  (multi_symbol) @_vimcmd_identifier
+  (#eq? @_vimcmd_identifier "vim.api.nvim_create_autocmd")
+  .
+  (_)
+  .
+  (table
+    (table_pair
+      key:
+        (string
+          (string_content) @_command
+          (#eq? @_command "command"))
+      value:
+        (string
+          (string_content) @injection.content
+          (#set! injection.language "vim")))))
+
+(list
+  .
+  (multi_symbol) @_user_cmd
+  (#eq? @_user_cmd "vim.api.nvim_create_user_command")
+  .
+  (_)
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "vim")))
+
+(list
+  .
+  (multi_symbol) @_user_cmd
+  (#eq? @_user_cmd "vim.api.nvim_buf_create_user_command")
+  .
+  (_)
+  .
+  (_)
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "vim")))
+
+(list
+  .
+  (multi_symbol) @_map
+  (#any-of? @_map "vim.api.nvim_set_keymap" "vim.keymap.set")
+  .
+  (_)
+  .
+  (_)
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "vim")))
+
+(list
+  .
+  (multi_symbol) @_map
+  (#eq? @_map "vim.api.nvim_buf_set_keymap")
+  .
+  (_)
+  .
+  (_)
+  .
+  (_)
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "vim")))
+
+; highlight string as query if starts with `; query`
+(string
+  (string_content) @injection.content
+  (#lua-match? @injection.content "^%s*;+%s?query")
+  (#set! injection.language "query"))
+
+; ──────────────────────────────────────────────────────────────────────
+; (string.match "123" "%d+")
+(list
+  .
+  (multi_symbol
+    member: (symbol_fragment) @_func
+    .
+    (#any-of? @_func "find" "match" "gmatch" "gsub"))
+  .
+  (_)
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "luap")
+    (#set! injection.include-children)))
+
+; (my-string:match "%d+")
+(list
+  .
+  (multi_symbol_method
+    method: (symbol_fragment) @_method
+    (#any-of? @_method "find" "match" "gmatch" "gsub"))
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "luap")
+    (#set! injection.include-children)))
+
+; (string.format "pi = %.2f" 3.14159)
+(list
+  .
+  (multi_symbol) @_func
+  (#eq? @_func "string.format")
+  .
+  (string
+    (string_content) @injection.content
+    (#set! injection.language "printf")))

--- a/queries/fennel/locals.scm
+++ b/queries/fennel/locals.scm
@@ -1,32 +1,26 @@
-[
-  (program)
-  (fn)
-  (lambda)
-  (let)
-  (each)
-  (for)
-  (match)
-] @local.scope
+; TODO: Add tests
+; TODO: Improve queries
+(program) @local.scope
 
 ((list
   .
-  (symbol) @_special) @local.scope
-  (#any-of? @_special "while" "if" "when" "do" "collect" "icollect" "accumulate"))
-
-(fn
-  name: (symbol) @local.definition.function
-  (#set! definition.function.scope "parent"))
-
-(lambda
-  name: (symbol) @local.definition.function
-  (#set! definition.function.scope "parent"))
-
-; TODO: use @local.definition.parameter for parameters
-(binding
-  (symbol) @local.definition.var)
-
-(for_clause
-  .
-  (symbol) @local.definition.var)
+  (symbol) @_call) @local.scope
+  (#any-of? @_call "let" "fn" "lambda" "λ" "while" "each" "for" "if" "when" "do" "collect" "icollect" "accumulate" "case" "match"))
 
 (symbol) @local.reference
+
+(list
+  .
+  (symbol) @_fn
+  (#any-of? @_fn "fn" "lambda" "λ")
+  .
+  [
+    (symbol) @local.definition.function
+    (multi_symbol
+      member: (symbol_fragment) @local.definition.function .)
+  ]
+  (#set! definition.function.scope "parent")
+  .
+  (sequence
+    (symbol)* @local.definition.parameter
+    (#not-contains? @local.definition.parameter "&")))


### PR DESCRIPTION
This PR changes the [original](https://github.com/TravonteD/tree-sitter-fennel) Fennel parser to my own fork.

I simplified the grammar in order to focus on ease of querying rather than hardcoding all the forms/macros into the grammar, making it easier to add support for new Fennel versions. For a full description of the parser see [README](https://github.com/alexmozaidze/tree-sitter-fennel/blob/main/README.md).

On queries side, I made sure `highlights.scm` and `injections.scm` are working correctly; I also replicated Lua's `injections.scm` to have full parity.
However, I didn't test `locals.scm` and `folds.scm`, I tried to adapt them from their old definitions. I don't really use folds, nor do I use any plugin which uses locals, so I am unable to test them (maybe I should remove those 2 entirely?).

<details><summary>Why a fork?</summary>

The maintainer of the parser ain't maintainin' no more. The last merged PR introduced a bug to tables which broke highlighting. I made a comment on that bug before he merged it, but it was ignored and merged anyway. I made a [PR](https://github.com/TravonteD/tree-sitter-fennel/pull/45) later, but it is yet to be merged. Since I use Fennel all the time, it prompted me to fork the project and fix everything myself.

</details>