### PR TITLE
feat: map gyp to python

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -31,6 +31,7 @@ for ft, lang in pairs {
   ecma = "javascript",
   jsx = "javascript",
   sh = "bash",
+  gyp = "python",
   html_tags = "html",
   ["typescript.tsx"] = "tsx",
   ["html.handlebars"] = "glimmer",


### PR DESCRIPTION
In fact gyp is python file can be `eval()`ed

Such as https://github.com/nodejs/gyp-next/blob/main/pylib/gyp/generator/gypd.py#L26
