### PR TITLE
ci(tests): use nvim nightly for win+cl

### DIFF
--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -41,7 +41,7 @@ jobs:
         include:
           - os: windows-latest
             cc: cl
-            nvim_tag: stable
+            nvim_tag: nightly
 
           - os: ubuntu-latest
             cc: gcc


### PR DESCRIPTION
This gives better error messages on an often flaky platform as well as better coverage (nightly on windows was not tested before).
