### PR TITLE
fix(install): do not generate bindings with parser

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -360,9 +360,9 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
     if not M.ts_generate_args then
       local ts_cli_version = utils.ts_cli_version()
       if ts_cli_version and vim.split(ts_cli_version, " ")[1] > "0.20.2" then
-        M.ts_generate_args = { "generate", "--abi", vim.treesitter.language_version }
+        M.ts_generate_args = { "generate", "--no-bindings", "--abi", vim.treesitter.language_version }
       else
-        M.ts_generate_args = { "generate" }
+        M.ts_generate_args = { "generate", "--no-bindings" }
       end
     end
   end

--- a/tests/query/highlights/wing/class.w
+++ b/tests/query/highlights/wing/class.w
@@ -1,0 +1,19 @@
+bring cloud;
+// <- @keyword
+
+class Foo {
+// <- @keyword
+//    ^   @variable
+//        ^ @punctuation.bracket
+  name: str;
+//^    @variable.member
+//      ^   @type.builtin
+//         ^ @punctuation.delimiter
+  new(name:  str) {
+//^    @keyword
+//    ^    @variable
+    this.name = name;
+//      ^ @punctuation.delimiter
+//            ^ @operator
+  }
+}

--- a/tests/query/highlights/wing/nested_method.w
+++ b/tests/query/highlights/wing/nested_method.w
@@ -1,0 +1,4 @@
+test1.test2.test3();
+// <- @variable
+//    ^ @variable.member
+//          ^ @function.method.call


### PR DESCRIPTION
These are irrelevant for us and may lead to conflicts with outdated committed bindings (e.g., wing).

Re-enable wing tests.
