### PR TITLE
feat!: Iterate filetype parts and search for available lang

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2393,10 +2393,17 @@ function M.ft_to_lang(ft)
   local result = get_lang(ft)
   if result then
     return result
-  else
-    ft = vim.split(ft, ".", { plain = true })[1]
-    return get_lang(ft) or ft
   end
+
+  local parts = vim.split(ft, ".", { plain = true })
+  local i = 1
+  local lang = nil
+  while lang == nil and parts[i] do
+    lang = get_lang(parts[i])
+    i = i + 1
+  end
+
+  return lang or parts[1]
 end
 
 -- Get a list of all available parsers


### PR DESCRIPTION
Like mentioned here: https://github.com/nvim-treesitter/nvim-treesitter/issues/6497

We could iterate over the different file types, separated by `.`, and take the first one that is available.