### PR TITLE
fix(configs): fall back to "site" dir as parser install dir

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -584,7 +584,7 @@ end
 function M.get_parser_install_dir(folder_name)
   folder_name = folder_name or "parser"
 
-  local install_dir = config.parser_install_dir or utils.get_package_path()
+  local install_dir = config.parser_install_dir or utils.get_default_parser_install_dir()
   local parser_dir = utils.join_path(install_dir, folder_name)
 
   return utils.create_or_reuse_writable_dir(

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -128,6 +128,18 @@ function M.get_package_path()
   return fn.fnamemodify(source, ":p:h:h:h")
 end
 
+--- Get the default parser install directory, which is:
+--- - The package dir of the nvim-treesitter plugin, if it exists and contains a writable "parser" dir
+--- - The "site" dir from the "runtimepath" (fallback)
+--- @return string
+function M.get_default_parser_install_dir()
+  local package_path = M.get_package_path()
+  if luv.fs_access(M.join_path(package_path, "parser"), "RW") then
+    return package_path
+  end
+  return M.get_site_dir()
+end
+
 function M.get_cache_dir()
   local cache_dir = fn.stdpath "data"
 


### PR DESCRIPTION
Installing nvim-treesitter with luarocks results in the following directory tree:

```sh
.
├── lib
│  └── luarocks
│     └── rocks-5.1
│        ├── nvim-treesitter # plugin, queries, parser etc.
└── share
   └── lua # lua libraries
      └── 5.1
         ├── nvim-treesitter
         ├── nvim-treesitter.lua
```

This results in `:TSInstall` creating a `parser` directory in `share/lua`.
I've investigated the following workarounds for rocks.nvim:

- Call `configs.setup` and set `parser_install_dir` + add it to the runtimepath.
  The caveat is that if `setup` is called again without `parser_install_dir`, it is reset to `nil`.
- Install nvim-treesitter with `lua_modules_path = "lua"` in the luarocks config.
  This is inconsistent with other rocks (for which this config could break things).
- A dirty hack with symlinks.

When looking at the config source, I noticed a comment:

https://github.com/nvim-treesitter/nvim-treesitter/blob/6e2b56cbe75ddf18e6efecee44bc3936d70b0b3e/lua/nvim-treesitter/configs.lua#L578-L584

Apparently at some point it was supposed to fall back to `"site"`?

This PR introduces a change that checks if the nvim-treesitter package dir contains a "parser" directory that is readable+writable. If so, it returns it as the default parser install dir. If not, it falls back to the "site" dir, as described in the comment.