### PR TITLE
feat(qml): add back `ecma` inheritance

### DIFF
--- a/queries/qmljs/highlights.scm
+++ b/queries/qmljs/highlights.scm
@@ -1,4 +1,5 @@
-; temporarily removed the ecma inherit due to it breaking
+; inherits: ecma
+
 "pragma" @keyword.import
 
 ; Annotations
@@ -67,40 +68,6 @@
   (nested_identifier
     (identifier) @module))
 
-; Properties
-;-----------
-(property_identifier) @property
-
-; function
-(call_expression
-  function: (member_expression
-    object: (identifier) @variable
-    property: (property_identifier) @function))
-
-; js
-; Literals
-;---------
-[
-  (true)
-  (false)
-] @boolean
-
-[
-  (null)
-  (undefined)
-] @constant.builtin
-
-(comment) @comment @spell
-
-[
-  (string)
-  (template_string)
-] @string
-
-(regex) @string.regexp
-
-(number) @number
-
 ; Tokens
 ;-------
 [
@@ -117,9 +84,6 @@
 (type_identifier) @type
 
 (predefined_type) @type.builtin
-
-((identifier) @type
-  (#lua-match? @type "^%u"))
 
 (type_arguments
   "<" @punctuation.bracket
@@ -142,8 +106,9 @@
   "export"
   "implements"
   "interface"
-  "keyof"
   "namespace"
   "type"
   "override"
 ] @keyword
+
+"keyof" @keyword.operator

--- a/queries/qmljs/injections.scm
+++ b/queries/qmljs/injections.scm
@@ -1,0 +1,1 @@
+; inherits: ecma


### PR DESCRIPTION
Fixed after the grammar dependencies were updated. This time inheritance is given to the injections queries also.