### PR TITLE
fix(markdown): align link with image highlights

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -33,10 +33,17 @@
   ] @markup.link
   (#set! conceal ""))
 
+[
+  (link_label)
+  (link_text)
+  (link_title)
+  (image_description)
+] @markup.link.label
+
 (inline_link
-  (link_text) @markup.link.label
-  (link_destination) @markup.link
-  (#set! @markup.link.label "url" @markup.link))
+  (link_text) @_label
+  (link_destination) @_url
+  (#set! @_label "url" @_url))
 
 ; Conceal image links
 (image
@@ -79,13 +86,6 @@
   (link_destination)
   (uri_autolink)
 ] @markup.link.url @nospell
-
-[
-  (link_label)
-  (link_text)
-  (link_title)
-  (image_description)
-] @markup.link.label
 
 ; Replace common HTML entities.
 ((entity_reference) @character.special


### PR DESCRIPTION
Right now there is a discrepancy between regular inline links and inline image link highlights: basically for something like
```markdown
[**link**](https://website.com/)
![**imglink**](https://website.com/img.png)
```

For the image link, the `@markup.strong` will take priority. For the regular link, `@markup.link.label` takes priority. This PR makes it so that in both cases the strong highlight will take precedence, and it also deduplicates some highlights by using underscore-prefixed captures