### PR TITLE
feat(php): add highlights for scoped_property_access

### DIFF
--- a/queries/php_only/highlights.scm
+++ b/queries/php_only/highlights.scm
@@ -249,6 +249,16 @@
   ]
   (name) @constant)
 
+(scoped_property_access_expression
+  scope: [
+    (name) @type
+    (qualified_name
+      (name) @type)
+  ])
+
+(scoped_property_access_expression
+  name: (variable_name) @variable.member)
+
 (trait_declaration
   name: (name) @type)
 

--- a/tests/query/highlights/php/variables.php
+++ b/tests/query/highlights/php/variables.php
@@ -23,5 +23,8 @@ class A {
 //         ^^^ @variable.member
     $this->foo(a: 5);
 //             ^ @variable.parameter
+    A::$foo::$bar;
+//      ^^^ @variable.member
+//            ^^^ @variable.member
   }
 }


### PR DESCRIPTION
Hello!

I noticed that scoped_property_access expressions weren't being highlighted:

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/4176520/a13f1b08-25d0-4152-aaeb-b8007f754148)

This PR adds those highlights:

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/4176520/da615e22-58af-4d9b-a23d-b3bca726ece1)


I had to use two separate queries in order to get recursive expression to work, with one query `$bar` wasn't getting highlighted.

Thanks!