### PR TITLE
feat(bash): align substitutions with expansions

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -124,10 +124,15 @@
 (test_operator) @operator
 
 (command_substitution
-  "$(" @punctuation.bracket)
+  "$(" @punctuation.special
+  ")" @punctuation.special)
 
 (process_substitution
-  "<(" @punctuation.bracket)
+  [
+    "<("
+    ">("
+  ] @punctuation.special
+  ")" @punctuation.special)
 
 (arithmetic_expansion
   [


### PR DESCRIPTION
Hi, I think that command and process substitutions [ie. $(), >(), and <() ] should be highlighted the same as other expansions, which use `@punctuation.special`. This PR sets that up.

In defense of this approach, the [bash manual](https://www.gnu.org/software/bash/manual/html_node/Shell-Expansions.html) considers command and process substitutions to be forms of expansions, so they should be highlighted as such. This is traditionally how they have been highlighted in the past too.

## Screenshots
The default colorscheme links both `@punctuation.special` and `@punctuation.default` to `Special` so they DO happen to look the same in that particular colorscheme, but this might not be the case for others. I ran this command to make the difference more apparent:

```colorscheme default | hi link @punctuation.special PreProc | hi PreProc guifg=#b854d4```

### Before
![2024-03-24_08-54](https://github.com/nvim-treesitter/nvim-treesitter/assets/7788329/fee549d9-f800-4fc6-9471-4019b9d272a8)


### After
![2024-03-24_08-54_1](https://github.com/nvim-treesitter/nvim-treesitter/assets/7788329/d210c2d0-be77-47cf-b5b7-6555823795b1)
