### PR TITLE
feat(lua): add injections for `vim.filetype.add`

### DIFF
--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -177,3 +177,21 @@
 (comment
   content: (_) @injection.content
   (#set! injection.language "comment"))
+
+; vim.filetype.add({ pattern = { ["some lua pattern here"] = "filetype" } })
+((function_call
+  name: (_) @_filetypeadd_identifier
+  arguments:
+    (arguments
+      (table_constructor
+        (field
+          name: (_) @_pattern_key
+          value:
+            (table_constructor
+              (field
+                name:
+                  (string
+                    content: _ @injection.content)))))))
+  (#set! injection.language "luap")
+  (#eq? @_filetypeadd_identifier "vim.filetype.add")
+  (#eq? @_pattern_key "pattern"))

--- a/queries/lua/injections.scm
+++ b/queries/lua/injections.scm
@@ -181,17 +181,14 @@
 ; vim.filetype.add({ pattern = { ["some lua pattern here"] = "filetype" } })
 ((function_call
   name: (_) @_filetypeadd_identifier
-  arguments:
-    (arguments
-      (table_constructor
-        (field
-          name: (_) @_pattern_key
-          value:
-            (table_constructor
-              (field
-                name:
-                  (string
-                    content: _ @injection.content)))))))
+  arguments: (arguments
+    (table_constructor
+      (field
+        name: (_) @_pattern_key
+        value: (table_constructor
+          (field
+            name: (string
+              content: _ @injection.content)))))))
   (#set! injection.language "luap")
   (#eq? @_filetypeadd_identifier "vim.filetype.add")
   (#eq? @_pattern_key "pattern"))


### PR DESCRIPTION
I have it working for the uses I have in my dotfiles and for the examples in the documentation:

<img width="1912" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/37723586/f00f8cf0-bcaa-4b59-946a-a19e25683dd6">
