### PR TITLE
feat(t32): use filetype "trace32"

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2004,6 +2004,7 @@ list.t32 = {
     url = "https://gitlab.com/xasc/tree-sitter-t32.git",
     files = { "src/parser.c", "src/scanner.c" },
   },
+  filetype = "trace32",
   maintainers = { "@xasc" },
 }
 


### PR DESCRIPTION
Neovim prerelease builds contain the filetype "trace32" for PRACTICE scripts (see [neovim#23967](https://github.com/neovim/neovim/pull/23967)). I would like to claim it for the `t32` parser.