### PR TITLE
Update Clojure highlights to be metadata aware

### DIFF
--- a/tests/query/highlights/clojure/test.clj
+++ b/tests/query/highlights/clojure/test.clj
@@ -13,10 +13,14 @@
 ;^^^^ @function.call
 ;     ^^^ @variable
 
- #(+ % %1 %&)
+ #(+ % %1 %& %a)
 ;^ @punctuation.special
 ;  ^ @function.call
 ;    ^ ^^ ^^ @variable.builtin
+;            ^^ @variable
+
+ abc#
+;^^^^ @variable
 
  &
 ;^ @variable.parameter
@@ -30,13 +34,16 @@
  *1 *2 *3 *e
 ;^^ ^^ ^^ ^^ @variable.builtin
 
-(.method)
+ .method
 ;^^^^^^^ @function.method
 
-(.-field)
+(.method foo)
+;^^^^^^^ @function.method
+
+(.-field foo)
 ;^^^^^^^ @variable.member
 
- Abc/method
+ Abc/member
 ;^^^^^^^^^^ @variable.member
 
 (Abc/method)
@@ -50,3 +57,58 @@
 
  ^abc
 ;^ @punctuation.special
+
+^java.io.File file
+; <- @punctuation.special
+;^^^^^^^^^^^^ @type
+;             ^^^^ @variable
+
+^java.io.File java.io.File.
+; <- @punctuation.special
+;^^^^^^^^^^^^ @type
+;             ^^^^ @variable
+
+^java.io.File file.
+; <- @punctuation.special
+;^^^^^^^^^^^^ @type
+;             ^^^^ @variable
+
+(^java.io.File file)
+;^ @punctuation.special
+; ^^^^^^^^^^^^ @type
+;              ^^^^ @function.call
+
+(^java.io.File .file foo)
+;^ @punctuation.special
+; ^^^^^^^^^^^^ @type
+;              ^^^^ @function.method
+;                    ^^^@variable
+
+(^java.io.File .-file foo)
+;^ @punctuation.special
+; ^^^^^^^^^^^^ @type
+;              ^^^^ @variable.member
+;                     ^^^@variable
+
+(^java.io.File Abc/method foo)
+;^ @punctuation.special
+; ^^^^^^^^^^^^ @type
+;              ^^^^^^^^^^ @function.method
+;                         ^^^ @variable
+
+ (defn foo [arg1] (+ arg1 1))
+;^         ^    ^ ^        ^^ @punctuation.bracket
+; ^^^^ @keyword.function
+;      ^^^ @function
+;           ^^^^     ^^^^ @variable
+;                  ^ @operator
+;                         ^ @number
+
+ clojure.core/dfn
+;^^^^^^^^^^^^^^^^ @variable
+
+ clojure.core/defn
+;^^^^^^^^^^^^^^^^ @keyword.function
+
+ any-ns/defn
+;^^^^^^^^^^^ @keyword.function


### PR DESCRIPTION
Clojure has the concept of metadata, where a symbol can hold "hidden" data. This is done with a ^ and data in front: `^java.util.Long some-foo`. The current clojure treesitter parser produces a tree that stores the metadata node on the `sym_lit` node. When a query matches on `sym_lit`, it's looking at the metadata too, which means that any queries that match the metadata will in fact leak across to the following symbol.

For example:

```
((sym_lit) @type
  (#lua-match? @type "^[%u][^/]*$"))
```

We can fix this by being more specific about what we're matching against, selecting the `name` or `namespace` field:

```
(sym_lit
  name: (sym_name) @_name
  (#lua-match? @_name "^[%u][^/%s]*$")) @type
```