### PR TITLE
fix(java): add highest priority to "var" keyword

### DIFF
--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -93,7 +93,8 @@
 (type_identifier) @type
 
 ((type_identifier) @type.builtin
-  (#eq? @type.builtin "var"))
+  (#eq? @type.builtin "var")
+  (#set! "priority" 155))
 
 ((method_invocation
   object: (identifier) @type)


### PR DESCRIPTION
Currently, the `var` keyword highlight will get changed depending of the right side of the equal sign, but in fact, it shouldn't do that because `var` is basically to declare a variable _without_ specifying its data type - therefor, its priority should be higher than _any_ for a consistent highlight.

### Examples

**Before this PR's changes**
<img width="135" alt="Screenshot 2024-05-06 at 15 28 43" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/59118341/888de124-4556-4a9a-9b54-4d7db70ceff3">


**After this PR's changes**
<img width="128" alt="Screenshot 2024-05-06 at 15 28 24" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/59118341/10e87870-9b21-4a58-8b60-e13f27339760">
