### PR TITLE
bug: remove extra space during cd

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -329,7 +329,7 @@ function M.make_directory_change_for_command(dir, command)
       return string.format("pushd %s ; %s ; popd", cmdpath(dir), command)
     end
   else
-    return string.format("cd %s;\n %s", dir, command)
+    return string.format("cd %s;\n%s", dir, command)
   end
 end
 


### PR DESCRIPTION
Probably very few people affected by this, but... I'm using the shell [xonsh](https://xon.sh/), and because of its syntax expectations (allows both python and bash in an interesting mix) whitespace is sometimes meaningful. Therefore, the newline + space combo after the semicolon in this shell command fails for me.

This might be better considered to be a bug in xonsh (although, I'm not actually sure if this is solvable, given the syntax it's trying to support; it might not be fixable; but I've [opened an issue over there](https://github.com/xonsh/xonsh/issues/5312) as well) but since this would be a 1 character fix in this repo, thought I'd open the PR in case this is amenable.

Before this PR, parser installation (e.g. `ensure_installed = {'python'}`) fails for me with the following:
```
Downloading tree-sitter-python...
  File "<string>", line 2
    curl  --silent -L https://github.com/tree-sitter/tree-sitter-python/archive/b8a4c64121ba66b460cb878e934e3157ecbfb124.tar.gz --output tree-sitter-python.tar.gz
SyntaxError: ('code:  ',)
Error during download, please verify your internet connection
Failed to execute the following command:
{
  cmd = "curl",
  err = "Error during download, please verify your internet connection",
  info = "Downloading tree-sitter-python...",
  opts = {
    args = { "--silent", "-L", "https://github.com/tree-sitter/tree-sitter-python/archive/b8a4c64121ba66b460cb878e934e3157ecbfb124.tar.gz", "--output", "tree-sitter-python.tar.gz" },
    cwd = "/home/laptopdude/.local/share/nvim"
  }
}
```

Where the `SyntaxError: ('code:  ',)` is from `xonsh`, because whitespace is meaningful in python, so seeing a space at the start of the second line is actually a syntax error because indentation implies structure. In other words, the current code produces a shell command like:
```
cd /path/to/somewhere;
 curl ...
```

And removing either the newline or the space fixes this for me. It looks like this might even have been an unintentional change anyway; looking at c7422dd, before we had:
```
ret = string.format('cd %s;\n', cmd.opts.cwd)
ret = string.format('%s%s ', ret, cmd.cmd)
```

And after (there's an extra space now):
```
string.format("cd %s;\n %s", dir, command)
```

So I understand if you view this as just a `xonsh` bug and don't think this is necessarily where to address it... but since it's such a small change (and potentially no one using other shells cares either way since it's just whitespace) wanted to propose it anyway.

I'll also say, I have an easy-ish workaround (which does have other consequences, but it works) which is to just `:set shell=/bin/bash` which of course is fine with the syntax.

Thanks!