### PR TITLE
fix(fidl): remove requires_generate_from_grammar

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -165,7 +165,7 @@
     "revision": "9265a7d635d2f82a10738b9ad65ba8dd8bd4a84a"
   },
   "fidl": {
-    "revision": "cdb35101270f2da3f0b151d11283a7965a09bf98"
+    "revision": "bdbb635a7f5035e424f6173f2f11b9cd79703f8d"
   },
   "firrtl": {
     "revision": "2b5adae629c8cba528c7b1e4aa67a8ae28934ea5"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -539,7 +539,6 @@ list.fidl = {
   install_info = {
     url = "https://github.com/google/tree-sitter-fidl",
     files = { "src/parser.c" },
-    requires_generate_from_grammar = true,
   },
   maintainers = { "@chaopeng" },
 }


### PR DESCRIPTION
parser new version does not `requires_generate_from_grammar` 