### PR TITLE
feat(lalrpop): highlight touchups, folds

### DIFF
--- a/queries/lalrpop/folds.scm
+++ b/queries/lalrpop/folds.scm
@@ -1,0 +1,5 @@
+[
+  (grammar_item)
+  (use)+
+  (action)
+] @fold

--- a/queries/lalrpop/highlights.scm
+++ b/queries/lalrpop/highlights.scm
@@ -1,3 +1,5 @@
+(comment) @comment @spell
+
 "grammar" @keyword
 
 [
@@ -8,6 +10,7 @@
 [
   "pub"
   "extern"
+  (mut)
 ] @keyword.modifier
 
 [
@@ -23,28 +26,25 @@
   ; =>
   "=>@L"
   "=>@R"
+  "="
+  "&"
 ] @operator
-
-(grammar_type_params
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
-
-(symbol
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
-
-(binding_symbol
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
 
 (binding_symbol
   name: (identifier) @variable.parameter)
+
+(annotation
+  "#" @punctuation.special)
+
+(grammar_parameter
+  (identifier) @variable.parameter)
+
+(associated_type
+  (identifier) @type)
+
+(parametrized_type
+  (path
+    (identifier) @type))
 
 (bare_symbol
   (macro
@@ -67,11 +67,17 @@
   ")"
   "["
   "]"
+  "}"
+  "{"
+  ">"
+  "<"
 ] @punctuation.bracket
 
 [
   ";"
   ":"
+  "::"
+  ","
 ] @punctuation.delimiter
 
 (lifetime

--- a/queries/lalrpop/injections.scm
+++ b/queries/lalrpop/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 ([
   (normal_action)
   (failible_action)


### PR DESCRIPTION
Adds a lot of missing highlights that weren't covered by rust injections. Reference file: https://github.com/vosen/ZLUDA/blob/bdc652f9ebcac9a79849eeee84a391a4ac107913/ptx/src/ptx.lalrpop