### PR TITLE
fix(inko): indent call nodes

### DIFF
--- a/queries/inko/indents.scm
+++ b/queries/inko/indents.scm
@@ -7,6 +7,7 @@
   (binary)
   (block)
   (bounds)
+  (call)
   (cast)
   (class)
   (class_pattern)


### PR DESCRIPTION
This ensures that when you add a new call line in the middle of a call chain, the line is indented like so:

    foo
      .bar
      .new_line_here
      .baz

Instead of it being indented like so:

    foo
      .bar
    .new_line_here
      .baz