### PR TITLE
feat(http): switch to new parser version

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [hoon](https://github.com/urbit-pilled/tree-sitter-hoon) (experimental, maintained by @urbit-pilled)
 - [x] [html](https://github.com/tree-sitter/tree-sitter-html) (maintained by @TravonteD)
 - [x] [htmldjango](https://github.com/interdependence/tree-sitter-htmldjango) (experimental, maintained by @ObserverOfTime)
-- [x] [http](https://github.com/rest-nvim/tree-sitter-http) (maintained by @amaanq)
+- [x] [http](https://github.com/rest-nvim/tree-sitter-http) (maintained by @amaanq, @NTBBloodbath)
 - [x] [hurl](https://github.com/pfeiferj/tree-sitter-hurl) (maintained by @pfeiferj)
 - [x] [hyprlang](https://github.com/luckasRanarison/tree-sitter-hyprlang) (maintained by @luckasRanarison)
 - [x] [ini](https://github.com/justinmk/tree-sitter-ini) (experimental, maintained by @theHamsta)

--- a/lockfile.json
+++ b/lockfile.json
@@ -300,7 +300,7 @@
     "revision": "ea71012d3fe14dd0b69f36be4f96bdfe9155ebae"
   },
   "http": {
-    "revision": "6824a247d1326079aab4fa9f9164e9319678081d"
+    "revision": "e1c1085f1b36a19e82892cc1fc912cc9c968bb26"
   },
   "hurl": {
     "revision": "cd1a0ada92cc73dd0f4d7eedc162be4ded758591"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -912,9 +912,8 @@ list.http = {
   install_info = {
     url = "https://github.com/rest-nvim/tree-sitter-http",
     files = { "src/parser.c" },
-    generate_requires_npm = true,
   },
-  maintainers = { "@amaanq" },
+  maintainers = { "@amaanq", "@NTBBloodbath" },
 }
 
 list.hurl = {

--- a/queries/http/highlights.scm
+++ b/queries/http/highlights.scm
@@ -1,5 +1,5 @@
-; Schemes
-(scheme) @type
+; Keywords
+(scheme) @module
 
 ; Methods
 (method) @function.method
@@ -7,12 +7,23 @@
 ; Constants
 (const_spec) @constant
 
+; Headers
+(header
+  name: (name) @constant)
+
 ; Variables
-(identifier) @variable
+(variable_declaration
+  name: (identifier) @variable)
 
 ; Fields
 (pair
   name: (identifier) @variable.member)
+
+; URL / Host
+(host) @string.special.url
+
+(path
+  (identifier) @string.special.url)
 
 ; Parameters
 (query_param
@@ -24,17 +35,19 @@
   "?"
   "&"
   "@"
+  "<"
 ] @operator
 
 ; Literals
-(string) @string
-
 (target_url) @string.special.url
+
+(http_version) @constant
+
+(string) @string
 
 (number) @number
 
-; (boolean) @boolean
-(null) @constant.builtin
+(boolean) @boolean
 
 ; Punctuation
 [
@@ -43,6 +56,10 @@
 ] @punctuation.bracket
 
 ":" @punctuation.delimiter
+
+; external JSON body
+(external_body
+  file_path: (path) @string.special.path)
 
 ; Comments
 (comment) @comment @spell

--- a/queries/http/injections.scm
+++ b/queries/http/injections.scm
@@ -1,11 +1,17 @@
+; Comments
 ((comment) @injection.content
   (#set! injection.language "comment"))
 
+; Body
 ((json_body) @injection.content
   (#set! injection.language "json"))
 
 ((xml_body) @injection.content
   (#set! injection.language "xml"))
 
-; ((graphql_body) @injection.content
-;  (#set! injection.language "graphql")) ; Not used as of now..
+((graphql_body) @injection.content
+  (#set! injection.language "graphql"))
+
+; Lua scripting
+((script_variable) @injection.content
+  (#set! injection.language "lua"))


### PR DESCRIPTION
Hey, I recently updated the HTTP parser with a lot of breaking changes. This PR is intended to update the parser here so that it works correctly.

Some of the changes:
- Update `http` revision in the lockfile
- Update queries
- Remove `generate_requires_npm` field in the `install_info` table, not required anymore

I have also added myself again as one of the maintainers, I now have free time again to help with that work. I hope there is no problem with that :)

---

Supersede #6315