### PR TITLE
feat(angular): add highlights for ICU expressions

### DIFF
--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -101,6 +101,12 @@
   (defer_end_expression)
 ] @punctuation.bracket
 
+(two_way_binding
+  [
+    "[("
+    ")]"
+  ] @punctuation.bracket)
+
 [
   "{{"
   "}}"
@@ -118,6 +124,10 @@
 
 (concatenation_expression
   "+" @operator)
+
+(icu_clause) @keyword.operator
+
+(icu_category) @keyword.conditional
 
 (binary_expression
   [


### PR DESCRIPTION
Added fixes for the highlights corresponding to the following:


```
Updated {minutes, plural,
=0 {just now}
=1 {one minute ago}
other {some minutes ago}}

---

(fragment
  (text)
  (icu_expression
    (expression
      (identifier))
    (icu_clause)
    (icu_case
      (icu_category)
      (text))
    (icu_case
      (icu_category)
      (text))
    (icu_case
      (icu_category)
      (text))))
 ```
 
 This PR also fixes broken highlights with two-way-binding syntax `[(name)]="something"`