### PR TITLE
Add Glimmer builtin tag to special identifiers in ECMA highlights

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -43,6 +43,9 @@
 
 (statement_identifier) @label
 
+(glimmer_opening_tag) @tag.builtin
+(glimmer_closing_tag) @tag.builtin
+
 ; Function and method definitions
 ;--------------------------------
 (function_expression


### PR DESCRIPTION
Previously PR'd here:
- https://github.com/tree-sitter/tree-sitter-javascript/pull/300
- https://github.com/tree-sitter/tree-sitter-typescript/pull/277