### PR TITLE
fix(markdown): @conceal for code fence delimiters

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -54,7 +54,7 @@
   (#set! "priority" 90))
 
 (fenced_code_block
-  (fenced_code_block_delimiter) @markup.raw.block
+  (fenced_code_block_delimiter) @conceal
   (#set! conceal ""))
 
 (fenced_code_block


### PR DESCRIPTION
All other concealed delimiters that I can see are given `@conceal` except for the code fence ones, resulting in them being the same color as the actual code fence content (not counting injectoins). Not sure if this was intentional? This PR applies the `@conceal` highlight to these delimiters as it is applied to the others