### PR TITLE
feat(markdown): yaml, toml metadata highlights

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -114,7 +114,7 @@
 ([
   (plus_metadata)
   (minus_metadata)
-] @string.special
+] @keyword.directive
   (#set! "priority" 90))
 
 [

--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -111,6 +111,12 @@
 ((block_quote) @markup.quote
   (#set! "priority" 90))
 
+([
+  (plus_metadata)
+  (minus_metadata)
+] @string.special
+  (#set! "priority" 90))
+
 [
   (block_continuation)
   (block_quote_marker)


### PR DESCRIPTION
Highlights metadata blocks such as the following:

```md
---
title: A title
author: An author
---
```

The highlight is given a lower priority because everything except the delimiting dashes/pluses will be injected with the appropriate metadata language.