### PR TITLE
fix(scripts): add missing \n for nested grouping

### DIFF
--- a/scripts/format-queries.lua
+++ b/scripts/format-queries.lua
@@ -204,13 +204,8 @@ local format_queries = [[
     (named_node)                  ; ((foo))
     (list)                        ; ([foo] (...))
     (anonymous_node)              ; ("foo")
+    (grouping . (_))
   ] @format.indent.begin
-  .
-  (_))
-(grouping
-  "("
-  .
-  (grouping . (_)) @format.indent.begin
   .
   (_))
 (grouping
@@ -225,6 +220,7 @@ local format_queries = [[
     (named_node)
     (list)
     (predicate)
+    (grouping . (_))
     "."
   ] @format.append-newline
   (_) .)


### PR DESCRIPTION
Once again, related: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/523