### PR TITLE
feat(diff): more comprehensive highlights

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -111,7 +111,7 @@
     "revision": "affb6ee38d629c9296749767ab832d69bb0d9ea8"
   },
   "diff": {
-    "revision": "710e881127512bda8157096e26c1f3e91702823a"
+    "revision": "629676fc3919606964231b2c7b9677d6998a2cb4"
   },
   "disassembly": {
     "revision": "0229c0211dba909c5d45129ac784a3f4d49c243a"

--- a/queries/diff/highlights.scm
+++ b/queries/diff/highlights.scm
@@ -12,4 +12,35 @@
 
 (location) @attribute
 
-(command) @function
+(command
+  "diff" @function
+  (argument) @variable.parameter)
+
+(filename) @string.special.path
+
+(mode) @number
+
+[
+  ".."
+  "+"
+  "++"
+  "+++"
+  "++++"
+  "-"
+  "--"
+  "---"
+  "----"
+] @punctuation.special
+
+[
+  (binary_change)
+  (similarity)
+  (file_change)
+] @label
+
+(index
+  "index" @keyword)
+
+(similarity
+  (score) @number
+  "%" @number)


### PR DESCRIPTION
More highlights for complicated diffs. Reference file:

```diff
diff --git a/CONTRIBUTING.md b/CONTRIBUTING_HERE.md
similarity index 100%
rename from CONTRIBUTING.md
rename to CONTRIBUTING_HERE.md
diff --git a/LICENSE b/LICENSE
old mode 100644
new mode 100755
diff --git a/Makefile b/Makefile
deleted file mode 100644
index 338c7546..00000000
--- a/Makefile
+++ /dev/null
@@ -1,7 +0,0 @@
-# https://github.com/luarocks/luarocks/wiki/Creating-a-Makefile-that-plays-nice-with-LuaRocks
-build:
-	echo "Do nothing"
-
-install:
-	mkdir -p $(INST_LUADIR)
-	cp -r lua/* $(INST_LUADIR)
diff --git a/hi.txt b/hi.txt
new file mode 100644
index 00000000..45b983be
--- /dev/null
+++ b/hi.txt
@@ -0,0 +1 @@
+hi
diff --git a/queries/rust/highlights.scm b/queries/rust/highlights.scm
index c392c030..1609a81a 100644
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -29,7 +29,10 @@
 (mod_item
   name: (identifier) @module)

-(self) @variable.builtin
+[
+  (self)
+  "_"
+] @variable.builtin

 (label
   [
@@ -45,7 +48,10 @@
   (identifier) @function)

 (parameter
-  (identifier) @variable.parameter)
+  [
+    (identifier)
+    "_"
+  ] @variable.parameter)

 (closure_parameters
   (_) @variable.parameter)
```