### PR TITLE
fix(julia): Update queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -348,7 +348,7 @@
     "revision": "d34615fa12cc1d1cfc1f1f1a80acc9db80ee4596"
   },
   "julia": {
-    "revision": "e84f10db8eeb8b9807786bfc658808edaa1b4fa2"
+    "revision": "c0acda09c0c70d4515402f9ebb1ad369fa0afabf"
   },
   "just": {
     "revision": "6c2f018ab1d90946c0ce029bb2f7d57f56895dff"

--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -4,14 +4,6 @@
 ; ;; If you want type highlighting based on Julia naming conventions (this might collide with mathematical notation)
 ; ((identifier) @type
 ;   (match? @type "^[A-Z][^_]"))  ; exception: Highlight `A_foo` sort of identifiers as variables
-(macro_identifier) @function.macro
-
-(macro_identifier
-  (identifier) @function.macro) ; for any one using the variable highlight
-
-(macro_definition
-  name: (identifier) @function.macro)
-
 (quote_expression
   ":" @string.special.symbol
   [
@@ -21,22 +13,6 @@
 
 (field_expression
   (identifier) @variable.member .)
-
-; Function names
-; Definitions
-(function_definition
-  name: (identifier) @function)
-
-(short_function_definition
-  name: (identifier) @function)
-
-(function_definition
-  name: (field_expression
-    (identifier) @function .))
-
-(short_function_definition
-  name: (field_expression
-    (identifier) @function .))
 
 ; calls
 (call_expression
@@ -59,6 +35,17 @@
   (identifier) @function.call
   (#any-of? @_pipe "|>" ".|>"))
 
+(macro_identifier) @function.macro
+
+(macro_identifier
+  (identifier) @function.macro) ; for any one using the variable highlight
+
+(macro_definition
+  (signature
+    (call_expression
+      .
+      (identifier) @function.macro)))
+
 ; Builtins
 ((identifier) @function.builtin
   (#any-of? @function.builtin
@@ -68,25 +55,6 @@
     "donotdelete" "fieldtype" "get_binding_type" "getfield" "ifelse" "invoke" "isa" "isdefined"
     "modifyfield!" "nfields" "replacefield!" "set_binding_type!" "setfield!" "sizeof" "svec"
     "swapfield!" "throw" "tuple" "typeassert" "typeof"))
-
-; Parameters
-(parameter_list
-  (identifier) @variable.parameter)
-
-(optional_parameter
-  .
-  (identifier) @variable.parameter)
-
-(slurp_parameter
-  (identifier) @variable.parameter)
-
-(typed_parameter
-  parameter: (identifier)? @variable.parameter
-  type: (_) @type)
-
-(function_expression
-  .
-  (identifier) @variable.parameter) ; Single parameter arrow functions
 
 ; Types
 ; Definitions
@@ -118,11 +86,8 @@
 (typed_expression
   (identifier) @type .)
 
-(function_definition
-  return_type: (identifier) @type)
-
-(short_function_definition
-  return_type: (identifier) @type)
+(unary_typed_expression
+  (identifier) @type .)
 
 (where_clause
   (identifier) @type)
@@ -387,7 +352,6 @@
     (abstract_definition)
     (struct_definition)
     (function_definition)
-    (short_function_definition)
     (assignment)
     (const_statement)
   ])

--- a/queries/julia/indents.scm
+++ b/queries/julia/indents.scm
@@ -47,10 +47,6 @@
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")"))
 
-((parameter_list) @indent.align
-  (#set! indent.open_delimiter "(")
-  (#set! indent.close_delimiter ")"))
-
 ((curly_expression) @indent.align
   (#set! indent.open_delimiter "{")
   (#set! indent.close_delimiter "}"))

--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -6,7 +6,6 @@
     (abstract_definition)
     (struct_definition)
     (function_definition)
-    (short_function_definition)
     (assignment)
     (const_statement)
   ]

--- a/queries/julia/locals.scm
+++ b/queries/julia/locals.scm
@@ -39,35 +39,18 @@
 (import_statement
   (identifier) @local.definition.import)
 
-; Parameters
-(parameter_list
-  (identifier) @local.definition.parameter)
-
-(optional_parameter
-  .
-  (identifier) @local.definition.parameter)
-
-(slurp_parameter
-  (identifier) @local.definition.parameter)
-
-(typed_parameter
-  parameter: (identifier) @local.definition.parameter
-  (_))
-
-; Single parameter arrow function
-(function_expression
-  .
-  (identifier) @local.definition.parameter)
-
 ; Function/macro definitions
 (function_definition
-  name: (identifier) @local.definition.function) @local.scope
-
-(short_function_definition
-  name: (identifier) @local.definition.function) @local.scope
+  (signature
+    (call_expression
+      .
+      (identifier) @local.definition.function))) @local.scope
 
 (macro_definition
-  name: (identifier) @local.definition.macro) @local.scope
+  (signature
+    (call_expression
+      .
+      (identifier) @local.definition.function))) @local.scope
 
 (identifier) @local.reference
 

--- a/tests/query/highlights/julia/test.jl
+++ b/tests/query/highlights/julia/test.jl
@@ -1,6 +1,6 @@
 function load_data(::Symbol; ::Int) :: Tuple
 # <- @keyword.function
-#        ^ @function
+#        ^ @function.call
 #                 ^ @punctuation.bracket
 #                  ^^ @punctuation.delimiter
 #                    ^ @type.builtin


### PR DESCRIPTION
This PR removes all patterns for parameters, but otherwise doesn't really change syntax highlighting.

See tree-sitter/tree-sitter-julia#135