### PR TITLE
python highlights: make @type.builtin consistent with @type

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -10,6 +10,26 @@
 ((identifier) @type
   (#lua-match? @type "^[A-Z].*[a-z]"))
 
+((identifier) @type.builtin
+  (#any-of? @type.builtin
+    ; https://docs.python.org/3/library/exceptions.html
+    "BaseException" "Exception" "ArithmeticError" "BufferError" "LookupError" "AssertionError"
+    "AttributeError" "EOFError" "FloatingPointError" "GeneratorExit" "ImportError"
+    "ModuleNotFoundError" "IndexError" "KeyError" "KeyboardInterrupt" "MemoryError" "NameError"
+    "NotImplementedError" "OSError" "OverflowError" "RecursionError" "ReferenceError" "RuntimeError"
+    "StopIteration" "StopAsyncIteration" "SyntaxError" "IndentationError" "TabError" "SystemError"
+    "SystemExit" "TypeError" "UnboundLocalError" "UnicodeError" "UnicodeEncodeError"
+    "UnicodeDecodeError" "UnicodeTranslateError" "ValueError" "ZeroDivisionError" "EnvironmentError"
+    "IOError" "WindowsError" "BlockingIOError" "ChildProcessError" "ConnectionError"
+    "BrokenPipeError" "ConnectionAbortedError" "ConnectionRefusedError" "ConnectionResetError"
+    "FileExistsError" "FileNotFoundError" "InterruptedError" "IsADirectoryError"
+    "NotADirectoryError" "PermissionError" "ProcessLookupError" "TimeoutError" "Warning"
+    "UserWarning" "DeprecationWarning" "PendingDeprecationWarning" "SyntaxWarning" "RuntimeWarning"
+    "FutureWarning" "ImportWarning" "UnicodeWarning" "BytesWarning" "ResourceWarning"
+    ; https://docs.python.org/3/library/stdtypes.html
+    "bool" "int" "float" "complex" "list" "tuple" "range" "str" "bytes" "bytearray" "memoryview"
+    "set" "frozenset" "dict" "type" "object"))
+
 ((identifier) @constant
   (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 
@@ -411,26 +431,6 @@
     (function_definition
       name: (identifier) @constructor)))
   (#any-of? @constructor "__new__" "__init__"))
-
-((identifier) @type.builtin
-  (#any-of? @type.builtin
-    ; https://docs.python.org/3/library/exceptions.html
-    "BaseException" "Exception" "ArithmeticError" "BufferError" "LookupError" "AssertionError"
-    "AttributeError" "EOFError" "FloatingPointError" "GeneratorExit" "ImportError"
-    "ModuleNotFoundError" "IndexError" "KeyError" "KeyboardInterrupt" "MemoryError" "NameError"
-    "NotImplementedError" "OSError" "OverflowError" "RecursionError" "ReferenceError" "RuntimeError"
-    "StopIteration" "StopAsyncIteration" "SyntaxError" "IndentationError" "TabError" "SystemError"
-    "SystemExit" "TypeError" "UnboundLocalError" "UnicodeError" "UnicodeEncodeError"
-    "UnicodeDecodeError" "UnicodeTranslateError" "ValueError" "ZeroDivisionError" "EnvironmentError"
-    "IOError" "WindowsError" "BlockingIOError" "ChildProcessError" "ConnectionError"
-    "BrokenPipeError" "ConnectionAbortedError" "ConnectionRefusedError" "ConnectionResetError"
-    "FileExistsError" "FileNotFoundError" "InterruptedError" "IsADirectoryError"
-    "NotADirectoryError" "PermissionError" "ProcessLookupError" "TimeoutError" "Warning"
-    "UserWarning" "DeprecationWarning" "PendingDeprecationWarning" "SyntaxWarning" "RuntimeWarning"
-    "FutureWarning" "ImportWarning" "UnicodeWarning" "BytesWarning" "ResourceWarning"
-    ; https://docs.python.org/3/library/stdtypes.html
-    "bool" "int" "float" "complex" "list" "tuple" "range" "str" "bytes" "bytearray" "memoryview"
-    "set" "frozenset" "dict" "type" "object"))
 
 ; Regex from the `re` module
 (call


### PR DESCRIPTION
Language: Python

Problem: when a `@type.builtin` is "called", its color does not change from that of a "type" to that of a "function". It should change to a function, because the symbol now represents a function being called (the constructor), not an expression of a type.

Reason: For Python's query highlights, the highlight match query for `@type.builtin` is currently placed much lower than the one for `@type`. This causes inconsistent highlighting behavior for the two.

Solution: This pull request moves the match query for `@type.builtin` to be next to the match query for `@type`.

Before:

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/3723671/be492e4c-b990-488c-98a6-a98e436f6db1)

After:

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/3723671/195a3969-b619-4415-b600-c48a965386a2)