### PR TITLE
ci: Don't run `Update lockfile` on forks

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -9,6 +9,7 @@ jobs:
   update-lockfile:
     name: Update lockfile
     runs-on: ubuntu-latest
+    if: github.repository == 'nvim-treesitter/nvim-treesitter'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Prevent the bot from opening PRs on forks of this repo.

See [jobs.<job_id>.if](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif)