### PR TITLE
Nix cleanups

### DIFF
--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -8,17 +8,6 @@
   "with"
 ] @keyword
 
-(variable_expression
-  name: (identifier) @keyword
-  (#eq? @keyword "derivation")
-  (#set! "priority" 101))
-
-; exceptions
-(variable_expression
-  name: (identifier) @keyword.exception
-  (#any-of? @keyword.exception "abort" "throw")
-  (#set! "priority" 101))
-
 ; if/then/else
 [
   "if"
@@ -113,16 +102,16 @@
 (variable_expression
   name: (identifier) @function.builtin
   (#any-of? @function.builtin
-    ; nix eval --impure --expr 'with builtins; filter (x: !(elem x [ "abort" "derivation" "import" "throw" ]) && isFunction builtins.${x}) (attrNames builtins)'
+    ; nix eval --impure --expr 'with builtins; filter (x: !(elem x [ "abort" "import" "throw" ]) && isFunction builtins.${x}) (attrNames builtins)'
     "add" "addErrorContext" "all" "any" "appendContext" "attrNames" "attrValues" "baseNameOf"
     "bitAnd" "bitOr" "bitXor" "break" "catAttrs" "ceil" "compareVersions" "concatLists" "concatMap"
-    "concatStringsSep" "deepSeq" "derivationStrict" "dirOf" "div" "elem" "elemAt" "fetchGit"
-    "fetchMercurial" "fetchTarball" "fetchTree" "fetchurl" "filter" "filterSource" "findFile"
-    "floor" "foldl'" "fromJSON" "fromTOML" "functionArgs" "genList" "genericClosure" "getAttr"
-    "getContext" "getEnv" "getFlake" "groupBy" "hasAttr" "hasContext" "hashFile" "hashString" "head"
-    "intersectAttrs" "isAttrs" "isBool" "isFloat" "isFunction" "isInt" "isList" "isNull" "isPath"
-    "isString" "length" "lessThan" "listToAttrs" "map" "mapAttrs" "match" "mul" "parseDrvName"
-    "partition" "path" "pathExists" "placeholder" "readDir" "readFile" "removeAttrs"
+    "concatStringsSep" "deepSeq" "derivation" "derivationStrict" "dirOf" "div" "elem" "elemAt"
+    "fetchGit" "fetchMercurial" "fetchTarball" "fetchTree" "fetchurl" "filter" "filterSource"
+    "findFile" "floor" "foldl'" "fromJSON" "fromTOML" "functionArgs" "genList" "genericClosure"
+    "getAttr" "getContext" "getEnv" "getFlake" "groupBy" "hasAttr" "hasContext" "hashFile"
+    "hashString" "head" "intersectAttrs" "isAttrs" "isBool" "isFloat" "isFunction" "isInt" "isList"
+    "isNull" "isPath" "isString" "length" "lessThan" "listToAttrs" "map" "mapAttrs" "match" "mul"
+    "parseDrvName" "partition" "path" "pathExists" "placeholder" "readDir" "readFile" "removeAttrs"
     "replaceStrings" "scopedImport" "seq" "sort" "split" "splitVersion" "storePath" "stringLength"
     "sub" "substring" "tail" "toFile" "toJSON" "toPath" "toString" "toXML" "trace" "traceVerbose"
     "tryEval" "typeOf" "unsafeDiscardOutputDependency" "unsafeDiscardStringContext"
@@ -211,3 +200,8 @@
     (float_expression))
   (float_expression)
 ] @number.float
+
+; exceptions
+(variable_expression
+  name: (identifier) @keyword.exception
+  (#any-of? @keyword.exception "abort" "throw"))

--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -33,11 +33,13 @@
 (comment) @comment @spell
 
 ; strings
-([
-  (string_expression)
-  (indented_string_expression)
-]
-  (#set! "priority" 99)) @string
+(string_fragment) @string
+
+(string_expression
+  "\"" @string)
+
+(indented_string_expression
+  "''" @string)
 
 ; paths and URLs
 [

--- a/queries/nix/injections.scm
+++ b/queries/nix/injections.scm
@@ -12,6 +12,18 @@
   (#gsub! @injection.language "/%*%s*([%w%p]+)%s*%*/" "%1")
   (#set! injection.combined))
 
+; #-style Comments
+((comment) @injection.language
+  . ; this is to make sure only adjacent comments are accounted for the injections
+  [
+    (string_expression
+      (string_fragment) @injection.content)
+    (indented_string_expression
+      (string_fragment) @injection.content)
+  ]
+  (#gsub! @injection.language "#%s*([%w%p]+)%s*" "%1")
+  (#set! injection.combined))
+
 (apply_expression
   function: (_) @_func
   argument: [

--- a/tests/query/highlights/nix/test.nix
+++ b/tests/query/highlights/nix/test.nix
@@ -13,4 +13,9 @@
 # ^ @variable.member
       # ^ @function.call
               # ^ @string.special.path
+  hi = if true then 9 else throw "an error ${here + "string"}";
+                           # ^ @keyword.exception
+                                  # ^ @string
+                                             # ^ @variable
+                                                     # ^ @string
 }


### PR DESCRIPTION
This PR gives two changes:

1. First commit fixes an issue where strings inside string interpolations weren't working:

    ```nix
    {
      test = "this ${would + "not work"}";
    }
    ```

    It does this by only applying the string highlights to the fragments themselves (which do not include the 
    interpolations) and the quote delimiters.

2. Second commit removes the special `derivation` query, lumping it in as a `@function.builtin` (as it is defined [here](https://nixos.org/manual/nix/stable/language/derivations)), and it also applies the `@keyword.import` queries at the end of the file so as to remove any need for using `priority` workarounds.

    It also adds tests.