### PR TITLE
docs: invalid structure at position -> do not lazy load nvim-treesitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,16 +717,19 @@ Try updating the parser that you suspect has changed (`:TSUpdate {language}`) or
 If the error persists after updating all parsers,
 please [open an issue](https://github.com/nvim-treesitter/nvim-treesitter/issues/new/choose).
 
-#### I get `query error: invalid node type at position`
+#### I get `query error: invalid node type at position` or `query: invalid structure at position xxx for language yyy`
 
 This could be due a query file outside this plugin using outdated nodes,
 or due to an outdated parser.
 
 - Make sure you have the parsers up to date with `:TSUpdate`
+- Make sure that you don't lazy load `nvim-treesitter`
 - Make sure you don't have more than one `parser` runtime directory.
   You can execute this command `:echo nvim_get_runtime_file('parser', v:true)` to find all runtime directories.
   If you get more than one path, remove the ones that are outside this plugin (`nvim-treesitter` directory),
   so the correct version of the parser is used.
+
+
 
 #### I experience weird highlighting issues similar to [#78](https://github.com/nvim-treesitter/nvim-treesitter/issues/78)
 


### PR DESCRIPTION
Explicitly mention `query: invalid structure at position` in the docs with the "do not use lazy-loading" advice. 


that way if will be more clear that when the user gets: 
```
Error executing vim.schedule lua callback: ...im/0.9.5/share/nvim/runtime/lua/vim/treesitter/query.lua:259: query: invalid structure at position 3158 for language lua                                                                                                                                            
stack traceback:                                                                                                                                                                                                                                                                                                  
        [C]: in function '_ts_parse_query'                                                                                                                                                                                                                                                                        
        ...im/0.9.5/share/nvim/runtime/lua/vim/treesitter/query.lua:259: in function 'get'                                                                                                                                                                                                                        
        ...5/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:114: in function 'new'                                                                                                                                                                                                                        
        ...r/neovim/0.9.5/share/nvim/runtime/lua/vim/treesitter.lua:61: in function '_create_parser'                                                                                                                                                                                                              
        ...r/neovim/0.9.5/share/nvim/runtime/lua/vim/treesitter.lua:131: in function 'get_parser'                                                                                                                                                                                                                 
        ...r/neovim/0.9.5/share/nvim/runtime/lua/vim/treesitter.lua:460: in function 'ts_highlighter'                                                                                                                                                                                                             
        ...m/lazy/telescope.nvim/lua/telescope/previewers/utils.lua:152: in function 'highlighter'                                                                                                                                                                                                                
        ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:234: in function ''                                                                                                                                                                                                                           
```

it's probably because they are using  `lazy.nvim` plugin manager and they set lazy loading for nvim-treesitter (like I did inadvertently by using `event='VeryLazy'` which still loads the nvim-treesitter but "too late". 


