### PR TITLE
feat(gitcommit): highlight overflow in commit body

### DIFF
--- a/queries/gitcommit/highlights.scm
+++ b/queries/gitcommit/highlights.scm
@@ -15,8 +15,7 @@
 
 (subject) @markup.heading @spell
 
-(subject
-  (overflow) @none @spell)
+(overflow) @comment.warning @spell
 
 (subject
   (subject_prefix) @function @nospell)


### PR DESCRIPTION
Highlights overflow differently per [this suggestion](https://github.com/gbprod/tree-sitter-gitcommit/pull/58#issuecomment-1970650563). This PR is in response to overflow being parsed for the git commit message body as well as the title. Here `@none` doesn't help because the commit message body already has no highlight.