### PR TITLE
fix!: use a different angular filetype

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -100,6 +100,7 @@ list.angular = {
     generate_requires_npm = true,
   },
   maintainers = { "@dlvandenberg" },
+  filetype = "angular.html",
   experimental = true,
 }
 


### PR DESCRIPTION
When the filetype is `angular.html` instead of `angular`, other HTML functionality keeps working. 

Things like using `%` to jump between opening and closing work again. 
Also specific plugin configuration for the `angular` filetype is no longer needed. Users had to write custom filehandling for plugins like:
> VonHeikemen/lsp-zero.nvim
> tpope/vim-commentary
> L3MON4D3/LuaSnip
> nvimtools/none-ls.nvim

Note: I do not know if this change should be marked as breaking. It does not change any treesitter code directly, but it does break angular highlighting for active users.