### PR TITLE
docs: add instructions to solve "invalid node type" or "invalid structure at"

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ Try updating the parser that you suspect has changed (`:TSUpdate {language}`) or
 If the error persists after updating all parsers,
 please [open an issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/new/choose).
 
-#### I get `query error: invalid node type at position`
+#### I get `query error: invalid node type at position` or `query: invalid structure at position xxx for language xxx`
 
 This could be due a query file outside this plugin using outdated nodes,
 or due to an outdated parser.
@@ -727,6 +727,10 @@ or due to an outdated parser.
   You can execute this command `:echo nvim_get_runtime_file('parser', v:true)` to find all runtime directories.
   If you get more than one path, remove the ones that are outside this plugin (`nvim-treesitter` directory),
   so the correct version of the parser is used.
+    - assuming that you have an "extra" path `/usr/local/Cellar/neovim/0.9.5/lib/nvim/parser`, you can get rid of that by
+      removing the `/usr/local/Cellar/neovim/0.9.5/lib/nvim` (note no `/parser` at the end)  from the `runtimepath`:
+    - ie. adding `set rtp-=/usr/local/Cellar/neovim/0.9.5/lib/nvim` at the end of your init.vim, 
+    - ie. `vim.opt.rtp:remove("/usr/local/Cellar/neovim/0.9.5/lib/nvim")` at the end of your init.lua 
 
 #### I experience weird highlighting issues similar to [#78](https://github.com/nvim-treesitter/nvim-treesitter/issues/78)
 


### PR DESCRIPTION
I got

```
Error executing vim.schedule lua callback: ...im/0.9.5/share/nvim/runtime/lua/vim/treesitter/query.lua:259: query: invalid structure at position 3158 for language lua                                                                                                                                            
stack traceback:                                                                                                                                                                                                                                                                                                  
        [C]: in function '_ts_parse_query'                                                                                                                                                                                                                                                                        
        ...im/0.9.5/share/nvim/runtime/lua/vim/treesitter/query.lua:259: in function 'get'                                                                                                                                                                                                                        
        ...5/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:114: in function 'new'                                                                                                                                                                                                                        
        ...r/neovim/0.9.5/share/nvim/runtime/lua/vim/treesitter.lua:61: in function '_create_parser'                                                                                                                                                                                                              
        ...r/neovim/0.9.5/share/nvim/runtime/lua/vim/treesitter.lua:131: in function 'get_parser'                                                                                                                                                                                                                 
        ...r/neovim/0.9.5/share/nvim/runtime/lua/vim/treesitter.lua:460: in function 'ts_highlighter'                                                                                                                                                                                                             
        ...m/lazy/telescope.nvim/lua/telescope/previewers/utils.lua:152: in function 'highlighter'                                                                                                                                                                                                                
        ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:234: in function ''                                                                                                                                                                                                                           
```

and it took me a while to realize that I was experiencing what is described at  https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#i-get-query-error-invalid-node-type-at-position , in part because the "invalid structure at position" is a different message from the only one mention in the docs "invalid node type at position". 

This change will enhanced the current troubleshooting information with

* a explicit mention of `query: invalid structure at position` so that easier to search for it
* examples on how to remove those "extra"  directories from the `runtimepath`/`rtp`, since it's not evident from the current text how you get rid of those. 

