### PR TITLE
Sync with tree-sitter-scala 8062487

### DIFF
--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -65,11 +65,11 @@
 
 ((import_declaration
   path: (identifier) @type)
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ((stable_identifier
   (identifier) @type)
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 (export_declaration
   path: (identifier) @module)
@@ -79,15 +79,15 @@
 
 ((export_declaration
   path: (identifier) @type)
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ((stable_identifier
   (identifier) @type)
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ((namespace_selectors
   (identifier) @type)
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ; method invocation
 (call_expression
@@ -103,7 +103,7 @@
 
 ((call_expression
   function: (identifier) @constructor)
-  (#lua-match? @constructor "^[A-Z]"))
+  (#match? @constructor "^[A-Z]"))
 
 (generic_function
   function: (identifier) @function.call)
@@ -127,7 +127,7 @@
 
 (field_expression
   value: (identifier) @type
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 (infix_expression
   operator: (identifier) @operator)
@@ -269,23 +269,27 @@
 ] @comment @spell
 
 ((block_comment) @comment.documentation
-  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
+  (#match? @comment.documentation "^/[*][*][^*].*[*]/$"))
 
 ; `case` is a conditional keyword in case_block
 (case_block
   (case_clause
     "case" @keyword.conditional))
 
+(indented_cases
+  (case_clause
+    "case" @keyword.conditional))
+
 (operator_identifier) @operator
 
 ((identifier) @type
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ((identifier) @variable.builtin
-  (#lua-match? @variable.builtin "^this$"))
+  (#match? @variable.builtin "^this$"))
 
 ((identifier) @function.builtin
-  (#lua-match? @function.builtin "^super$"))
+  (#match? @function.builtin "^super$"))
 
 ; Scala CLI using directives
 (using_directive_key) @variable.parameter


### PR DESCRIPTION
Change `lua-match` to `match` to maintain sync with `tree-sitter-scala` https://github.com/tree-sitter/tree-sitter-scala/commit/65fdb1743fa50ca47ca34feabd9cbb3a1505aebf

Add "conditional" to case in indented_cases https://github.com/tree-sitter/tree-sitter-scala/commit/b7a63ca032e24295f00233cf946694603ee9a503