### PR TITLE
feat(rust): move pub to `@keyword.modifier`

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -256,7 +256,6 @@
   "impl"
   "let"
   "move"
-  "pub"
   "struct"
   "trait"
   "type"
@@ -274,10 +273,8 @@
 
 [
   "ref"
+  "pub"
   (mutable_specifier)
-] @keyword.modifier
-
-[
   "const"
   "static"
   "dyn"


### PR DESCRIPTION
Trying to match this to e.g. C++ `public` keyword. Also consolidates most of the captures into one set