### PR TITLE
fix(ecma): template string injections

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -9,7 +9,7 @@
 (call_expression
   function: [
     (await_expression
-      (identifier)) @injection.language
+      (identifier) @injection.language)
     (identifier) @injection.language
   ]
   arguments: [
@@ -31,8 +31,8 @@
     (await_expression
       (identifier) @_name
       (#eq? @_name "svg"))
-    (identifier) @_name
-    (#eq? @_name "svg")
+    ((identifier) @_name
+      (#eq? @_name "svg"))
   ]
   arguments: [
     (arguments
@@ -48,8 +48,8 @@
     (await_expression
       (identifier) @_name
       (#eq? @_name "gql"))
-    (identifier) @_name
-    (#eq? @_name "gql")
+    ((identifier) @_name
+      (#eq? @_name "gql"))
   ]
   arguments: ((template_string) @injection.content
     (#offset! @injection.content 0 1 0 -1)
@@ -61,8 +61,8 @@
     (await_expression
       (identifier) @_name
       (#eq? @_name "hbs"))
-    (identifier) @_name
-    (#eq? @_name "hbs")
+    ((identifier) @_name
+      (#eq? @_name "hbs"))
   ]
   arguments: ((template_string) @injection.content
     (#offset! @injection.content 0 1 0 -1)
@@ -78,8 +78,8 @@
     (await_expression
       (identifier) @_name
       (#any-of? @_name "css" "keyframes"))
-    (identifier) @_name
-    (#any-of? @_name "css" "keyframes")
+    ((identifier) @_name
+      (#any-of? @_name "css" "keyframes"))
   ]
   arguments: ((template_string) @injection.content
     (#offset! @injection.content 0 1 0 -1)


### PR DESCRIPTION
This PR fixes a regression that used to work before #6550.

| Before (#6550) | After (This PR) |
| ------ | ----- |
| ![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/4299733/01b0b847-daf5-48d4-b6c8-37e47108e789) | ![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/4299733/c923594f-2c29-4990-b1bc-d32ac0dc4c6a) |