### PR TITLE
Special highlight group for Rust's `?` operator

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -372,7 +372,6 @@
   ">="
   ">>"
   ">>="
-  "?"
   "@"
   "^"
   "^="
@@ -380,6 +379,8 @@
   "|="
   "||"
 ] @operator
+
+"?" @operator.controlFlow
 
 ; Punctuation
 [


### PR DESCRIPTION
The `?` or "try" operator in Rust acts as syntax sugar for conditional checks
followed by early returns. This means that it manipulates control flow, which
is unusual for operators. Because it's a postfix operator and just a single
character, it can be hard to see, especially if your `@operator` highlights
aren't very bright colors. `?` is used heavily in Rust code, and an important
detail, so in my opinion it should stand out more.

By simply removing it from the list for `@operator` tokens and giving it a
special highlight group, which I call `@operator.controlFlow`, users can link
it to `Conditional` or anything else they see fit, to make `?` stand out
more. Because it is a subgroup of `@operator`, this will not change / break
anything for current users, but give more flexibility to those who want it.

I'm not hung up on the name; I don't know of another language which has control
flow operators, so I wasn't sure what to name it. If there is already an
established naming pattern for this, I'm happy to change the name!