### PR TITLE
fix(python): add staticmethod to builtin decorators

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -79,7 +79,7 @@
 
 ((decorator
   (identifier) @attribute.builtin)
-  (#any-of? @attribute.builtin "classmethod" "property"))
+  (#any-of? @attribute.builtin "classmethod" "property" "staticmethod"))
 
 ; Builtin functions
 ((call


### PR DESCRIPTION
Add "staticmethod" to built in decorators