### PR TITLE
ci: add back upload-artifact

### DIFF
--- a/.github/workflows/test-queries.yml
+++ b/.github/workflows/test-queries.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Post compile Windows
         if: runner.os == 'Windows'
         run: cp -r ~/AppData/Local/nvim/pack/nvim-treesitter/start/nvim-treesitter/parser/* parser
-
+        
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: parsers-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.nvim_tag }}-x86_64
+          path: parser/*
+       
       - name: Check query files
         run: $NVIM -l scripts/check-queries.lua


### PR DESCRIPTION
Since #2320, artifact uploading had been removed with "binary release archives soonish?". But till then, we still have no parser binary release archive, and it's really inconvenient for users who have trouble to compile parsers. 
Could we keep artifacts until we figure out a more proper solution?