### PR TITLE
feat(fennel): update parser and queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -162,7 +162,7 @@
     "revision": "f3b9274514b5f9bf6b0dd4a01c30f9cc15c58bc4"
   },
   "fennel": {
-    "revision": "215e3913524abc119daa9db7cf6ad2f2f5620189"
+    "revision": "63e16deb8e66bff61a09f7582c60945ed216cd65"
   },
   "fidl": {
     "revision": "0a8910f293268e27ff554357c229ba172b0eaed2"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -531,7 +531,7 @@ list.faust = {
 list.fennel = {
   install_info = {
     url = "https://github.com/alexmozaidze/tree-sitter-fennel",
-    files = { "src/parser.c" },
+    files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@alexmozaidze" },
 }

--- a/queries/fennel/folds.scm
+++ b/queries/fennel/folds.scm
@@ -1,35 +1,49 @@
+; compounds
 [
   (list)
   (table)
   (sequence)
 ] @fold
 
-(list
-  .
-  (symbol) @_let
-  (#eq? @_let "let")
-  .
-  (sequence) @fold) @fold
+; sub-forms / special compounds
+[
+  (list_binding)
+  (table_binding)
+  (sequence_binding)
+  (table_metadata)
+  (sequence_arguments)
+  (let_vars)
+  (case_guard_or_special)
+  (case_guard)
+  (case_catch)
+] @fold
 
-(list
-  .
-  (symbol) @_local
-  (#eq? @_local "local")) @fold
+; forms
+[
+  (quote_form)
+  (unquote_form)
+  (local_form)
+  (var_form)
+  (set_form)
+  (global_form)
+  (let_form)
+  (fn_form)
+  (lambda_form)
+  (hashfn_form)
+  (each_form)
+  (collect_form)
+  (icollect_form)
+  (accumulate_form)
+  (for_form)
+  (fcollect_form)
+  (faccumulate_form)
+  (case_form)
+  (match_form)
+] @fold
 
-(list
-  .
-  (symbol) @_global
-  (#eq? @_global "global")) @fold
+; reader macros
+(quote_reader_macro
+  expression: (_) @fold)
 
-(list
-  .
-  (symbol) @_fn
-  (#any-of? @_fn "fn" "lambda" "λ" "hashfn")) @fold
-
-(reader_macro
-  macro:
-    [
-      "'"
-      "`"
-    ]
+(quasi_quote_reader_macro
   expression: (_) @fold)

--- a/queries/fennel/highlights.scm
+++ b/queries/fennel/highlights.scm
@@ -12,44 +12,90 @@
   "]"
 ] @punctuation.bracket
 
-(nil) @constant.builtin
+[
+  (nil)
+  (nil_binding)
+] @constant.builtin
 
-(boolean) @boolean
+[
+  (boolean)
+  (boolean_binding)
+] @boolean
 
-(number) @number
+[
+  (number)
+  (number_binding)
+] @number
 
-(string) @string
+[
+  (string)
+  (string_binding)
+] @string
+
+[
+  (symbol)
+  (symbol_binding)
+] @variable
+
+(symbol_option) @keyword.directive
 
 (escape_sequence) @string.escape
-
-(symbol) @variable
 
 (multi_symbol
   "." @punctuation.delimiter
   member: (symbol_fragment) @variable.member)
 
 (list
-  .
-  (symbol) @function.call)
+  call: (symbol) @function.call)
 
 (list
-  .
-  (multi_symbol
-    member: (symbol_fragment) @function.call .))
+  call:
+    (multi_symbol
+      member: (symbol_fragment) @function.call .))
 
 (multi_symbol_method
   ":" @punctuation.delimiter
-  method: (symbol_fragment) @function.method.call .)
+  method: (symbol_fragment) @function.method.call)
 
-; Just `&` is only used in destructuring
-((symbol) @punctuation.special
-  (#eq? @punctuation.special "&"))
+(quasi_quote_reader_macro
+  macro: _ @punctuation.special)
 
-; BUG: $ arguments should only be valid inside hashfn of any depth, but
-; it's impossible to express such query at the moment of writing.
-; See tree-sitter/tree-sitter#880
+(quote_reader_macro
+  macro: _ @punctuation.special)
+
+(unquote_reader_macro
+  macro: _ @punctuation.special)
+
+(hashfn_reader_macro
+  macro: _ @keyword.function)
+
+(sequence_arguments
+  (symbol_binding) @variable.parameter)
+
+(sequence_arguments
+  (rest_binding
+    rhs: (symbol_binding) @variable.parameter))
+
+(docstring) @string.documentation
+
+(fn_form
+  name:
+    [
+      (symbol) @function
+      (multi_symbol
+        member: (symbol_fragment) @function .)
+    ])
+
+(lambda_form
+  name:
+    [
+      (symbol) @function
+      (multi_symbol
+        member: (symbol_fragment) @function .)
+    ])
+
 ((symbol) @variable.parameter
-  (#eq? @variable.parameter "$..."))
+  (#any-of? @variable.parameter "$" "$..."))
 
 ((symbol) @variable.parameter
   (#lua-match? @variable.parameter "^%$[1-9]$"))
@@ -74,8 +120,11 @@
     ; other
     "length"))
 
-(reader_macro
-  macro: "#" @keyword.function)
+(case_guard
+  call: (_) @keyword)
+
+(case_guard_or_special
+  call: (_) @keyword)
 
 ((symbol) @keyword.function
   (#any-of? @keyword.function "fn" "lambda" "λ" "hashfn"))
@@ -92,12 +141,20 @@
     "quote" "tset" "values" "tail!"))
 
 ((symbol) @keyword.import
-  (#any-of? @keyword.import "require" "require-macros" "import-macros" "include"))
+  (#any-of? @keyword.import "require-macros" "import-macros" "include"))
 
 ((symbol) @function.macro
   (#any-of? @function.macro
     "collect" "icollect" "fcollect" "accumulate" "faccumulate" "->" "->>" "-?>" "-?>>" "?." "doto"
     "macro" "macrodebug" "partial" "pick-args" "pick-values" "with-open"))
+
+(list
+  call: (symbol) @keyword.import
+  (#eq? @keyword.import "import-macros")
+  .
+  (table
+    (table_pair
+      value: (symbol) @function.macro)))
 
 ; TODO: Highlight builtin methods (`table.unpack`, etc) as @function.builtin
 ([
@@ -127,68 +184,3 @@
     "assert" "collectgarbage" "dofile" "error" "getmetatable" "ipairs" "load" "loadfile" "next"
     "pairs" "pcall" "print" "rawequal" "rawget" "rawlen" "rawset" "require" "select" "setmetatable"
     "tonumber" "tostring" "type" "warn" "xpcall" "module" "setfenv" "loadstring" "unpack"))
-
-(table
-  (table_pair
-    key: (symbol) @keyword.directive
-    (#eq? @keyword.directive "&as")))
-
-(list
-  .
-  (symbol) @keyword.function
-  (#any-of? @keyword.function "fn" "lambda" "λ")
-  .
-  [
-    (symbol) @function
-    (multi_symbol
-      (symbol_fragment) @function .)
-  ]
-  .
-  (sequence
-    ((symbol) @variable.parameter
-      (#not-any-of? @variable.parameter "&" "..."))))
-
-(list
-  .
-  (symbol) @function.macro
-  (#any-of? @function.macro "collect" "icollect" "fcollect")
-  .
-  (sequence
-    [
-      (symbol)
-      (string)
-    ] @keyword.directive
-    (#any-of? @keyword.directive "&into" ":into")))
-
-(list
-  .
-  (symbol) @function.macro
-  (#any-of? @function.macro "for" "each" "collect" "icollect" "fcollect" "accumulate" "faccumulate")
-  .
-  (sequence
-    [
-      (symbol)
-      (string)
-    ] @keyword.directive
-    (#any-of? @keyword.directive "&until" ":until")))
-
-(list
-  .
-  (symbol) @keyword.conditional
-  (#any-of? @keyword.conditional "match" "case")
-  .
-  (_)
-  .
-  ((list
-    .
-    (symbol) @keyword
-    (#eq? @keyword "where"))
-    .
-    (_))*
-  .
-  (list
-    .
-    (symbol) @keyword
-    (#eq? @keyword "where"))
-  .
-  (_)? .)

--- a/queries/fennel/injections.scm
+++ b/queries/fennel/injections.scm
@@ -1,107 +1,107 @@
-((comment) @injection.content
+((comment_body) @injection.content
   (#set! injection.language "comment"))
 
 (list
-  .
-  (multi_symbol) @_vimcmd_identifier
+  call: (multi_symbol) @_vimcmd_identifier
   (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec2")
   .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "vim")))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "vim")))
 
 ; NOTE: Matches *exactly* `ffi.cdef`
 (list
-  .
-  (multi_symbol) @_cdef_identifier
+  call: (multi_symbol) @_cdef_identifier
   (#eq? @_cdef_identifier "ffi.cdef")
   .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "c")))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "c")))
 
 (list
-  .
-  (multi_symbol) @_ts_query_identifier
+  call: (multi_symbol) @_ts_query_identifier
   (#any-of? @_ts_query_identifier "vim.treesitter.query.set" "vim.treesitter.query.parse")
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "query")))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "query")))
 
 (list
-  .
-  (multi_symbol) @_vimcmd_identifier
+  call: (multi_symbol) @_vimcmd_identifier
   (#eq? @_vimcmd_identifier "vim.api.nvim_create_autocmd")
   .
-  (_)
+  item: (_)
   .
-  (table
-    (table_pair
-      key:
-        (string
-          (string_content) @_command
-          (#eq? @_command "command"))
-      value:
-        (string
-          (string_content) @injection.content
-          (#set! injection.language "vim")))))
+  item:
+    (table
+      (table_pair
+        key:
+          (string
+            (string_content) @_command
+            (#eq? @_command "command"))
+        value:
+          (string
+            (string_content) @injection.content
+            (#set! injection.language "vim")))))
 
 (list
-  .
-  (multi_symbol) @_user_cmd
+  call: (multi_symbol) @_user_cmd
   (#eq? @_user_cmd "vim.api.nvim_create_user_command")
   .
-  (_)
+  item: (_)
   .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "vim")))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "vim")))
 
 (list
-  .
-  (multi_symbol) @_user_cmd
+  call: (multi_symbol) @_user_cmd
   (#eq? @_user_cmd "vim.api.nvim_buf_create_user_command")
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "vim")))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "vim")))
 
 (list
-  .
-  (multi_symbol) @_map
+  call: (multi_symbol) @_map
   (#any-of? @_map "vim.api.nvim_set_keymap" "vim.keymap.set")
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "vim")))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "vim")))
 
 (list
-  .
-  (multi_symbol) @_map
+  call: (multi_symbol) @_map
   (#eq? @_map "vim.api.nvim_buf_set_keymap")
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "vim")))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "vim")))
 
 ; highlight string as query if starts with `; query`
 (string
@@ -109,40 +109,41 @@
   (#lua-match? @injection.content "^%s*;+%s?query")
   (#set! injection.language "query"))
 
-; ──────────────────────────────────────────────────────────────────────
 ; (string.match "123" "%d+")
 (list
+  call:
+    (multi_symbol
+      member: (symbol_fragment) @_func
+      .
+      (#any-of? @_func "find" "match" "gmatch" "gsub"))
   .
-  (multi_symbol
-    member: (symbol_fragment) @_func
-    .
-    (#any-of? @_func "find" "match" "gmatch" "gsub"))
+  item: (_)
   .
-  (_)
-  .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "luap")
-    (#set! injection.include-children)))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "luap")
+      (#set! injection.include-children)))
 
 ; (my-string:match "%d+")
 (list
+  call:
+    (multi_symbol_method
+      method: (symbol_fragment) @_method
+      (#any-of? @_method "find" "match" "gmatch" "gsub"))
   .
-  (multi_symbol_method
-    method: (symbol_fragment) @_method
-    (#any-of? @_method "find" "match" "gmatch" "gsub"))
-  .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "luap")
-    (#set! injection.include-children)))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "luap")
+      (#set! injection.include-children)))
 
 ; (string.format "pi = %.2f" 3.14159)
 (list
-  .
-  (multi_symbol) @_func
+  call: (multi_symbol) @_func
   (#eq? @_func "string.format")
   .
-  (string
-    (string_content) @injection.content
-    (#set! injection.language "printf")))
+  item:
+    (string
+      (string_content) @injection.content
+      (#set! injection.language "printf")))

--- a/queries/fennel/locals.scm
+++ b/queries/fennel/locals.scm
@@ -1,28 +1,48 @@
-; TODO: Add tests
-; TODO: Improve queries
 (program) @local.scope
-
-((list
-  .
-  (symbol) @_call) @local.scope
-  (#any-of? @_call
-    "let" "fn" "lambda" "λ" "while" "each" "for" "if" "when" "do" "collect" "icollect" "accumulate"
-    "case" "match"))
 
 (symbol) @local.reference
 
+[
+  (let_form)
+  (fn_form)
+  (lambda_form)
+  (each_form)
+  (for_form)
+  (collect_form)
+  (icollect_form)
+  (accumulate_form)
+  (for_form)
+  (fcollect_form)
+  (faccumulate_form)
+  (case_form)
+  (match_form)
+] @local.scope
+
 (list
-  .
-  (symbol) @_fn
-  (#any-of? @_fn "fn" "lambda" "λ")
-  .
-  [
-    (symbol) @local.definition.function
-    (multi_symbol
-      member: (symbol_fragment) @local.definition.function .)
-  ]
-  (#set! definition.function.scope "parent")
-  .
-  (sequence
-    (symbol)* @local.definition.parameter
-    (#not-contains? @local.definition.parameter "&")))
+  call: (symbol) @_call
+  (#any-of? @_call "while" "if" "when" "do")) @local.scope
+
+(fn_form
+  name:
+    [
+      (symbol) @local.definition.function
+      (multi_symbol
+        member: (symbol_fragment) @local.definition.function .)
+    ]
+  args:
+    (sequence_arguments
+      (symbol_binding) @local.definition.parameter)
+  (#set! definition.function.scope "parent"))
+
+; NOTE: Body should be identical to fn_form above
+(lambda_form
+  name:
+    [
+      (symbol) @local.definition.function
+      (multi_symbol
+        member: (symbol_fragment) @local.definition.function .)
+    ]
+  args:
+    (sequence_arguments
+      (symbol_binding) @local.definition.parameter)
+  (#set! definition.function.scope "parent"))


### PR DESCRIPTION
WIP version of the parser. It works fine, but there are some bugs.

If you think I should do something that's not in TODO, please let me know ^^

## TODO

- [ ] Correctly distinguish function docstring/metadata from function body (function body's first string/table gets parsed as docstring/metadata)
- [x] Detect double-quoted special table metadata keys (`:fnl/docstring` is detected, while `"fnl/docstring"` is parsed as a regular string)
- [x] Separate `;` from the comment body
- [ ] Support `comment` form (if possible)
- [ ] Ensure form error recovery doesn't leak outside its own paren scope
- [ ] Refactor internals

## Queries

I used `#has-ancestor?`, which is available in Neovim >0.10. Removing it would only make highlighting a *little* incorrect, which would be fine.
I also Removed queries I couldn't use and test, so that there are no broken queries.

## Notes on forms support

I only support forms that have destructuring, complex syntax, or forms that might need to be queried with `#has-ancestor?`/`#has-parent?`.