### PR TITLE
fix(rust): indentation in multi-line tuple pattern

### DIFF
--- a/queries/rust/indents.scm
+++ b/queries/rust/indents.scm
@@ -8,6 +8,7 @@
   (tuple_struct_pattern)
   (tuple_expression)
   (tuple_type)
+  (tuple_pattern)
   (match_block)
   (call_expression)
   (assignment_expression)
@@ -86,6 +87,9 @@
   ")" @indent.end)
 
 (tuple_type
+  ")" @indent.end)
+
+(tuple_pattern
   ")" @indent.end)
 
 (trait_item

--- a/tests/indent/rust/tuple.rs
+++ b/tests/indent/rust/tuple.rs
@@ -1,0 +1,8 @@
+fn foo() {
+    for (
+        a,
+        b
+    ) in c.iter() {
+        // ...
+    }
+}


### PR DESCRIPTION
previous:
```rust
    for (
    abc,
    def
) in thing.iter() {
        // ...
    }
```

new:
```rust
    for (
        abc,
        def
    ) in thing.iter() {
        // ...
    }
```