### PR TITLE
fix(rust): indentation in tuple type patterns

### DIFF
--- a/queries/rust/indents.scm
+++ b/queries/rust/indents.scm
@@ -3,7 +3,6 @@
   (struct_item)
   (enum_item)
   (impl_item)
-  (for_expression)
   (struct_expression)
   (struct_pattern)
   (tuple_struct_pattern)

--- a/queries/rust/indents.scm
+++ b/queries/rust/indents.scm
@@ -8,6 +8,7 @@
   (struct_pattern)
   (tuple_struct_pattern)
   (tuple_expression)
+  (tuple_type)
   (match_block)
   (call_expression)
   (assignment_expression)
@@ -83,6 +84,9 @@
   "}" @indent.end)
 
 (tuple_struct_pattern
+  ")" @indent.end)
+
+(tuple_type
   ")" @indent.end)
 
 (trait_item


### PR DESCRIPTION
Fix indentation when tuple are on multiple lines.

Example:

previous:

```rust
fn do_stuff(
  mut thing_query: Query<(
  &Transform,
  &Sprite,
)>
) {
  // ...
}
```
new:

```rust
fn do_stuff(
  mut thing_query: Query<(
    &Transform,
    &Sprite,
  )>
) {
  // ...
}
```