### PR TITLE
feat: `@keyword.modifier`,  `@type.modifier`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,6 @@ As languages differ quite a lot, here is a set of captures available to you when
 @type             ; type or class definitions and annotations
 @type.builtin     ; built-in types
 @type.definition  ; identifiers in type definitions (e.g. `typedef <type> <identifier>` in C)
-@type.qualifier   ; type qualifiers (e.g. `const`)
 
 @attribute          ; attribute annotations (e.g. Python decorators)
 @attribute.builtin  ; builtin annotations (e.g. `@property` in Python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,7 @@ As languages differ quite a lot, here is a set of captures available to you when
 @keyword.import            ; keywords for including modules (e.g. `import` / `from` in Python)
 @keyword.storage           ; modifiers that affect storage in memory or life-time
 @keyword.type              ; keywords describing composite types (e.g. `struct`, `enum`)
+@keyword.modifier          ; keywords modifying other constructs (e.g. `const`, `static`, `public`)
 @keyword.repeat            ; keywords related to loops (e.g. `for` / `while`)
 @keyword.return            ; keywords like `return` and `yield`
 @keyword.debug             ; keywords related to debugging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,6 @@ As languages differ quite a lot, here is a set of captures available to you when
 @keyword.function          ; keywords that define a function (e.g. `func` in Go, `def` in Python)
 @keyword.operator          ; operators that are English words (e.g. `and` / `or`)
 @keyword.import            ; keywords for including modules (e.g. `import` / `from` in Python)
-@keyword.storage           ; modifiers that affect storage in memory or life-time
 @keyword.type              ; keywords describing composite types (e.g. `struct`, `enum`)
 @keyword.modifier          ; keywords modifying other constructs (e.g. `const`, `static`, `public`)
 @keyword.repeat            ; keywords related to loops (e.g. `for` / `while`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ As languages differ quite a lot, here is a set of captures available to you when
 @type.builtin     ; built-in types
 @type.definition  ; identifiers in type definitions (e.g. `typedef <type> <identifier>` in C)
 
-@attribute          ; attribute annotations (e.g. Python decorators)
+@attribute          ; attribute annotations (e.g. Python decorators, Rust lifetimes)
 @attribute.builtin  ; builtin annotations (e.g. `@property` in Python)
 @property           ; the key in key/value pairs
 ```

--- a/queries/ada/highlights.scm
+++ b/queries/ada/highlights.scm
@@ -54,7 +54,7 @@
   "aliased"
   "constant"
   "renames"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "with"

--- a/queries/apex/highlights.scm
+++ b/queries/apex/highlights.scm
@@ -202,7 +202,7 @@
   "protected"
   "public"
   "static"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "if"

--- a/queries/bitbake/highlights.scm
+++ b/queries/bitbake/highlights.scm
@@ -86,7 +86,7 @@
 [
   "before"
   "after"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "append"

--- a/queries/bitbake/highlights.scm
+++ b/queries/bitbake/highlights.scm
@@ -92,7 +92,7 @@
   "append"
   "prepend"
   "remove"
-] @type.qualifier
+] @keyword.modifier
 
 ; Variables
 [

--- a/queries/blueprint/highlights.scm
+++ b/queries/blueprint/highlights.scm
@@ -49,9 +49,6 @@
 (menu_item
   "item" @function.macro)
 
-(template_definition
-  (template_name_qualifier) @type.qualifier)
-
 (import_statement
   (gobject_library) @module)
 

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -175,7 +175,7 @@
   (type_qualifier)
   (gnu_asm_qualifier)
   "__extension__"
-] @type.qualifier
+] @keyword.modifier
 
 (linkage_specification
   "extern" @keyword.storage)

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -169,7 +169,7 @@
   (type_descriptor)
 ] @type
 
-(storage_class_specifier) @keyword.storage
+(storage_class_specifier) @keyword.modifier
 
 [
   (type_qualifier)
@@ -178,7 +178,7 @@
 ] @keyword.modifier
 
 (linkage_specification
-  "extern" @keyword.storage)
+  "extern" @keyword.modifier)
 
 (type_definition
   declarator: (type_identifier) @type.definition)

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -450,7 +450,7 @@
   "partial"
   "sealed"
   "virtual"
-] @type.qualifier
+] @keyword.modifier
 
 (parameter_modifier) @operator
 

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -439,7 +439,7 @@
   "static"
   "volatile"
   "required"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "abstract"

--- a/queries/cairo/highlights.scm
+++ b/queries/cairo/highlights.scm
@@ -138,7 +138,7 @@
 [
   "tempvar"
   "extern"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "if"

--- a/queries/capnp/highlights.scm
+++ b/queries/capnp/highlights.scm
@@ -27,7 +27,7 @@
 ] @keyword
 
 ; Builtins
-"const" @type.qualifier
+"const" @keyword.modifier
 
 [
   (primitive_type)

--- a/queries/chatito/highlights.scm
+++ b/queries/chatito/highlights.scm
@@ -30,7 +30,7 @@
 
 (slot) @type
 
-(variation) @type.qualifier
+(variation) @attribute
 
 (alias) @keyword.directive
 

--- a/queries/cmake/highlights.scm
+++ b/queries/cmake/highlights.scm
@@ -136,7 +136,7 @@
   (argument_list
     .
     (argument)
-    ((argument) @_cache @keyword.storage
+    ((argument) @_cache @keyword.modifier
       .
       (argument) @_type @type
       (#any-of? @_cache "CACHE")
@@ -148,8 +148,8 @@
   (argument_list
     .
     (argument)
-    (argument) @keyword.storage
-    (#any-of? @keyword.storage "CACHE" "PARENT_SCOPE")))
+    (argument) @keyword.modifier
+    (#any-of? @keyword.modifier "CACHE" "PARENT_SCOPE")))
 
 (normal_command
   (identifier) @_function

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -232,7 +232,7 @@
   "protected"
   "virtual"
   "final"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "new"

--- a/queries/css/highlights.scm
+++ b/queries/css/highlights.scm
@@ -56,7 +56,7 @@
   "only"
 ] @keyword.operator
 
-(important) @type.qualifier
+(important) @keyword.modifier
 
 (attribute_selector
   (plain_value) @string)

--- a/queries/cuda/highlights.scm
+++ b/queries/cuda/highlights.scm
@@ -13,4 +13,4 @@
   "__noinline__"
 ] @keyword.storage
 
-"__launch_bounds__" @type.qualifier
+"__launch_bounds__" @keyword.modifier

--- a/queries/cuda/highlights.scm
+++ b/queries/cuda/highlights.scm
@@ -11,6 +11,6 @@
   "__global__"
   "__forceinline__"
   "__noinline__"
-] @keyword.storage
+] @keyword.modifier
 
 "__launch_bounds__" @keyword.modifier

--- a/queries/d/highlights.scm
+++ b/queries/d/highlights.scm
@@ -68,7 +68,7 @@
   (const)
   (override)
   (static)
-] @type.qualifier
+] @keyword.modifier
 
 [
   (assert)

--- a/queries/d/highlights.scm
+++ b/queries/d/highlights.scm
@@ -102,16 +102,16 @@
   (gshared)
   (out)
   (inout)
-] @keyword.storage
+] @keyword.modifier
 
 (parameter_attribute
-  (return) @keyword.storage)
+  (return) @keyword.modifier)
 
 (parameter_attribute
-  (in) @keyword.storage)
+  (in) @keyword.modifier)
 
 (parameter_attribute
-  (out) @keyword.storage)
+  (out) @keyword.modifier)
 
 (debug) @keyword.debug
 

--- a/queries/dart/highlights.scm
+++ b/queries/dart/highlights.scm
@@ -245,7 +245,7 @@
   "final"
   "base"
   "sealed"
-] @type.qualifier
+] @keyword.modifier
 
 ; when used as an identifier:
 ((identifier) @variable.builtin

--- a/queries/doxygen/highlights.scm
+++ b/queries/doxygen/highlights.scm
@@ -31,7 +31,7 @@
   "in"
   "out"
   "inout"
-] @keyword.storage
+] @keyword.modifier
 
 "~" @operator
 

--- a/queries/dtd/highlights.scm
+++ b/queries/dtd/highlights.scm
@@ -31,7 +31,7 @@
 [
   "EMPTY"
   "ANY"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "*"

--- a/queries/eds/highlights.scm
+++ b/queries/eds/highlights.scm
@@ -27,21 +27,7 @@
   (section_name) @_name
   (statement
     (key) @_key) @type
-  (#match? @_key "\\c^ObjectType$")
-  (#not-match? @_name "\\c^Comments$"))
-
-(section
-  (section_name) @_name
-  (statement
-    (key) @_key) @type
-  (#match? @_key "\\c^DataType$")
-  (#not-match? @_name "\\c^Comments$"))
-
-(section
-  (section_name) @_name
-  (statement
-    (key) @_key) @type.qualifier
-  (#match? @_key "\\c^AccessType$")
+  (#match? @_key "\\c^(ObjectType|DataType|AccessType)$")
   (#not-match? @_name "\\c^Comments$"))
 
 (section

--- a/queries/firrtl/highlights.scm
+++ b/queries/firrtl/highlights.scm
@@ -38,7 +38,7 @@
 ] @keyword
 
 ; Qualifiers
-(qualifier) @type.qualifier
+(qualifier) @keyword.modifier
 
 ; Storageclasses
 [

--- a/queries/firrtl/highlights.scm
+++ b/queries/firrtl/highlights.scm
@@ -44,7 +44,7 @@
 [
   "input"
   "output"
-] @keyword.storage
+] @keyword.modifier
 
 ; Conditionals
 [

--- a/queries/fortran/highlights.scm
+++ b/queries/fortran/highlights.scm
@@ -137,7 +137,7 @@
   "in"
   "inout"
   "out"
-] @keyword.storage
+] @keyword.modifier
 
 ; Labels
 [

--- a/queries/fortran/highlights.scm
+++ b/queries/fortran/highlights.scm
@@ -130,7 +130,7 @@
   "value"
   "volatile"
   (procedure_qualifier)
-] @type.qualifier
+] @keyword.modifier
 
 [
   "common"

--- a/queries/func/highlights.scm
+++ b/queries/func/highlights.scm
@@ -54,7 +54,7 @@
   "const"
   "global"
   (var)
-] @type.qualifier
+] @keyword.modifier
 
 ; Variables
 (identifier) @variable

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -28,7 +28,7 @@
 (get_body
   "get" @keyword.function)
 
-(static_keyword) @type.qualifier
+(static_keyword) @keyword.modifier
 
 (tool_statement) @keyword
 
@@ -50,7 +50,7 @@
   (name) @type) @keyword
 
 (const_statement
-  "const" @type.qualifier
+  "const" @keyword.modifier
   (name) @constant)
 
 (expression_statement

--- a/queries/gdshader/highlights.scm
+++ b/queries/gdshader/highlights.scm
@@ -13,7 +13,7 @@
 [
   (precision_qualifier)
   (interpolation_qualifier)
-] @type.qualifier
+] @keyword.modifier
 
 [
   "in"

--- a/queries/gdshader/highlights.scm
+++ b/queries/gdshader/highlights.scm
@@ -19,7 +19,7 @@
   "in"
   "out"
   "inout"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "while"

--- a/queries/gleam/highlights.scm
+++ b/queries/gleam/highlights.scm
@@ -159,7 +159,7 @@
   "external"
   (opacity_modifier)
   (visibility_modifier)
-] @type.qualifier
+] @keyword.modifier
 
 ; Tuples
 (tuple_access

--- a/queries/glsl/highlights.scm
+++ b/queries/glsl/highlights.scm
@@ -25,7 +25,7 @@
   "noperspective"
   "invariant"
   "precise"
-] @type.qualifier
+] @keyword.modifier
 
 "subroutine" @keyword.function
 

--- a/queries/glsl/highlights.scm
+++ b/queries/glsl/highlights.scm
@@ -29,7 +29,7 @@
 
 "subroutine" @keyword.function
 
-(extension_storage_class) @keyword.storage
+(extension_storage_class) @keyword.modifier
 
 ((identifier) @variable.builtin
   (#lua-match? @variable.builtin "^gl_"))

--- a/queries/gpg/highlights.scm
+++ b/queries/gpg/highlights.scm
@@ -26,7 +26,7 @@
 
 (format) @character.special
 
-"sensitive:" @type.qualifier
+"sensitive:" @keyword.modifier
 
 (filter_name) @variable.parameter
 

--- a/queries/groovy/highlights.scm
+++ b/queries/groovy/highlights.scm
@@ -67,7 +67,7 @@
   "public"
   "static"
   "synchronized"
-] @type.qualifier
+] @keyword.modifier
 
 (comment) @comment @spell
 

--- a/queries/hack/highlights.scm
+++ b/queries/hack/highlights.scm
@@ -64,7 +64,7 @@
   (static_modifier)
   (visibility_modifier)
   (xhp_modifier)
-] @type.qualifier
+] @keyword.modifier
 
 [
   "shape"

--- a/queries/hare/highlights.scm
+++ b/queries/hare/highlights.scm
@@ -74,7 +74,7 @@
   "const"
   "static"
   "nullable"
-] @type.qualifier
+] @keyword.modifier
 
 ; Attributes
 [

--- a/queries/hlsl/highlights.scm
+++ b/queries/hlsl/highlights.scm
@@ -24,7 +24,7 @@
   "triangleadj"
   "lineadj"
   "triangle"
-] @type.qualifier
+] @keyword.modifier
 
 ((identifier) @variable.builtin
   (#lua-match? @variable.builtin "^SV_"))

--- a/queries/ispc/highlights.scm
+++ b/queries/ispc/highlights.scm
@@ -31,7 +31,7 @@
 [
   "varying"
   "uniform"
-] @type.qualifier
+] @keyword.modifier
 
 "__regcall" @attribute
 

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -207,7 +207,7 @@
 [
   "transient"
   "volatile"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "return"

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -199,10 +199,10 @@
   "static"
   "strictfp"
   "transitive"
-] @type.qualifier
+] @keyword.modifier
 
 (modifiers
-  "synchronized" @type.qualifier)
+  "synchronized" @keyword.modifier)
 
 [
   "transient"

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -309,7 +309,7 @@
 [
   "const"
   "mutable"
-] @type.qualifier
+] @keyword.modifier
 
 ; Operators & Punctuation
 [

--- a/queries/kotlin/highlights.scm
+++ b/queries/kotlin/highlights.scm
@@ -237,7 +237,7 @@
   (visibility_modifier)
   (reification_modifier)
   (inheritance_modifier)
-] @type.qualifier
+] @keyword.modifier
 
 [
   "val"

--- a/queries/kusto/highlights.scm
+++ b/queries/kusto/highlights.scm
@@ -42,7 +42,7 @@
 
 (type) @type
 
-(join_types) @type.qualifier
+(join_types) @keyword.modifier
 
 [
   "("

--- a/queries/lalrpop/highlights.scm
+++ b/queries/lalrpop/highlights.scm
@@ -72,7 +72,14 @@
 ] @punctuation.delimiter
 
 (lifetime
-  (identifier) @keyword.modifier)
+  "'" @keyword.modifier)
+
+(lifetime
+  (identifier) @attribute)
+
+(lifetime
+  (identifier) @attribute.builtin
+  (#any-of? @attribute.builtin "static" "_"))
 
 (string_literal) @string
 

--- a/queries/lalrpop/highlights.scm
+++ b/queries/lalrpop/highlights.scm
@@ -72,7 +72,7 @@
 ] @punctuation.delimiter
 
 (lifetime
-  (identifier) @keyword.storage)
+  (identifier) @keyword.modifier)
 
 (string_literal) @string
 

--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -24,7 +24,7 @@
   "constant"
   "private"
   "public"
-] @type.qualifier
+] @keyword.modifier
 
 "self" @variable.builtin
 

--- a/queries/llvm/highlights.scm
+++ b/queries/llvm/highlights.scm
@@ -100,7 +100,7 @@
   (dso_local)
   (linkage_aux)
   (visibility)
-] @type.qualifier
+] @keyword.modifier
 
 [
   "thread_local"

--- a/queries/llvm/highlights.scm
+++ b/queries/llvm/highlights.scm
@@ -109,7 +109,7 @@
   "localexec"
   (unnamed_addr)
   (dll_storage_class)
-] @keyword.storage
+] @keyword.modifier
 
 (attribute_name) @attribute
 

--- a/queries/luadoc/highlights.scm
+++ b/queries/luadoc/highlights.scm
@@ -62,7 +62,7 @@
   "@private"
   "(exact)"
   "(key)"
-] @type.qualifier @nospell
+] @keyword.modifier @nospell
 
 ; Variables
 (identifier) @variable @nospell

--- a/queries/mermaid/highlights.scm
+++ b/queries/mermaid/highlights.scm
@@ -244,6 +244,6 @@
 [
   (er_attribute_key_type_pk)
   (er_attribute_key_type_fk)
-] @type.qualifier
+] @keyword.modifier
 
 (er_attribute_comment) @string @spell

--- a/queries/nim/highlights.scm
+++ b/queries/nim/highlights.scm
@@ -724,36 +724,36 @@
         ])))
 
 ; =============================================================================
-; @type.qualifier  ; type qualifiers (e.g. `const`)
+; @keyword.modifier  ; type qualifier keywords (e.g. `const`)
 (var_type
-  "var" @type.qualifier)
+  "var" @keyword.modifier)
 
 (out_type
-  "out" @type.qualifier)
+  "out" @keyword.modifier)
 
 (distinct_type
-  "distinct" @type.qualifier)
+  "distinct" @keyword.modifier)
 
 (ref_type
-  "ref" @type.qualifier)
+  "ref" @keyword.modifier)
 
 (pointer_type
-  "ptr" @type.qualifier)
+  "ptr" @keyword.modifier)
 
 (var_parameter
-  "var" @type.qualifier)
+  "var" @keyword.modifier)
 
 (type_parameter
-  "type" @type.qualifier)
+  "type" @keyword.modifier)
 
 (static_parameter
-  "static" @type.qualifier)
+  "static" @keyword.modifier)
 
 (ref_parameter
-  "ref" @type.qualifier)
+  "ref" @keyword.modifier)
 
 (pointer_parameter
-  "ptr" @type.qualifier)
+  "ptr" @keyword.modifier)
 
 ; =============================================================================
 ; @variable.member           ; object and struct fields

--- a/queries/objc/highlights.scm
+++ b/queries/objc/highlights.scm
@@ -21,7 +21,7 @@
   "__covariant"
   "__contravariant"
   (visibility_specification)
-] @type.qualifier
+] @keyword.modifier
 
 ; Storageclasses
 [

--- a/queries/objc/highlights.scm
+++ b/queries/objc/highlights.scm
@@ -30,7 +30,7 @@
   "@dynamic"
   "volatile"
   (protocol_qualifier)
-] @keyword.storage
+] @keyword.modifier
 
 ; Keywords
 [

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -153,7 +153,7 @@
   "rec"
   "private"
   "virtual"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "fun"

--- a/queries/odin/highlights.scm
+++ b/queries/odin/highlights.scm
@@ -36,7 +36,7 @@
 [
   "distinct"
   "dynamic"
-] @keyword.storage
+] @keyword.modifier
 
 ; Conditionals
 [

--- a/queries/pascal/highlights.scm
+++ b/queries/pascal/highlights.scm
@@ -84,7 +84,7 @@
 [
   (kPacked)
   (kAbsolute)
-] @keyword.storage
+] @keyword.modifier
 
 (kUses) @keyword.import
 

--- a/queries/pascal/highlights.scm
+++ b/queries/pascal/highlights.scm
@@ -79,7 +79,7 @@
   (kStrict)
   (kRequired)
   (kOptional)
-] @type.qualifier
+] @keyword.modifier
 
 [
   (kPacked)

--- a/queries/php_only/highlights.scm
+++ b/queries/php_only/highlights.scm
@@ -266,7 +266,7 @@
   "public"
   "readonly"
   "static"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "return"

--- a/queries/pioasm/highlights.scm
+++ b/queries/pioasm/highlights.scm
@@ -62,7 +62,7 @@
 [
   (optional)
   (irq_modifiers)
-] @type.qualifier
+] @keyword.modifier
 
 [
   "block"

--- a/queries/pioasm/highlights.scm
+++ b/queries/pioasm/highlights.scm
@@ -75,7 +75,7 @@
   "ifempty"
 ] @keyword.conditional
 
-"public" @keyword.storage
+"public" @keyword.modifier
 
 (integer) @number
 

--- a/queries/pony/highlights.scm
+++ b/queries/pony/highlights.scm
@@ -45,7 +45,7 @@
   "#share"
   "#alias"
   "#any"
-] @type.qualifier
+] @keyword.modifier
 
 ; Conditionals
 [

--- a/queries/proto/highlights.scm
+++ b/queries/proto/highlights.scm
@@ -19,7 +19,7 @@
   "optional"
   "repeated"
   "required"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "package"

--- a/queries/prql/highlights.scm
+++ b/queries/prql/highlights.scm
@@ -106,7 +106,7 @@ alias: (identifier) @variable.member
 [
   (keyword_version)
   (keyword_target)
-] @type.qualifier
+] @keyword.modifier
 
 (target) @function.builtin
 

--- a/queries/purescript/highlights.scm
+++ b/queries/purescript/highlights.scm
@@ -113,7 +113,7 @@
 
 (type_role_declaration
   "role" @keyword
-  role: (type_role) @type.qualifier)
+  role: (type_role) @keyword.modifier)
 
 (hole) @character.special
 

--- a/queries/ql/highlights.scm
+++ b/queries/ql/highlights.scm
@@ -54,7 +54,7 @@
 [
   "asc"
   "desc"
-] @type.qualifier
+] @keyword.modifier
 
 [
   (true)

--- a/queries/qmljs/highlights.scm
+++ b/queries/qmljs/highlights.scm
@@ -116,7 +116,7 @@
   "default"
   "readonly"
   "required"
-] @type.qualifier
+] @keyword.modifier
 
 ; from typescript
 (type_identifier) @type

--- a/queries/rasi/highlights.scm
+++ b/queries/rasi/highlights.scm
@@ -104,7 +104,7 @@
     "normal"
     "urgent"
     "active"
-  ] @type.qualifier)
+  ] @keyword.modifier)
 
 (hex_color) @number
 

--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -37,7 +37,7 @@
   "prepend"
 ] @function.method
 
-(visibility) @type.qualifier
+(visibility) @keyword.modifier
 
 (comment) @comment @spell
 

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -62,8 +62,8 @@
 
 (constant) @constant
 
-((identifier) @type.qualifier
-  (#any-of? @type.qualifier "private" "protected" "public"))
+((identifier) @keyword.modifier
+  (#any-of? @keyword.modifier "private" "protected" "public"))
 
 [
   "rescue"

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -282,13 +282,13 @@
   "static"
   "dyn"
   "extern"
-] @keyword.storage
+] @keyword.modifier
 
 (lifetime
   [
     "'"
     (identifier)
-  ] @keyword.storage)
+  ] @keyword.modifier)
 
 "fn" @keyword.function
 

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -275,7 +275,7 @@
 [
   "ref"
   (mutable_specifier)
-] @type.qualifier
+] @keyword.modifier
 
 [
   "const"

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -285,10 +285,14 @@
 ] @keyword.modifier
 
 (lifetime
-  [
-    "'"
-    (identifier)
-  ] @keyword.modifier)
+  "'" @keyword.modifier)
+
+(lifetime
+  (identifier) @attribute)
+
+(lifetime
+  (identifier) @attribute.builtin
+  (#any-of? @attribute.builtin "static" "_"))
 
 "fn" @keyword.function
 

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -161,13 +161,13 @@
   "$" @punctuation.special)
 
 ; keywords
-(opaque_modifier) @type.qualifier
+(opaque_modifier) @keyword.modifier
 
 (infix_modifier) @keyword
 
-(transparent_modifier) @type.qualifier
+(transparent_modifier) @keyword.modifier
 
-(open_modifier) @type.qualifier
+(open_modifier) @keyword.modifier
 
 [
   "case"
@@ -201,7 +201,7 @@
   "sealed"
   "private"
   "protected"
-] @type.qualifier
+] @keyword.modifier
 
 (inline_modifier) @keyword.storage
 

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -203,7 +203,7 @@
   "protected"
 ] @keyword.modifier
 
-(inline_modifier) @keyword.storage
+(inline_modifier) @keyword.modifier
 
 (null_literal) @constant.builtin
 

--- a/queries/slint/highlights.scm
+++ b/queries/slint/highlights.scm
@@ -28,11 +28,11 @@
   (relative_font_size_value)
 ] @number.float
 
-(purity) @type.qualifier
+(purity) @keyword.modifier
 
-(function_visibility) @type.qualifier
+(function_visibility) @keyword.modifier
 
-(property_visibility) @type.qualifier
+(property_visibility) @keyword.modifier
 
 (builtin_type_identifier) @type.builtin
 

--- a/queries/smali/highlights.scm
+++ b/queries/smali/highlights.scm
@@ -192,7 +192,7 @@
 ; Misc
 (annotation_visibility) @keyword.storage
 
-(access_modifier) @type.qualifier
+(access_modifier) @keyword.modifier
 
 (array_type
   "[" @punctuation.special)

--- a/queries/smali/highlights.scm
+++ b/queries/smali/highlights.scm
@@ -190,7 +190,7 @@
 (null) @constant.builtin
 
 ; Misc
-(annotation_visibility) @keyword.storage
+(annotation_visibility) @keyword.modifier
 
 (access_modifier) @keyword.modifier
 

--- a/queries/solidity/highlights.scm
+++ b/queries/solidity/highlights.scm
@@ -172,7 +172,7 @@
   "view"
   "payable"
   (immutable)
-] @type.qualifier
+] @keyword.modifier
 
 [
   "memory"

--- a/queries/solidity/highlights.scm
+++ b/queries/solidity/highlights.scm
@@ -179,7 +179,7 @@
   "storage"
   "calldata"
   "constant"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "for"

--- a/queries/soql/highlights.scm
+++ b/queries/soql/highlights.scm
@@ -32,7 +32,7 @@
 (alias_expression
   (identifier) @label)
 
-(storage_identifier) @keyword.storage
+(storage_identifier) @keyword.modifier
 
 (_
   function_name: (identifier) @function)

--- a/queries/sourcepawn/highlights.scm
+++ b/queries/sourcepawn/highlights.scm
@@ -149,7 +149,7 @@
 ; Non-type Keywords
 (variable_storage_class) @keyword.storage
 
-(visibility) @type.qualifier
+(visibility) @keyword.modifier
 
 (assertion) @function.builtin
 
@@ -298,4 +298,4 @@
   "static"
   "stock"
   "forward"
-] @type.qualifier
+] @keyword.modifier

--- a/queries/sourcepawn/highlights.scm
+++ b/queries/sourcepawn/highlights.scm
@@ -147,7 +147,7 @@
   name: (identifier) @function.method)
 
 ; Non-type Keywords
-(variable_storage_class) @keyword.storage
+(variable_storage_class) @keyword.modifier
 
 (visibility) @keyword.modifier
 

--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -333,7 +333,7 @@
   (keyword_statistics)
   (keyword_maxvalue)
   (keyword_minvalue)
-] @type.qualifier
+] @keyword.modifier
 
 [
   (keyword_int)

--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -95,7 +95,7 @@
   (keyword_jsonfile)
   (keyword_sequencefile)
   (keyword_volatile)
-] @keyword.storage
+] @keyword.modifier
 
 [
   (keyword_case)

--- a/queries/squirrel/highlights.scm
+++ b/queries/squirrel/highlights.scm
@@ -55,7 +55,7 @@
 ] @keyword.exception
 
 ; Storageclasses
-"local" @keyword.storage
+"local" @keyword.modifier
 
 ; Qualifiers
 [

--- a/queries/squirrel/highlights.scm
+++ b/queries/squirrel/highlights.scm
@@ -61,7 +61,7 @@
 [
   "static"
   "const"
-] @type.qualifier
+] @keyword.modifier
 
 ; Variables
 [

--- a/queries/svelte/highlights.scm
+++ b/queries/svelte/highlights.scm
@@ -10,7 +10,7 @@
   "render"
 ] @keyword
 
-"const" @type.qualifier
+"const" @keyword.modifier
 
 [
   "if"

--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -34,7 +34,7 @@
   (parameter_modifier)
   (inheritance_modifier)
   (mutation_modifier)
-] @type.qualifier
+] @keyword.modifier
 
 (function_declaration
   (simple_identifier) @function.method)

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -153,6 +153,6 @@
 
 "@define" @keyword.directive.define
 
-"private" @type.qualifier
+"private" @keyword.modifier
 
 "global" @keyword.storage

--- a/queries/systemtap/highlights.scm
+++ b/queries/systemtap/highlights.scm
@@ -155,4 +155,4 @@
 
 "private" @keyword.modifier
 
-"global" @keyword.storage
+"global" @keyword.modifier

--- a/queries/t32/highlights.scm
+++ b/queries/t32/highlights.scm
@@ -68,7 +68,7 @@
 [
   "const"
   "volatile"
-] @type.qualifier
+] @keyword.modifier
 
 ; Operators in comma and conditional HLL expressions
 (hll_comma_expression
@@ -120,7 +120,7 @@
   (hll_type_descriptor)
 ] @type
 
-(hll_type_qualifier) @type.qualifier
+(hll_type_qualifier) @keyword.modifier
 
 (hll_primitive_type) @type.builtin
 

--- a/queries/thrift/highlights.scm
+++ b/queries/thrift/highlights.scm
@@ -177,7 +177,7 @@
   "server"
   "stateful"
   "transient"
-] @type.qualifier
+] @keyword.modifier
 
 ; Literals
 (string) @string

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -41,7 +41,7 @@
   "protected"
   "public"
   "readonly"
-] @type.qualifier
+] @keyword.modifier
 
 ; types
 (type_identifier) @type

--- a/queries/unison/highlights.scm
+++ b/queries/unison/highlights.scm
@@ -24,9 +24,9 @@
 
 (kw_equals) @keyword.operator
 
-(structural) @type.qualifier
+(structural) @keyword.modifier
 
-(unique) @type.qualifier
+(unique) @keyword.modifier
 
 (type_constructor) @constructor
 

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -54,7 +54,7 @@
   "shared"
   "static"
   "const"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "pub"

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -59,7 +59,7 @@
 [
   "pub"
   "mut"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "go"

--- a/queries/vala/highlights.scm
+++ b/queries/vala/highlights.scm
@@ -208,7 +208,7 @@
   "owned"
   "weak"
   "unowned"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "case"

--- a/queries/vala/highlights.scm
+++ b/queries/vala/highlights.scm
@@ -229,7 +229,7 @@
   "protected"
   "public"
   "static"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "and"

--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -237,7 +237,7 @@
 (net_declaration
   (simple_identifier) @type)
 
-(lifetime) @label
+(lifetime) @keyword.modifier
 
 (function_identifier
   (function_identifier

--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -154,7 +154,7 @@
 [
   "signed"
   "unsigned"
-] @type.qualifier
+] @keyword.modifier
 
 (data_type
   (simple_identifier) @type)
@@ -263,7 +263,7 @@
 ;(parameter_identifier) @variable.member))
 (type_declaration
   (data_type
-    "packed" @type.qualifier))
+    "packed" @keyword.modifier))
 
 (struct_union) @type
 

--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -140,7 +140,7 @@
 
 (edge_identifier) @attribute
 
-(port_direction) @keyword.storage
+(port_direction) @keyword.modifier
 
 (port_identifier
   (simple_identifier) @variable)

--- a/queries/wgsl/highlights.scm
+++ b/queries/wgsl/highlights.scm
@@ -44,7 +44,7 @@
   "storage"
   "uniform"
   "workgroup"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "read"

--- a/queries/wgsl/highlights.scm
+++ b/queries/wgsl/highlights.scm
@@ -50,7 +50,7 @@
   "read"
   "read_write"
   "write"
-] @type.qualifier
+] @keyword.modifier
 
 "fn" @keyword.function
 

--- a/queries/xcompose/highlights.scm
+++ b/queries/xcompose/highlights.scm
@@ -15,7 +15,7 @@
 [
   (modifier)
   "None"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "%L"

--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -154,7 +154,7 @@ field_constant: (IDENTIFIER) @constant
   "volatile"
   "allowzero"
   "noalias"
-] @type.qualifier
+] @keyword.modifier
 
 [
   "addrspace"

--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -161,7 +161,7 @@ field_constant: (IDENTIFIER) @constant
   "align"
   "callconv"
   "linksection"
-] @keyword.storage
+] @keyword.modifier
 
 [
   "comptime"

--- a/tests/query/highlights/capnp/test.capnp
+++ b/tests/query/highlights/capnp/test.capnp
@@ -328,7 +328,7 @@ struct TestEmptyStruct {}
 
 struct TestConstants {
   const voidConst      :Void    = void;
-# ^^^^^ @type.qualifier
+# ^^^^^ @keyword.modifier
   const boolConst      :Bool    = true;
   const int8Const      :Int8    = -123;
   const int16Const     :Int16   = -12345;

--- a/tests/query/highlights/gleam/function.gleam
+++ b/tests/query/highlights/gleam/function.gleam
@@ -1,5 +1,5 @@
 pub fn add(x: Int, y: Int) -> Int {
-// <- @type.qualifier
+// <- @keyword.modifier
 //  ^^ @keyword.function
 //     ^^^ @function
 //        ^ @punctuation.bracket
@@ -18,7 +18,7 @@ pub fn add(x: Int, y: Int) -> Int {
 // <- @punctuation.bracket
 
 pub fn twice(f: fn(t) -> t, x: t) -> t {
-// <- @type.qualifier
+// <- @keyword.modifier
 //  ^ @keyword.function
 //     ^^^^^ @function
 //          ^ @punctuation.bracket
@@ -100,8 +100,8 @@ fn replace(
 // <- @punctuation.bracket
 
 pub external fn random_float() -> Float = "rand" "uniform"
-// <- @type.qualifier
-//  ^^^^^^^^ @type.qualifier
+// <- @keyword.modifier
+//  ^^^^^^^^ @keyword.modifier
 //           ^^ @keyword.function
 //              ^^^^^^^^^^^^ @function
 //                          ^ @punctuation.bracket
@@ -113,8 +113,8 @@ pub external fn random_float() -> Float = "rand" "uniform"
 //                                               ^^^^^^^^^ @function
 
 pub external fn inspect(a) -> a = "Elixir.IO" "inspect"
-// <- @type.qualifier
-//  ^^^^^^^^ @type.qualifier
+// <- @keyword.modifier
+//  ^^^^^^^^ @keyword.modifier
 //           ^^ @keyword.function
 //              ^^^^^^^ @function
 //                     ^ @punctuation.bracket

--- a/tests/query/highlights/gleam/type.gleam
+++ b/tests/query/highlights/gleam/type.gleam
@@ -1,5 +1,5 @@
 pub type Cat {
-// <- @type.qualifier
+// <- @keyword.modifier
 //  ^^^^ @keyword
 //       ^^^ @type
 //           ^ @punctuation.bracket
@@ -54,8 +54,8 @@ type Box(inner_type) {
 }
 
 pub opaque type Counter {
-// <- @type.qualifier
-//  ^^^^^^ @type.qualifier
+// <- @keyword.modifier
+//  ^^^^^^ @keyword.modifier
 //         ^^^^ @keyword
 //              ^^^^^^^ @type
 //                      ^ @punctuation.bracket

--- a/tests/query/highlights/hack/generics.hack
+++ b/tests/query/highlights/hack/generics.hack
@@ -2,21 +2,21 @@ class Box<T> {
   //      ^ @type
   //   ^ @type
   protected T $data;
-  // ^ @type.qualifier
+  // ^ @keyword.modifier
   //        ^ @type
 
   public function __construct(T $data) {
   //                          ^ @type
   //                             ^ @variable.parameter
   //        ^ @keyword.function
-  // ^ @type.qualifier
+  // ^ @keyword.modifier
   //                    ^ @function.method
     $this->data = $data;
   }
 
   public function getData(): T {
                 // ^ @function.method
-  // ^ @type.qualifier
+  // ^ @keyword.modifier
     return $this->data;
               // ^ @operator
           // ^ @variable.builtin

--- a/tests/query/highlights/smali/baksmali_test_class.smali
+++ b/tests/query/highlights/smali/baksmali_test_class.smali
@@ -1,6 +1,6 @@
 .class public Lbaksmali/test/class;
 # <- @keyword
-#      ^^^^^^ @type.qualifier
+#      ^^^^^^ @keyword.modifier
 .super Ljava/lang/Object;
 #      ^ @character.special
 #       ^^^^ @type.builtin

--- a/tests/query/highlights/smali/baksmali_test_class.smali
+++ b/tests/query/highlights/smali/baksmali_test_class.smali
@@ -14,7 +14,7 @@
 
 
 .annotation build Lsome/annotation;
-#           ^^^^^ @keyword.storage
+#           ^^^^^ @keyword.modifier
 #                  ^^^^ @type
 #                                 ^ @punctuation.delimiter
     value1 = "test"
@@ -93,7 +93,7 @@
 
 .field public static staticFieldWithAnnotation:I
     .annotation runtime La/field/annotation;
-#               ^^^^^^^ @keyword.storage
+#               ^^^^^^^ @keyword.modifier
         this = "is"
         a = "test"
     .end annotation

--- a/tests/query/highlights/t32/var.cmm
+++ b/tests/query/highlights/t32/var.cmm
@@ -39,8 +39,8 @@ Var.Assign sp = &s.n+offset
 Var.Assign padd = (CAddition const * volatile)&d
 ;          ^ @variable
 ;                  ^ @type
-;                            ^ @type.qualifier
-;                                    ^ @type.qualifier
+;                            ^ @keyword.modifier
+;                                    ^ @keyword.modifier
 ;                                              ^ @variable
 Var.Assign e1 = (enum e2)&e
 ;          ^ @variable

--- a/tests/query/highlights/xhp-intro.hack
+++ b/tests/query/highlights/xhp-intro.hack
@@ -5,8 +5,8 @@ use type Facebook\XHP\HTML\{XHPHTMLHelpers, a, form};
 
 
 final xhp class a_post extends x\element {
-// ^ @type.qualifier
-//     ^ @type.qualifier
+// ^ @keyword.modifier
+//     ^ @keyword.modifier
 //                        ^ @keyword
   use XHPHTMLHelpers;
 


### PR DESCRIPTION
Changes most of `@type.qualifier` to a new capture name `@keyword.modifier`.

Discussion: the first bullet point in #6238. (The second point is not addressed in the PR)

These are not changed as they seem to be used for user-provided identifiers
* https://github.com/nvim-treesitter/nvim-treesitter/blob/f8d4e5c1ba2b24b7d13830eeca394fc24c808d83/queries/blueprint/highlights.scm#L53
* https://github.com/nvim-treesitter/nvim-treesitter/blob/f8d4e5c1ba2b24b7d13830eeca394fc24c808d83/queries/chatito/highlights.scm#L33
* https://github.com/nvim-treesitter/nvim-treesitter/blob/f8d4e5c1ba2b24b7d13830eeca394fc24c808d83/queries/eds/highlights.scm#L43