### PR TITLE
feat(rust): underscore match arms, parameters

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -29,7 +29,10 @@
 (mod_item
   name: (identifier) @module)
 
-(self) @variable.builtin
+[
+  (self)
+  "_"
+] @variable.builtin
 
 (label
   [
@@ -45,7 +48,10 @@
   (identifier) @function)
 
 (parameter
-  (identifier) @variable.parameter)
+  [
+    (identifier)
+    "_"
+  ] @variable.parameter)
 
 (closure_parameters
   (_) @variable.parameter)


### PR DESCRIPTION
Some missing `_` highlights. Reference:
```rust
fn test(_: i32) {
    //
}

fn main() {
    if let Some(_) = x {};
    let p = (1, 2);
    let mut a = 0;
    (_, a) = p;
    let _ = 8;
    match p {
        "hi" => {}
        _ => {}
    }
}
```
Note that this will still not highlight the underscore in `(_, a) = p;`. This could be done with an `eq?` query but I left it out because most everywhere else exposes that as a `"_"` node so maybe the parser should do it there too