### PR TITLE
feat: import statement folds for common languages

### DIFF
--- a/queries/c/folds.scm
+++ b/queries/c/folds.scm
@@ -16,6 +16,7 @@
   (preproc_function_def)
   (initializer_list)
   (gnu_asm_expression)
+  (preproc_include)+
 ] @fold
 
 (compound_statement

--- a/queries/c_sharp/folds.scm
+++ b/queries/c_sharp/folds.scm
@@ -8,4 +8,7 @@ accessors: (accessor_list) @fold
 
 initializer: (initializer_expression) @fold
 
-(block) @fold
+[
+  (block)
+  (using_directive)+
+] @fold

--- a/queries/css/folds.scm
+++ b/queries/css/folds.scm
@@ -1,1 +1,4 @@
-(rule_set) @fold
+[
+  (rule_set)
+  (import_statement)+
+] @fold

--- a/queries/ecma/folds.scm
+++ b/queries/ecma/folds.scm
@@ -13,7 +13,7 @@
   (switch_statement)
   (switch_case)
   (switch_default)
-  (import_statement)
+  (import_statement)+
   (if_statement)
   (try_statement)
   (catch_clause)

--- a/queries/haskell/folds.scm
+++ b/queries/haskell/folds.scm
@@ -2,4 +2,5 @@
   (exp_apply)
   (exp_do)
   (function)
+  (import)+
 ] @fold

--- a/queries/java/folds.scm
+++ b/queries/java/folds.scm
@@ -4,4 +4,5 @@
   (constructor_declaration)
   (argument_list)
   (annotation_argument_list)
+  (import_declaration)+
 ] @fold

--- a/queries/python/folds.scm
+++ b/queries/python/folds.scm
@@ -21,3 +21,8 @@
   (dictionary)
   (string)
 ] @fold
+
+[
+  (import_statement)
+  (import_from_statement)
+]+ @fold

--- a/queries/rust/folds.scm
+++ b/queries/rust/folds.scm
@@ -9,7 +9,7 @@
   (type_item)
   (union_item)
   (const_item)
-  (use_declaration)
+  (use_declaration)+
   (let_declaration)
   (loop_expression)
   (for_expression)


### PR DESCRIPTION
Some fold queries for import statements (or the equivalent) across some common languages. Pre-0.9 nvim is unaffected by these queries, except in cases (like the rust one) where the quantifier was added to a node already in the fold set. In these cases the fold will no longer apply to that node. I think this isn't too big a deal, but feel free to suggest only partially merging if it is :+1:

Also I think these are the only additions needed for the parsers bundled in neovim, so once they are upstreamed, there should be nothing left to do