### PR TITLE
fix(php): parameter and operator touch-ups

### DIFF
--- a/queries/php_only/highlights.scm
+++ b/queries/php_only/highlights.scm
@@ -317,10 +317,12 @@
   ])
 
 ; Parameters
-[
-  (simple_parameter)
-  (variadic_parameter)
-] @variable.parameter
+(variadic_parameter
+  "..." @operator
+  name: (variable_name) @variable.parameter)
+
+(simple_parameter
+  name: (variable_name) @variable.parameter)
 
 (argument
   (name) @variable.parameter)
@@ -362,7 +364,9 @@
 (attribute_list) @attribute
 
 ; Conditions ( ? : )
-(conditional_expression) @keyword.conditional
+(conditional_expression
+  "?" @keyword.conditional.ternary
+  ":" @keyword.conditional.ternary)
 
 ; Directives
 (declare_directive

--- a/tests/query/highlights/php/types.php
+++ b/tests/query/highlights/php/types.php
@@ -2,7 +2,7 @@
 
 function b(int $a, string $b): Foo\Dog {}
 //         ^^^ @type.builtin
-//             ^^ @variable
+//             ^^ @variable.parameter
 //                 ^^^^^^ @type.builtin
 //                             ^^^ @module
 //                                 ^^^ @type

--- a/tests/query/highlights/php/variables.php
+++ b/tests/query/highlights/php/variables.php
@@ -2,7 +2,7 @@
 
 class A {
   public function foo(self $a): self {
-//                          ^ @variable
+//                          ^ @variable.parameter
     new self();
 //      ^^^^ @constructor
     new static();


### PR DESCRIPTION
Using italics to show capture ranges easier. Basically the parameter and ternary highlights were being too generous (and also not specific enough so they were being overridden)
Before:
![Screenshot_20240423_105501](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/cd96f71b-2cdc-4b9c-866d-4f2eb500e75b)
After:
![Screenshot_20240423_105402](https://github.com/nvim-treesitter/nvim-treesitter/assets/55766287/53d6c522-cf6f-48db-a078-f0587b971116)
