### PR TITLE
feat: standardize and document export keywords

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ As languages differ quite a lot, here is a set of captures available to you when
 @keyword.coroutine         ; keywords related to coroutines (e.g. `go` in Go, `async/await` in Python)
 @keyword.function          ; keywords that define a function (e.g. `func` in Go, `def` in Python)
 @keyword.operator          ; operators that are English words (e.g. `and` / `or`)
-@keyword.import            ; keywords for including modules (e.g. `import` / `from` in Python)
+@keyword.import            ; keywords for including or exporting modules (e.g. `import` / `from` in Python)
 @keyword.type              ; keywords describing namespaces and composite types (e.g. `struct`, `enum`)
 @keyword.modifier          ; keywords modifying other constructs (e.g. `const`, `static`, `public`)
 @keyword.repeat            ; keywords related to loops (e.g. `for` / `while`)

--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -93,12 +93,13 @@
 [
   "declare"
   "typeset"
-  "export"
   "readonly"
   "local"
   "unset"
   "unsetenv"
 ] @keyword
+
+"export" @keyword.import
 
 "function" @keyword.function
 

--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -314,19 +314,9 @@
 [
   "import"
   "from"
+  "as"
+  "export"
 ] @keyword.import
-
-(export_specifier
-  "as" @keyword.import)
-
-(import_specifier
-  "as" @keyword.import)
-
-(namespace_export
-  "as" @keyword.import)
-
-(namespace_import
-  "as" @keyword.import)
 
 [
   "for"
@@ -340,7 +330,6 @@
   "break"
   "const"
   "debugger"
-  "export"
   "extends"
   "get"
   "let"

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -215,7 +215,6 @@
   "signal"
   "var"
   "onready"
-  "export"
   "setget"
   "remote"
   "master"
@@ -224,6 +223,8 @@
   "mastersync"
   "puppetsync"
 ] @keyword
+
+"export" @keyword.import
 
 [
   "enum"

--- a/queries/hare/highlights.scm
+++ b/queries/hare/highlights.scm
@@ -20,7 +20,10 @@
   (#lua-match? @constant "^[A-Z_]+$"))
 
 ; Includes
-"use" @keyword.import
+[
+  "use"
+  "export"
+] @keyword.import
 
 (use_statement
   (scoped_type_identifier
@@ -41,7 +44,6 @@
 ; Keywords
 [
   "def"
-  "export"
   "let"
 ] @keyword
 

--- a/queries/luau/highlights.scm
+++ b/queries/luau/highlights.scm
@@ -7,8 +7,9 @@
 [
   "local"
   "type"
-  "export"
 ] @keyword
+
+"export" @keyword.import
 
 (do_statement
   [

--- a/queries/make/highlights.scm
+++ b/queries/make/highlights.scm
@@ -37,8 +37,10 @@
     "|"
   ] @operator)
 
-(export_directive
-  "export" @keyword)
+[
+  "export"
+  "unexport"
+] @keyword.import
 
 (override_directive
   "override" @keyword)

--- a/queries/qmljs/highlights.scm
+++ b/queries/qmljs/highlights.scm
@@ -102,7 +102,6 @@
   "property"
   "signal"
   "declare"
-  "export"
   "implements"
   "override"
 ] @keyword

--- a/queries/slint/highlights.scm
+++ b/queries/slint/highlights.scm
@@ -184,7 +184,7 @@
 ; Keywords:
 (animate_option_identifier) @keyword
 
-(export) @keyword
+(export) @keyword.import
 
 (if_statement
   "if" @keyword.conditional)

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -7,7 +7,6 @@
 
 [
   "declare"
-  "export"
   "implements"
   "type"
   "override"
@@ -30,9 +29,6 @@
 ] @keyword.operator
 
 (as_expression
-  "as" @keyword.operator)
-
-(export_statement
   "as" @keyword.operator)
 
 (mapped_type_clause

--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -139,7 +139,10 @@ field_constant: (IDENTIFIER) @constant
   "continue"
 ] @keyword.repeat
 
-"usingnamespace" @keyword.import
+[
+  "usingnamespace"
+  "export"
+] @keyword.import
 
 [
   "try"
@@ -168,7 +171,6 @@ field_constant: (IDENTIFIER) @constant
 
 [
   "comptime"
-  "export"
   "extern"
   "inline"
   "noinline"


### PR DESCRIPTION
Many export keywords are captured as `@keyword.import`. This commit makes it so they are all captured like that, and mentions it in the documentation.