### PR TITLE
fix(c): improve doxygen comment matching

### DIFF
--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -9,7 +9,7 @@
   (#set! injection.language "re2c"))
 
 ((comment) @injection.content
-  (#lua-match? @injection.content "/[*][!<*][^a-zA-Z]")
+  (#lua-match? @injection.content "/[*\/][!*\/][^a-zA-Z]")
   (#set! injection.language "doxygen"))
 
 ((call_expression

--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -9,7 +9,7 @@
   (#set! injection.language "re2c"))
 
 ((comment) @injection.content
-  (#lua-match? @injection.content "/[*\/][!*\/][^a-zA-Z]")
+  (#lua-match? @injection.content "/[*\/][!*\/]<?[^a-zA-Z]")
   (#set! injection.language "doxygen"))
 
 ((call_expression

--- a/queries/cpp/injections.scm
+++ b/queries/cpp/injections.scm
@@ -5,7 +5,7 @@
   (#set! injection.language "comment"))
 
 ((comment) @injection.content
-  (#lua-match? @injection.content "/[*][!<*][^a-zA-Z]")
+  (#lua-match? @injection.content "/[*\/][!*\/][^a-zA-Z]")
   (#set! injection.language "doxygen"))
 
 (raw_string_literal

--- a/queries/cpp/injections.scm
+++ b/queries/cpp/injections.scm
@@ -5,7 +5,7 @@
   (#set! injection.language "comment"))
 
 ((comment) @injection.content
-  (#lua-match? @injection.content "/[*\/][!*\/][^a-zA-Z]")
+  (#lua-match? @injection.content "/[*\/][!*\/]<?[^a-zA-Z]")
   (#set! injection.language "doxygen"))
 
 (raw_string_literal


### PR DESCRIPTION
Add support for `///` and `//!` comments.

Closes #6276