### PR TITLE
fix(bash): fix printf injection queries

### DIFF
--- a/queries/bash/injections.scm
+++ b/queries/bash/injections.scm
@@ -14,13 +14,15 @@
   name: (command_name) @_command
   .
   argument: [
-    (string)
+    (string
+      (string_content) @injection.content)
     (concatenation
-      (string) @injection.content)
-    (raw_string)
+      (string
+        (string_content) @injection.content))
+    (raw_string) @injection.content
     (concatenation
       (raw_string) @injection.content)
-  ] @injection.content)
+  ])
   (#eq? @_command "printf")
   (#set! injection.language "printf")
   (#set! injection.include-children))
@@ -33,13 +35,15 @@
   (_)
   .
   argument: [
-    (string)
+    (string
+      (string_content) @injection.content)
     (concatenation
-      (string) @injection.content)
-    (raw_string)
+      (string
+        (string_content) @injection.content))
+    (raw_string) @injection.content
     (concatenation
       (raw_string) @injection.content)
-  ] @injection.content)
+  ])
   (#eq? @_command "printf")
   (#eq? @_arg "-v")
   (#set! injection.language "printf")
@@ -51,13 +55,15 @@
   argument: (word) @_arg
   .
   argument: [
-    (string)
+    (string
+      (string_content) @injection.content)
     (concatenation
-      (string) @injection.content)
-    (raw_string)
+      (string
+        (string_content) @injection.content))
+    (raw_string) @injection.content
     (concatenation
       (raw_string) @injection.content)
-  ] @injection.content)
+  ])
   (#eq? @_command "printf")
   (#eq? @_arg "--")
   (#set! injection.language "printf")

--- a/queries/bash/injections.scm
+++ b/queries/bash/injections.scm
@@ -24,8 +24,7 @@
       (raw_string) @injection.content)
   ])
   (#eq? @_command "printf")
-  (#set! injection.language "printf")
-  (#set! injection.include-children))
+  (#set! injection.language "printf"))
 
 ; printf -v var 'format'
 ((command
@@ -46,8 +45,7 @@
   ])
   (#eq? @_command "printf")
   (#eq? @_arg "-v")
-  (#set! injection.language "printf")
-  (#set! injection.include-children))
+  (#set! injection.language "printf"))
 
 ; printf -- 'format'
 ((command
@@ -66,5 +64,4 @@
   ])
   (#eq? @_command "printf")
   (#eq? @_arg "--")
-  (#set! injection.language "printf")
-  (#set! injection.include-children))
+  (#set! injection.language "printf"))

--- a/queries/bash/injections.scm
+++ b/queries/bash/injections.scm
@@ -15,10 +15,15 @@
   .
   argument: [
     (string)
+    (concatenation
+      (string) @injection.content)
     (raw_string)
+    (concatenation
+      (raw_string) @injection.content)
   ] @injection.content)
   (#eq? @_command "printf")
-  (#set! injection.language "printf"))
+  (#set! injection.language "printf")
+  (#set! injection.include-children))
 
 ; printf -v var 'format'
 ((command
@@ -29,11 +34,16 @@
   .
   argument: [
     (string)
+    (concatenation
+      (string) @injection.content)
     (raw_string)
+    (concatenation
+      (raw_string) @injection.content)
   ] @injection.content)
   (#eq? @_command "printf")
   (#eq? @_arg "-v")
-  (#set! injection.language "printf"))
+  (#set! injection.language "printf")
+  (#set! injection.include-children))
 
 ; printf -- 'format'
 ((command
@@ -42,8 +52,13 @@
   .
   argument: [
     (string)
+    (concatenation
+      (string) @injection.content)
     (raw_string)
+    (concatenation
+      (raw_string) @injection.content)
   ] @injection.content)
   (#eq? @_command "printf")
   (#eq? @_arg "--")
-  (#set! injection.language "printf"))
+  (#set! injection.language "printf")
+  (#set! injection.include-children))


### PR DESCRIPTION
The `(string)` node has a `(string_content)` child which breaks the injection of `printf`. The solution was to use `(#set! injection.include-children)`.

I also added support for `(concatenation)` nodes.

### Before

<img width="1912" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/37723586/6b3bdcbd-fb88-4aa2-b450-ee872cc40fe0">

### After

<img width="1912" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/37723586/fab9d732-efb9-42c2-9cf1-0ccebf967124">
