### PR TITLE
feat(vue): switch to new parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -759,7 +759,7 @@
     "revision": "016ad75faa854e4e13bc40c517015183b795eed9"
   },
   "vue": {
-    "revision": "7e48557b903a9db9c38cea3b7839ef7e1f36c693"
+    "revision": "085e99bcc46b2e63ff06a830a31a55132ce95aa5"
   },
   "wgsl": {
     "revision": "40259f3c77ea856841a4e0c4c807705f3e4a2b65"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2204,6 +2204,7 @@ list.vue = {
   install_info = {
     url = "https://github.com/tree-sitter-grammars/tree-sitter-vue",
     files = { "src/parser.c", "src/scanner.c" },
+    branch = "main",
   },
   maintainers = { "@WhyNotHugo" },
 }

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2206,7 +2206,7 @@ list.vue = {
     files = { "src/parser.c", "src/scanner.c" },
     branch = "main",
   },
-  maintainers = { "@WhyNotHugo" },
+  maintainers = { "@WhyNotHugo", "@lucario387" },
 }
 
 list.wgsl = {

--- a/queries/vue/highlights.scm
+++ b/queries/vue/highlights.scm
@@ -1,7 +1,5 @@
 ; inherits: html_tags
 
-(dynamic_directive_inner_value) @tag
-
 [
   "["
   "]"
@@ -13,6 +11,25 @@
   (raw_text) @none)
 
 (directive_name) @tag.attribute
+
+; Accessing a component object's field
+(":"
+  .
+  (directive_value) @variable.member)
+
+("."
+  .
+  (directive_value) @property)
+
+; @click is like onclick for HTML
+("@"
+  .
+  (directive_value) @function.method)
+
+; Used in v-slot, declaring position the element should be put in
+("#"
+  .
+  (directive_value) @variable)
 
 (directive_attribute
   (quoted_attribute_value) @punctuation.special)

--- a/queries/vue/highlights.scm
+++ b/queries/vue/highlights.scm
@@ -10,6 +10,8 @@
 (interpolation
   (raw_text) @none)
 
+(dynamic_directive_inner_value) @variable
+
 (directive_name) @tag.attribute
 
 ; Accessing a component object's field
@@ -38,7 +40,4 @@
   (quoted_attribute_value
     (attribute_value) @none))
 
-[
-  (directive_modifier)
-  (directive_value)
-] @function.method
+(directive_modifier) @function.method

--- a/queries/vue/highlights.scm
+++ b/queries/vue/highlights.scm
@@ -1,9 +1,11 @@
 ; inherits: html_tags
 
+(dynamic_directive_inner_value) @tag
+
 [
-  (directive_dynamic_argument)
-  (directive_dynamic_argument_value)
-] @tag
+  "["
+  "]"
+] @punctuation.bracket
 
 (interpolation) @punctuation.special
 
@@ -21,5 +23,5 @@
 
 [
   (directive_modifier)
-  (directive_argument)
+  (directive_value)
 ] @function.method


### PR DESCRIPTION
The new branch is renamed to `main`; the old to `fork` but still default so previous commits of this plugin remain working. We'll switch the default (and delete the old branch) after a grace period.

@amaanq queries may need adaptation; feel free to push to this PR (and mark as breaking).