### PR TITLE
feat: add just parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -344,6 +344,9 @@
   "julia": {
     "revision": "e84f10db8eeb8b9807786bfc658808edaa1b4fa2"
   },
+  "just": {
+    "revision": "5fe40d3622042c66465c4673b209a71e8376f902"
+  },
   "kconfig": {
     "revision": "486fea71f61ad9f3fd4072a118402e97fe88d26c"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1033,6 +1033,14 @@ list.julia = {
   maintainers = { "@theHamsta" },
 }
 
+list.just = {
+  install_info = {
+    url = "https://github.com/IndianBoy42/tree-sitter-just",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@Hubro" },
+}
+
 list.kconfig = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-kconfig",

--- a/queries/just/folds.scm
+++ b/queries/just/folds.scm
@@ -1,0 +1,6 @@
+([
+  (recipe)
+  (string)
+  (external_command)
+] @fold
+  (#trim! @fold))

--- a/queries/just/highlights.scm
+++ b/queries/just/highlights.scm
@@ -1,0 +1,133 @@
+[
+  "true"
+  "false"
+] @boolean
+
+[
+  "if"
+  "else"
+] @keyword.conditional
+
+[
+  "alias"
+  "set"
+  "shell"
+  "mod"
+] @keyword
+
+[
+  "import"
+  "export"
+] @keyword.import
+
+[
+  ":="
+  "?"
+  "=="
+  "!="
+  "=~"
+  "@"
+  "="
+  "$"
+  "*"
+  "+"
+  "&&"
+  "@-"
+  "-@"
+  "-"
+  "/"
+  ":"
+] @operator
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{{"
+  "}}"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  "`"
+  "```"
+] @punctuation.special
+
+"," @punctuation.delimiter
+
+(shebang) @keyword.directive
+
+(comment) @comment @spell
+
+[
+  (string)
+  (external_command)
+] @string
+
+(escape_sequence) @string.escape
+
+(module
+  (identifier) @module)
+
+(assignment
+  (identifier) @variable)
+
+(alias
+  (identifier) @variable)
+
+(value
+  (identifier) @variable)
+
+; Recipe definitions
+(recipe_header
+  (identifier) @function)
+
+(dependency
+  (identifier) @function.call)
+
+(dependency_expression
+  (identifier) @function.call)
+
+(parameter
+  (identifier) @variable.parameter)
+
+(dependency_expression
+  (expression
+    (value
+      (identifier) @variable.parameter)))
+
+; Fallback highlighting for recipe bodies
+(recipe
+  (recipe_body) @string
+  (#set! "priority" 90))
+
+; Ref: https://just.systems/man/en/chapter_26.html
+;(setting (identifier) @error)
+(setting
+  (identifier) @constant.builtin
+  (#any-of? @constant.builtin
+    "allow-duplicate-recipes" "dotenv-filename" "dotenv-load" "dotenv-path" "export" "fallback"
+    "ignore-comments" "positional-arguments" "tempdir" "windows-powershell" "windows-shell"))
+
+; Ref: https://just.systems/man/en/chapter_32.html
+;(recipe (attribute (identifier) @error))
+(recipe
+  (attribute
+    (identifier) @attribute)
+  (#any-of? @attribute
+    "confirm" "linux" "macos" "no-cd" "no-exit-message" "no-quiet" "private" "unix" "windows"))
+
+; Ref: https://just.systems/man/en/chapter_31.html
+;(function_call (identifier) @error)
+(function_call
+  (identifier) @function.call
+  (#any-of? @function.call
+    "arch" "num_cpus" "os" "os_family" "env_var" "env_var_or_default" "env" "invocation_directory"
+    "invocation_directory_native" "justfile" "justfile_directory" "just_executable" "quote"
+    "replace" "replace_regex" "trim" "trim_end" "trim_end_match" "trim_end_matches" "trim_start"
+    "trim_start_match" "trim_start_matches" "capitalize" "kebabcase" "lowercamelcase" "lowercase"
+    "shoutykebabcase" "shoutysnakecase" "snakecase" "titlecase" "uppercamelcase" "uppercase"
+    "absolute_path" "extension" "file_name" "file_stem" "parent_directory" "without_extension"
+    "clean" "join" "path_exists" "error" "sha256" "sha256_file" "uuid" "semver_matches"))

--- a/queries/just/indents.scm
+++ b/queries/just/indents.scm
@@ -1,0 +1,14 @@
+; Source: https://github.com/IndianBoy42/tree-sitter-just/blob/main/queries/just/indents.scm
+[
+  (recipe)
+  (string)
+  (external_command)
+] @indent.begin
+
+(string
+  [
+    "'''"
+    "\"\"\""
+  ] @indent.branch @indent.end)
+
+(comment) @indent.auto

--- a/queries/just/injections.scm
+++ b/queries/just/injections.scm
@@ -1,0 +1,41 @@
+; The right side of =~ literals
+(regex_literal
+  (_) @injection.content
+  (#set! injection.language "regex"))
+
+; Default to bash highlighting for non-shebang recipes and commands
+(recipe
+  (recipe_body
+    !shebang) @injection.content
+  (#set! injection.include-children)
+  (#set! injection.language "bash"))
+
+(external_command
+  (command_body) @injection.content
+  (#set! injection.language "bash"))
+
+; For shebang recipes, use the shebang executable name as the language by default
+(recipe
+  (recipe_body
+    (shebang
+      (language) @injection.language)) @injection.content
+  (#not-any-of? @injection.language "python3" "nodejs" "node")
+  (#set! injection.include-children))
+
+; python3 -> python
+(recipe
+  (recipe_body
+    (shebang
+      (language) @_lang)) @injection.content
+  (#eq? @_lang "python3")
+  (#set! injection.language "python")
+  (#set! injection.include-children))
+
+; node/nodejs -> javascript
+(recipe
+  (recipe_body
+    (shebang
+      (language) @_lang)) @injection.content
+  (#any-of? @_lang "node" "nodejs")
+  (#set! injection.language "javascript")
+  (#set! injection.include-children))

--- a/queries/just/locals.scm
+++ b/queries/just/locals.scm
@@ -1,0 +1,35 @@
+; Source: https://github.com/IndianBoy42/tree-sitter-just/blob/main/queries/just/locals.scm
+; Scope
+(recipe) @local.scope
+
+; Definitions
+(alias
+  left: (identifier) @local.definition.var)
+
+(assignment
+  left: (identifier) @local.definition.var)
+
+(module
+  name: (identifier) @local.definition.namespace)
+
+(parameter
+  name: (identifier) @local.definition.var)
+
+(recipe_header
+  name: (identifier) @local.definition.function)
+
+; References
+(alias
+  right: (identifier) @local.reference)
+
+(function_call
+  name: (identifier) @local.reference)
+
+(dependency
+  name: (identifier) @local.reference)
+
+(dependency_expression
+  name: (identifier) @local.reference)
+
+(value
+  (identifier) @local.reference)


### PR DESCRIPTION
Following up on: https://github.com/nvim-treesitter/nvim-treesitter/pull/5696

The parser has gotten some attention since last time. Most importantly, it no longer uses c++ for the scanner, so it should now be possible to add it to nvim-treesitter.