### PR TITLE
docs: Replace vim.treesitter.query.set_query() to set()

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ If you want to completely override a query, you can use `:h vim.treesitter.query
 For example, to override the `injections` queries from `c` with your own:
 
 ```lua
-require("vim.treesitter.query").set("c", "injections", "(comment) @comment")
+vim.treesitter.query.set("c", "injections", "(comment) @comment")
 ```
 
 Note: when using `set`, all queries in the runtime directories will be ignored.

--- a/README.md
+++ b/README.md
@@ -623,14 +623,14 @@ All queries found in the runtime directories will be combined.
 By convention, if you want to write a query, use the `queries/` directory,
 but if you want to extend a query use the `after/queries/` directory.
 
-If you want to completely override a query, you can use `:h set_query()`.
+If you want to completely override a query, you can use `:h vim.treesitter.query.set()`.
 For example, to override the `injections` queries from `c` with your own:
 
 ```lua
-require("vim.treesitter.query").set_query("c", "injections", "(comment) @comment")
+require("vim.treesitter.query").set("c", "injections", "(comment) @comment")
 ```
 
-Note: when using `set_query`, all queries in the runtime directories will be ignored.
+Note: when using `set`, all queries in the runtime directories will be ignored.
 
 ## Adding modules
 


### PR DESCRIPTION
vim.treesitter.query.set_query() is deprecated and will be removed in nvim 0.10

use vim.treesitter.query.set() instead