### PR TITLE
fix(python) - @spell now captures inner string contents

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -204,19 +204,41 @@
   (comment)*
   .
   (expression_statement
-    (string) @string.documentation @spell))
+    (string) @string.documentation))
 
 (class_definition
   body: (block
     .
     (expression_statement
-      (string) @string.documentation @spell)))
+      (string) @string.documentation)))
 
 (function_definition
   body: (block
     .
     (expression_statement
-      (string) @string.documentation @spell)))
+      (string) @string.documentation)))
+
+(module
+  .
+  (comment)*
+  .
+  (expression_statement
+    (string
+      (string_content) @spell)))
+
+(class_definition
+  body: (block
+    .
+    (expression_statement
+      (string
+        (string_content) @spell))))
+
+(function_definition
+  body: (block
+    .
+    (expression_statement
+      (string
+        (string_content) @spell))))
 
 ; Tokens
 [


### PR DESCRIPTION
Closes: https://github.com/nvim-treesitter/nvim-treesitter/issues/6451
Related: https://github.com/neovim/neovim/issues/28365

In short, the `r"` portion of the string is related to Python's syntax and shouldn't be counted as a target for spellchecking. This PR makes only the inside of the string considered for spellchecking.

## Before
![image](https://github.com/neovim/neovim/assets/10103049/17e8df8e-65e3-428c-af04-f0df629e6f5d)

## After
![image](https://github.com/neovim/neovim/assets/10103049/13f6000c-aa30-4208-a189-41096ac47fe5)