### PR TITLE
feat(slint): highlight enum members as constants

### DIFF
--- a/queries/slint/highlights.scm
+++ b/queries/slint/highlights.scm
@@ -47,6 +47,9 @@
 
 (user_type_identifier) @type
 
+(enum_block
+  (user_type_identifier) @constant)
+
 ; Functions and callbacks
 (argument) @variable.parameter
 


### PR DESCRIPTION
Reference file:
```slint
export enum CardSuit { clubs, diamonds, hearts, spade }
// vim: ft=slint
```