### PR TITLE
fix(commonlisp): correctly highlight quotes

### DIFF
--- a/queries/commonlisp/highlights.scm
+++ b/queries/commonlisp/highlights.scm
@@ -105,24 +105,19 @@
   (#lua-match? @variable.builtin "^[*].+[*]$"))
 
 ; quote
-"'" @string.escape
-
 (format_specifier) @string.escape
 
-(quoting_lit) @string.escape
+(quoting_lit
+  "'" @string.escape)
 
-; syntax quote
-"`" @string.escape
+(syn_quoting_lit
+  "`" @string.escape)
 
-"," @string.escape
+(unquoting_lit
+  "," @string.escape)
 
-",@" @string.escape
-
-(syn_quoting_lit) @string.escape
-
-(unquoting_lit) @none
-
-(unquote_splicing_lit) @none
+(unquote_splicing_lit
+  ",@" @string.escape)
 
 [
   "("


### PR DESCRIPTION
the previous queries caused issues like highlighting `(quoting_lit)` and `(format_directive_type "'")` twice which made them really annoying to overwrite.