### PR TITLE
fix(vimscript): miscellaneous fixups

### DIFF
--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -126,6 +126,7 @@
   "view"
   "eval"
   "sign"
+  "abort"
 ] @keyword
 
 (map_statement
@@ -277,8 +278,6 @@
   "/"
   "%"
   ".."
-  "is"
-  "isnot"
   "=="
   "!="
   ">"
@@ -297,8 +296,14 @@
   "..="
   "<<"
   "=<<"
+  "->"
   (match_case)
 ] @operator
+
+[
+  "is"
+  "isnot"
+] @keyword.operator
 
 ; Some characters have different meanings based on the context
 (unary_operation


### PR DESCRIPTION
- Highlights the `abort` keyword
- Moves `is(not)?` from `@operator` to `@keyword.operator`
- Highlights the `->` operator