### PR TITLE
make sass to be highlighted in vue files

### DIFF
--- a/queries/vue/injections.scm
+++ b/queries/vue/injections.scm
@@ -20,7 +20,7 @@
         (attribute_value) @_scss)))
   (raw_text) @injection.content
   (#eq? @_lang "lang")
-  (#any-of? @_scss "less" "postcss")
+  (#any-of? @_scss "less" "postcss" "sass")
   (#set! injection.language "scss"))
 
 ; <script lang="js">


### PR DESCRIPTION
The reason for this patch is that I found it to be impossible to find instructions in internet on how to enable `sass` syntax highlight for `vue` files.
I spent couple of hours both googling it and asking chart-gpt-4 how to do this. 

Since there is no `sass` parser for Treesitter lets use `css` or `scss` if such is available. It is not ideal solution, but it is so much better to have it this way than to have no syntax highlighting at all.

before patch
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/134610/c69525c9-6603-450c-bb8b-510e077b7e30)

after patch
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/134610/4374df27-f6bb-4a8b-8ddf-9da2f663080d)
