### PR TITLE
Fix compact constructor highlights for Java

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -87,6 +87,9 @@
 (constructor_declaration
   name: (identifier) @type)
 
+(compact_constructor_declaration
+  name: (identifier) @type)
+
 (type_identifier) @type
 
 ((type_identifier) @type.builtin


### PR DESCRIPTION
This makes the record name in record constructors highlight properly because they are currently highlighted as `@variable` and not `@type`