### PR TITLE
fix(c): don't highlight preproc_arg

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -142,9 +142,6 @@
 
 (char_literal) @character
 
-((preproc_arg) @function.macro
-  (#set! "priority" 90))
-
 (preproc_defined) @function.macro
 
 ((field_expression


### PR DESCRIPTION
`preproc_arg` is used for the body of `#define` macro definition, which is not appropriate to highlight with `@function.macro`. In addition, this region has an injection to C, so it will get highlights anyway.