### PR TITLE
added #set-lang-by-filetype! directive

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -175,6 +175,26 @@ query.add_directive("set-lang-from-info-string!", function(match, _, bufnr, pred
   metadata["injection.language"] = get_parser_from_markdown_info_string(injection_alias)
 end, true)
 
+---@param _ (TSNode|nil)[]
+---@param _ string
+---@param bufnr integer
+---@param pred string[]
+---@param metadata table
+---@return boolean|nil
+query.add_directive("set-lang-by-filetype!", function(_, _, bufnr, pred, metadata)
+  if not valid_args("set-lang-by-filetype!", pred, 2, true) then
+    return
+  end
+  local filename = vim.fn.expand("#" .. bufnr .. ":t")
+  local extension_index = filename:find "%."
+  if not extension_index then
+    return
+  end
+  if pred[2] == filename:sub(extension_index + 1) then
+    metadata["injection.language"] = pred[3]
+  end
+end, true)
+
 -- Just avoid some annoying warnings for this directive
 query.add_directive("make-range!", function() end, true)
 


### PR DESCRIPTION
In some languages, we'd like to be able to inject a different languages depending on the file extension/file type. For example -- in the Liquid template language, if the extension is simply `.liquid` we would like to inject HTML as the template content. But, if we have a `.js.liquid` file, we would like to inject JavaScript as the template content. As such, I added a query directive that will inject a language if the file extension of the current buffer matches the specified extension.

Usage example:
``` lisp
((template_content) @injection.content
 (#set-lang-by-filetype! "liquid" "html")
 (#set-lang-by-filetype! "js.liquid" "javascript")
 (#set-lang-by-filetype! "css.liquid" "css")
 (#set-lang-by-filetype! "scss.liquid" "scss")
 (#set! injection.combined))
```