### PR TITLE
feat(fennel)!: update parser and queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -168,7 +168,7 @@
     "revision": "f3b9274514b5f9bf6b0dd4a01c30f9cc15c58bc4"
   },
   "fennel": {
-    "revision": "215e3913524abc119daa9db7cf6ad2f2f5620189"
+    "revision": "63e16deb8e66bff61a09f7582c60945ed216cd65"
   },
   "fidl": {
     "revision": "0a8910f293268e27ff554357c229ba172b0eaed2"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -547,7 +547,7 @@ list.faust = {
 list.fennel = {
   install_info = {
     url = "https://github.com/alexmozaidze/tree-sitter-fennel",
-    files = { "src/parser.c" },
+    files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@alexmozaidze" },
 }

--- a/queries/fennel/folds.scm
+++ b/queries/fennel/folds.scm
@@ -1,34 +1,49 @@
+; compounds
 [
   (list)
   (table)
   (sequence)
 ] @fold
 
-(list
-  .
-  (symbol) @_let
-  (#eq? @_let "let")
-  .
-  (sequence) @fold) @fold
+; sub-forms / special compounds
+[
+  (list_binding)
+  (table_binding)
+  (sequence_binding)
+  (table_metadata)
+  (sequence_arguments)
+  (let_vars)
+  (case_guard_or_special)
+  (case_guard)
+  (case_catch)
+] @fold
 
-(list
-  .
-  (symbol) @_local
-  (#eq? @_local "local")) @fold
+; forms
+[
+  (quote_form)
+  (unquote_form)
+  (local_form)
+  (var_form)
+  (set_form)
+  (global_form)
+  (let_form)
+  (fn_form)
+  (lambda_form)
+  (hashfn_form)
+  (each_form)
+  (collect_form)
+  (icollect_form)
+  (accumulate_form)
+  (for_form)
+  (fcollect_form)
+  (faccumulate_form)
+  (case_form)
+  (match_form)
+] @fold
 
-(list
-  .
-  (symbol) @_global
-  (#eq? @_global "global")) @fold
+; reader macros
+(quote_reader_macro
+  expression: (_) @fold)
 
-(list
-  .
-  (symbol) @_fn
-  (#any-of? @_fn "fn" "lambda" "λ" "hashfn")) @fold
-
-(reader_macro
-  macro: [
-    "'"
-    "`"
-  ]
+(quasi_quote_reader_macro
   expression: (_) @fold)

--- a/queries/fennel/highlights.scm
+++ b/queries/fennel/highlights.scm
@@ -12,44 +12,87 @@
   "]"
 ] @punctuation.bracket
 
-(nil) @constant.builtin
+[
+  (nil)
+  (nil_binding)
+] @constant.builtin
 
-(boolean) @boolean
+[
+  (boolean)
+  (boolean_binding)
+] @boolean
 
-(number) @number
+[
+  (number)
+  (number_binding)
+] @number
 
-(string) @string
+[
+  (string)
+  (string_binding)
+] @string
+
+[
+  (symbol)
+  (symbol_binding)
+] @variable
+
+(symbol_option) @keyword.directive
 
 (escape_sequence) @string.escape
-
-(symbol) @variable
 
 (multi_symbol
   "." @punctuation.delimiter
   member: (symbol_fragment) @variable.member)
 
 (list
-  .
-  (symbol) @function.call)
+  call: (symbol) @function.call)
 
 (list
-  .
-  (multi_symbol
+  call: (multi_symbol
     member: (symbol_fragment) @function.call .))
 
 (multi_symbol_method
   ":" @punctuation.delimiter
-  method: (symbol_fragment) @function.method.call .)
+  method: (symbol_fragment) @function.method.call)
 
-; Just `&` is only used in destructuring
-((symbol) @punctuation.special
-  (#eq? @punctuation.special "&"))
+(quasi_quote_reader_macro
+  macro: _ @punctuation.special)
 
-; BUG: $ arguments should only be valid inside hashfn of any depth, but
-; it's impossible to express such query at the moment of writing.
-; See tree-sitter/tree-sitter#880
+(quote_reader_macro
+  macro: _ @punctuation.special)
+
+(unquote_reader_macro
+  macro: _ @punctuation.special)
+
+(hashfn_reader_macro
+  macro: _ @keyword.function)
+
+(sequence_arguments
+  (symbol_binding) @variable.parameter)
+
+(sequence_arguments
+  (rest_binding
+    rhs: (symbol_binding) @variable.parameter))
+
+(docstring) @string.documentation
+
+(fn_form
+  name: [
+    (symbol) @function
+    (multi_symbol
+      member: (symbol_fragment) @function .)
+  ])
+
+(lambda_form
+  name: [
+    (symbol) @function
+    (multi_symbol
+      member: (symbol_fragment) @function .)
+  ])
+
 ((symbol) @variable.parameter
-  (#eq? @variable.parameter "$..."))
+  (#any-of? @variable.parameter "$" "$..."))
 
 ((symbol) @variable.parameter
   (#lua-match? @variable.parameter "^%$[1-9]$"))
@@ -74,8 +117,11 @@
     ; other
     "length"))
 
-(reader_macro
-  macro: "#" @keyword.function)
+(case_guard
+  call: (_) @keyword.conditional)
+
+(case_guard_or_special
+  call: (_) @keyword.conditional)
 
 ((symbol) @keyword.function
   (#any-of? @keyword.function "fn" "lambda" "λ" "hashfn"))
@@ -84,7 +130,7 @@
   (#any-of? @keyword.repeat "for" "each" "while"))
 
 ((symbol) @keyword.conditional
-  (#any-of? @keyword.conditional "if" "when" "match" "case"))
+  (#any-of? @keyword.conditional "if" "when" "match" "case" "match-try" "case-try"))
 
 ((symbol) @keyword
   (#any-of? @keyword
@@ -92,12 +138,23 @@
     "quote" "tset" "values" "tail!"))
 
 ((symbol) @keyword.import
-  (#any-of? @keyword.import "require" "require-macros" "import-macros" "include"))
+  (#any-of? @keyword.import "require-macros" "import-macros" "include"))
 
 ((symbol) @function.macro
   (#any-of? @function.macro
     "collect" "icollect" "fcollect" "accumulate" "faccumulate" "->" "->>" "-?>" "-?>>" "?." "doto"
     "macro" "macrodebug" "partial" "pick-args" "pick-values" "with-open"))
+
+(case_catch
+  call: (symbol) @keyword)
+
+(list
+  call: (symbol) @keyword.import
+  (#eq? @keyword.import "import-macros")
+  .
+  (table
+    (table_pair
+      value: (symbol) @function.macro)))
 
 ; TODO: Highlight builtin methods (`table.unpack`, etc) as @function.builtin
 ([
@@ -127,68 +184,3 @@
     "assert" "collectgarbage" "dofile" "error" "getmetatable" "ipairs" "load" "loadfile" "next"
     "pairs" "pcall" "print" "rawequal" "rawget" "rawlen" "rawset" "require" "select" "setmetatable"
     "tonumber" "tostring" "type" "warn" "xpcall" "module" "setfenv" "loadstring" "unpack"))
-
-(table
-  (table_pair
-    key: (symbol) @keyword.directive
-    (#eq? @keyword.directive "&as")))
-
-(list
-  .
-  (symbol) @keyword.function
-  (#any-of? @keyword.function "fn" "lambda" "λ")
-  .
-  [
-    (symbol) @function
-    (multi_symbol
-      (symbol_fragment) @function .)
-  ]
-  .
-  (sequence
-    ((symbol) @variable.parameter
-      (#not-any-of? @variable.parameter "&" "..."))))
-
-(list
-  .
-  (symbol) @function.macro
-  (#any-of? @function.macro "collect" "icollect" "fcollect")
-  .
-  (sequence
-    [
-      (symbol)
-      (string)
-    ] @keyword.directive
-    (#any-of? @keyword.directive "&into" ":into")))
-
-(list
-  .
-  (symbol) @function.macro
-  (#any-of? @function.macro "for" "each" "collect" "icollect" "fcollect" "accumulate" "faccumulate")
-  .
-  (sequence
-    [
-      (symbol)
-      (string)
-    ] @keyword.directive
-    (#any-of? @keyword.directive "&until" ":until")))
-
-(list
-  .
-  (symbol) @keyword.conditional
-  (#any-of? @keyword.conditional "match" "case")
-  .
-  (_)
-  .
-  ((list
-    .
-    (symbol) @keyword
-    (#eq? @keyword "where"))
-    .
-    (_))*
-  .
-  (list
-    .
-    (symbol) @keyword
-    (#eq? @keyword "where"))
-  .
-  (_)? .)

--- a/queries/fennel/injections.scm
+++ b/queries/fennel/injections.scm
@@ -1,46 +1,42 @@
-((comment) @injection.content
+((comment_body) @injection.content
   (#set! injection.language "comment"))
 
 (list
-  .
-  (multi_symbol) @_vimcmd_identifier
+  call: (multi_symbol) @_vimcmd_identifier
   (#any-of? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command" "vim.api.nvim_exec2")
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "vim")))
 
 ; NOTE: Matches *exactly* `ffi.cdef`
 (list
-  .
-  (multi_symbol) @_cdef_identifier
+  call: (multi_symbol) @_cdef_identifier
   (#eq? @_cdef_identifier "ffi.cdef")
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "c")))
 
 (list
-  .
-  (multi_symbol) @_ts_query_identifier
+  call: (multi_symbol) @_ts_query_identifier
   (#any-of? @_ts_query_identifier "vim.treesitter.query.set" "vim.treesitter.query.parse")
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "query")))
 
 (list
-  .
-  (multi_symbol) @_vimcmd_identifier
+  call: (multi_symbol) @_vimcmd_identifier
   (#eq? @_vimcmd_identifier "vim.api.nvim_create_autocmd")
   .
-  (_)
+  item: (_)
   .
-  (table
+  item: (table
     (table_pair
       key: (string
         (string_content) @_command
@@ -50,54 +46,50 @@
         (#set! injection.language "vim")))))
 
 (list
-  .
-  (multi_symbol) @_user_cmd
+  call: (multi_symbol) @_user_cmd
   (#eq? @_user_cmd "vim.api.nvim_create_user_command")
   .
-  (_)
+  item: (_)
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "vim")))
 
 (list
-  .
-  (multi_symbol) @_user_cmd
+  call: (multi_symbol) @_user_cmd
   (#eq? @_user_cmd "vim.api.nvim_buf_create_user_command")
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "vim")))
 
 (list
-  .
-  (multi_symbol) @_map
+  call: (multi_symbol) @_map
   (#any-of? @_map "vim.api.nvim_set_keymap" "vim.keymap.set")
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "vim")))
 
 (list
-  .
-  (multi_symbol) @_map
+  call: (multi_symbol) @_map
   (#eq? @_map "vim.api.nvim_buf_set_keymap")
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (_)
+  item: (_)
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "vim")))
 
@@ -107,40 +99,36 @@
   (#lua-match? @injection.content "^%s*;+%s?query")
   (#set! injection.language "query"))
 
-; ──────────────────────────────────────────────────────────────────────
 ; (string.match "123" "%d+")
 (list
-  .
-  (multi_symbol
+  call: (multi_symbol
     member: (symbol_fragment) @_func
     .
     (#any-of? @_func "find" "match" "gmatch" "gsub"))
   .
-  (_)
+  item: (_)
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "luap")
     (#set! injection.include-children)))
 
 ; (my-string:match "%d+")
 (list
-  .
-  (multi_symbol_method
+  call: (multi_symbol_method
     method: (symbol_fragment) @_method
     (#any-of? @_method "find" "match" "gmatch" "gsub"))
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "luap")
     (#set! injection.include-children)))
 
 ; (string.format "pi = %.2f" 3.14159)
 (list
-  .
-  (multi_symbol) @_func
+  call: (multi_symbol) @_func
   (#eq? @_func "string.format")
   .
-  (string
+  item: (string
     (string_content) @injection.content
     (#set! injection.language "printf")))

--- a/queries/fennel/locals.scm
+++ b/queries/fennel/locals.scm
@@ -1,28 +1,44 @@
-; TODO: Add tests
-; TODO: Improve queries
 (program) @local.scope
-
-((list
-  .
-  (symbol) @_call) @local.scope
-  (#any-of? @_call
-    "let" "fn" "lambda" "λ" "while" "each" "for" "if" "when" "do" "collect" "icollect" "accumulate"
-    "case" "match"))
 
 (symbol) @local.reference
 
+[
+  (let_form)
+  (fn_form)
+  (lambda_form)
+  (each_form)
+  (for_form)
+  (collect_form)
+  (icollect_form)
+  (accumulate_form)
+  (for_form)
+  (fcollect_form)
+  (faccumulate_form)
+  (case_form)
+  (match_form)
+] @local.scope
+
 (list
-  .
-  (symbol) @_fn
-  (#any-of? @_fn "fn" "lambda" "λ")
-  .
-  [
+  call: (symbol) @_call
+  (#any-of? @_call "while" "if" "when" "do")) @local.scope
+
+(fn_form
+  name: [
     (symbol) @local.definition.function
     (multi_symbol
       member: (symbol_fragment) @local.definition.function .)
   ]
-  (#set! definition.function.scope "parent")
-  .
-  (sequence
-    (symbol)* @local.definition.parameter
-    (#not-contains? @local.definition.parameter "&")))
+  args: (sequence_arguments
+    (symbol_binding) @local.definition.parameter)
+  (#set! definition.function.scope "parent"))
+
+; NOTE: Body should be identical to fn_form above
+(lambda_form
+  name: [
+    (symbol) @local.definition.function
+    (multi_symbol
+      member: (symbol_fragment) @local.definition.function .)
+  ]
+  args: (sequence_arguments
+    (symbol_binding) @local.definition.parameter)
+  (#set! definition.function.scope "parent"))


### PR DESCRIPTION
> A continuation of #6323

Updated parser to support:
1. complex forms (`case`, `case-try`, `fn`, `lambda`)
2. forms with destructuring (`global`, `local`, `var`, `set`)
3. forms that may be viable to query via `#has-parent?`/`#has-ancestor?` (`hashfn`, `quote`)

The queries are updated as well to support the new parser.

> [!NOTE]\
> `locals.scm` and `folds.scm` are supported on a best-effort basis. If you encounter any issues regarding those queries, open an issue and @ me so I can fix it as quickly as I can.