### PR TITLE
Deactivate spelling in shebangs

### DIFF
--- a/queries/awk/highlights.scm
+++ b/queries/awk/highlights.scm
@@ -31,7 +31,7 @@
 
 ((program
   .
-  (comment) @keyword.directive)
+  (comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^#!/"))
 
 (ns_qualified_name

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -228,5 +228,5 @@
 
 ((program
   .
-  (comment) @keyword.directive)
+  (comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^#!/"))

--- a/queries/cmake/highlights.scm
+++ b/queries/cmake/highlights.scm
@@ -219,5 +219,5 @@
 
 ((source_file
   .
-  (line_comment) @keyword.directive)
+  (line_comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^#!/"))

--- a/queries/fish/highlights.scm
+++ b/queries/fish/highlights.scm
@@ -172,5 +172,5 @@
 
 ((program
   .
-  (comment) @keyword.directive)
+  (comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^#!/"))

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -332,8 +332,8 @@
   (comment_environment)
 ] @comment @spell
 
-((line_comment) @keyword.directive
+((line_comment) @keyword.directive @nospell
   (#lua-match? @keyword.directive "^%% !TeX"))
 
-((line_comment) @keyword.directive
+((line_comment) @keyword.directive @nospell
   (#lua-match? @keyword.directive "^%%&"))

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -252,7 +252,7 @@
 (keyval_expression
   hash: (_) @variable)
 
-(comment) @comment
+(comment) @comment @spell
 
 [
   "=>"

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -1,6 +1,6 @@
 ((source_file
   .
-  (comment) @keyword.directive)
+  (comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^#!/"))
 
 [

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -188,7 +188,7 @@
 
 ((module
   .
-  (comment) @keyword.directive)
+  (comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^#!/"))
 
 (string) @string

--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -53,17 +53,17 @@
   .
   (comment)*
   .
-  (comment) @keyword.import)
+  (comment) @keyword.import @nospell)
   (#lua-match? @keyword.import "^;+ *inherits *:"))
 
 ((program
   .
   (comment)*
   .
-  (comment) @keyword.directive)
+  (comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^;+ *extends *$"))
 
-((comment) @keyword.directive
+((comment) @keyword.directive @nospell
   (#lua-match? @keyword.directive "^;+%s*format%-ignore%s*$"))
 
 ((predicate

--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -15,7 +15,7 @@
 
 ((program
   .
-  (comment) @keyword.directive)
+  (comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^#!/"))
 
 (identifier) @variable

--- a/queries/starlark/highlights.scm
+++ b/queries/starlark/highlights.scm
@@ -171,7 +171,7 @@
 
 ((module
   .
-  (comment) @keyword.directive)
+  (comment) @keyword.directive @nospell)
   (#lua-match? @keyword.directive "^#!/"))
 
 (string) @string

--- a/queries/tablegen/highlights.scm
+++ b/queries/tablegen/highlights.scm
@@ -152,5 +152,5 @@
   (multiline_comment)
 ] @comment @spell
 
-((comment) @keyword.directive
+((comment) @keyword.directive @nospell
   (#lua-match? @keyword.directive "^.*RUN"))

--- a/queries/thrift/highlights.scm
+++ b/queries/thrift/highlights.scm
@@ -238,5 +238,5 @@
 ((comment) @comment.documentation
   (#lua-match? @comment.documentation "^///$"))
 
-((comment) @keyword.directive
+((comment) @keyword.directive @nospell
   (#lua-match? @keyword.directive "#!.*"))


### PR DESCRIPTION
This deactivates spell checking in the following languages' shebangs:
- awk
- bash
- cmake
- fish
- perl
- python
- r
- starlark

Also it activates spelling in perl comments in the first place.