### PR TITLE
slint: Update SHA of tree-sitter parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -582,7 +582,7 @@
     "revision": "ac07aa2c875ef6ada2ec468d8a4d0c7c5efd96d7"
   },
   "slint": {
-    "revision": "00c8a2d3645766f68c0d0460086c0a994e5b0d85"
+    "revision": "3c82235f41b63f35a01ae3888206e93585cbb84a"
   },
   "smali": {
     "revision": "72e334b2630f5852825ba5ff9dfd872447175eb5"


### PR DESCRIPTION
Fix some MISSING nodes being generated by the parser that slipped through the cracks before.