### PR TITLE
feat: support quantifiers for folding

### DIFF
--- a/lua/nvim-treesitter/fold.lua
+++ b/lua/nvim-treesitter/fold.lua
@@ -47,7 +47,12 @@ local folds_levels = tsutils.memoize_by_buf_tick(function(bufnr)
     if match.metadata and match.metadata.range then
       start, _, stop, stop_col = unpack(match.metadata.range) ---@type integer, integer, integer, integer
     else
-      start, _, stop, stop_col = match.node:range() ---@type integer, integer, integer, integer
+      if match.node[1] ~= nil then
+        start, _, _, _ = match.node[1]:range() ---@type integer, integer, integer, integer
+        _, _, stop, stop_col = match.node[#match.node]:range() ---@type integer, integer, integer, integer
+      else
+        start, _, stop, stop_col = match.node:range() ---@type integer, integer, integer, integer
+      end
     end
 
     if stop_col == 0 then

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -248,7 +248,7 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
     return t
   end
 
-  local matches = query:iter_matches(qnode, bufnr, start_row, end_row)
+  local matches = query:iter_matches(qnode, bufnr, start_row, end_row, { all = true })
 
   local function iterator()
     local pattern, match, metadata = matches()


### PR DESCRIPTION
Solves #3196

With https://github.com/neovim/neovim/pull/24738 merged in nightly neovim, quantifiers can be all matched and folded as one

Tested with:

```lua
local folds_query = [[
  ((import_statement)+ @fold)
]]

require("vim.treesitter.query").set("typescript", "folds", folds_query)
```
