### PR TITLE
fix(format): fix supertypes formatting

### DIFF
--- a/scripts/format-queries.lua
+++ b/scripts/format-queries.lua
@@ -152,6 +152,22 @@ local format_queries = [[
     (anonymous_node)
     "."
   ])
+(named_node
+  name: (identifier)
+  .
+  (ERROR) @format.indent.begin
+  .
+  [
+    (list)              ; (foo [...])
+    (grouping)          ; (foo ((foo)))
+    (negated_field)     ; (foo !field)
+    (field_definition)  ; (foo field: (...))
+    (named_node)        ; (foo (bar))
+    (predicate)         ; (named_node (#set!))
+    (anonymous_node)
+    "."
+  ]
+  (#lua-match? @format.indent.begin "^/")) ; supertype nodes
 ;; Honoring comment's position within a node
 (named_node
   [


### PR DESCRIPTION
Fix the issues with formatting raised in #6580. I'm still wondering whether the parser should adapt to add a new node for supertypes, but for the mean time this will help with that.