### PR TITLE
Misc nix fixes

### DIFF
--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -75,7 +75,7 @@
   "?"? @operator)
 
 ; `...` in `{ ... }`, used to ignore unknown named function arguments (see above)
-(ellipses) @punctuation.special
+(ellipses) @variable.parameter.builtin
 
 ; universal is the parameter of the function expression
 ; `:` in `x: y`, used to separate function argument from body (see above)

--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -55,6 +55,7 @@
 [
   "."
   ";"
+  ":"
   ","
 ] @punctuation.delimiter
 
@@ -186,6 +187,12 @@
 ; binary operators
 (binary_expression
   operator: _ @operator)
+
+[
+  "="
+  "@"
+  "?"
+] @operator
 
 ; integers, also highlight a unary -
 [


### PR DESCRIPTION
Adds some punctuation highlights that seem to be missing, and also changes the ellipsis parameter to parameter.builtin to match other languages that do this to their ellipsis params, like lua e.g.