### PR TITLE
feat(julia): broadcast pipe

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -59,7 +59,7 @@
   (_)
   (operator) @_pipe
   (identifier) @function.call
-  (#eq? @_pipe "|>"))
+  (#any-of? @_pipe "|>" ".|>"))
 
 ; Builtins
 ((identifier) @function.builtin


### PR DESCRIPTION
Add support for capturing function call after a broadcasted pipe. Currently works for unbroadcasted pipe.
There might be a better more complicated way to do this, since this will capture the broadcasting dot as part of the `@_pipe` capture.