### PR TITLE
feat(http): switch to new parser version

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -300,7 +300,7 @@
     "revision": "ea71012d3fe14dd0b69f36be4f96bdfe9155ebae"
   },
   "http": {
-    "revision": "6824a247d1326079aab4fa9f9164e9319678081d"
+    "revision": "e1c1085f1b36a19e82892cc1fc912cc9c968bb26"
   },
   "hurl": {
     "revision": "cd1a0ada92cc73dd0f4d7eedc162be4ded758591"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -961,9 +961,9 @@ M.configs = {
     install_info = {
       url = 'https://github.com/rest-nvim/tree-sitter-http',
       files = { 'src/parser.c' },
-      generate_requires_npm = true,
+      branch = 'main',
     },
-    maintainers = { '@amaanq' },
+    maintainers = { '@amaanq', '@NTBBloodbath' },
     tier = 2,
   },
 

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -961,7 +961,6 @@ M.configs = {
     install_info = {
       url = 'https://github.com/rest-nvim/tree-sitter-http',
       files = { 'src/parser.c' },
-      branch = 'main',
     },
     maintainers = { '@amaanq', '@NTBBloodbath' },
     tier = 2,

--- a/runtime/queries/http/highlights.scm
+++ b/runtime/queries/http/highlights.scm
@@ -1,48 +1,86 @@
-; Schemes
-(scheme) @type
+; Keywords
+
+(scheme) @namespace
 
 ; Methods
-(method) @function.method
+
+(method) @method
 
 ; Constants
+
 (const_spec) @constant
 
+; Headers
+
+(header
+  name: (name) @constant)
+
 ; Variables
-(identifier) @variable
+
+(variable_declaration
+  name: (identifier) @variable)
+
+(variable_declaration
+  value: (number) @number)
+
+(variable_declaration
+  value: (boolean) @boolean)
+
+(variable_declaration
+  value: (string) @string)
 
 ; Fields
-(pair
-  name: (identifier) @variable.member)
+
+(pair name: (identifier) @field)
+
+; URL / Host
+(host) @text.uri
+(host (identifier) @text.uri)
+(path (identifier) @text.uri)
 
 ; Parameters
-(query_param
-  (key) @variable.parameter)
+
+(query_param (key) @parameter)
 
 ; Operators
+
 [
   "="
   "?"
   "&"
   "@"
+  "<"
 ] @operator
 
 ; Literals
-(string) @string
 
-(target_url) @string.special.url
+(target_url) @text.uri
+
+(http_version) @constant
+
+(string) @string
 
 (number) @number
 
-; (boolean) @boolean
-(null) @constant.builtin
+(boolean) @boolean
 
 ; Punctuation
-[
-  "{{"
-  "}}"
-] @punctuation.bracket
 
-":" @punctuation.delimiter
+[ "{{" "}}" ] @punctuation.bracket
+
+[
+  ":"
+] @punctuation.delimiter
+
+; external JSON body
+
+(external_body
+  file_path: (path) @text.uri)
 
 ; Comments
+
 (comment) @comment @spell
+
+; Errors
+
+(ERROR) @error

--- a/runtime/queries/http/injections.scm
+++ b/runtime/queries/http/injections.scm
@@ -1,11 +1,17 @@
-((comment) @injection.content
-  (#set! injection.language "comment"))
+; (comment) @comment
+
+; Body
 
 ((json_body) @injection.content
-  (#set! injection.language "json"))
+ (#set! injection.language "json"))
 
 ((xml_body) @injection.content
-  (#set! injection.language "xml"))
+ (#set! injection.language "xml"))
 
-; ((graphql_body) @injection.content
-;  (#set! injection.language "graphql")) ; Not used as of now..
+((graphql_body) @injection.content
+ (#set! injection.language "graphql"))
+
+; Lua scripting
+
+((script_variable) @injection.content
+ (#set! injection.language "lua"))


### PR DESCRIPTION
Hey, I recently updated the HTTP parser with a lot of breaking changes. This PR is intended to update the parser here so that it works correctly.

Some of the changes:
- Add `branch` field in the `install_info` table as the default branch name is `main` (I've had problems trying to install the parser if I don't set the branch manually as it tries to use `master` which does not exist, not sure if this is necessary)
- Update `http` revision in the lockfile
- Update queries
- Remove `generate_requires_npm` field in the `install_info` table, not required anymore

I have also added myself again as one of the maintainers, I now have free time again to help with that work. I hope there is no problem with that :)