### PR TITLE
Add ECMA injections for additional CSS-in-JS frameworks

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -57,6 +57,16 @@
 ((glimmer_template) @injection.content
   (#set! injection.language "glimmer"))
 
+; css`<css>`, keyframes`<css>`
+(call_expression
+  function: (identifier) @_name
+  (#any-of? @_name "css" "keyframes")
+  arguments:
+    ((template_string) @injection.content
+      (#offset! @injection.content 0 1 0 -1)
+      (#set! injection.include-children)
+      (#set! injection.language "styled")))
+
 ; styled.div`<css>`
 (call_expression
   function:

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -17,9 +17,12 @@
   (#lua-match? @injection.language "^[a-zA-Z][a-zA-Z0-9]*$")
   (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children)
-  (#not-eq? @injection.language "svg"))
+  ; Languages excluded from auto-injection due to special rules
+  ; - svg uses the html parser
+  ; - css uses the styled parser
+  (#not-any-of? @injection.language "svg" "css"))
 
-; svg`...` or svg(`...`), which uses the html parser, so is not included in the previous query
+; svg`...` or svg(`...`)
 (call_expression
   function:
     ((identifier) @_name


### PR DESCRIPTION
This adds support for `css` and `keyframes` tagged templates to support additional CSS-in-JS frameworks like Emotion.

```js
const style = css`
  border: 1px solid red;
`

const animation = keyframes`
  from { opacity: 0; }
  to { opacity: 1; }
`
```

https://emotion.sh/docs/introduction