### PR TITLE
fix(latex): Fold \iffalse..\fi comments

### DIFF
--- a/queries/latex/folds.scm
+++ b/queries/latex/folds.scm
@@ -9,5 +9,6 @@
   (generic_environment)
   (math_environment)
   (comment_environment)
+  (block_comment)
   (displayed_equation)
 ] @fold


### PR DESCRIPTION
Folds comments between `\iffalse` and `\fi`.