### PR TITLE
feat(fennel): in-depth form support and fixes

### DIFF
--- a/queries/fennel/highlights.scm
+++ b/queries/fennel/highlights.scm
@@ -29,13 +29,12 @@
   member: (symbol_fragment) @variable.member)
 
 (list
-  .
-  (symbol) @function.call)
+  call: (symbol) @function.call)
 
 (list
-  .
-  (multi_symbol
-    member: (symbol_fragment) @function.call .))
+  call:
+    (multi_symbol
+      member: (symbol_fragment) @function.call .))
 
 (multi_symbol_method
   ":" @punctuation.delimiter
@@ -61,7 +60,7 @@
     ; comparison
     ">" "<" ">=" "<=" "=" "~="
     ; other
-    "#" "." "?." ".."))
+    "#" ":" "." "?." ".."))
 
 ((symbol) @keyword.operator
   (#any-of? @keyword.operator
@@ -84,12 +83,12 @@
   (#any-of? @keyword.repeat "for" "each" "while"))
 
 ((symbol) @keyword.conditional
-  (#any-of? @keyword.conditional "if" "when" "match" "case"))
+  (#any-of? @keyword.conditional "if" "when" "case" "case-try" "match" "match-try"))
 
 ((symbol) @keyword
   (#any-of? @keyword
-    "global" "local" "let" "set" "var" "comment" "do" "doc" "eval-compiler" "lua" "macros" "unquote"
-    "quote" "tset" "values" "tail!"))
+    "global" "local" "let" "set" "var" "comment" "do" "doc" "eval-compiler" "lua" "macro" "macros"
+    "macrodebug" "unquote" "quote" "tset" "values" "tail!"))
 
 ((symbol) @keyword.import
   (#any-of? @keyword.import "require" "require-macros" "import-macros" "include"))
@@ -97,7 +96,10 @@
 ((symbol) @function.macro
   (#any-of? @function.macro
     "collect" "icollect" "fcollect" "accumulate" "faccumulate" "->" "->>" "-?>" "-?>>" "?." "doto"
-    "macro" "macrodebug" "partial" "pick-args" "pick-values" "with-open"))
+    "partial" "pick-args" "pick-values" "with-open"
+    ; compiler scope
+    "list" "sym" "gensym" "list?" "sym?" "table?" "sequence?" "varg?" "multi-sym?" "comment?" "view"
+    "get-scope" "assert-compile" "in-scope?" "macroexpand"))
 
 ; TODO: Highlight builtin methods (`table.unpack`, etc) as @function.builtin
 ([
@@ -130,28 +132,355 @@
 
 (table
   (table_pair
+    key: (symbol) @punctuation.special
+    (#eq? @punctuation.special ":")))
+
+(table
+  (table_pair
     key: (symbol) @keyword.directive
     (#eq? @keyword.directive "&as")))
 
+; List destructuring support for `let`
 (list
+  call: (symbol) @keyword
+  (#eq? @keyword "let")
   .
-  (symbol) @keyword.function
+  (comment)*
+  .
+  (sequence
+    .
+    ((comment)*
+      .
+      item:
+        [
+          (_)
+          (list
+            call: (symbol) @variable)
+        ].
+      (comment)*
+      .
+      item: (_).
+      (comment)*)*))
+
+; List destructuring support for "variable forms"
+(list
+  call: (symbol) @keyword
+  (#any-of? @keyword "local" "var" "set" "global")
+  .
+  (comment)*
+  .
+  (list
+    call: (symbol) @variable))
+
+(list
+  call: (symbol) @keyword.import
+  (#eq? @keyword.import "import-macros")
+  .
+  (comment)*
+  .
+  (table
+    (table_pair
+      value: (symbol) @function.macro)))
+
+(list
+  call: (symbol) @keyword
+  (#eq? @keyword "macro")
+  .
+  (comment)*
+  .
+  (symbol) @function.macro
+  .
+  (comment)*
+  .
+  [
+    (sequence
+      !item)
+    (sequence
+      [
+        (symbol) @variable.parameter
+        ((symbol) @punctuation.special
+          (#eq? @punctuation.special "&"))
+        ((symbol) @variable.builtin
+          (#eq? @variable.builtin "..."))
+      ])
+  ])
+
+(list
+  call: (symbol) @keyword
+  (#eq? @keyword "macros")
+  .
+  (comment)*
+  .
+  (table
+    (table_pair
+      key:
+        (string
+          ":"? @function.macro
+          (string_content) @function.macro))))
+
+; Function definition (without metadata/docstring)
+(list
+  call: (symbol) @keyword.function
   (#any-of? @keyword.function "fn" "lambda" "λ")
+  .
+  (comment)*
   .
   [
     (symbol) @function
     (multi_symbol
       (symbol_fragment) @function .)
+  ]?
+  .
+  (comment)*
+  .
+  [
+    (sequence
+      !item)
+    (sequence
+      [
+        (symbol) @variable.parameter
+        ((symbol) @punctuation.special
+          (#eq? @punctuation.special "&"))
+        ((symbol) @variable.builtin
+          (#eq? @variable.builtin "..."))
+      ])
+  ])
+
+; Function definition with docstring
+(list
+  call: (symbol) @keyword.function
+  (#any-of? @keyword.function "fn" "lambda" "λ")
+  .
+  (comment)*
+  .
+  [
+    (symbol)
+    (multi_symbol
+      (symbol_fragment) .)
+  ]?
+  .
+  (comment)*
+  .
+  [
+    (sequence
+      !item)
+    (sequence
+      (symbol))
   ]
   .
+  (comment)*
+  .
+  ((string) @string.documentation
+    .
+    (comment)*
+    .
+    item: (_))?)
+
+; Function definition with table metadata
+(list
+  call: (symbol) @keyword.function
+  (#any-of? @keyword.function "fn" "lambda" "λ")
+  .
+  (comment)*
+  .
+  [
+    (symbol)
+    (multi_symbol
+      (symbol_fragment) .)
+  ]?
+  .
+  (comment)*
+  .
+  [
+    (sequence
+      !item)
+    (sequence
+      (symbol))
+  ]
+  .
+  (comment)*
+  .
+  ((string)?
+    .
+    (comment)*
+    .
+    (table
+      (table_pair
+        key:
+          (string
+            (string_content) @string
+            (#eq? @string "fnl/docstring"))
+        value: (string) @string.documentation))
+    .
+    (comment)*
+    .
+    item: (_))?)
+
+; Function definition with table arglist metadata
+(list
+  call: (symbol) @keyword.function
+  (#any-of? @keyword.function "fn" "lambda" "λ")
+  .
+  (comment)*
+  .
+  [
+    (symbol)
+    (multi_symbol
+      (symbol_fragment) .)
+  ]?
+  .
+  (comment)*
+  .
+  [
+    (sequence
+      !item)
+    (sequence
+      (symbol))
+  ]
+  .
+  (comment)*
+  .
+  ((string)?
+    .
+    (comment)*
+    .
+    (table
+      (table_pair
+        key:
+          (string
+            (string_content) @string
+            (#eq? @string "fnl/arglist"))
+        value:
+          [
+            (sequence
+              !item)
+            (sequence
+              [
+                (symbol) @variable.parameter
+                ((symbol) @punctuation.special
+                  (#eq? @punctuation.special "&"))
+                ((symbol) @variable.builtin
+                  (#eq? @variable.builtin "..."))
+              ])
+          ]))
+    .
+    (comment)*
+    .
+    item: (_))?)
+
+; Table comprehension macros destructuring support
+(list
+  call:
+    [
+      ((symbol) @function.macro
+        (#any-of? @function.macro "collect" "icollect"))
+      ((symbol) @keyword.repeat
+        (#eq? @keyword.repeat "each"))
+    ]
+  .
+  (comment)*
+  .
   (sequence
-    ((symbol) @variable.parameter
-      (#not-any-of? @variable.parameter "&" "..."))))
+    .
+    (comment)*
+    .
+    [
+      (comment)
+      (list
+        call: (_) @variable)
+      (sequence)
+      (table)
+      ((symbol) @variable
+        (#lua-match? @variable "^[^&]"))
+    ]*
+    .
+    [
+      (list)
+      (sequence)
+      (table)
+      ((symbol) @_variable
+        (#lua-match? @_variable "^[^&]"))
+    ]
+    .
+    (comment)*
+    .
+    [
+      (string)
+      (symbol)
+    ]? @_option
+    (#lua-match? @_option "^[&:]")))
 
 (list
+  call: (symbol) @function.macro
+  (#eq? @function.macro "accumulate")
   .
-  (symbol) @function.macro
+  (comment)*
+  .
+  (sequence
+    .
+    (comment)*
+    .
+    (symbol)
+    .
+    (comment)*
+    .
+    ; HACK: Just (_) won't work since it will also capture (comment)
+    ; TODO: Remove `item:` once tree-sitter/tree-sitter#1454 is resolved
+    item: (_)
+    .
+    (comment)*
+    .
+    [
+      (comment)
+      (list
+        call: (_) @variable)
+      (sequence)
+      (table)
+      ((symbol) @variable
+        (#lua-match? @variable "^[^&]"))
+    ]*
+    .
+    [
+      (list)
+      (sequence)
+      (table)
+      ((symbol) @_variable
+        (#lua-match? @_variable "^[^&]"))
+    ]
+    .
+    (comment)*
+    .
+    [
+      (string)
+      (symbol)
+    ]? @_option
+    (#lua-match? @_option "^[&:]")))
+
+; Iterator &until option
+(list
+  call:
+    [
+      ((symbol) @function.macro
+        (#any-of? @function.macro "collect" "icollect" "fcollect" "accumulate" "faccumulate"))
+      ((symbol) @keyword.repeat
+        (#any-of? @keyword.repeat "for" "each"))
+    ]
+  .
+  (comment)*
+  .
+  (sequence
+    [
+      (symbol)
+      (string)
+    ] @keyword.directive
+    (#any-of? @keyword.directive "&until" ":until")))
+
+; Iterator &into option
+(list
+  call: (symbol) @function.macro
   (#any-of? @function.macro "collect" "icollect" "fcollect")
+  .
+  (comment)*
   .
   (sequence
     [
@@ -161,34 +490,119 @@
     (#any-of? @keyword.directive "&into" ":into")))
 
 (list
+  call: (symbol) @keyword.conditional
+  (#any-of? @keyword.conditional "case" "match")
   .
-  (symbol) @function.macro
-  (#any-of? @function.macro "for" "each" "collect" "icollect" "fcollect" "accumulate" "faccumulate")
+  (comment)*
   .
-  (sequence
-    [
-      (symbol)
-      (string)
-    ] @keyword.directive
-    (#any-of? @keyword.directive "&until" ":until")))
-
-(list
+  item: (_)
   .
-  (symbol) @keyword.conditional
-  (#any-of? @keyword.conditional "match" "case")
-  .
-  (_)
-  .
-  ((list
-    .
-    (symbol) @keyword
-    (#eq? @keyword "where"))
-    .
-    (_))*
+  [
+    (comment)
+    ((list
+      call:
+        [
+          (symbol) @variable
+          ((symbol) @keyword
+            (#eq? @keyword "where"))
+        ])
+      .
+      (comment)*
+      .
+      item: (_))
+  ]*
   .
   (list
-    .
-    (symbol) @keyword
-    (#eq? @keyword "where"))
+    call:
+      [
+        (symbol) @variable
+        ((symbol) @keyword
+          (#eq? @keyword "where"))
+      ]))
+
+; Same as above, but for `-try` variants
+(list
+  call: (symbol) @keyword.conditional
+  (#any-of? @keyword.conditional "case-try" "match-try")
   .
-  (_)? .)
+  (comment)*
+  .
+  item: (_)
+  .
+  [
+    (comment)
+    ((list
+      call:
+        [
+          (symbol) @variable
+          ((symbol) @keyword
+            (#eq? @keyword "where"))
+        ])
+      .
+      (comment)*
+      .
+      item: (_))
+  ]*
+  .
+  (list
+    call:
+      [
+        (symbol) @variable
+        ((symbol) @keyword
+          (#eq? @keyword "where"))
+      ]))
+
+; Catch block of `case-try` and `match-try`
+(list
+  call: (symbol) @keyword.conditional
+  (#any-of? @keyword.conditional "case-try" "match-try")
+  .
+  (comment)*
+  .
+  item: (_)
+  ; NOTE: I am not sure wether `catch` can appear anywhere or just at the end
+  (list
+    call: (symbol) @keyword @_catch
+    (#eq? @_catch "catch")
+    .
+    [
+      (comment)
+      ((list
+        call:
+          [
+            (symbol) @variable
+            ((symbol) @_where
+              (#eq? @_where "where"))
+          ])
+        .
+        (comment)*
+        .
+        item: (_))
+    ]*
+    .
+    (list
+      call:
+        [
+          (symbol) @variable
+          ((symbol) @keyword @_where
+            (#eq? @_where "where"))
+        ])?)
+  .
+  (comment)* .)
+
+((list
+  call: (symbol) @keyword
+  (#eq? @keyword "comment")) @comment
+  ; BUG: Offset for an unclosed list errors on Nightly *and* Stable:
+  ; Invalid 'end_col': out of range
+  ;
+  ; With offset, parentheses are colored properly, without it, they're part
+  ; of the comment (which is incorrect, but ok for now)
+  ;
+  ; (#offset! @comment 0 1 0 -1)
+  (#set! "priority" 101))
+
+(list
+  call: (symbol) @keyword
+  (#eq? @keyword "comment")
+  (#set! "priority" 102))


### PR DESCRIPTION
This commit adds support for destructuring in **all** built-in forms/macros, but it involves a lot of tedious and ugly hacks.

# Problems

This PR has to be a draft because of the issues with queries it makes apparent.

## Limitations

Fennel is a Lisp, there is a lot of nesting, and comments can appear anywhere. Not only that, but some forms/macros have sequential syntax and key/value syntax combined (`each`, `collect`, etc), so implementing highlighting for every form/macro and have it consistent is incredibly, **incredibly** hard. I had to explicitly state where a comment might appear, as to not break the highlighting for the simplest scenarios.

The comments part may be fixed sometime in the future with https://github.com/tree-sitter/tree-sitter/issues/1454 being resolved.

## Rendering

Rendering is f_cked. Due to a lot of overriding highlights, their sheer amount and the large amount of queries, the highlighting is overloaded and sometimes it doesn't render correctly, especially on captures with large amount of text.

I do not know why rendering is inconsistent, but I assume it's because of https://github.com/neovim/neovim/issues/26325, though, I'm not sure, since `:Inspect` shows that all the extmarks are in place.

## Duplicate extmarks

There is a lot of duplicate highlights because of keyword checking, and that can't be helped. This is [expected behaviour](https://github.com/tree-sitter/tree-sitter/discussions/2101) on Tree-sitter's part.

So the only thing that can be done is to fold the duplicate captures into one and add a number of how many times it repeated for `:Inspect`.

## Maintainability

As already stated, it is incredibly hard to maintain queries, since most of them are duplicates of one another, but with slight variations. Unless a superset query language appears (like SCSS is to CSS) there is not much to be done; queries are explicit by nature.

### Potential fix

Add a new way of highlighting. Mark certain regions to be parsed with a custom Lua module that is given the sub-tree of what it needs to highlight, and returns ranges and their highlight name:

```lua
-- custom-highlighter.lua

return {
  highlight = function(tree)
    -- code...

    return {
      {20, 26, name = "@keyword"},
      -- more highlights...
    }
  end,
}
```