### PR TITLE
feat(markdown): highlight link label delimiter

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -69,6 +69,10 @@
   (link_label)
 ] @markup.link.label
 
+((link_label)
+  .
+  ":" @punctuation.delimiter)
+
 [
   (list_marker_plus)
   (list_marker_minus)


### PR DESCRIPTION
Highlights the colon following a link label:

```md
[1]: website.com
   ^ here
```