### PR TITLE
feat: change astro injections to match parser rewrite

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -18,7 +18,7 @@
     "revision": "afdc3d5da18d42cbb471c0f40527dbed9cace7ad"
   },
   "astro": {
-    "revision": "4e766a11148e174a109851d746e8ab8fc43ef419"
+    "revision": "b422ccd41f0b433260a3d28df7e39fa2ff63ef9c"
   },
   "authzed": {
     "revision": "1dec7e1af96c56924e3322cd85fdce15d0a31d00"

--- a/queries/astro/injections.scm
+++ b/queries/astro/injections.scm
@@ -1,12 +1,16 @@
 ; inherits: html_tags
 
 (frontmatter
-  (raw_text) @injection.content
+  (frontmatter_js_block) @injection.content
   (#set! injection.language "typescript"))
 
-(interpolation
-  (raw_text) @injection.content
-  (#set! injection.language "tsx"))
+(attribute_interpolation
+  (attribute_js_expr) @injection.content
+  (#set! injection.language "typescript"))
+
+(html_interpolation
+  (permissible_text) @injection.content
+  (#set! injection.language "typescript"))
 
 (script_element
   (raw_text) @injection.content


### PR DESCRIPTION
The Astro parser's extension logic has been almost entirely rewritten to match up with the actual Astro compiler; these are the new injections after the rewrite.