### PR TITLE
feat(c-sharp): add enum member declaration highlight query

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -141,6 +141,9 @@
 (enum_declaration
   name: (identifier) @type)
 
+(enum_member_declaration
+  name: (identifier) @variable.member)
+
 (constructor_declaration
   name: (identifier) @constructor)
 


### PR DESCRIPTION
Highlight enum member declaration in C#:

before:
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/46619169/b0284139-0d7e-43bc-a75a-031043f9587b)

after:
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/46619169/6c78b307-9a3b-44da-b5c6-cbc8f5a313e5)
