### PR TITLE
feat(incremental_selection): Add countable motions

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -177,6 +177,8 @@ Note: The api is not stable yet.
 INCREMENTAL SELECTION              *nvim-treesitter-incremental-selection-mod*
 
 Incremental selection based on the named nodes from the grammar.
+This supports a count beforehand, e.g. `4grn` to increment to the 4th. 
+upper named parent.
 
 Query files: `locals.scm`.
 Supported options:

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -140,7 +140,11 @@ function M.attach(bufnr)
   for funcname, mapping in pairs(config.keymaps) do
     if mapping then
       local mode = funcname == "init_selection" and "n" or "x"
-      local rhs = M[funcname] ---@type function
+      local rhs = function()
+        for _ = 1, math.max(vim.v.count, 1) do
+          M[funcname]()
+        end
+      end
 
       if not rhs then
         utils.notify("Unknown keybinding: " .. funcname .. debug.traceback(), vim.log.levels.ERROR)


### PR DESCRIPTION
Currently it is not possible to use a count before the motions that manipulate the incremental_selection, e.g. to select 4 nodes out with 4grn

This PR changes the created keymaps to respect the count before the motion if it was set. This should not affect the current behavior if count is omitted.