### PR TITLE
fix(angular): Fix capture name

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "d3dc807692e6bca671d4491b3bf5c67eeca8c016"
   },
   "angular": {
-    "revision": "6d02054ae9aa1fedf5097fe6d93dd78f751dff21"
+    "revision": "a1b5ff462875e5f92e6265fc630702847e0dcbb3"
   },
   "apex": {
     "revision": "857077f9e6bb04df0f769c18d32bfe036911adc8"

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -116,7 +116,7 @@
 (nullish_coalescing_expression
   (coalescing_operator) @operator)
 
-(concatination_expression
+(concatenation_expression
   "+" @operator)
 
 (binary_expression


### PR DESCRIPTION
- Fixes typo in `concatination_expression` -> `concatenation_expression`