### PR TITLE
feat(c): local label highlights

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -159,6 +159,11 @@
 
 (statement_identifier) @label
 
+(declaration
+  type: (type_identifier) @_type
+  declarator: (identifier) @label
+  (#eq? @_type "__label__"))
+
 [
   (type_identifier)
   (type_descriptor)


### PR DESCRIPTION
Highlights for local label declarations.
Before:
![beforeclabel](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/b4023ef0-14e8-46a6-80f0-c4dc42cdb1d9)
After:
![afterclabel](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/2c3861d2-4df8-46df-b379-0fcb40297272)
