### PR TITLE
feat(zig): misc improvements

### DIFF
--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -100,6 +100,8 @@ field_constant: (IDENTIFIER) @constant
   "test"
   "opaque"
   "error"
+  "const"
+  "var"
 ] @keyword
 
 [
@@ -155,27 +157,22 @@ field_constant: (IDENTIFIER) @constant
 ] @type.builtin
 
 [
-  "const"
-  "var"
   "volatile"
   "allowzero"
   "noalias"
-] @keyword.modifier
-
-[
   "addrspace"
   "align"
   "callconv"
   "linksection"
+  "pub"
+  "inline"
+  "noinline"
+  "extern"
 ] @keyword.modifier
 
 [
   "comptime"
-  "extern"
-  "inline"
-  "noinline"
   "packed"
-  "pub"
   "threadlocal"
 ] @attribute
 
@@ -206,6 +203,7 @@ field_constant: (IDENTIFIER) @constant
   "."
   ","
   ":"
+  "=>"
 ] @punctuation.delimiter
 
 [
@@ -220,10 +218,18 @@ field_constant: (IDENTIFIER) @constant
   ")"
   "{"
   "}"
-  (Payload
-    "|")
-  (PtrPayload
-    "|")
-  (PtrIndexPayload
-    "|")
 ] @punctuation.bracket
+
+(Payload
+  "|" @punctuation.bracket)
+
+(PtrPayload
+  "|" @punctuation.bracket)
+
+(PtrIndexPayload
+  "|" @punctuation.bracket)
+
+(ParamType
+  (ErrorUnionExpr
+    (SuffixExpr
+      variable_type_function: (IDENTIFIER) @type)))


### PR DESCRIPTION
Moves some keyword highlights around, highlights parameter types and `=>`, and specifies only the `|` brackets in a payload receive the bracket highlight