### PR TITLE
Improved error message when unknown keybinding

### DIFF
--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -143,7 +143,7 @@ function M.attach(bufnr)
       local rhs = M[funcname] ---@type function
 
       if not rhs then
-        utils.notify("Unknown keybinding: " .. funcname .. debug.traceback(), vim.log.levels.ERROR)
+        utils.notify("Unknown keybinding: " .. mapping .. " " .. funcname .. " " .. debug.traceback(), vim.log.levels.ERROR)
       else
         vim.keymap.set(mode, mapping, rhs, { buffer = bufnr, silent = true, desc = FUNCTION_DESCRIPTIONS[funcname] })
       end

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -143,7 +143,8 @@ function M.attach(bufnr)
       local rhs = M[funcname] ---@type function
 
       if not rhs then
-        utils.notify("Unknown keybinding: " .. mapping .. " " .. funcname .. " " .. debug.traceback(), vim.log.levels.ERROR)
+        local traceback = debug.traceback()
+        utils.notify(string.format('Unknown keybinding: %s %s %s', mapping, funcname, traceback), vim.log.levels.ERROR)
       else
         vim.keymap.set(mode, mapping, rhs, { buffer = bufnr, silent = true, desc = FUNCTION_DESCRIPTIONS[funcname] })
       end

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -144,7 +144,7 @@ function M.attach(bufnr)
 
       if not rhs then
         local traceback = debug.traceback()
-        utils.notify(string.format('Unknown keybinding: %s %s %s', mapping, funcname, traceback), vim.log.levels.ERROR)
+        utils.notify(string.format("Unknown keybinding: %s %s %s", mapping, funcname, traceback), vim.log.levels.ERROR)
       else
         vim.keymap.set(mode, mapping, rhs, { buffer = bufnr, silent = true, desc = FUNCTION_DESCRIPTIONS[funcname] })
       end


### PR DESCRIPTION
Makes a small change to the unknown keybinding message to improve readability

<img width="1679" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/191564/518fc9d0-532a-47a3-9a7e-7c76e36170fd">

The original concatenates the `funcname` and the traceback with no space which makes it a little harder for someone who's just googling for the error (as I was) to find something.

In my example, the original error contained `scope_decrementalstack traceback` which was kind of weird, but also as someone who isn't familiar with the codebase it didn't seem unreasonable that `scope_decrementalstack` was a key part of the error.

I added the mapping itself too, which I thought was useful when grepping my configs.

Reproduction steps: the root cause of this was I copied a treesitter configuration for reference, and it had these lines:

```lua
  incremental_selection = {
    enable = true,
    keymaps = {
      -- other stuff
      scope_decremental = '<s-cr>', --- this was breaking
    },
  },
```

This could also happen with someone making a typo with a keymap.

Update: 
Reformatted it to meet the style check. Retested it locally, I think this is still correct (my shell theme changed between this and first)

<img width="1639" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/191564/d0e640e3-871f-4212-a856-9bf3b74561a9">
