### PR TITLE
Add env option to install_info for parser configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ parser_config.zimbu = {
     branch = "main", -- default branch in case of git repo if different from master
     generate_requires_npm = false, -- if stand-alone parser without npm dependencies
     requires_generate_from_grammar = false, -- if folder contains pre-generated src/parser.c
+    env = {}  -- add any environment variables you may need when requires_generate_from_grammar is true
   },
   filetype = "zu", -- if filetype does not match the parser name
 }
@@ -592,6 +593,20 @@ Note this requires Nvim v0.9.
 4. Start `nvim` and `:TSInstall zimbu`.
 
 You can also skip step 2 and use `:TSInstallFromGrammar zimbu` to install directly from a `grammar.js` in the top-level directory specified by `url`.
+You may define environment variables to modify options for grammar generation
+using `install_info.env`. For example, if you wanted to add support for *tags*
+and *wiki-links* in the markdown parser:
+
+```lua
+-- keep default options and modify `requires_generate_from_grammar` and `env`
+local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
+parser_config.markdown_inline.install_info.requires_generate_from_grammar = true
+parser_config.markdown_inline.install_info.env = {
+  EXTENSION_TAGS = 1,
+  EXTENSION_WIKI_LINK = 1
+}
+```
+
 Once the parser is installed, you can update it (from the latest revision of the `main` branch if `url` is a Github repository) with `:TSUpdate zimbu`.
 
 Note that neither `:TSInstall` nor `:TSInstallFromGrammar` copy query files from the grammar repository.

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -423,6 +423,24 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
         },
       })
     end
+    --- uv.spawn will completely overwrite the environment
+    --- when we just want to modify the existing one, so
+    --- make sure to prepopulate it with the current env.
+    --- @param env? table<string,string|number>
+    --- @return string[]?
+    local function add_to_env(env)
+      --- @type table<string,string|number>
+      env = vim.tbl_extend('force', vim.fn.environ(), env or {})
+
+      local renv = {} --- @type string[]
+      for k, v in pairs(env) do
+        renv[#renv + 1] = string.format('%s=%s', k, tostring(v))
+      end
+
+      return renv
+    end
+    local env = add_to_env(parsers.list[lang].install_info.env)
+
     vim.list_extend(command_list, {
       {
         cmd = vim.fn.exepath "tree-sitter",
@@ -431,6 +449,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
         opts = {
           args = M.ts_generate_args,
           cwd = compile_location,
+          env = env
         },
       },
     })

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -57,6 +57,7 @@ end
 ---@field files string[]
 ---@field generate_requires_npm boolean|nil
 ---@field requires_generate_from_grammar boolean|nil
+---@field env table|nil
 ---@field location string|nil
 ---@field use_makefile boolean|nil
 ---@field cxx_standard string|nil


### PR DESCRIPTION
This PR adds support for the `env` variable in `install_info` for parser configuration.

Certain parsers may have different grammar options at build time that may be triggered using environment variables. When `requires_generate_from_grammar` is `true`, the `env` table can be used to set those options understood by `tree-sitter generate`.

For example, the markdown parser supports `tags` and `wiki links`, but are disabled by default. To enable the extensions, the parser can be configured to be built from grammar and enable those optional features:

```lua
local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
parser_config.markdown_inline.install_info.requires_generate_from_grammar = true
parser_config.markdown_inline.install_info.env = {
  EXTENSION_TAGS = 1,
  EXTENSION_WIKI_LINK = 1
}
```