### PR TITLE
fix(vimdoc): adapt to breaking Neovim change

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -33,6 +33,11 @@
   ] @markup.link
   (#set! conceal ""))
 
+(inline_link
+  (link_text) @markup.link.label
+  (link_destination) @markup.link
+  (#set! @markup.link.label "url" @markup.link))
+
 ; Conceal image links
 (image
   [

--- a/queries/vimdoc/highlights.scm
+++ b/queries/vimdoc/highlights.scm
@@ -12,12 +12,16 @@
 
 (tag
   "*" @label
-  (#set! conceal "")
+  (#set! conceal ""))
+
+(tag
   text: (_) @label)
 
 (taglink
   "|" @markup.link
-  (#set! conceal "")
+  (#set! conceal ""))
+
+(taglink
   text: (_) @markup.link)
 
 (optionlink
@@ -25,7 +29,9 @@
 
 (codespan
   "`" @markup.raw
-  (#set! conceal "")
+  (#set! conceal ""))
+
+(codespan
   text: (_) @markup.raw)
 
 ((codeblock) @markup.raw.block


### PR DESCRIPTION
Problem:
https://github.com/neovim/neovim/commit/cb46f6e467268edf917cc3617b4c024a66b256de#diff-edf997b0c2d42d31828800641ac1f5a46487fe24a0d46ccf70bcd58a14f3868f
introduced a regression on how `#set!` behaves with several matches in a
single pattern, breaking conceals in, e.g., taglinks.

Solution: Separate taglink etc. patterns into concealed marker and
contents. Also add URL support for concealed markdown links.
