### PR TITLE
fix(inko): fix highlighting of numeric call names

### DIFF
--- a/queries/inko/highlights.scm
+++ b/queries/inko/highlights.scm
@@ -190,6 +190,9 @@
   name: _ @variable.parameter)
 
 (call
-  name: _ @function)
+  name: [
+    (name)
+    (constant)
+  ] @function)
 
 (field) @variable.member


### PR DESCRIPTION
Inko allows for syntax such as `some_value.42.to_string`, where `42` is a method name. Similar to other languages that allow this (e.g. Rust), these numeric names should be highlighted as numbers instead of identifiers.

To fix this, the query to highlight call names is adjusted to only highlight "name" and "constant" nodes as the function group, ensuring the remaining possible node ("integer") continues to use the same group as regular numbers.