### PR TITLE
fix(r): highlight comma separators

### DIFF
--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -101,6 +101,8 @@
   "}"
 ] @punctuation.bracket
 
+"," @punctuation.delimiter
+
 (dollar
   _
   "$" @operator)


### PR DESCRIPTION
Missing comma separators for parameters, array elements
EDIT: This PR also `chmod -x`'s the R highlights file, which for some reason was marked as executable for all groups
Before:
![beforercomma](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/a7c65d33-9451-4a70-b2cf-10847d374d3a)

After:
![afterrcomma](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/0315c5f9-fd41-4aa3-a59b-9285193181b1)
