### PR TITLE
highlights(php): fix property access using nullsafe operator

### DIFF
--- a/queries/php_only/highlights.scm
+++ b/queries/php_only/highlights.scm
@@ -153,6 +153,14 @@
 (member_access_expression
   name: (name) @property)
 
+(nullsafe_member_access_expression
+  name:
+    (variable_name
+      (name)) @property)
+
+(nullsafe_member_access_expression
+  name: (name) @property)
+
 ; Variables
 (relative_scope) @variable.builtin
 

--- a/queries/php_only/highlights.scm
+++ b/queries/php_only/highlights.scm
@@ -148,18 +148,18 @@
 (member_access_expression
   name:
     (variable_name
-      (name)) @property)
+      (name)) @variable.member)
 
 (member_access_expression
-  name: (name) @property)
+  name: (name) @variable.member)
 
 (nullsafe_member_access_expression
   name:
     (variable_name
-      (name)) @property)
+      (name)) @variable.member)
 
 (nullsafe_member_access_expression
-  name: (name) @property)
+  name: (name) @variable.member)
 
 ; Variables
 (relative_scope) @variable.builtin


### PR DESCRIPTION
With this change, properties that are accessed using nullsafe operator will be highlighted correctly.

After | Before
![Screenshot_20240307_161558](https://github.com/nvim-treesitter/nvim-treesitter/assets/15798381/feaace3b-9e4a-488f-94b7-5ac875b8330a)
