### PR TITLE
fix(highlights): highlight @type in phpdoc

### DIFF
--- a/queries/phpdoc/highlights.scm
+++ b/queries/phpdoc/highlights.scm
@@ -23,6 +23,13 @@
 (parameter
   (variable_name) @variable.parameter)
 
+[
+  (array_type)
+  (primitive_type)
+  (named_type)
+  (optional_type)
+] @type
+
 (union_type
   [
     (array_type)


### PR DESCRIPTION
Currently, phpdoc types that are not union type are not highlighted, this change allows to apply `@type` group to all types.

Eg:

Without this change
![2024-02-21-150834_723x177_scrot](https://github.com/nvim-treesitter/nvim-treesitter/assets/3751019/98a5260e-84c5-4c04-b100-41936bcefb62)

With this change
![2024-02-21-150817_728x262_scrot](https://github.com/nvim-treesitter/nvim-treesitter/assets/3751019/09ad46dc-a1e1-40c1-9b70-f7075ede9cb6)

