### PR TITLE
fix(wing): move wing to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [vue](https://github.com/tree-sitter-grammars/tree-sitter-vue) (maintained by @WhyNotHugo, @lucario387)
 - [x] [wgsl](https://github.com/szebniok/tree-sitter-wgsl) (maintained by @szebniok)
 - [x] [wgsl_bevy](https://github.com/theHamsta/tree-sitter-wgsl-bevy) (maintained by @theHamsta)
-- [x] [wing](https://github.com/winglang/wing) (experimental, maintained by @gshpychka, @MarkMcCulloh)
+- [x] [wing](https://github.com/winglang/tree-sitter-wing) (experimental, maintained by @gshpychka, @MarkMcCulloh)
 - [x] [xcompose](https://github.com/ObserverOfTime/tree-sitter-xcompose) (maintained by @ObserverOfTime)
 - [x] [xml](https://github.com/tree-sitter-grammars/tree-sitter-xml) (maintained by @ObserverOfTime)
 - [x] [yaml](https://github.com/tree-sitter-grammars/tree-sitter-yaml) (maintained by @amaanq)

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [vue](https://github.com/tree-sitter-grammars/tree-sitter-vue) (maintained by @WhyNotHugo, @lucario387)
 - [x] [wgsl](https://github.com/szebniok/tree-sitter-wgsl) (maintained by @szebniok)
 - [x] [wgsl_bevy](https://github.com/theHamsta/tree-sitter-wgsl-bevy) (maintained by @theHamsta)
-- [x] [wing](https://github.com/winglang/tree-sitter-wing) (experimental, maintained by @gshpychka, @MarkMcCulloh)
+- [x] [wing](https://github.com/winglang/tree-sitter-wing) (maintained by @gshpychka, @MarkMcCulloh)
 - [x] [xcompose](https://github.com/ObserverOfTime/tree-sitter-xcompose) (maintained by @ObserverOfTime)
 - [x] [xml](https://github.com/tree-sitter-grammars/tree-sitter-xml) (maintained by @ObserverOfTime)
 - [x] [yaml](https://github.com/tree-sitter-grammars/tree-sitter-yaml) (maintained by @amaanq)

--- a/lockfile.json
+++ b/lockfile.json
@@ -792,7 +792,7 @@
     "revision": "f5980f534ee64256b1e64b0a42e2864d91154a5d"
   },
   "wing": {
-    "revision": "65d7da7211ef5d40d22aa9dcfb59aa7a757fcdeb"
+    "revision": "5b6c2a5818a602557778d1bfc265d016cafa0712"
   },
   "xcompose": {
     "revision": "2383cc69a2c42cfade41c7cb971fb3862bec6df1"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2297,10 +2297,8 @@ list.wgsl_bevy = {
 
 list.wing = {
   install_info = {
-    url = "https://github.com/winglang/wing",
+    url = "https://github.com/winglang/tree-sitter-wing",
     files = { "src/parser.c", "src/scanner.c" },
-    location = "libs/tree-sitter-wing",
-    requires_generate_from_grammar = true,
   },
   maintainers = { "@gshpychka", "@MarkMcCulloh" },
   experimental = true,

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2301,7 +2301,6 @@ list.wing = {
     files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@gshpychka", "@MarkMcCulloh" },
-  experimental = true,
 }
 
 list.xcompose = {

--- a/queries/wing/highlights.scm
+++ b/queries/wing/highlights.scm
@@ -95,4 +95,10 @@
   "else"
 ] @keyword.conditional
 
+[
+  "pub"
+  "protected"
+  "internal"
+] @keyword.modifier
+
 "return" @keyword.return

--- a/tests/query/highlights/wing/class.w
+++ b/tests/query/highlights/wing/class.w
@@ -3,7 +3,7 @@ bring cloud;
 
 class Foo {
 // <- @keyword
-//    ^   @variable
+//    ^   @type
 //        ^ @punctuation.bracket
   name: str;
 //^    @variable.member


### PR DESCRIPTION
Thanks for dealing with the annoying constant updates from https://github.com/winglang/wing 🙏 

https://github.com/winglang/tree-sitter-wing should now only be updated when there is a change to the grammar (still sourced from the wing monorepo), and all the files are already committed so there should be no need to `generate`.

Also updated the queries/tests to match the current state of the repo