### PR TITLE
feat(install)!: generate from json instead of requiring node

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ zimbu = {
     branch = 'develop', -- only needed if different from default branch
     location = 'parser', -- only needed if the parser is in subdirectory of a "monorepo"
     revision = 'v2.1', -- tag or commit hash; bypasses automated updates
-    requires_generate_from_grammar = true, -- only needed if repo does not contain pre-generated src/parser.c
-    generate_requires_npm = true, -- only needed if parser has npm dependencies
+    generate = true, -- only needed if repo does not contain pre-generated src/parser.c
+    generate_from_json = true, -- only needed if grammar.js has npm-installed dependencies
   },
   maintainers = { '@me' }, -- the _query_ maintainers
   tier = 3, -- community-contributed parser

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ parser_config.zimbu = {
     -- optional entries:
     branch = 'develop', -- only needed if different from default branch
     location= 'parser', -- only needed if the parser is in subdirectory of a "monorepo"
-    requires_generate_from_grammar = true, -- only needed if repo does not contain pre-generated src/parser.c
-    generate_requires_npm = true, -- only needed if parser has npm dependencies
+    generate = true, -- only needed if repo does not contain pre-generated src/parser.c
+    generate_from_json = true, -- only needed if parser has npm dependencies
   },
 }
 ```

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -5,288 +5,287 @@ The following is a list of languages for which a parser can be installed through
 Legend:
 - **Tier:** _stable_, _core_, _community_, or _unsupported_
 - **CLI:** `:TSInstall` requires `tree-sitter` CLI installed
-- **NPM:** `:TSInstallFromGrammar` requires `node` installed
 - **Queries** available for **H**ighlights, **I**ndents, **F**olds, In**J**ections, **L**ocals
 
 <!--This section of the README is automatically updated by a CI job-->
 <!--parserinfo-->
-Language | Tier | Queries | CLI | NPM | Maintainer
--------- |:----:|:-------:|:---:|:---:| ----------
-[ada](https://github.com/briot/tree-sitter-ada) | community | `HF  L` |  |  | @briot
-[agda](https://github.com/tree-sitter/tree-sitter-agda) | community | `HF   ` |  |  | @Decodetalkers
-[angular](https://github.com/dlvandenberg/tree-sitter-angular) | unsupported | `HFIJL` |  | ✓ | @dlvandenberg
-[apex](https://github.com/aheber/tree-sitter-sfapex) | community | `HF  L` |  |  | @aheber
-[arduino](https://github.com/ObserverOfTime/tree-sitter-arduino) | core | `HFIJL` |  |  | @ObserverOfTime
-[asm](https://github.com/RubixDev/tree-sitter-asm) | community | `H  J ` |  |  | @RubixDev
-[astro](https://github.com/virchau13/tree-sitter-astro) | community | `HFIJL` |  |  | @virchau13
-[authzed](https://github.com/mleonidas/tree-sitter-authzed) | community | `H  J ` |  |  | @mattpolzin
-[awk](https://github.com/Beaglefoot/tree-sitter-awk) | unsupported | `H  J ` |  |  | 
-[bash](https://github.com/tree-sitter/tree-sitter-bash) | community | `HF JL` |  |  | @TravonteD
-[bass](https://github.com/vito/tree-sitter-bass) | core | `HFIJL` |  |  | @amaanq
-[beancount](https://github.com/polarmutex/tree-sitter-beancount) | community | `HF J ` |  |  | @polarmutex
-[bibtex](https://github.com/latex-lsp/tree-sitter-bibtex) | core | `HFI  ` |  |  | @theHamsta, @clason
-[bicep](https://github.com/amaanq/tree-sitter-bicep) | core | `HFIJL` |  |  | @amaanq
-[bitbake](https://github.com/amaanq/tree-sitter-bitbake) | core | `HFIJL` |  |  | @amaanq
-[blueprint](https://gitlab.com/gabmus/tree-sitter-blueprint.git) | unsupported | `H    ` |  |  | @gabmus
-[c](https://github.com/tree-sitter/tree-sitter-c) | stable | `HFIJL` |  |  | @amaanq
-[c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) | community | `HF JL` |  |  | @Luxed
-[cairo](https://github.com/amaanq/tree-sitter-cairo) | core | `HFIJL` |  |  | @amaanq
-[capnp](https://github.com/amaanq/tree-sitter-capnp) | core | `HFIJL` |  |  | @amaanq
-[chatito](https://github.com/ObserverOfTime/tree-sitter-chatito) | core | `HFIJL` |  |  | @ObserverOfTime
-[clojure](https://github.com/sogaiu/tree-sitter-clojure) | community | `HF JL` |  |  | @NoahTheDuke
-[cmake](https://github.com/uyha/tree-sitter-cmake) | unsupported | `HFI  ` |  |  | @uyha
-[comment](https://github.com/stsewd/tree-sitter-comment) | core | `H    ` |  |  | @stsewd
-[commonlisp](https://github.com/theHamsta/tree-sitter-commonlisp) | core | `HF  L` |  | ✓ | @theHamsta
-[cooklang](https://github.com/addcninblue/tree-sitter-cooklang) | community | `H    ` |  |  | @addcninblue
-[corn](https://github.com/jakestanger/tree-sitter-corn) | community | `HFI L` |  |  | @jakestanger
-[cpon](https://github.com/amaanq/tree-sitter-cpon) | core | `HFIJL` |  |  | @amaanq
-[cpp](https://github.com/tree-sitter/tree-sitter-cpp) | stable | `HFIJL` |  | ✓ | @theHamsta
-[css](https://github.com/tree-sitter/tree-sitter-css) | community | `HFIJ ` |  |  | @TravonteD
-[csv](https://github.com/amaanq/tree-sitter-csv) | core | `H    ` |  |  | @amaanq
-[cuda](https://github.com/theHamsta/tree-sitter-cuda) | core | `HFIJL` |  | ✓ | @theHamsta
-[cue](https://github.com/eonpatapon/tree-sitter-cue) | core | `HFIJL` |  |  | @amaanq
-[d](https://github.com/gdamore/tree-sitter-d) | core | `HFIJL` |  |  | @amaanq
-[dart](https://github.com/UserNobody14/tree-sitter-dart) | unsupported | `HFIJL` |  |  | @akinsho
-[devicetree](https://github.com/joelspadin/tree-sitter-devicetree) | community | `HFIJL` |  |  | @jedrzejboczar
-[dhall](https://github.com/jbellerb/tree-sitter-dhall) | core | `HF J ` |  |  | @amaanq
-[diff](https://github.com/the-mikedavis/tree-sitter-diff) | community | `H    ` |  |  | @gbprod
-[disassembly](https://github.com/ColinKennedy/tree-sitter-disassembly) | community | `H  J ` |  |  | @ColinKennedy
-[djot](https://github.com/treeman/tree-sitter-djot) | community | `HFIJL` |  |  | @NoahTheDuke
-[dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) | community | `H  J ` |  |  | @camdencheek
-[dot](https://github.com/rydesun/tree-sitter-dot) | community | `H IJ ` |  |  | @rydesun
-[doxygen](https://github.com/amaanq/tree-sitter-doxygen) | core | `H IJ ` |  |  | @amaanq
-[dtd](https://github.com/tree-sitter-grammars/tree-sitter-xml) | core | `HF JL` |  |  | @ObserverOfTime
-[earthfile](https://github.com/glehmann/tree-sitter-earthfile) | community | `H  J ` |  |  | @glehmann
-[ebnf](https://github.com/RubixDev/ebnf) | unsupported | `H    ` |  |  | @RubixDev
-ecma (queries only)[^ecma] | core | `HFIJL` |  |  | @steelsojka
-[eds](https://github.com/uyha/tree-sitter-eds) | community | `HF   ` |  |  | @uyha
-[eex](https://github.com/connorlay/tree-sitter-eex) | community | `H  J ` |  |  | @connorlay
-[elixir](https://github.com/elixir-lang/tree-sitter-elixir) | community | `HFIJL` |  |  | @connorlay
-[elm](https://github.com/elm-tooling/tree-sitter-elm) | unsupported | `H  J ` |  |  | @zweimach
-[elsa](https://github.com/glapa-grossklag/tree-sitter-elsa) | core | `HFIJL` |  |  | @glapa-grossklag, @amaanq
-[elvish](https://github.com/elves/tree-sitter-elvish) | community | `H  J ` |  |  | @elves
-[embedded_template](https://github.com/tree-sitter/tree-sitter-embedded-template) | unsupported | `H  J ` |  |  | 
-[erlang](https://github.com/WhatsApp/tree-sitter-erlang) | community | `HF   ` |  |  | @filmor
-[facility](https://github.com/FacilityApi/tree-sitter-facility) | community | `HFIJ ` |  |  | @bryankenote
-[faust](https://github.com/khiner/tree-sitter-faust) | community | `H  J ` |  |  | @khiner
-[fennel](https://github.com/alexmozaidze/tree-sitter-fennel) | community | `HF JL` |  | ✓ | @alexmozaidze
-[fidl](https://github.com/google/tree-sitter-fidl) | community | `HF J ` |  |  | @chaopeng
-[firrtl](https://github.com/amaanq/tree-sitter-firrtl) | core | `HFIJL` |  |  | @amaanq
-[fish](https://github.com/ram02z/tree-sitter-fish) | community | `HFIJL` |  |  | @ram02z
-[foam](https://github.com/FoamScience/tree-sitter-foam) | community | `HFIJL` |  |  | @FoamScience
-[forth](https://github.com/AlexanderBrevig/tree-sitter-forth) | core | `HFIJL` |  |  | @amaanq
-[fortran](https://github.com/stadelmanma/tree-sitter-fortran) | core | `HFI  ` |  |  | @amaanq
-[fsh](https://github.com/mgramigna/tree-sitter-fsh) | community | `H    ` |  |  | @mgramigna
-[func](https://github.com/amaanq/tree-sitter-func) | core | `H    ` |  |  | @amaanq
-[fusion](https://gitlab.com/jirgn/tree-sitter-fusion.git) | community | `HFI L` |  |  | @jirgn
-[gdscript](https://github.com/PrestonKnopp/tree-sitter-gdscript)[^gdscript] | community | `HFIJL` |  |  | @PrestonKnopp
-[gdshader](https://github.com/GodOfAvacyn/tree-sitter-gdshader) | community | `H  J ` |  |  | @godofavacyn
-[git_config](https://github.com/the-mikedavis/tree-sitter-git-config) | core | `HF J ` |  |  | @amaanq
-[git_rebase](https://github.com/the-mikedavis/tree-sitter-git-rebase) | community | `H  J ` |  |  | @gbprod
-[gitattributes](https://github.com/ObserverOfTime/tree-sitter-gitattributes) | core | `H  JL` |  |  | @ObserverOfTime
-[gitcommit](https://github.com/gbprod/tree-sitter-gitcommit) | community | `H  J ` |  |  | @gbprod
-[gitignore](https://github.com/shunsambongi/tree-sitter-gitignore) | core | `H    ` |  |  | @theHamsta
-[gleam](https://github.com/gleam-lang/tree-sitter-gleam) | core | `HFIJL` |  |  | @amaanq
-[glimmer](https://github.com/alexlafroscia/tree-sitter-glimmer)[^glimmer] | community | `HFI L` |  |  | @NullVoxPopuli
-[glsl](https://github.com/theHamsta/tree-sitter-glsl) | core | `HFIJL` |  | ✓ | @theHamsta
-[gn](https://github.com/amaanq/tree-sitter-gn) | core | `HFIJL` |  |  | @amaanq
-[gnuplot](https://github.com/dpezto/tree-sitter-gnuplot) | community | `H  J ` |  |  | @dpezto
-[go](https://github.com/tree-sitter/tree-sitter-go) | stable | `HFIJL` |  |  | @theHamsta, @WinWisely268
-[godot_resource](https://github.com/PrestonKnopp/tree-sitter-godot-resource)[^godot_resource] | community | `HF JL` |  |  | @pierpo
-[gomod](https://github.com/camdencheek/tree-sitter-go-mod) | community | `H  J ` |  |  | @camdencheek
-[gosum](https://github.com/amaanq/tree-sitter-go-sum) | core | `H    ` |  |  | @amaanq
-[gotmpl](https://github.com/ngalaiko/tree-sitter-go-template) | community | `H  J ` |  |  | @qvalentin
-[gowork](https://github.com/omertuc/tree-sitter-go-work) | community | `H  J ` |  |  | @omertuc
-[gpg](https://github.com/ObserverOfTime/tree-sitter-gpg-config) | core | `H  J ` |  |  | @ObserverOfTime
-[graphql](https://github.com/bkegley/tree-sitter-graphql) | community | `H IJ ` |  |  | @bkegley
-[groovy](https://github.com/murtaza64/tree-sitter-groovy) | community | `HFIJL` |  |  | @murtaza64
-[gstlaunch](https://github.com/theHamsta/tree-sitter-gstlaunch) | core | `H    ` |  |  | @theHamsta
-[hack](https://github.com/slackhq/tree-sitter-hack) | unsupported | `H    ` |  |  | 
-[hare](https://github.com/amaanq/tree-sitter-hare) | core | `HFIJL` |  |  | @amaanq
-[haskell](https://github.com/tree-sitter/tree-sitter-haskell) | community | `HF J ` |  |  | @mrcjkb
-[haskell_persistent](https://github.com/MercuryTechnologies/tree-sitter-haskell-persistent) | community | `HF   ` |  |  | @lykahb
-[hcl](https://github.com/MichaHoffmann/tree-sitter-hcl) | community | `HFIJ ` |  |  | @MichaHoffmann
-[heex](https://github.com/connorlay/tree-sitter-heex) | community | `HFIJL` |  |  | @connorlay
-[helm](https://github.com/ngalaiko/tree-sitter-go-template) | community | `H  J ` |  |  | @qvalentin
-[hjson](https://github.com/winston0410/tree-sitter-hjson) | community | `HFIJL` |  | ✓ | @winston0410
-[hlsl](https://github.com/theHamsta/tree-sitter-hlsl) | core | `HFIJL` |  | ✓ | @theHamsta
-[hlsplaylist](https://github.com/Freed-Wu/tree-sitter-hlsplaylist) | community | `H  J ` |  |  | @Freed-Wu
-[hocon](https://github.com/antosha417/tree-sitter-hocon) | unsupported | `HF J ` |  | ✓ | @antosha417
-[hoon](https://github.com/urbit-pilled/tree-sitter-hoon) | unsupported | `HF  L` |  |  | @urbit-pilled
-[html](https://github.com/tree-sitter/tree-sitter-html) | community | `HFIJL` |  |  | @TravonteD
-html_tags (queries only)[^html_tags] | community | `H IJ ` |  |  | @TravonteD
-[htmldjango](https://github.com/interdependence/tree-sitter-htmldjango) | unsupported | `HFIJ ` |  |  | @ObserverOfTime
-[http](https://github.com/rest-nvim/tree-sitter-http) | core | `H  J ` |  |  | @amaanq, @NTBBloodbath
-[hurl](https://github.com/pfeiferj/tree-sitter-hurl) | community | `HFIJ ` |  |  | @pfeiferj
-[hyprlang](https://github.com/luckasRanarison/tree-sitter-hyprlang) | community | `HFIJ ` |  |  | @luckasRanarison
-[ini](https://github.com/justinmk/tree-sitter-ini) | unsupported | `HF   ` |  |  | @theHamsta
-[ispc](https://github.com/fab4100/tree-sitter-ispc) | community | `HFIJL` |  | ✓ | @fab4100
-[janet_simple](https://github.com/sogaiu/tree-sitter-janet-simple) | community | `HF JL` |  |  | @sogaiu
-[java](https://github.com/tree-sitter/tree-sitter-java) | community | `HFIJL` |  |  | @p00f
-[javascript](https://github.com/tree-sitter/tree-sitter-javascript) | core | `HFIJL` |  |  | @steelsojka
-[jq](https://github.com/flurie/tree-sitter-jq) | core | `H  JL` |  |  | @ObserverOfTime
-[jsdoc](https://github.com/tree-sitter/tree-sitter-jsdoc) | core | `H    ` |  |  | @steelsojka
-[json](https://github.com/tree-sitter/tree-sitter-json) | core | `HFI L` |  |  | @steelsojka
-[json5](https://github.com/Joakker/tree-sitter-json5) | community | `H  J ` |  |  | @Joakker
-[jsonc](https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git) | community | `HFIJL` |  | ✓ | @WhyNotHugo
-[jsonnet](https://github.com/sourcegraph/tree-sitter-jsonnet) | community | `HF  L` |  |  | @nawordar
-jsx (queries only)[^jsx] | core | `HFIJ ` |  |  | @steelsojka
-[julia](https://github.com/tree-sitter/tree-sitter-julia) | core | `HFIJL` |  |  | @theHamsta
-[just](https://github.com/IndianBoy42/tree-sitter-just) | community | `HFIJL` |  |  | @Hubro
-[kconfig](https://github.com/amaanq/tree-sitter-kconfig) | core | `HFIJL` |  |  | @amaanq
-[kdl](https://github.com/amaanq/tree-sitter-kdl) | core | `HFIJL` |  |  | @amaanq
-[kotlin](https://github.com/fwcd/tree-sitter-kotlin) | community | `HF JL` |  |  | @SalBakraa
-[kusto](https://github.com/Willem-J-an/tree-sitter-kusto) | community | `H  J ` |  |  | @Willem-J-an
-[lalrpop](https://github.com/traxys/tree-sitter-lalrpop) | community | `H  JL` |  |  | @traxys
-[latex](https://github.com/latex-lsp/tree-sitter-latex) | core | `HF J ` |  |  | @theHamsta, @clason
-[ledger](https://github.com/cbarrete/tree-sitter-ledger) | community | `HFIJ ` |  |  | @cbarrete
-[leo](https://github.com/r001/tree-sitter-leo) | community | `H IJ ` |  |  | @r001
-[linkerscript](https://github.com/amaanq/tree-sitter-linkerscript) | core | `HFIJL` |  |  | @amaanq
-[liquid](https://github.com/hankthetank27/tree-sitter-liquid) | community | `H  J ` |  |  | @hankthetank27
-[liquidsoap](https://github.com/savonet/tree-sitter-liquidsoap) | community | `HFI L` |  |  | @toots
-[llvm](https://github.com/benwilliamgraham/tree-sitter-llvm) | community | `H    ` |  |  | @benwilliamgraham
-[lua](https://github.com/MunifTanjim/tree-sitter-lua) | stable | `HFIJL` |  |  | @muniftanjim
-[luadoc](https://github.com/amaanq/tree-sitter-luadoc) | core | `H    ` |  |  | @amaanq
-[luap](https://github.com/amaanq/tree-sitter-luap)[^luap] | core | `H    ` |  |  | @amaanq
-[luau](https://github.com/amaanq/tree-sitter-luau) | core | `HFIJL` |  |  | @amaanq
-[m68k](https://github.com/grahambates/tree-sitter-m68k) | community | `HF JL` |  |  | @grahambates
-[make](https://github.com/alemuller/tree-sitter-make) | core | `HF J ` |  |  | @lewis6991
-[markdown](https://github.com/MDeiml/tree-sitter-markdown)[^markdown] | stable | `HFIJ ` |  |  | @MDeiml
-[markdown_inline](https://github.com/MDeiml/tree-sitter-markdown)[^markdown_inline] | stable | `H  J ` |  |  | @MDeiml
-[matlab](https://github.com/acristoffers/tree-sitter-matlab) | community | `HFIJL` |  |  | @acristoffers
-[menhir](https://github.com/Kerl13/tree-sitter-menhir) | community | `H  J ` |  |  | @Kerl13
-[mermaid](https://github.com/monaqa/tree-sitter-mermaid) | unsupported | `H    ` |  |  | 
-[meson](https://github.com/Decodetalkers/tree-sitter-meson) | community | `HFIJ ` |  |  | @Decodetalkers
-[mlir](https://github.com/artagnon/tree-sitter-mlir) | unsupported | `H   L` |  |  | @artagnon
-[muttrc](https://github.com/neomutt/tree-sitter-muttrc) | community | `H  J ` |  |  | @Freed-Wu
-[nasm](https://github.com/naclsn/tree-sitter-nasm) | core | `H  J ` |  |  | @ObserverOfTime
-[nickel](https://github.com/nickel-lang/tree-sitter-nickel) | unsupported | `H I  ` |  |  | 
-[nim](https://github.com/alaviss/tree-sitter-nim) | community | `HF JL` |  |  | @aMOPel
-[nim_format_string](https://github.com/aMOPel/tree-sitter-nim-format-string) | community | `H  J ` |  |  | @aMOPel
-[ninja](https://github.com/alemuller/tree-sitter-ninja) | community | `HFI  ` |  |  | @alemuller
-[nix](https://github.com/cstrahan/tree-sitter-nix) | community | `HF JL` |  |  | @leo60228
-[nqc](https://github.com/amaanq/tree-sitter-nqc) | core | `HFIJL` |  |  | @amaanq
-[objc](https://github.com/amaanq/tree-sitter-objc) | core | `HFIJL` |  |  | @amaanq
-[objdump](https://github.com/ColinKennedy/tree-sitter-objdump) | community | `H  J ` |  |  | @ColinKennedy
-[ocaml](https://github.com/tree-sitter/tree-sitter-ocaml) | community | `HFIJL` |  |  | @undu
-[ocaml_interface](https://github.com/tree-sitter/tree-sitter-ocaml) | community | `HFIJL` |  |  | @undu
-[ocamllex](https://github.com/atom-ocaml/tree-sitter-ocamllex) | community | `H  J ` |  |  | @undu
-[odin](https://github.com/amaanq/tree-sitter-odin) | core | `HFIJL` |  |  | @amaanq
-[org](https://github.com/milisims/tree-sitter-org) | unsupported | `     ` |  |  | 
-[pascal](https://github.com/Isopod/tree-sitter-pascal.git) | community | `HFIJL` |  |  | @Isopod
-[passwd](https://github.com/ath3/tree-sitter-passwd) | community | `H    ` |  |  | @amaanq
-[pem](https://github.com/ObserverOfTime/tree-sitter-pem) | core | `HF J ` |  |  | @ObserverOfTime
-[perl](https://github.com/tree-sitter-perl/tree-sitter-perl) | community | `HF J ` |  |  | @RabbiVeesh, @LeoNerd
-[php](https://github.com/tree-sitter/tree-sitter-php)[^php] | community | `HFIJL` |  |  | @tk-shirasaka
-[php_only](https://github.com/tree-sitter/tree-sitter-php)[^php_only] | community | `HFIJL` |  |  | @tk-shirasaka
-[phpdoc](https://github.com/claytonrcarter/tree-sitter-phpdoc) | unsupported | `H    ` |  | ✓ | @mikehaertl
-[pioasm](https://github.com/leo60228/tree-sitter-pioasm) | community | `H  J ` |  |  | @leo60228
-[po](https://github.com/erasin/tree-sitter-po) | core | `HF J ` |  |  | @amaanq
-[pod](https://github.com/tree-sitter-perl/tree-sitter-pod) | community | `H    ` |  |  | @RabbiVeesh, @LeoNerd
-[poe_filter](https://github.com/ObserverOfTime/tree-sitter-poe-filter)[^poe_filter] | unsupported | `HFIJ ` |  |  | @ObserverOfTime
-[pony](https://github.com/amaanq/tree-sitter-pony) | core | `HFIJL` |  |  | @amaanq, @mfelsche
-[printf](https://github.com/ObserverOfTime/tree-sitter-printf) | core | `H    ` |  |  | @ObserverOfTime
-[prisma](https://github.com/victorhqc/tree-sitter-prisma) | community | `HF   ` |  |  | @elianiva
-[promql](https://github.com/MichaHoffmann/tree-sitter-promql) | unsupported | `H  J ` |  |  | @MichaHoffmann
-[properties](https://github.com/ObserverOfTime/tree-sitter-properties)[^properties] | core | `H  JL` |  |  | @ObserverOfTime
-[proto](https://github.com/treywood/tree-sitter-proto) | community | `HF   ` |  |  | @treywood
-[prql](https://github.com/PRQL/tree-sitter-prql) | core | `H  J ` |  |  | @matthias-Q
-[psv](https://github.com/amaanq/tree-sitter-csv) | core | `H    ` |  |  | @amaanq
-[pug](https://github.com/zealot128/tree-sitter-pug) | unsupported | `H  J ` |  |  | @zealot128
-[puppet](https://github.com/amaanq/tree-sitter-puppet) | core | `HFIJL` |  |  | @amaanq
-[purescript](https://github.com/postsolar/tree-sitter-purescript) | community | `H  JL` |  |  | @postsolar
-[pymanifest](https://github.com/ObserverOfTime/tree-sitter-pymanifest) | core | `H  J ` |  |  | @ObserverOfTime
-[python](https://github.com/tree-sitter/tree-sitter-python) | stable | `HFIJL` |  |  | @stsewd, @theHamsta
-[ql](https://github.com/tree-sitter/tree-sitter-ql) | community | `HFIJL` |  |  | @pwntester
-[qmldir](https://github.com/Decodetalkers/tree-sitter-qmldir) | core | `H  J ` |  |  | @amaanq
-[qmljs](https://github.com/yuja/tree-sitter-qmljs) | community | `HF   ` |  |  | @Decodetalkers
-[query](https://github.com/nvim-treesitter/tree-sitter-query)[^query] | stable | `HFIJL` |  |  | @steelsojka
-[r](https://github.com/r-lib/tree-sitter-r) | community | `H IJL` |  |  | @echasnovski
-[racket](https://github.com/6cdh/tree-sitter-racket) | unsupported | `HF J ` |  |  | 
-[rasi](https://github.com/Fymyte/tree-sitter-rasi) | community | `HFI L` |  |  | @Fymyte
-[rbs](https://github.com/joker1007/tree-sitter-rbs) | community | `HFIJ ` |  |  | @joker1007
-[re2c](https://github.com/amaanq/tree-sitter-re2c) | core | `HFIJL` |  |  | @amaanq
-[readline](https://github.com/ribru17/tree-sitter-readline) | community | `HFIJ ` |  |  | @ribru17
-[regex](https://github.com/tree-sitter/tree-sitter-regex) | stable | `H    ` |  |  | @theHamsta
-[rego](https://github.com/FallenAngel97/tree-sitter-rego) | community | `H  J ` |  |  | @FallenAngel97
-[requirements](https://github.com/ObserverOfTime/tree-sitter-requirements) | core | `H  J ` |  |  | @ObserverOfTime
-[rnoweb](https://github.com/bamonroe/tree-sitter-rnoweb) | community | `HF J ` |  |  | @bamonroe
-[robot](https://github.com/Hubro/tree-sitter-robot) | community | `HFI  ` |  |  | @Hubro
-[roc](https://github.com/nat-418/tree-sitter-roc) | community | `H  JL` |  |  | @nat-418
-[ron](https://github.com/amaanq/tree-sitter-ron) | core | `HFIJL` |  |  | @amaanq
-[rst](https://github.com/stsewd/tree-sitter-rst) | core | `H  JL` |  |  | @stsewd
-[ruby](https://github.com/tree-sitter/tree-sitter-ruby) | community | `HFIJL` |  |  | @TravonteD
-[rust](https://github.com/tree-sitter/tree-sitter-rust) | core | `HFIJL` |  |  | @amaanq
-[scala](https://github.com/tree-sitter/tree-sitter-scala) | community | `HF JL` |  |  | @stevanmilic
-[scfg](https://git.sr.ht/~rockorager/tree-sitter-scfg) | community | `H  J ` |  |  | @WhyNotHugo
-[scheme](https://github.com/6cdh/tree-sitter-scheme) | unsupported | `HF J ` |  |  | 
-[scss](https://github.com/serenadeai/tree-sitter-scss) | community | `HFI  ` |  |  | @elianiva
-[slang](https://github.com/theHamsta/tree-sitter-slang)[^slang] | unsupported | `HFIJL` |  | ✓ | @theHamsta
-[slint](https://github.com/slint-ui/tree-sitter-slint) | community | `HFIJL` |  |  | @hunger
-[smali](https://github.com/tree-sitter-grammars/tree-sitter-smali) | core | `HFIJL` |  |  | @amaanq
-[smithy](https://github.com/indoorvivants/tree-sitter-smithy) | core | `H    ` |  |  | @amaanq, @keynmol
-[snakemake](https://github.com/osthomas/tree-sitter-snakemake) | unsupported | `HFIJL` |  |  | 
-[solidity](https://github.com/JoranHonig/tree-sitter-solidity) | core | `HF   ` |  |  | @amaanq
-[soql](https://github.com/aheber/tree-sitter-sfapex) | community | `H    ` |  |  | @aheber
-[sosl](https://github.com/aheber/tree-sitter-sfapex) | community | `H    ` |  |  | @aheber
-[sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn) | community | `H  JL` |  |  | @Sarrus1
-[sparql](https://github.com/BonaBeavis/tree-sitter-sparql) | community | `HFIJL` |  |  | @BonaBeavis
-[sql](https://github.com/derekstride/tree-sitter-sql) | community | `H IJ ` |  |  | @derekstride
-[squirrel](https://github.com/amaanq/tree-sitter-squirrel) | core | `HFIJL` |  |  | @amaanq
-[ssh_config](https://github.com/ObserverOfTime/tree-sitter-ssh-config) | core | `HFIJL` |  |  | @ObserverOfTime
-[starlark](https://github.com/amaanq/tree-sitter-starlark) | core | `HFIJL` |  |  | @amaanq
-[strace](https://github.com/sigmaSd/tree-sitter-strace) | core | `H  J ` |  |  | @amaanq
-[styled](https://github.com/mskelton/tree-sitter-styled) | community | `HFIJ ` |  |  | @mskelton
-[supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) | community | `HFIJL` |  |  | @madskjeldgaard
-[surface](https://github.com/connorlay/tree-sitter-surface) | community | `HFIJ ` |  |  | @connorlay
-[svelte](https://github.com/tree-sitter-grammars/tree-sitter-svelte) | core | `HFIJL` |  |  | @amaanq
-[swift](https://github.com/alex-pinkus/tree-sitter-swift) | community | `H I L` |  |  | @alex-pinkus
-[sxhkdrc](https://github.com/RaafatTurki/tree-sitter-sxhkdrc) | community | `HF J ` |  |  | @RaafatTurki
-[systemtap](https://github.com/ok-ryoko/tree-sitter-systemtap) | community | `HF JL` |  |  | @ok-ryoko
-[t32](https://gitlab.com/xasc/tree-sitter-t32.git) | community | `HFIJL` |  |  | @xasc
-[tablegen](https://github.com/amaanq/tree-sitter-tablegen) | core | `HFIJL` |  |  | @amaanq
-[tcl](https://github.com/tree-sitter-grammars/tree-sitter-tcl) | core | `HFI  ` |  |  | @lewis6991
-[teal](https://github.com/euclidianAce/tree-sitter-teal) | community | `HFIJL` |  |  | @euclidianAce
-[templ](https://github.com/vrischmann/tree-sitter-templ) | community | `H  J ` |  |  | @vrischmann
-[terraform](https://github.com/MichaHoffmann/tree-sitter-hcl) | community | `HFIJ ` |  |  | @MichaHoffmann
-[textproto](https://github.com/PorterAtGoogle/tree-sitter-textproto) | community | `HFI  ` |  |  | @Porter
-[thrift](https://github.com/duskmoon314/tree-sitter-thrift) | core | `HFIJL` |  |  | @amaanq, @duskmoon314
-[tiger](https://github.com/ambroisie/tree-sitter-tiger) | community | `HFIJL` |  |  | @ambroisie
-[tlaplus](https://github.com/tlaplus-community/tree-sitter-tlaplus) | community | `HF JL` |  |  | @ahelwer, @susliko
-[tmux](https://github.com/Freed-Wu/tree-sitter-tmux) | community | `H  J ` |  |  | @Freed-Wu
-[todotxt](https://github.com/arnarg/tree-sitter-todotxt.git) | unsupported | `H    ` |  |  | @arnarg
-[toml](https://github.com/ikatyang/tree-sitter-toml) | community | `HFIJL` |  | ✓ | @tk-shirasaka
-[tsv](https://github.com/amaanq/tree-sitter-csv) | core | `H    ` |  |  | @amaanq
-[tsx](https://github.com/tree-sitter/tree-sitter-typescript) | core | `HFIJL` |  | ✓ | @steelsojka
-[turtle](https://github.com/BonaBeavis/tree-sitter-turtle) | community | `HFIJL` |  |  | @BonaBeavis
-[twig](https://github.com/gbprod/tree-sitter-twig) | community | `H  J ` |  |  | @gbprod
-[typescript](https://github.com/tree-sitter/tree-sitter-typescript) | core | `HFIJL` |  | ✓ | @steelsojka
-[typoscript](https://github.com/Teddytrombone/tree-sitter-typoscript) | community | `HFIJ ` |  |  | @Teddytrombone
-[typst](https://github.com/uben0/tree-sitter-typst) | community | `HFIJ ` |  |  | @uben0, @RaafatTurki
-[udev](https://github.com/ObserverOfTime/tree-sitter-udev) | core | `H  JL` |  |  | @ObserverOfTime
-[ungrammar](https://github.com/Philipp-M/tree-sitter-ungrammar) | community | `HFIJL` |  |  | @Philipp-M, @amaanq
-[unison](https://github.com/kylegoetz/tree-sitter-unison) | unsupported | `H  J ` |  |  | @tapegram
-[usd](https://github.com/ColinKennedy/tree-sitter-usd) | community | `HFI L` |  |  | @ColinKennedy
-[uxntal](https://github.com/amaanq/tree-sitter-uxntal) | core | `HFIJL` |  |  | @amaanq
-[v](https://github.com/vlang/v-analyzer) | community | `HFIJL` |  |  | @kkharji, @amaanq
-[vala](https://github.com/vala-lang/tree-sitter-vala) | community | `HF   ` |  |  | @Prince781
-[vento](https://github.com/ventojs/tree-sitter-vento) | community | `H  J ` |  |  | @wrapperup, @oscarotero
-[verilog](https://github.com/tree-sitter/tree-sitter-verilog) | community | `HF JL` |  |  | @zegervdv
-[vhs](https://github.com/charmbracelet/tree-sitter-vhs) | community | `H    ` |  |  | @caarlos0
-[vim](https://github.com/neovim/tree-sitter-vim) | stable | `HF JL` |  |  | @clason
-[vimdoc](https://github.com/neovim/tree-sitter-vimdoc) | stable | `H  J ` |  |  | @clason
-[vue](https://github.com/tree-sitter-grammars/tree-sitter-vue) | core | `HFIJ ` |  |  | @WhyNotHugo, @lucario387
-[wgsl](https://github.com/szebniok/tree-sitter-wgsl) | community | `HFI  ` |  |  | @szebniok
-[wgsl_bevy](https://github.com/theHamsta/tree-sitter-wgsl-bevy) | core | `HFI  ` |  | ✓ | @theHamsta
-[wing](https://github.com/winglang/tree-sitter-wing) | community | `HF  L` |  |  | @gshpychka, @MarkMcCulloh
-[wit](https://github.com/liamwh/tree-sitter-wit) | community | `H  J ` |  |  | @liamwh
-[xcompose](https://github.com/ObserverOfTime/tree-sitter-xcompose) | core | `H  JL` |  |  | @ObserverOfTime
-[xml](https://github.com/tree-sitter-grammars/tree-sitter-xml) | core | `HFIJL` |  |  | @ObserverOfTime
-[yaml](https://github.com/tree-sitter-grammars/tree-sitter-yaml) | core | `HFIJL` |  |  | @amaanq
-[yang](https://github.com/Hubro/tree-sitter-yang) | community | `HFIJ ` |  |  | @Hubro
-[yuck](https://github.com/Philipp-M/tree-sitter-yuck) | community | `HFIJL` |  |  | @Philipp-M, @amaanq
-[zathurarc](https://github.com/Freed-Wu/tree-sitter-zathurarc) | community | `H  J ` |  |  | @Freed-Wu
-[zig](https://github.com/maxxnino/tree-sitter-zig) | community | `HFIJL` |  |  | @maxxnino
+Language | Tier | Queries | CLI | Maintainer
+-------- |:----:|:-------:|:---:| ----------
+[ada](https://github.com/briot/tree-sitter-ada) | community | `HF  L` |  | @briot
+[agda](https://github.com/tree-sitter/tree-sitter-agda) | core | `HF   ` |  | @Decodetalkers
+[angular](https://github.com/dlvandenberg/tree-sitter-angular) | community | `HFIJL` |  | @dlvandenberg
+[apex](https://github.com/aheber/tree-sitter-sfapex) | community | `HF  L` |  | @aheber
+[arduino](https://github.com/tree-sitter-grammars/tree-sitter-arduino) | core | `HFIJL` |  | @ObserverOfTime
+[asm](https://github.com/RubixDev/tree-sitter-asm) | community | `H  J ` |  | @RubixDev
+[astro](https://github.com/virchau13/tree-sitter-astro) | community | `HFIJL` |  | @virchau13
+[authzed](https://github.com/mleonidas/tree-sitter-authzed) | community | `H  J ` |  | @mattpolzin
+[awk](https://github.com/Beaglefoot/tree-sitter-awk) | unsupported | `H  J ` |  | 
+[bash](https://github.com/tree-sitter/tree-sitter-bash) | stable | `HF JL` |  | @TravonteD
+[bass](https://github.com/vito/tree-sitter-bass) | community | `HFIJL` |  | @amaanq
+[beancount](https://github.com/polarmutex/tree-sitter-beancount) | community | `HF J ` |  | @polarmutex
+[bibtex](https://github.com/latex-lsp/tree-sitter-bibtex) | community | `HFI  ` |  | @theHamsta, @clason
+[bicep](https://github.com/tree-sitter-grammars/tree-sitter-bicep) | core | `HFIJL` |  | @amaanq
+[bitbake](https://github.com/tree-sitter-grammars/tree-sitter-bitbake) | core | `HFIJL` |  | @amaanq
+[blueprint](https://gitlab.com/gabmus/tree-sitter-blueprint.git) | unsupported | `H    ` |  | @gabmus
+[c](https://github.com/tree-sitter/tree-sitter-c) | stable | `HFIJL` |  | @amaanq
+[c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) | core | `HF JL` |  | @Luxed
+[cairo](https://github.com/tree-sitter-grammars/tree-sitter-cairo) | core | `HFIJL` |  | @amaanq
+[capnp](https://github.com/tree-sitter-grammars/tree-sitter-capnp) | core | `HFIJL` |  | @amaanq
+[chatito](https://github.com/tree-sitter-grammars/tree-sitter-chatito) | core | `HFIJL` |  | @ObserverOfTime
+[clojure](https://github.com/sogaiu/tree-sitter-clojure) | community | `HF JL` |  | @NoahTheDuke
+[cmake](https://github.com/uyha/tree-sitter-cmake) | community | `HFI  ` |  | @uyha
+[comment](https://github.com/stsewd/tree-sitter-comment) | community | `H    ` |  | @stsewd
+[commonlisp](https://github.com/tree-sitter-grammars/tree-sitter-commonlisp) | core | `HF  L` |  | @theHamsta
+[cooklang](https://github.com/addcninblue/tree-sitter-cooklang) | community | `H    ` |  | @addcninblue
+[corn](https://github.com/jakestanger/tree-sitter-corn) | community | `HFI L` |  | @jakestanger
+[cpon](https://github.com/tree-sitter-grammars/tree-sitter-cpon) | core | `HFIJL` |  | @amaanq
+[cpp](https://github.com/tree-sitter/tree-sitter-cpp) | core | `HFIJL` |  | @theHamsta
+[css](https://github.com/tree-sitter/tree-sitter-css) | core | `HFIJ ` |  | @TravonteD
+[csv](https://github.com/tree-sitter-grammars/tree-sitter-csv) | core | `H    ` |  | @amaanq
+[cuda](https://github.com/tree-sitter-grammars/tree-sitter-cuda) | core | `HFIJL` |  | @theHamsta
+[cue](https://github.com/eonpatapon/tree-sitter-cue) | community | `HFIJL` |  | @amaanq
+[d](https://github.com/gdamore/tree-sitter-d) | community | `HFIJL` |  | @amaanq
+[dart](https://github.com/UserNobody14/tree-sitter-dart) | community | `HFIJL` |  | @akinsho
+[devicetree](https://github.com/joelspadin/tree-sitter-devicetree) | community | `HFIJL` |  | @jedrzejboczar
+[dhall](https://github.com/jbellerb/tree-sitter-dhall) | community | `HF J ` |  | @amaanq
+[diff](https://github.com/the-mikedavis/tree-sitter-diff) | community | `H    ` |  | @gbprod
+[disassembly](https://github.com/ColinKennedy/tree-sitter-disassembly) | community | `H  J ` |  | @ColinKennedy
+[djot](https://github.com/treeman/tree-sitter-djot) | community | `HFIJL` |  | @NoahTheDuke
+[dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) | community | `H  J ` |  | @camdencheek
+[dot](https://github.com/rydesun/tree-sitter-dot) | community | `H IJ ` |  | @rydesun
+[doxygen](https://github.com/tree-sitter-grammars/tree-sitter-doxygen) | core | `H IJ ` |  | @amaanq
+[dtd](https://github.com/tree-sitter-grammars/tree-sitter-xml) | core | `HF JL` |  | @ObserverOfTime
+[earthfile](https://github.com/glehmann/tree-sitter-earthfile) | community | `H  J ` |  | @glehmann
+[ebnf](https://github.com/RubixDev/ebnf) | community | `H    ` |  | @RubixDev
+ecma (queries only)[^ecma] | community | `HFIJL` |  | @steelsojka
+[eds](https://github.com/uyha/tree-sitter-eds) | community | `HF   ` |  | @uyha
+[eex](https://github.com/connorlay/tree-sitter-eex) | community | `H  J ` |  | @connorlay
+[elixir](https://github.com/elixir-lang/tree-sitter-elixir) | community | `HFIJL` |  | @connorlay
+[elm](https://github.com/elm-tooling/tree-sitter-elm) | community | `H  J ` |  | @zweimach
+[elsa](https://github.com/glapa-grossklag/tree-sitter-elsa) | community | `HFIJL` |  | @glapa-grossklag, @amaanq
+[elvish](https://github.com/elves/tree-sitter-elvish) | community | `H  J ` |  | @elves
+[embedded_template](https://github.com/tree-sitter/tree-sitter-embedded-template) | unsupported | `H  J ` |  | 
+[erlang](https://github.com/WhatsApp/tree-sitter-erlang) | community | `HF   ` |  | @filmor
+[facility](https://github.com/FacilityApi/tree-sitter-facility) | community | `HFIJ ` |  | @bryankenote
+[faust](https://github.com/khiner/tree-sitter-faust) | community | `H  J ` |  | @khiner
+[fennel](https://github.com/alexmozaidze/tree-sitter-fennel) | community | `HF JL` |  | @alexmozaidze
+[fidl](https://github.com/google/tree-sitter-fidl) | community | `HF J ` |  | @chaopeng
+[firrtl](https://github.com/tree-sitter-grammars/tree-sitter-firrtl) | core | `HFIJL` |  | @amaanq
+[fish](https://github.com/ram02z/tree-sitter-fish) | community | `HFIJL` |  | @ram02z
+[foam](https://github.com/FoamScience/tree-sitter-foam) | community | `HFIJL` |  | @FoamScience
+[forth](https://github.com/AlexanderBrevig/tree-sitter-forth) | community | `HFIJL` |  | @amaanq
+[fortran](https://github.com/stadelmanma/tree-sitter-fortran) | community | `HFI  ` |  | @amaanq
+[fsh](https://github.com/mgramigna/tree-sitter-fsh) | community | `H    ` |  | @mgramigna
+[func](https://github.com/tree-sitter-grammars/tree-sitter-func) | core | `H    ` |  | @amaanq
+[fusion](https://gitlab.com/jirgn/tree-sitter-fusion.git) | community | `HFI L` |  | @jirgn
+[gdscript](https://github.com/PrestonKnopp/tree-sitter-gdscript)[^gdscript] | community | `HFIJL` |  | @PrestonKnopp
+[gdshader](https://github.com/GodOfAvacyn/tree-sitter-gdshader) | community | `H  J ` |  | @godofavacyn
+[git_config](https://github.com/the-mikedavis/tree-sitter-git-config) | community | `HF J ` |  | @amaanq
+[git_rebase](https://github.com/the-mikedavis/tree-sitter-git-rebase) | community | `H  J ` |  | @gbprod
+[gitattributes](https://github.com/tree-sitter-grammars/tree-sitter-gitattributes) | core | `H  JL` |  | @ObserverOfTime
+[gitcommit](https://github.com/gbprod/tree-sitter-gitcommit) | community | `H  J ` |  | @gbprod
+[gitignore](https://github.com/shunsambongi/tree-sitter-gitignore) | community | `H    ` |  | @theHamsta
+[gleam](https://github.com/gleam-lang/tree-sitter-gleam) | community | `HFIJL` |  | @amaanq
+[glimmer](https://github.com/alexlafroscia/tree-sitter-glimmer)[^glimmer] | community | `HFI L` |  | @NullVoxPopuli
+[glsl](https://github.com/tree-sitter-grammars/tree-sitter-glsl) | core | `HFIJL` |  | @theHamsta
+[gn](https://github.com/tree-sitter-grammars/tree-sitter-gn) | core | `HFIJL` |  | @amaanq
+[gnuplot](https://github.com/dpezto/tree-sitter-gnuplot) | community | `H  J ` |  | @dpezto
+[go](https://github.com/tree-sitter/tree-sitter-go) | core | `HFIJL` |  | @theHamsta, @WinWisely268
+[godot_resource](https://github.com/PrestonKnopp/tree-sitter-godot-resource)[^godot_resource] | community | `HF JL` |  | @pierpo
+[gomod](https://github.com/camdencheek/tree-sitter-go-mod) | community | `H  J ` |  | @camdencheek
+[gosum](https://github.com/tree-sitter-grammars/tree-sitter-go-sum) | core | `H    ` |  | @amaanq
+[gotmpl](https://github.com/ngalaiko/tree-sitter-go-template) | community | `H  J ` |  | @qvalentin
+[gowork](https://github.com/omertuc/tree-sitter-go-work) | community | `H  J ` |  | @omertuc
+[gpg](https://github.com/tree-sitter-grammars/tree-sitter-gpg-config) | core | `H  J ` |  | @ObserverOfTime
+[graphql](https://github.com/bkegley/tree-sitter-graphql) | community | `H IJ ` |  | @bkegley
+[groovy](https://github.com/murtaza64/tree-sitter-groovy) | community | `HFIJL` |  | @murtaza64
+[gstlaunch](https://github.com/tree-sitter-grammars/tree-sitter-gstlaunch) | core | `H    ` |  | @theHamsta
+[hack](https://github.com/slackhq/tree-sitter-hack) | unsupported | `H    ` |  | 
+[hare](https://github.com/tree-sitter-grammars/tree-sitter-hare) | core | `HFIJL` |  | @amaanq
+[haskell](https://github.com/tree-sitter/tree-sitter-haskell) | core | `HF J ` |  | @mrcjkb
+[haskell_persistent](https://github.com/MercuryTechnologies/tree-sitter-haskell-persistent) | community | `HF   ` |  | @lykahb
+[hcl](https://github.com/tree-sitter-grammars/tree-sitter-hcl) | core | `HFIJ ` |  | @MichaHoffmann
+[heex](https://github.com/connorlay/tree-sitter-heex) | community | `HFIJL` |  | @connorlay
+[helm](https://github.com/ngalaiko/tree-sitter-go-template) | community | `H  J ` |  | @qvalentin
+[hjson](https://github.com/winston0410/tree-sitter-hjson) | community | `HFIJL` |  | @winston0410
+[hlsl](https://github.com/tree-sitter-grammars/tree-sitter-hlsl) | core | `HFIJL` |  | @theHamsta
+[hlsplaylist](https://github.com/Freed-Wu/tree-sitter-hlsplaylist) | community | `H  J ` |  | @Freed-Wu
+[hocon](https://github.com/antosha417/tree-sitter-hocon) | unsupported | `HF J ` |  | @antosha417
+[hoon](https://github.com/urbit-pilled/tree-sitter-hoon) | community | `HF  L` |  | @urbit-pilled
+[html](https://github.com/tree-sitter/tree-sitter-html) | core | `HFIJL` |  | @TravonteD
+html_tags (queries only)[^html_tags] | community | `H IJ ` |  | @TravonteD
+[htmldjango](https://github.com/interdependence/tree-sitter-htmldjango) | community | `HFIJ ` |  | @ObserverOfTime
+[http](https://github.com/rest-nvim/tree-sitter-http) | community | `H  J ` |  | @amaanq, @NTBBloodbath
+[hurl](https://github.com/pfeiferj/tree-sitter-hurl) | community | `HFIJ ` |  | @pfeiferj
+[hyprlang](https://github.com/tree-sitter-grammars/tree-sitter-hyprlang) | core | `HFIJ ` |  | @luckasRanarison
+[ini](https://github.com/justinmk/tree-sitter-ini) | community | `HF   ` |  | @theHamsta
+[ispc](https://github.com/tree-sitter-grammars/tree-sitter-ispc) | core | `HFIJL` |  | @fab4100
+[janet_simple](https://github.com/sogaiu/tree-sitter-janet-simple) | community | `HF JL` |  | @sogaiu
+[java](https://github.com/tree-sitter/tree-sitter-java) | core | `HFIJL` |  | @p00f
+[javascript](https://github.com/tree-sitter/tree-sitter-javascript) | core | `HFIJL` |  | @steelsojka
+[jq](https://github.com/flurie/tree-sitter-jq) | community | `H  JL` |  | @ObserverOfTime
+[jsdoc](https://github.com/tree-sitter/tree-sitter-jsdoc) | core | `H    ` |  | @steelsojka
+[json](https://github.com/tree-sitter/tree-sitter-json) | core | `HFI L` |  | @steelsojka
+[json5](https://github.com/Joakker/tree-sitter-json5) | community | `H  J ` |  | @Joakker
+[jsonc](https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git) | community | `HFIJL` |  | @WhyNotHugo
+[jsonnet](https://github.com/sourcegraph/tree-sitter-jsonnet) | community | `HF  L` |  | @nawordar
+jsx (queries only)[^jsx] | community | `HFIJ ` |  | @steelsojka
+[julia](https://github.com/tree-sitter/tree-sitter-julia) | core | `HFIJL` |  | @theHamsta
+[just](https://github.com/IndianBoy42/tree-sitter-just) | community | `HFIJL` |  | @Hubro
+[kconfig](https://github.com/tree-sitter-grammars/tree-sitter-kconfig) | core | `HFIJL` |  | @amaanq
+[kdl](https://github.com/tree-sitter-grammars/tree-sitter-kdl) | core | `HFIJL` |  | @amaanq
+[kotlin](https://github.com/fwcd/tree-sitter-kotlin) | community | `HF JL` |  | @SalBakraa
+[kusto](https://github.com/Willem-J-an/tree-sitter-kusto) | community | `H  J ` |  | @Willem-J-an
+[lalrpop](https://github.com/traxys/tree-sitter-lalrpop) | community | `H  JL` |  | @traxys
+[latex](https://github.com/latex-lsp/tree-sitter-latex) | community | `HF J ` |  | @theHamsta, @clason
+[ledger](https://github.com/cbarrete/tree-sitter-ledger) | community | `HFIJ ` |  | @cbarrete
+[leo](https://github.com/r001/tree-sitter-leo) | community | `H IJ ` |  | @r001
+[linkerscript](https://github.com/tree-sitter-grammars/tree-sitter-linkerscript) | core | `HFIJL` |  | @amaanq
+[liquid](https://github.com/hankthetank27/tree-sitter-liquid) | community | `H  J ` |  | @hankthetank27
+[liquidsoap](https://github.com/savonet/tree-sitter-liquidsoap) | community | `HFI L` |  | @toots
+[llvm](https://github.com/benwilliamgraham/tree-sitter-llvm) | community | `H    ` |  | @benwilliamgraham
+[lua](https://github.com/tree-sitter-grammars/tree-sitter-lua) | stable | `HFIJL` |  | @muniftanjim
+[luadoc](https://github.com/tree-sitter-grammars/tree-sitter-luadoc) | core | `H    ` |  | @amaanq
+[luap](https://github.com/tree-sitter-grammars/tree-sitter-luap)[^luap] | core | `H    ` |  | @amaanq
+[luau](https://github.com/tree-sitter-grammars/tree-sitter-luau) | core | `HFIJL` |  | @amaanq
+[m68k](https://github.com/grahambates/tree-sitter-m68k) | community | `HF JL` |  | @grahambates
+[make](https://github.com/alemuller/tree-sitter-make) | community | `HF J ` |  | @lewis6991
+[markdown](https://github.com/tree-sitter-grammars/tree-sitter-markdown)[^markdown] | stable | `HFIJ ` |  | @MDeiml
+[markdown_inline](https://github.com/tree-sitter-grammars/tree-sitter-markdown)[^markdown_inline] | stable | `H  J ` |  | @MDeiml
+[matlab](https://github.com/acristoffers/tree-sitter-matlab) | community | `HFIJL` |  | @acristoffers
+[menhir](https://github.com/Kerl13/tree-sitter-menhir) | community | `H  J ` |  | @Kerl13
+[mermaid](https://github.com/monaqa/tree-sitter-mermaid) | unsupported | `H    ` |  | 
+[meson](https://github.com/tree-sitter-grammars/tree-sitter-meson) | core | `HFIJ ` |  | @Decodetalkers
+[mlir](https://github.com/artagnon/tree-sitter-mlir) | community | `H   L` |  | @artagnon
+[muttrc](https://github.com/neomutt/tree-sitter-muttrc) | community | `H  J ` |  | @Freed-Wu
+[nasm](https://github.com/naclsn/tree-sitter-nasm) | community | `H  J ` |  | @ObserverOfTime
+[nickel](https://github.com/nickel-lang/tree-sitter-nickel) | unsupported | `H I  ` |  | 
+[nim](https://github.com/alaviss/tree-sitter-nim) | community | `HF JL` |  | @aMOPel
+[nim_format_string](https://github.com/aMOPel/tree-sitter-nim-format-string) | community | `H  J ` |  | @aMOPel
+[ninja](https://github.com/alemuller/tree-sitter-ninja) | community | `HFI  ` |  | @alemuller
+[nix](https://github.com/cstrahan/tree-sitter-nix) | community | `HF JL` |  | @leo60228
+[nqc](https://github.com/tree-sitter-grammars/tree-sitter-nqc) | core | `HFIJL` |  | @amaanq
+[objc](https://github.com/tree-sitter-grammars/tree-sitter-objc) | core | `HFIJL` |  | @amaanq
+[objdump](https://github.com/ColinKennedy/tree-sitter-objdump) | community | `H  J ` |  | @ColinKennedy
+[ocaml](https://github.com/tree-sitter/tree-sitter-ocaml) | core | `HFIJL` |  | @undu
+[ocaml_interface](https://github.com/tree-sitter/tree-sitter-ocaml) | core | `HFIJL` |  | @undu
+[ocamllex](https://github.com/atom-ocaml/tree-sitter-ocamllex) | community | `H  J ` |  | @undu
+[odin](https://github.com/tree-sitter-grammars/tree-sitter-odin) | core | `HFIJL` |  | @amaanq
+[org](https://github.com/milisims/tree-sitter-org) | unsupported | `     ` |  | 
+[pascal](https://github.com/Isopod/tree-sitter-pascal.git) | community | `HFIJL` |  | @Isopod
+[passwd](https://github.com/ath3/tree-sitter-passwd) | community | `H    ` |  | @amaanq
+[pem](https://github.com/tree-sitter-grammars/tree-sitter-pem) | core | `HF J ` |  | @ObserverOfTime
+[perl](https://github.com/tree-sitter-perl/tree-sitter-perl) | community | `HF J ` |  | @RabbiVeesh, @LeoNerd
+[php](https://github.com/tree-sitter/tree-sitter-php)[^php] | core | `HFIJL` |  | @tk-shirasaka
+[php_only](https://github.com/tree-sitter/tree-sitter-php)[^php_only] | core | `HFIJL` |  | @tk-shirasaka
+[phpdoc](https://github.com/claytonrcarter/tree-sitter-phpdoc) | community | `H    ` |  | @mikehaertl
+[pioasm](https://github.com/leo60228/tree-sitter-pioasm) | community | `H  J ` |  | @leo60228
+[po](https://github.com/tree-sitter-grammars/tree-sitter-po) | core | `HF J ` |  | @amaanq
+[pod](https://github.com/tree-sitter-perl/tree-sitter-pod) | community | `H    ` |  | @RabbiVeesh, @LeoNerd
+[poe_filter](https://github.com/tree-sitter-grammars/tree-sitter-poe-filter)[^poe_filter] | core | `HFIJ ` |  | @ObserverOfTime
+[pony](https://github.com/tree-sitter-grammars/tree-sitter-pony) | core | `HFIJL` |  | @amaanq, @mfelsche
+[printf](https://github.com/tree-sitter-grammars/tree-sitter-printf) | core | `H    ` |  | @ObserverOfTime
+[prisma](https://github.com/victorhqc/tree-sitter-prisma) | community | `HF   ` |  | @elianiva
+[promql](https://github.com/MichaHoffmann/tree-sitter-promql) | community | `H  J ` |  | @MichaHoffmann
+[properties](https://github.com/tree-sitter-grammars/tree-sitter-properties)[^properties] | core | `H  JL` |  | @ObserverOfTime
+[proto](https://github.com/treywood/tree-sitter-proto) | community | `HF   ` |  | @treywood
+[prql](https://github.com/PRQL/tree-sitter-prql) | community | `H  J ` |  | @matthias-Q
+[psv](https://github.com/tree-sitter-grammars/tree-sitter-csv) | core | `H    ` |  | @amaanq
+[pug](https://github.com/zealot128/tree-sitter-pug) | community | `H  J ` |  | @zealot128
+[puppet](https://github.com/tree-sitter-grammars/tree-sitter-puppet) | core | `HFIJL` |  | @amaanq
+[purescript](https://github.com/postsolar/tree-sitter-purescript) | community | `H  JL` |  | @postsolar
+[pymanifest](https://github.com/tree-sitter-grammars/tree-sitter-pymanifest) | core | `H  J ` |  | @ObserverOfTime
+[python](https://github.com/tree-sitter/tree-sitter-python) | stable | `HFIJL` |  | @stsewd, @theHamsta
+[ql](https://github.com/tree-sitter/tree-sitter-ql) | core | `HFIJL` |  | @pwntester
+[qmldir](https://github.com/tree-sitter-grammars/tree-sitter-qmldir) | core | `H  J ` |  | @amaanq
+[qmljs](https://github.com/yuja/tree-sitter-qmljs) | community | `HF   ` |  | @Decodetalkers
+[query](https://github.com/tree-sitter-grammars/tree-sitter-query)[^query] | stable | `HFIJL` |  | @steelsojka
+[r](https://github.com/r-lib/tree-sitter-r) | community | `H IJL` |  | @echasnovski
+[racket](https://github.com/6cdh/tree-sitter-racket) | unsupported | `HF J ` |  | 
+[rasi](https://github.com/Fymyte/tree-sitter-rasi) | community | `HFI L` |  | @Fymyte
+[rbs](https://github.com/joker1007/tree-sitter-rbs) | community | `HFIJ ` |  | @joker1007
+[re2c](https://github.com/tree-sitter-grammars/tree-sitter-re2c) | core | `HFIJL` |  | @amaanq
+[readline](https://github.com/tree-sitter-grammars/tree-sitter-readline) | core | `HFIJ ` |  | @ribru17
+[regex](https://github.com/tree-sitter/tree-sitter-regex) | core | `H    ` |  | @theHamsta
+[rego](https://github.com/FallenAngel97/tree-sitter-rego) | community | `H  J ` |  | @FallenAngel97
+[requirements](https://github.com/tree-sitter-grammars/tree-sitter-requirements) | core | `H  J ` |  | @ObserverOfTime
+[rnoweb](https://github.com/bamonroe/tree-sitter-rnoweb) | community | `HF J ` |  | @bamonroe
+[robot](https://github.com/Hubro/tree-sitter-robot) | community | `HFI  ` |  | @Hubro
+[roc](https://github.com/nat-418/tree-sitter-roc) | community | `H  JL` |  | @nat-418
+[ron](https://github.com/tree-sitter-grammars/tree-sitter-ron) | core | `HFIJL` |  | @amaanq
+[rst](https://github.com/stsewd/tree-sitter-rst) | community | `H  JL` |  | @stsewd
+[ruby](https://github.com/tree-sitter/tree-sitter-ruby) | core | `HFIJL` |  | @TravonteD
+[rust](https://github.com/tree-sitter/tree-sitter-rust) | core | `HFIJL` |  | @amaanq
+[scala](https://github.com/tree-sitter/tree-sitter-scala) | core | `HF JL` |  | @stevanmilic
+[scfg](https://git.sr.ht/~rockorager/tree-sitter-scfg) | community | `H  J ` |  | @WhyNotHugo
+[scheme](https://github.com/6cdh/tree-sitter-scheme) | unsupported | `HF J ` |  | 
+[scss](https://github.com/serenadeai/tree-sitter-scss) | community | `HFI  ` |  | @elianiva
+[slang](https://github.com/tree-sitter-grammars/tree-sitter-slang)[^slang] | core | `HFIJL` |  | @theHamsta
+[slint](https://github.com/slint-ui/tree-sitter-slint) | community | `HFIJL` |  | @hunger
+[smali](https://github.com/tree-sitter-grammars/tree-sitter-smali) | core | `HFIJL` |  | @amaanq
+[smithy](https://github.com/indoorvivants/tree-sitter-smithy) | community | `H    ` |  | @amaanq, @keynmol
+[snakemake](https://github.com/osthomas/tree-sitter-snakemake) | community | `HFIJL` |  | 
+[solidity](https://github.com/JoranHonig/tree-sitter-solidity) | community | `HF   ` |  | @amaanq
+[soql](https://github.com/aheber/tree-sitter-sfapex) | community | `H    ` |  | @aheber
+[sosl](https://github.com/aheber/tree-sitter-sfapex) | community | `H    ` |  | @aheber
+[sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn) | community | `H  JL` |  | @Sarrus1
+[sparql](https://github.com/BonaBeavis/tree-sitter-sparql) | community | `HFIJL` |  | @BonaBeavis
+[sql](https://github.com/derekstride/tree-sitter-sql) | community | `H IJ ` |  | @derekstride
+[squirrel](https://github.com/tree-sitter-grammars/tree-sitter-squirrel) | core | `HFIJL` |  | @amaanq
+[ssh_config](https://github.com/tree-sitter-grammars/tree-sitter-ssh-config) | core | `HFIJL` |  | @ObserverOfTime
+[starlark](https://github.com/tree-sitter-grammars/tree-sitter-starlark) | core | `HFIJL` |  | @amaanq
+[strace](https://github.com/sigmaSd/tree-sitter-strace) | community | `H  J ` |  | @amaanq
+[styled](https://github.com/mskelton/tree-sitter-styled) | community | `HFIJ ` |  | @mskelton
+[supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) | community | `HFIJL` |  | @madskjeldgaard
+[surface](https://github.com/connorlay/tree-sitter-surface) | community | `HFIJ ` |  | @connorlay
+[svelte](https://github.com/tree-sitter-grammars/tree-sitter-svelte) | core | `HFIJL` |  | @amaanq
+[swift](https://github.com/alex-pinkus/tree-sitter-swift) | community | `H I L` |  | @alex-pinkus
+[sxhkdrc](https://github.com/RaafatTurki/tree-sitter-sxhkdrc) | community | `HF J ` |  | @RaafatTurki
+[systemtap](https://github.com/ok-ryoko/tree-sitter-systemtap) | community | `HF JL` |  | @ok-ryoko
+[t32](https://gitlab.com/xasc/tree-sitter-t32.git) | community | `HFIJL` |  | @xasc
+[tablegen](https://github.com/tree-sitter-grammars/tree-sitter-tablegen) | core | `HFIJL` |  | @amaanq
+[tcl](https://github.com/tree-sitter-grammars/tree-sitter-tcl) | core | `HFI  ` |  | @lewis6991
+[teal](https://github.com/euclidianAce/tree-sitter-teal) | community | `HFIJL` |  | @euclidianAce
+[templ](https://github.com/vrischmann/tree-sitter-templ) | community | `H  J ` |  | @vrischmann
+[terraform](https://github.com/MichaHoffmann/tree-sitter-hcl) | community | `HFIJ ` |  | @MichaHoffmann
+[textproto](https://github.com/PorterAtGoogle/tree-sitter-textproto) | community | `HFI  ` |  | @Porter
+[thrift](https://github.com/tree-sitter-grammars/tree-sitter-thrift) | core | `HFIJL` |  | @amaanq, @duskmoon314
+[tiger](https://github.com/ambroisie/tree-sitter-tiger) | community | `HFIJL` |  | @ambroisie
+[tlaplus](https://github.com/tlaplus-community/tree-sitter-tlaplus) | community | `HF JL` |  | @ahelwer, @susliko
+[tmux](https://github.com/Freed-Wu/tree-sitter-tmux) | community | `H  J ` |  | @Freed-Wu
+[todotxt](https://github.com/arnarg/tree-sitter-todotxt.git) | community | `H    ` |  | @arnarg
+[toml](https://github.com/tree-sitter-grammars/tree-sitter-toml) | core | `HFIJL` |  | @tk-shirasaka
+[tsv](https://github.com/tree-sitter-grammars/tree-sitter-csv) | core | `H    ` |  | @amaanq
+[tsx](https://github.com/tree-sitter/tree-sitter-typescript) | core | `HFIJL` |  | @steelsojka
+[turtle](https://github.com/BonaBeavis/tree-sitter-turtle) | community | `HFIJL` |  | @BonaBeavis
+[twig](https://github.com/gbprod/tree-sitter-twig) | community | `H  J ` |  | @gbprod
+[typescript](https://github.com/tree-sitter/tree-sitter-typescript) | core | `HFIJL` |  | @steelsojka
+[typoscript](https://github.com/Teddytrombone/tree-sitter-typoscript) | community | `HFIJ ` |  | @Teddytrombone
+[typst](https://github.com/uben0/tree-sitter-typst) | community | `HFIJ ` |  | @uben0, @RaafatTurki
+[udev](https://github.com/tree-sitter-grammars/tree-sitter-udev) | core | `H  JL` |  | @ObserverOfTime
+[ungrammar](https://github.com/tree-sitter-grammars/tree-sitter-ungrammar) | core | `HFIJL` |  | @Philipp-M, @amaanq
+[unison](https://github.com/kylegoetz/tree-sitter-unison) | community | `H  J ` |  | @tapegram
+[usd](https://github.com/ColinKennedy/tree-sitter-usd) | community | `HFI L` |  | @ColinKennedy
+[uxntal](https://github.com/tree-sitter-grammars/tree-sitter-uxntal) | core | `HFIJL` |  | @amaanq
+[v](https://github.com/vlang/v-analyzer) | community | `HFIJL` |  | @kkharji, @amaanq
+[vala](https://github.com/vala-lang/tree-sitter-vala) | community | `HF   ` |  | @Prince781
+[vento](https://github.com/ventojs/tree-sitter-vento) | community | `H  J ` |  | @wrapperup, @oscarotero
+[verilog](https://github.com/tree-sitter/tree-sitter-verilog) | core | `HF JL` |  | @zegervdv
+[vhs](https://github.com/charmbracelet/tree-sitter-vhs) | community | `H    ` |  | @caarlos0
+[vim](https://github.com/tree-sitter-grammars/tree-sitter-vim) | stable | `HF JL` |  | @clason
+[vimdoc](https://github.com/neovim/tree-sitter-vimdoc) | stable | `H  J ` |  | @clason
+[vue](https://github.com/tree-sitter-grammars/tree-sitter-vue) | core | `HFIJ ` |  | @WhyNotHugo, @lucario387
+[wgsl](https://github.com/szebniok/tree-sitter-wgsl) | community | `HFI  ` |  | @szebniok
+[wgsl_bevy](https://github.com/tree-sitter-grammars/tree-sitter-wgsl-bevy) | core | `HFI  ` |  | @theHamsta
+[wing](https://github.com/winglang/tree-sitter-wing) | community | `HF  L` |  | @gshpychka, @MarkMcCulloh
+[wit](https://github.com/liamwh/tree-sitter-wit) | community | `H  J ` |  | @liamwh
+[xcompose](https://github.com/tree-sitter-grammars/tree-sitter-xcompose) | core | `H  JL` |  | @ObserverOfTime
+[xml](https://github.com/tree-sitter-grammars/tree-sitter-xml) | core | `HFIJL` |  | @ObserverOfTime
+[yaml](https://github.com/tree-sitter-grammars/tree-sitter-yaml) | core | `HFIJL` |  | @amaanq
+[yang](https://github.com/Hubro/tree-sitter-yang) | community | `HFIJ ` |  | @Hubro
+[yuck](https://github.com/tree-sitter-grammars/tree-sitter-yuck) | core | `HFIJL` |  | @Philipp-M, @amaanq
+[zathurarc](https://github.com/Freed-Wu/tree-sitter-zathurarc) | community | `H  J ` |  | @Freed-Wu
+[zig](https://github.com/maxxnino/tree-sitter-zig) | community | `HFIJL` |  | @maxxnino
 [^ecma]: queries required by javascript, typescript, tsx, qmljs
 [^gdscript]: Godot
 [^glimmer]: Glimmer and Ember

--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -37,16 +37,8 @@ local function install_health()
     )
   end
 
-  if vim.fn.executable('node') == 0 then
-    health.warn('`node` executable not found (only needed for `:TSInstallFromGrammar`.')
-  else
-    local result = assert(vim.system({ 'node', '--version' }):wait().stdout)
-    local version = vim.split(result, '\n')[1]
-    health.ok('`node` found ' .. version .. ' (only needed for `:TSInstallFromGrammar`)')
-  end
-
   if vim.fn.executable('git') == 0 then
-    health.error(
+    health.warn(
       '`git` executable not found.',
       'Install it with your package manager and check that your `$PATH` is set correctly.'
     )

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -4,8 +4,8 @@
 ---@field branch? string
 ---@field revision? string
 ---@field files string[]
----@field generate_requires_npm? boolean
 ---@field generate? boolean
+---@field generate_from_json? boolean
 ---@field location? string
 
 ---@class ParserInfo
@@ -36,18 +36,18 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@Decodetalkers' },
-    tier = 3,
+    tier = 2,
   },
 
   angular = {
     install_info = {
       url = 'https://github.com/dlvandenberg/tree-sitter-angular',
       files = { 'src/parser.c', 'src/scanner.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@dlvandenberg' },
     requires = { 'html', 'html_tags' },
-    tier = 4,
+    tier = 3,
   },
 
   apex = {
@@ -62,8 +62,9 @@ M.configs = {
 
   arduino = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-arduino',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-arduino',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@ObserverOfTime' },
     requires = { 'cpp' },
@@ -83,6 +84,7 @@ M.configs = {
     install_info = {
       url = 'https://github.com/virchau13/tree-sitter-astro',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@virchau13' },
     requires = { 'html', 'html_tags' },
@@ -112,7 +114,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@TravonteD' },
-    tier = 3,
+    tier = 1,
   },
 
   bass = {
@@ -121,7 +123,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   beancount = {
@@ -139,12 +141,12 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@theHamsta', '@clason' },
-    tier = 2,
+    tier = 3,
   },
 
   bicep = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-bicep',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-bicep',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -153,7 +155,7 @@ M.configs = {
 
   bitbake = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-bitbake',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-bitbake',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -184,12 +186,12 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@Luxed' },
-    tier = 3,
+    tier = 2,
   },
 
   cairo = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-cairo',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-cairo',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -198,7 +200,7 @@ M.configs = {
 
   capnp = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-capnp',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-capnp',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -207,7 +209,7 @@ M.configs = {
 
   chatito = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-chatito',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-chatito',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -229,7 +231,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@uyha' },
-    tier = 4,
+    tier = 3,
   },
 
   comment = {
@@ -238,14 +240,14 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@stsewd' },
-    tier = 2,
+    tier = 3,
   },
 
   commonlisp = {
     install_info = {
-      url = 'https://github.com/theHamsta/tree-sitter-commonlisp',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-commonlisp',
       files = { 'src/parser.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@theHamsta' },
     tier = 2,
@@ -271,7 +273,7 @@ M.configs = {
 
   cpon = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-cpon',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-cpon',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -282,11 +284,11 @@ M.configs = {
     install_info = {
       url = 'https://github.com/tree-sitter/tree-sitter-cpp',
       files = { 'src/parser.c', 'src/scanner.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@theHamsta' },
     requires = { 'c' },
-    tier = 1,
+    tier = 2,
   },
 
   css = {
@@ -295,12 +297,12 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@TravonteD' },
-    tier = 3,
+    tier = 2,
   },
 
   csv = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-csv',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-csv',
       files = { 'src/parser.c' },
       location = 'csv',
     },
@@ -311,9 +313,9 @@ M.configs = {
 
   cuda = {
     install_info = {
-      url = 'https://github.com/theHamsta/tree-sitter-cuda',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-cuda',
       files = { 'src/parser.c', 'src/scanner.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@theHamsta' },
     requires = { 'cpp' },
@@ -326,7 +328,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   d = {
@@ -334,7 +336,7 @@ M.configs = {
       url = 'https://github.com/gdamore/tree-sitter-d',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
-    tier = 2,
+    tier = 3,
     maintainers = { '@amaanq' },
   },
 
@@ -344,7 +346,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@akinsho' },
-    tier = 4,
+    tier = 3,
   },
 
   devicetree = {
@@ -362,7 +364,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   diff = {
@@ -412,7 +414,7 @@ M.configs = {
 
   doxygen = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-doxygen',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-doxygen',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -437,6 +439,7 @@ M.configs = {
     maintainers = { '@glehmann' },
     tier = 3,
   },
+
   ebnf = {
     install_info = {
       url = 'https://github.com/RubixDev/ebnf',
@@ -444,13 +447,13 @@ M.configs = {
       location = 'crates/tree-sitter-ebnf',
     },
     maintainers = { '@RubixDev' },
-    tier = 4,
+    tier = 3,
   },
 
   ecma = {
     maintainers = { '@steelsojka' },
     readme_note = 'queries required by javascript, typescript, tsx, qmljs',
-    tier = 2,
+    tier = 3,
   },
 
   eds = {
@@ -486,7 +489,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@zweimach' },
-    tier = 4,
+    tier = 3,
   },
 
   elsa = {
@@ -495,7 +498,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@glapa-grossklag', '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   elvish = {
@@ -563,7 +566,7 @@ M.configs = {
 
   firrtl = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-firrtl',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-firrtl',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -594,7 +597,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   fortran = {
@@ -603,7 +606,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   fsh = {
@@ -617,7 +620,7 @@ M.configs = {
 
   func = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-func',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-func',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -663,7 +666,7 @@ M.configs = {
 
   gitattributes = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-gitattributes',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-gitattributes',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -685,7 +688,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   gitignore = {
@@ -694,7 +697,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@theHamsta' },
-    tier = 2,
+    tier = 3,
   },
 
   gleam = {
@@ -703,7 +706,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   glimmer = {
@@ -718,9 +721,9 @@ M.configs = {
 
   glsl = {
     install_info = {
-      url = 'https://github.com/theHamsta/tree-sitter-glsl',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-glsl',
       files = { 'src/parser.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@theHamsta' },
     requires = { 'c' },
@@ -729,7 +732,7 @@ M.configs = {
 
   gn = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-gn',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-gn',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -752,7 +755,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@theHamsta', '@WinWisely268' },
-    tier = 1,
+    tier = 2,
   },
 
   godot_resource = {
@@ -776,7 +779,7 @@ M.configs = {
 
   gosum = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-go-sum',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-go-sum',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -812,7 +815,7 @@ M.configs = {
 
   gpg = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-gpg-config',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-gpg-config',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -830,7 +833,7 @@ M.configs = {
 
   gstlaunch = {
     install_info = {
-      url = 'https://github.com/theHamsta/tree-sitter-gstlaunch',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-gstlaunch',
       files = { 'src/parser.c' },
     },
     maintainers = { '@theHamsta' },
@@ -847,7 +850,7 @@ M.configs = {
 
   hare = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-hare',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-hare',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -860,7 +863,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@mrcjkb' },
-    tier = 3,
+    tier = 2,
   },
 
   haskell_persistent = {
@@ -874,11 +877,11 @@ M.configs = {
 
   hcl = {
     install_info = {
-      url = 'https://github.com/MichaHoffmann/tree-sitter-hcl',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-hcl',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@MichaHoffmann' },
-    tier = 3,
+    tier = 2,
   },
 
   heex = {
@@ -904,7 +907,7 @@ M.configs = {
     install_info = {
       url = 'https://github.com/winston0410/tree-sitter-hjson',
       files = { 'src/parser.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@winston0410' },
     requires = { 'json' },
@@ -913,9 +916,9 @@ M.configs = {
 
   hlsl = {
     install_info = {
-      url = 'https://github.com/theHamsta/tree-sitter-hlsl',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-hlsl',
       files = { 'src/parser.c', 'src/scanner.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@theHamsta' },
     requires = { 'cpp' },
@@ -935,7 +938,7 @@ M.configs = {
     install_info = {
       url = 'https://github.com/antosha417/tree-sitter-hocon',
       files = { 'src/parser.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@antosha417' },
     tier = 4,
@@ -947,7 +950,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@urbit-pilled' },
-    tier = 4,
+    tier = 3,
   },
 
   html_tags = {
@@ -963,7 +966,7 @@ M.configs = {
     },
     maintainers = { '@TravonteD' },
     requires = { 'html_tags' },
-    tier = 3,
+    tier = 2,
   },
 
   htmldjango = {
@@ -972,7 +975,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
-    tier = 4,
+    tier = 3,
   },
 
   http = {
@@ -981,7 +984,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq', '@NTBBloodbath' },
-    tier = 2,
+    tier = 3,
   },
 
   hurl = {
@@ -995,11 +998,11 @@ M.configs = {
 
   hyprlang = {
     install_info = {
-      url = 'https://github.com/luckasRanarison/tree-sitter-hyprlang',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-hyprlang',
       files = { 'src/parser.c' },
     },
     maintainers = { '@luckasRanarison' },
-    tier = 3,
+    tier = 2,
   },
 
   ini = {
@@ -1008,18 +1011,18 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@theHamsta' },
-    tier = 4,
+    tier = 3,
   },
 
   ispc = {
     install_info = {
-      url = 'https://github.com/fab4100/tree-sitter-ispc',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-ispc',
       files = { 'src/parser.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@fab4100' },
     requires = { 'c' },
-    tier = 3,
+    tier = 2,
   },
 
   janet_simple = {
@@ -1037,7 +1040,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@p00f' },
-    tier = 3,
+    tier = 2,
   },
 
   javascript = {
@@ -1056,7 +1059,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
-    tier = 2,
+    tier = 3,
   },
 
   jsdoc = {
@@ -1090,7 +1093,7 @@ M.configs = {
     install_info = {
       url = 'https://gitlab.com/WhyNotHugo/tree-sitter-jsonc.git',
       files = { 'src/parser.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@WhyNotHugo' },
     requires = { 'json' },
@@ -1109,7 +1112,7 @@ M.configs = {
   jsx = {
     maintainers = { '@steelsojka' },
     readme_note = 'queries required by javascript, tsx',
-    tier = 2,
+    tier = 3,
   },
 
   julia = {
@@ -1132,7 +1135,7 @@ M.configs = {
 
   kconfig = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-kconfig',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-kconfig',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -1141,7 +1144,7 @@ M.configs = {
 
   kdl = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-kdl',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-kdl',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -1182,7 +1185,7 @@ M.configs = {
       generate = true,
     },
     maintainers = { '@theHamsta', '@clason' },
-    tier = 2,
+    tier = 3,
   },
 
   ledger = {
@@ -1214,7 +1217,7 @@ M.configs = {
 
   linkerscript = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-linkerscript',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-linkerscript',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -1241,7 +1244,7 @@ M.configs = {
 
   lua = {
     install_info = {
-      url = 'https://github.com/MunifTanjim/tree-sitter-lua',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-lua',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@muniftanjim' },
@@ -1250,7 +1253,7 @@ M.configs = {
 
   luadoc = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-luadoc',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-luadoc',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -1259,7 +1262,7 @@ M.configs = {
 
   luap = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-luap',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-luap',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -1269,8 +1272,9 @@ M.configs = {
 
   luau = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-luau',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-luau',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@amaanq' },
     requires = { 'lua' },
@@ -1292,12 +1296,12 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@lewis6991' },
-    tier = 2,
+    tier = 3,
   },
 
   markdown = {
     install_info = {
-      url = 'https://github.com/MDeiml/tree-sitter-markdown',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-markdown',
       location = 'tree-sitter-markdown',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
@@ -1309,7 +1313,7 @@ M.configs = {
 
   markdown_inline = {
     install_info = {
-      url = 'https://github.com/MDeiml/tree-sitter-markdown',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-markdown',
       location = 'tree-sitter-markdown-inline',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
@@ -1346,11 +1350,11 @@ M.configs = {
 
   meson = {
     install_info = {
-      url = 'https://github.com/Decodetalkers/tree-sitter-meson',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-meson',
       files = { 'src/parser.c' },
     },
     maintainers = { '@Decodetalkers' },
-    tier = 3,
+    tier = 2,
   },
 
   mlir = {
@@ -1360,7 +1364,7 @@ M.configs = {
       generate = true,
     },
     maintainers = { '@artagnon' },
-    tier = 4,
+    tier = 3,
   },
 
   muttrc = {
@@ -1378,7 +1382,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
-    tier = 2,
+    tier = 3,
   },
 
   nickel = {
@@ -1428,8 +1432,9 @@ M.configs = {
 
   nqc = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-nqc',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-nqc',
       files = { 'src/parser.c' },
+      generate_from_json = true,
     },
     maintainers = { '@amaanq' },
     tier = 2,
@@ -1437,8 +1442,9 @@ M.configs = {
 
   objc = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-objc',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-objc',
       files = { 'src/parser.c' },
+      generate_from_json = true,
     },
     maintainers = { '@amaanq' },
     requires = { 'c' },
@@ -1461,7 +1467,7 @@ M.configs = {
       location = 'grammars/ocaml',
     },
     maintainers = { '@undu' },
-    tier = 3,
+    tier = 2,
   },
 
   ocaml_interface = {
@@ -1472,7 +1478,7 @@ M.configs = {
     },
     maintainers = { '@undu' },
     requires = { 'ocaml' },
-    tier = 3,
+    tier = 2,
   },
 
   ocamllex = {
@@ -1487,7 +1493,7 @@ M.configs = {
 
   odin = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-odin',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-odin',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -1522,7 +1528,7 @@ M.configs = {
 
   pem = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-pem',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-pem',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -1534,6 +1540,7 @@ M.configs = {
       url = 'https://github.com/tree-sitter-perl/tree-sitter-perl',
       branch = 'release',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@RabbiVeesh', '@LeoNerd' },
     tier = 3,
@@ -1548,7 +1555,7 @@ M.configs = {
     maintainers = { '@tk-shirasaka' },
     requires = { 'php_only' },
     readme_note = 'PHP with embedded HTML',
-    tier = 3,
+    tier = 2,
   },
 
   php_only = {
@@ -1559,17 +1566,17 @@ M.configs = {
     },
     maintainers = { '@tk-shirasaka' },
     readme_note = 'PHP without embedded HTML',
-    tier = 3,
+    tier = 2,
   },
 
   phpdoc = {
     install_info = {
       url = 'https://github.com/claytonrcarter/tree-sitter-phpdoc',
       files = { 'src/parser.c', 'src/scanner.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@mikehaertl' },
-    tier = 4,
+    tier = 3,
   },
 
   pioasm = {
@@ -1583,7 +1590,7 @@ M.configs = {
 
   po = {
     install_info = {
-      url = 'https://github.com/erasin/tree-sitter-po',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-po',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -1595,6 +1602,7 @@ M.configs = {
       url = 'https://github.com/tree-sitter-perl/tree-sitter-pod',
       files = { 'src/parser.c', 'src/scanner.c' },
       branch = 'release',
+      generate_from_json = true,
     },
     maintainers = { '@RabbiVeesh', '@LeoNerd' },
     tier = 3,
@@ -1602,17 +1610,17 @@ M.configs = {
 
   poe_filter = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-poe-filter',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-poe-filter',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
     readme_note = 'Path of Exile item filter',
-    tier = 4,
+    tier = 2,
   },
 
   pony = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-pony',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-pony',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq', '@mfelsche' },
@@ -1621,7 +1629,7 @@ M.configs = {
 
   printf = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-printf',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-printf',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -1639,7 +1647,7 @@ M.configs = {
 
   properties = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-properties',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-properties',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -1662,7 +1670,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@MichaHoffmann' },
-    tier = 4,
+    tier = 3,
   },
 
   prql = {
@@ -1671,12 +1679,12 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@matthias-Q' },
-    tier = 2,
+    tier = 3,
   },
 
   psv = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-csv',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-csv',
       files = { 'src/parser.c' },
       location = 'psv',
     },
@@ -1691,12 +1699,12 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@zealot128' },
-    tier = 4,
+    tier = 3,
   },
 
   puppet = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-puppet',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-puppet',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -1714,7 +1722,7 @@ M.configs = {
 
   pymanifest = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-pymanifest',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-pymanifest',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -1737,12 +1745,12 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@pwntester' },
-    tier = 3,
+    tier = 2,
   },
 
   qmldir = {
     install_info = {
-      url = 'https://github.com/Decodetalkers/tree-sitter-qmldir',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-qmldir',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -1753,6 +1761,7 @@ M.configs = {
     install_info = {
       url = 'https://github.com/yuja/tree-sitter-qmljs',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@Decodetalkers' },
     requires = { 'ecma' },
@@ -1761,7 +1770,7 @@ M.configs = {
 
   query = {
     install_info = {
-      url = 'https://github.com/nvim-treesitter/tree-sitter-query',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-query',
       files = { 'src/parser.c' },
     },
     maintainers = { '@steelsojka' },
@@ -1806,7 +1815,7 @@ M.configs = {
 
   re2c = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-re2c',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-re2c',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
@@ -1815,11 +1824,11 @@ M.configs = {
 
   readline = {
     install_info = {
-      url = 'https://github.com/ribru17/tree-sitter-readline',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-readline',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ribru17' },
-    tier = 3,
+    tier = 2,
   },
 
   regex = {
@@ -1828,7 +1837,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@theHamsta' },
-    tier = 1,
+    tier = 2,
   },
 
   rego = {
@@ -1842,7 +1851,7 @@ M.configs = {
 
   requirements = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-requirements',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-requirements',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -1879,7 +1888,7 @@ M.configs = {
 
   ron = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-ron',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-ron',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -1892,7 +1901,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@stsewd' },
-    tier = 2,
+    tier = 3,
   },
 
   ruby = {
@@ -1901,7 +1910,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@TravonteD' },
-    tier = 3,
+    tier = 2,
   },
 
   rust = {
@@ -1919,7 +1928,7 @@ M.configs = {
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@stevanmilic' },
-    tier = 3,
+    tier = 2,
   },
 
   scfg = {
@@ -1952,13 +1961,13 @@ M.configs = {
 
   slang = {
     install_info = {
-      url = 'https://github.com/theHamsta/tree-sitter-slang',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-slang',
       files = { 'src/parser.c', 'src/scanner.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     readme_note = 'Shader Slang',
     maintainers = { '@theHamsta' },
-    tier = 4,
+    tier = 2,
   },
 
   slint = {
@@ -1983,9 +1992,10 @@ M.configs = {
     install_info = {
       url = 'https://github.com/osthomas/tree-sitter-snakemake',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainer = { '@osthomas' },
-    tier = 4,
+    tier = 3,
   },
 
   smithy = {
@@ -1994,7 +2004,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq', '@keynmol' },
-    tier = 2,
+    tier = 3,
   },
 
   solidity = {
@@ -2003,7 +2013,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   soql = {
@@ -2039,6 +2049,7 @@ M.configs = {
     install_info = {
       url = 'https://github.com/BonaBeavis/tree-sitter-sparql',
       files = { 'src/parser.c' },
+      generate_from_json = true,
     },
     maintainers = { '@BonaBeavis' },
     tier = 3,
@@ -2049,6 +2060,7 @@ M.configs = {
       url = 'https://github.com/derekstride/tree-sitter-sql',
       files = { 'src/parser.c', 'src/scanner.c' },
       branch = 'gh-pages',
+      generate_from_json = true,
     },
     maintainers = { '@derekstride' },
     tier = 3,
@@ -2056,7 +2068,7 @@ M.configs = {
 
   squirrel = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-squirrel',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-squirrel',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -2065,7 +2077,7 @@ M.configs = {
 
   ssh_config = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-ssh-config',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-ssh-config',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -2074,8 +2086,9 @@ M.configs = {
 
   starlark = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-starlark',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-starlark',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@amaanq' },
     tier = 2,
@@ -2087,13 +2100,14 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq' },
-    tier = 2,
+    tier = 3,
   },
 
   styled = {
     install_info = {
       url = 'https://github.com/mskelton/tree-sitter-styled',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@mskelton' },
     tier = 3,
@@ -2121,6 +2135,7 @@ M.configs = {
     install_info = {
       url = 'https://github.com/tree-sitter-grammars/tree-sitter-svelte',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@amaanq' },
     requires = { 'html_tags' },
@@ -2166,7 +2181,7 @@ M.configs = {
 
   tablegen = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-tablegen',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-tablegen',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -2187,6 +2202,7 @@ M.configs = {
     install_info = {
       url = 'https://github.com/vrischmann/tree-sitter-templ',
       files = { 'src/parser.c', 'src/scanner.c' },
+      generate_from_json = true,
     },
     maintainers = { '@vrischmann' },
     tier = 3,
@@ -2223,7 +2239,7 @@ M.configs = {
 
   thrift = {
     install_info = {
-      url = 'https://github.com/duskmoon314/tree-sitter-thrift',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-thrift',
       files = { 'src/parser.c' },
     },
     maintainers = { '@amaanq', '@duskmoon314' },
@@ -2263,22 +2279,22 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@arnarg' },
-    tier = 4,
+    tier = 3,
   },
 
   toml = {
     install_info = {
-      url = 'https://github.com/ikatyang/tree-sitter-toml',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-toml',
       files = { 'src/parser.c', 'src/scanner.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@tk-shirasaka' },
-    tier = 3,
+    tier = 2,
   },
 
   tsv = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-csv',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-csv',
       files = { 'src/parser.c' },
       location = 'tsv',
     },
@@ -2291,7 +2307,7 @@ M.configs = {
       url = 'https://github.com/tree-sitter/tree-sitter-typescript',
       files = { 'src/parser.c', 'src/scanner.c' },
       location = 'tsx',
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@steelsojka' },
     requires = { 'ecma', 'jsx', 'typescript' },
@@ -2321,7 +2337,7 @@ M.configs = {
       url = 'https://github.com/tree-sitter/tree-sitter-typescript',
       files = { 'src/parser.c', 'src/scanner.c' },
       location = 'typescript',
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@steelsojka' },
     requires = { 'ecma' },
@@ -2348,7 +2364,7 @@ M.configs = {
 
   udev = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-udev',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-udev',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -2357,11 +2373,11 @@ M.configs = {
 
   ungrammar = {
     install_info = {
-      url = 'https://github.com/Philipp-M/tree-sitter-ungrammar',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-ungrammar',
       files = { 'src/parser.c' },
     },
     maintainers = { '@Philipp-M', '@amaanq' },
-    tier = 3,
+    tier = 2,
   },
 
   unison = {
@@ -2371,7 +2387,7 @@ M.configs = {
       generate = true,
     },
     maintainers = { '@tapegram' },
-    tier = 4,
+    tier = 3,
   },
 
   usd = {
@@ -2385,7 +2401,7 @@ M.configs = {
 
   uxntal = {
     install_info = {
-      url = 'https://github.com/amaanq/tree-sitter-uxntal',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-uxntal',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@amaanq' },
@@ -2426,7 +2442,7 @@ M.configs = {
       files = { 'src/parser.c' },
     },
     maintainers = { '@zegervdv' },
-    tier = 3,
+    tier = 2,
   },
 
   vhs = {
@@ -2440,7 +2456,7 @@ M.configs = {
 
   vim = {
     install_info = {
-      url = 'https://github.com/neovim/tree-sitter-vim',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-vim',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@clason' },
@@ -2461,6 +2477,7 @@ M.configs = {
       url = 'https://github.com/tree-sitter-grammars/tree-sitter-vue',
       files = { 'src/parser.c', 'src/scanner.c' },
       branch = 'main',
+      generate_from_json = true,
     },
     maintainers = { '@WhyNotHugo', '@lucario387' },
     requires = { 'html_tags' },
@@ -2487,9 +2504,9 @@ M.configs = {
 
   wgsl_bevy = {
     install_info = {
-      url = 'https://github.com/theHamsta/tree-sitter-wgsl-bevy',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-wgsl-bevy',
       files = { 'src/parser.c', 'src/scanner.c' },
-      generate_requires_npm = true,
+      generate_from_json = true,
     },
     maintainers = { '@theHamsta' },
     tier = 2,
@@ -2503,9 +2520,10 @@ M.configs = {
     maintainers = { '@liamwh' },
     tier = 3,
   },
+
   xcompose = {
     install_info = {
-      url = 'https://github.com/ObserverOfTime/tree-sitter-xcompose',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-xcompose',
       files = { 'src/parser.c' },
     },
     maintainers = { '@ObserverOfTime' },
@@ -2543,11 +2561,11 @@ M.configs = {
 
   yuck = {
     install_info = {
-      url = 'https://github.com/Philipp-M/tree-sitter-yuck',
+      url = 'https://github.com/tree-sitter-grammars/tree-sitter-yuck',
       files = { 'src/parser.c', 'src/scanner.c' },
     },
     maintainers = { '@Philipp-M', '@amaanq' },
-    tier = 3,
+    tier = 2,
   },
 
   zathurarc = {
@@ -2585,12 +2603,11 @@ function M.get_available(tier)
       parsers
     )
   end
-  if vim.fn.executable('tree-sitter') == 0 or vim.fn.executable('node') == 0 then
+  if vim.fn.executable('tree-sitter') == 0 then
     parsers = vim.tbl_filter(
       --- @param p string
       function(p)
-        return M.configs[p].install_info ~= nil
-          and not M.configs[p].install_info.requires_generate_from_grammar
+        return M.configs[p].install_info ~= nil and not M.configs[p].install_info.generate
       end,
       parsers
     )

--- a/scripts/update-readme.lua
+++ b/scripts/update-readme.lua
@@ -15,8 +15,8 @@ table.sort(sorted_parsers, function(a, b)
 end)
 
 local generated_text = [[
-Language | Tier | Queries | CLI | NPM | Maintainer
--------- |:----:|:-------:|:---:|:---:| ----------
+Language | Tier | Queries | CLI | Maintainer
+-------- |:----:|:-------:|:---:| ----------
 ]]
 local footnotes = ''
 
@@ -60,11 +60,6 @@ for _, v in ipairs(sorted_parsers) do
   -- CLI
   generated_text = generated_text
     .. (p.install_info and p.install_info.requires_generate_from_grammar and '✓' or '')
-    .. ' | '
-
-  -- NPM
-  generated_text = generated_text
-    .. (p.install_info and p.install_info.generate_requires_npm and '✓' or '')
     .. ' | '
 
   -- Maintainer


### PR DESCRIPTION
Problem: Many parsers require node/npm to evaluate the `grammar.js` before being able to generate a parser from it.

Solution: Generate from `grammar.json` instead, which is fully resolved. Drops `node` and `npm` as (optional) requirements for nvim-treesitter.

Note that this requires parsers to commit the generated json **iff** the grammar requires evaluation (which is currently the case for all tracked languages).

Part #2 of my series of PRs simplifying the install code. While testing this, I found out that a good 20% of the listed parsers actually fail to generate from grammar, mostly due to breaking changes in `tree-sitter` that parsers didn't adapt to. The failures roughly fall into three classes:

* **Invalid regex:** Upstream switched to Rust regex, so the common `escape_sequence` pattern `/u{[\da-fA-F]+}/` now needs to escape the braces: `/u\{[\da-fA-F]+\}/`. This affects

- [ ] bass
- [ ] blueprint
- [ ] dart
- [x] fennel
- [ ] fsh
- [ ] nasm
- [ ] qmljs
- [ ] r
- [ ] rbs
- [ ] smithy
- [ ] supercollider
- [ ] usd

* **Invalid `package.json`:** Upstream now errors out if the `package.json` doesn't contain a `"tree-sitter"` key. This should only affect generating bindings (which we don't), so this is in fact an upstream bug. Nevertheless, grammars may want to fix that for other users. This affects

- [ ] beancount
- [ ] comment
- [ ] eds
- [ ] elvish
- [ ] gdscript
- [ ] godot_resource
- [ ] gowork
- [ ] graphql
- [ ] hjson
- [ ] htmldjango
- [ ] jq
- [ ] json5
- [ ] jsonc
- [ ] kusto
- [ ] liquid
- [ ] menhir
- [ ] nim_format_string
- [ ] org
- [ ] passwd
- [ ] pioasm
- [ ] prisma
- [ ] prql
- [ ] rnoweb
- [ ] surface
- [ ] turtle
- [ ] verilog
- [ ] yang

* If  there is a `tree-sitter` key, it must be an array: ` "tree-sitter": [{...}]`, not `"tree-sitter": {...}`. This affects

- [ ] angular
- [ ] cooklang

* **Upstream bug**: (probably https://github.com/tree-sitter/tree-sitter/issues/768)

- [ ] haskell_persistent

