### PR TITLE
feat: add support for Tact

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [systemtap](https://github.com/ok-ryoko/tree-sitter-systemtap) (maintained by @ok-ryoko)
 - [x] [t32](https://gitlab.com/xasc/tree-sitter-t32.git) (maintained by @xasc)
 - [x] [tablegen](https://github.com/amaanq/tree-sitter-tablegen) (maintained by @amaanq)
+- [x] [tact](https://github.com/tact-lang/tree-sitter-tact) (maintained by @novusnota)
 - [x] [tcl](https://github.com/tree-sitter-grammars/tree-sitter-tcl) (maintained by @lewis6991)
 - [x] [teal](https://github.com/euclidianAce/tree-sitter-teal) (maintained by @euclidianAce)
 - [x] [templ](https://github.com/vrischmann/tree-sitter-templ) (maintained by @vrischmann)

--- a/lockfile.json
+++ b/lockfile.json
@@ -698,6 +698,9 @@
   "tablegen": {
     "revision": "6b7eb096621443627cc5e29c8c34ff1fde482cf3"
   },
+  "tact": {
+    "revision": "83d5de4c0566ce4415c30cd4633e4ebb09a1d6b8"
+  },
   "tcl": {
     "revision": "8784024358c233efd0f3a6fd9e7a3c5852e628bc"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2033,6 +2033,14 @@ list.tablegen = {
   maintainers = { "@amaanq" },
 }
 
+list.tact = {
+  install_info = {
+    url = "https://github.com/tact-lang/tree-sitter-tact",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@novusnota" },
+}
+
 list.teal = {
   install_info = {
     url = "https://github.com/euclidianAce/tree-sitter-teal",

--- a/queries/tact/folds.scm
+++ b/queries/tact/folds.scm
@@ -1,0 +1,15 @@
+; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#folds
+[
+  ; (…, …)
+  (parameter_list)
+  (argument_list)
+  ; {…, …}
+  (instance_argument_list)
+  ; {…; …}
+  (message_body)
+  (struct_body)
+  (contract_body)
+  (trait_body)
+  (function_body)
+  (block_statement)
+] @fold

--- a/queries/tact/folds.scm
+++ b/queries/tact/folds.scm
@@ -1,4 +1,6 @@
 [
+  ; import …
+  (import_statement)+
   ; (…, …)
   (parameter_list)
   (argument_list)

--- a/queries/tact/folds.scm
+++ b/queries/tact/folds.scm
@@ -1,4 +1,3 @@
-; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#folds
 [
   ; (…, …)
   (parameter_list)

--- a/queries/tact/highlights.scm
+++ b/queries/tact/highlights.scm
@@ -96,7 +96,7 @@
   (#any-of? @type.builtin "Address" "Bool" "Builder" "Cell" "Int" "Slice" "String" "StringBuilder"))
 
 (tlb_serialization
-  "as" @keyword.storage
+  "as" @keyword.type
   type: (identifier) @type.builtin
   (#any-of? @type.builtin
     "int8" "int16" "int32" "int64" "int128" "int256" "int257" "uint8" "uint16" "uint32" "uint64"

--- a/queries/tact/highlights.scm
+++ b/queries/tact/highlights.scm
@@ -93,13 +93,13 @@
   ">" @punctuation.bracket)
 
 ((type_identifier) @type.builtin
-  (#match? @type.builtin "^(Address|Bool|Builder|Cell|Int|Slice|String|StringBuilder)$"))
+  (#any-of? @type.builtin "Address" "Bool" "Builder" "Cell" "Int" "Slice" "String" "StringBuilder"))
 
 (tlb_serialization
   "as" @keyword.storage
   type: (identifier) @type.builtin
-  (#match? @type.builtin
-    "^(int8|int16|int32|int64|int128|int256|int257|uint8|uint16|uint32|uint64|uint128|uint256|coins|remaining|bytes32|bytes64)$"))
+  (#any-of? @type.builtin
+    "int8" "int16" "int32" "int64" "int128" "int256" "int257" "uint8" "uint16" "uint32" "uint64" "uint128" "uint256" "coins" "remaining" "bytes32" "bytes64"))
 
 ; string
 ; ------
@@ -128,8 +128,8 @@
 (null) @constant.builtin
 
 ((identifier) @constant.builtin
-  (#match? @constant.builtin
-    "^(SendBounceIfActionFail|SendPayGasSeparately|SendIgnoreErrors|SendDestroyIfZero|SendRemainingValue|SendRemainingBalance|ReserveExact|ReserveAllExcept|ReserveAtMost|ReserveAddOriginalBalance|ReserveInvertSign|ReserveBounceIfActionFail)$"))
+  (#any-of? @constant.builtin
+    "SendBounceIfActionFail" "SendPayGasSeparately" "SendIgnoreErrors" "SendDestroyIfZero" "SendRemainingValue" "SendRemainingBalance" "ReserveExact" "ReserveAllExcept" "ReserveAtMost" "ReserveAddOriginalBalance" "ReserveInvertSign" "ReserveBounceIfActionFail"))
 
 ; property
 ; --------
@@ -197,7 +197,7 @@
   "override"
   "inline"
   "abstract"
-] @keyword.storage
+] @keyword.modifier
 
 ; keyword.repeat
 ; --------------
@@ -280,8 +280,8 @@
 ; ----------------
 (static_call_expression
   name: (identifier) @function.builtin
-  (#match? @function.builtin
-    "^(log|log2|send|sender|require|now|myBalance|myAddress|newAddress|contractAddress|contractAddressExt|emit|cell|ton|dump|dumpStack|beginString|beginComment|beginTailString|beginStringFromBuilder|beginCell|emptyCell|randomInt|random|checkSignature|checkDataSignature|sha256|min|max|abs|pow|pow2|throw|nativeThrowWhen|nativeThrowUnless|getConfigParam|nativeRandomize|nativeRandomizeLt|nativePrepareRandom|nativeRandom|nativeRandomInterval|nativeReserve)$"))
+  (#any-of? @function.builtin
+    "log" "log2" "send" "sender" "require" "now" "myBalance" "myAddress" "newAddress" "contractAddress" "contractAddressExt" "emit" "cell" "ton" "dump" "dumpStack" "beginString" "beginComment" "beginTailString" "beginStringFromBuilder" "beginCell" "emptyCell" "randomInt" "random" "checkSignature" "checkDataSignature" "sha256" "min" "max" "abs" "pow" "pow2" "throw" "nativeThrowWhen" "nativeThrowUnless" "getConfigParam" "nativeRandomize" "nativeRandomizeLt" "nativePrepareRandom" "nativeRandom" "nativeRandomInterval" "nativeReserve"))
 
 ; comment
 ; -------

--- a/queries/tact/highlights.scm
+++ b/queries/tact/highlights.scm
@@ -1,7 +1,3 @@
-; NOTE: Neovim's highlight order differs from Tree-sitter's and Helix's,
-; NOTE: as broad captures should be placed first, narrow queries - second.
-; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#highlights
-; ----------------------------------------------------------------------------------------------
 ; variable
 ; --------
 (identifier) @variable

--- a/queries/tact/highlights.scm
+++ b/queries/tact/highlights.scm
@@ -1,0 +1,298 @@
+; NOTE: Neovim's highlight order differs from Tree-sitter's and Helix's,
+; NOTE: as broad captures should be placed first, narrow queries - second.
+; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#highlights
+; ----------------------------------------------------------------------------------------------
+; variable
+; --------
+(identifier) @variable
+
+; variable.builtin
+; ----------------
+(self) @variable.builtin
+
+; variable.parameter
+; ------------------
+(parameter
+  name: (identifier) @variable.parameter)
+
+; punctuation.delimiter
+; ---------------------
+[
+  ";"
+  ","
+  "."
+  ":"
+  "?"
+] @punctuation.delimiter
+
+; punctuation.bracket
+; -------------------
+[
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket
+
+; operator
+; --------
+[
+  "-"
+  "-="
+  "+"
+  "+="
+  "*"
+  "*="
+  "/"
+  "/="
+  "%"
+  "%="
+  "="
+  "=="
+  "!"
+  "!="
+  "!!"
+  "<"
+  "<="
+  "<<"
+  ">"
+  ">="
+  ">>"
+  "&"
+  "|"
+  "^"
+  "&&"
+  "||"
+] @operator
+
+; constructor
+; -----------
+(instance_expression
+  name: (identifier) @constructor)
+
+(initOf
+  name: (identifier) @constructor)
+
+; type
+; ----
+(type_identifier) @type
+
+; type.builtin
+; ------------
+((identifier) @type.builtin
+  (#eq? @type.builtin "SendParameters"))
+
+(bounced_type
+  "bounced" @type.builtin
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+
+(map_type
+  "map" @type.builtin
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+
+((type_identifier) @type.builtin
+  (#match? @type.builtin "^(Address|Bool|Builder|Cell|Int|Slice|String|StringBuilder)$"))
+
+(tlb_serialization
+  "as" @keyword.storage
+  type: (identifier) @type.builtin
+  (#match? @type.builtin
+    "^(int8|int16|int32|int64|int128|int256|int257|uint8|uint16|uint32|uint64|uint128|uint256|coins|remaining|bytes32|bytes64)$"))
+
+; string
+; ------
+(string) @string
+
+; string.escape
+; -------------
+(escape_sequence) @string.escape
+
+; string.special.path
+; -------------------
+(import_statement
+  library: (string) @string.special.path)
+
+; boolean
+; -------
+(boolean) @boolean
+
+; constant
+; --------
+(constant
+  name: (identifier) @constant)
+
+; constant.builtin
+; ----------------
+(null) @constant.builtin
+
+((identifier) @constant.builtin
+  (#match? @constant.builtin
+    "^(SendBounceIfActionFail|SendPayGasSeparately|SendIgnoreErrors|SendDestroyIfZero|SendRemainingValue|SendRemainingBalance|ReserveExact|ReserveAllExcept|ReserveAtMost|ReserveAddOriginalBalance|ReserveInvertSign|ReserveBounceIfActionFail)$"))
+
+; property
+; --------
+(instance_argument
+  name: (identifier) @property)
+
+(lvalue
+  (_)
+  (_) @property)
+
+(field_access_expression
+  name: (identifier) @property)
+
+(trait_body
+  (constant
+    name: (identifier) @property))
+
+(contract_body
+  (constant
+    name: (identifier) @property))
+
+(field
+  name: (identifier) @property)
+
+; number
+; ------
+(integer) @number
+
+; keyword
+; -------
+[
+  "contract"
+  "trait"
+  "struct"
+  "message"
+  "with"
+  "const"
+  "let"
+  ; "public" ; -- not used, but declared in grammar.ohm
+  ; "extend" ; -- not used, but declared in grammar.ohm
+] @keyword
+
+; keyword.function
+; ----------------
+[
+  "fun"
+  "native"
+] @keyword.function
+
+; keyword.operator
+; ----------------
+"initOf" @keyword.operator
+
+; keyword.import
+; --------------
+"import" @keyword.import
+
+; keyword.storage
+; ---------------
+[
+  "get"
+  "mutates"
+  "extends"
+  "virtual"
+  "override"
+  "inline"
+  "abstract"
+] @keyword.storage
+
+; keyword.repeat
+; --------------
+(foreach_statement
+  .
+  (_)
+  .
+  (_)
+  .
+  "in" @keyword.repeat)
+
+[
+  "while"
+  "repeat"
+  "do"
+  "until"
+  "foreach"
+] @keyword.repeat
+
+; keyword.return
+; --------------
+"return" @keyword.return
+
+; keyword.exception
+; -----------------
+[
+  "try"
+  "catch"
+] @keyword.exception
+
+; keyword.conditional
+; -------------------
+[
+  "if"
+  "else"
+] @keyword.conditional
+
+; keyword.directive.define
+; ------------------------
+"primitive" @keyword.directive.define
+
+; function
+; --------
+(native_function
+  name: (identifier) @function)
+
+(static_function
+  name: (identifier) @function)
+
+(func_identifier) @function
+
+; function.method
+; ---------------
+(init_function
+  "init" @function.method)
+
+(receive_function
+  "receive" @function.method)
+
+(bounced_function
+  "bounced" @function.method)
+
+(external_function
+  "external" @function.method)
+
+(function
+  name: (identifier) @function.method)
+
+; function.call
+; -------------
+(static_call_expression
+  name: (identifier) @function.call)
+
+; function.method.call
+; ---------------
+(method_call_expression
+  name: (identifier) @function.method.call)
+
+; function.builtin
+; ----------------
+(static_call_expression
+  name: (identifier) @function.builtin
+  (#match? @function.builtin
+    "^(log|log2|send|sender|require|now|myBalance|myAddress|newAddress|contractAddress|contractAddressExt|emit|cell|ton|dump|dumpStack|beginString|beginComment|beginTailString|beginStringFromBuilder|beginCell|emptyCell|randomInt|random|checkSignature|checkDataSignature|sha256|min|max|abs|pow|pow2|throw|nativeThrowWhen|nativeThrowUnless|getConfigParam|nativeRandomize|nativeRandomizeLt|nativePrepareRandom|nativeRandom|nativeRandomInterval|nativeReserve)$"))
+
+; comment
+; -------
+(comment) @comment @spell
+
+((comment) @comment.documentation
+  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
+
+; attribute
+; ---------
+[
+  "@name"
+  "@interface"
+] @attribute

--- a/queries/tact/highlights.scm
+++ b/queries/tact/highlights.scm
@@ -92,7 +92,7 @@
   (#any-of? @type.builtin "Address" "Bool" "Builder" "Cell" "Int" "Slice" "String" "StringBuilder"))
 
 (tlb_serialization
-  "as" @keyword.type
+  "as" @keyword
   type: (identifier) @type.builtin
   (#any-of? @type.builtin
     "int8" "int16" "int32" "int64" "int128" "int256" "int257" "uint8" "uint16" "uint32" "uint64"
@@ -133,25 +133,25 @@
 ; property
 ; --------
 (instance_argument
-  name: (identifier) @property)
+  name: (identifier) @variable.member)
 
 (lvalue
   (_)
-  (_) @property)
+  (_) @variable.member)
 
 (field_access_expression
-  name: (identifier) @property)
+  name: (identifier) @variable.member)
 
 (trait_body
   (constant
-    name: (identifier) @property))
+    name: (identifier) @variable.member))
 
 (contract_body
   (constant
-    name: (identifier) @property))
+    name: (identifier) @variable.member))
 
 (field
-  name: (identifier) @property)
+  name: (identifier) @variable.member)
 
 ; number
 ; ------

--- a/queries/tact/highlights.scm
+++ b/queries/tact/highlights.scm
@@ -99,7 +99,8 @@
   "as" @keyword.storage
   type: (identifier) @type.builtin
   (#any-of? @type.builtin
-    "int8" "int16" "int32" "int64" "int128" "int256" "int257" "uint8" "uint16" "uint32" "uint64" "uint128" "uint256" "coins" "remaining" "bytes32" "bytes64"))
+    "int8" "int16" "int32" "int64" "int128" "int256" "int257" "uint8" "uint16" "uint32" "uint64"
+    "uint128" "uint256" "coins" "remaining" "bytes32" "bytes64"))
 
 ; string
 ; ------
@@ -129,7 +130,9 @@
 
 ((identifier) @constant.builtin
   (#any-of? @constant.builtin
-    "SendBounceIfActionFail" "SendPayGasSeparately" "SendIgnoreErrors" "SendDestroyIfZero" "SendRemainingValue" "SendRemainingBalance" "ReserveExact" "ReserveAllExcept" "ReserveAtMost" "ReserveAddOriginalBalance" "ReserveInvertSign" "ReserveBounceIfActionFail"))
+    "SendBounceIfActionFail" "SendPayGasSeparately" "SendIgnoreErrors" "SendDestroyIfZero"
+    "SendRemainingValue" "SendRemainingBalance" "ReserveExact" "ReserveAllExcept" "ReserveAtMost"
+    "ReserveAddOriginalBalance" "ReserveInvertSign" "ReserveBounceIfActionFail"))
 
 ; property
 ; --------
@@ -161,16 +164,21 @@
 ; keyword
 ; -------
 [
-  "contract"
-  "trait"
-  "struct"
-  "message"
   "with"
   "const"
   "let"
   ; "public" ; -- not used, but declared in grammar.ohm
   ; "extend" ; -- not used, but declared in grammar.ohm
 ] @keyword
+
+; keyword.type
+; ------------
+[
+  "contract"
+  "trait"
+  "struct"
+  "message"
+] @keyword.type
 
 ; keyword.function
 ; ----------------
@@ -187,7 +195,7 @@
 ; --------------
 "import" @keyword.import
 
-; keyword.storage
+; keyword.modifier
 ; ---------------
 [
   "get"
@@ -281,7 +289,12 @@
 (static_call_expression
   name: (identifier) @function.builtin
   (#any-of? @function.builtin
-    "log" "log2" "send" "sender" "require" "now" "myBalance" "myAddress" "newAddress" "contractAddress" "contractAddressExt" "emit" "cell" "ton" "dump" "dumpStack" "beginString" "beginComment" "beginTailString" "beginStringFromBuilder" "beginCell" "emptyCell" "randomInt" "random" "checkSignature" "checkDataSignature" "sha256" "min" "max" "abs" "pow" "pow2" "throw" "nativeThrowWhen" "nativeThrowUnless" "getConfigParam" "nativeRandomize" "nativeRandomizeLt" "nativePrepareRandom" "nativeRandom" "nativeRandomInterval" "nativeReserve"))
+    "log" "log2" "send" "sender" "require" "now" "myBalance" "myAddress" "newAddress"
+    "contractAddress" "contractAddressExt" "emit" "cell" "ton" "dump" "dumpStack" "beginString"
+    "beginComment" "beginTailString" "beginStringFromBuilder" "beginCell" "emptyCell" "randomInt"
+    "random" "checkSignature" "checkDataSignature" "sha256" "min" "max" "abs" "pow" "pow2" "throw"
+    "nativeThrowWhen" "nativeThrowUnless" "getConfigParam" "nativeRandomize" "nativeRandomizeLt"
+    "nativePrepareRandom" "nativeRandom" "nativeRandomInterval" "nativeReserve"))
 
 ; comment
 ; -------

--- a/queries/tact/indents.scm
+++ b/queries/tact/indents.scm
@@ -1,0 +1,51 @@
+; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#indents
+; indent.begin       ; indent children when matching this node
+; ------------
+[
+  ; (..., ...)
+  (parameter_list)
+  (argument_list)
+  ; {..., ...}
+  (instance_argument_list)
+  ; {...; ...}
+  (message_body)
+  (struct_body)
+  (contract_body)
+  (trait_body)
+  (function_body)
+  (block_statement)
+  ; misc.
+  (binary_expression)
+  (ternary_expression)
+  (return_statement)
+  (static_call_expression)
+  (method_call_expression)
+] @indent.begin
+
+; indent.branch      ; dedent itself when matching this node
+; -------------
+[
+  "}"
+  ")"
+  ">"
+] @indent.branch
+
+; indent.end         ; marks the end of indented block
+; ----------
+[
+  "}"
+  ")"
+  ">"
+] @indent.end
+
+; indent.auto        ; behaves like 'autoindent' buffer option
+; -----------
+[
+  (comment)
+  (ERROR)
+] @indent.auto
+
+; indent.align       ; behaves like python aligned/hanging indent
+; indent.dedent      ; dedent children when matching this node
+; indent.ignore      ; do not indent in this node
+; indent.zero        ; sets this node at position 0 (no indent)

--- a/queries/tact/indents.scm
+++ b/queries/tact/indents.scm
@@ -1,4 +1,3 @@
-; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#indents
 ; indent.begin       ; indent children when matching this node
 ; ------------
 [

--- a/queries/tact/injections.scm
+++ b/queries/tact/injections.scm
@@ -1,4 +1,3 @@
 ; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#injections
 ((comment) @injection.content
-  (#set! injection.language "comment")
-  (#match? @injection.content "^//"))
+  (#set! injection.language "comment"))

--- a/queries/tact/injections.scm
+++ b/queries/tact/injections.scm
@@ -1,0 +1,4 @@
+; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#injections
+((comment) @injection.content
+  (#set! injection.language "comment")
+  (#match? @injection.content "^//"))

--- a/queries/tact/injections.scm
+++ b/queries/tact/injections.scm
@@ -1,3 +1,2 @@
-; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#injections
 ((comment) @injection.content
   (#set! injection.language "comment"))

--- a/queries/tact/locals.scm
+++ b/queries/tact/locals.scm
@@ -30,19 +30,19 @@
 
 ; methods (functions off of contracts and traits)
 (init_function
-  name: (identifier) @local.definition.method
+  "init" @local.definition.method
   (#set! definition.var.scope parent))
 
 (bounced_function
-  name: (identifier) @local.definition.method
+  "bounced" @local.definition.method
   (#set! definition.var.scope parent))
 
 (receive_function
-  name: (identifier) @local.definition.method
+  "receive" @local.definition.method
   (#set! definition.var.scope parent))
 
 (external_function
-  name: (identifier) @local.definition.method
+  "external" @local.definition.method
   (#set! definition.var.scope parent))
 
 (function

--- a/queries/tact/locals.scm
+++ b/queries/tact/locals.scm
@@ -1,0 +1,75 @@
+; NOTE: The following queries are NOT used for highlighting, unlike in Tree-sitter or Helix. These are more like tags.scm.
+; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#locals
+; ------------------------------------------------------------------------------------------
+; Scopes       @local.scope
+; -------------------------
+[
+  (static_function)
+  (init_function)
+  (bounced_function)
+  (receive_function)
+  (external_function)
+  (function)
+  (block_statement)
+] @local.scope
+
+; Definitions  @local.definition
+; ------------------------------
+; variables
+(let_statement
+  name: (identifier) @local.definition.var)
+
+; constants
+(constant
+  name: (identifier) @local.definition.constant)
+
+; functions
+(static_function
+  name: (identifier) @local.definition.function
+  (#set! definition.var.scope parent))
+
+; methods (functions off of contracts and traits)
+(init_function
+  name: (identifier) @local.definition.method
+  (#set! definition.var.scope parent))
+
+(bounced_function
+  name: (identifier) @local.definition.method
+  (#set! definition.var.scope parent))
+
+(receive_function
+  name: (identifier) @local.definition.method
+  (#set! definition.var.scope parent))
+
+(external_function
+  name: (identifier) @local.definition.method
+  (#set! definition.var.scope parent))
+
+(function
+  name: (identifier) @local.definition.method
+  (#set! definition.var.scope parent))
+
+; parameters
+(parameter
+  name: (identifier) @local.definition.parameter)
+
+; user-defined types (structs and messages)
+(type_identifier) @local.definition.type
+
+; fields (and properties)
+(field
+  name: (identifier) @local.definition.field)
+
+; imports
+(import_statement
+  (string) @local.definition.import)
+
+; References   @local.reference
+; -----------------------------
+(self) @local.reference
+
+(value_expression
+  (identifier) @local.reference)
+
+(lvalue
+  (identifier) @local.reference)

--- a/queries/tact/locals.scm
+++ b/queries/tact/locals.scm
@@ -1,6 +1,3 @@
-; NOTE: The following queries are NOT used for highlighting, unlike in Tree-sitter or Helix. These are more like tags.scm.
-; See: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#locals
-; ------------------------------------------------------------------------------------------
 ; Scopes       @local.scope
 ; -------------------------
 [


### PR DESCRIPTION
This adds support for [Tact](https://github.com/tact-lang/tact) language using [tree-sitter-tact](https://github.com/tact-lang/tree-sitter-tact).

The following queries are included (formatted according to [format-queries.lua](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/scripts/format-queries.lua)):
* highlights.scm
* folds.scm
* indents.scm
* injections.scm
* locals.scm