### PR TITLE
feat(typespec): add support for typespec

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [turtle](https://github.com/BonaBeavis/tree-sitter-turtle) (maintained by @BonaBeavis)
 - [x] [twig](https://github.com/gbprod/tree-sitter-twig) (maintained by @gbprod)
 - [x] [typescript](https://github.com/tree-sitter/tree-sitter-typescript) (maintained by @steelsojka)
+- [x] [typespec](https://github.com/happenslol/tree-sitter-typespec) (maintained by @happenslol)
 - [x] [typoscript](https://github.com/Teddytrombone/tree-sitter-typoscript) (maintained by @Teddytrombone)
 - [x] [typst](https://github.com/uben0/tree-sitter-typst) (maintained by @uben0, @RaafatTurki)
 - [x] [udev](https://github.com/ObserverOfTime/tree-sitter-udev) (maintained by @ObserverOfTime)

--- a/lockfile.json
+++ b/lockfile.json
@@ -752,6 +752,9 @@
   "typescript": {
     "revision": "7b4275d077ae196fc0ce42ab3ad091574e3ec519"
   },
+  "typespec": {
+    "revision": "fd9a83c6c0aaaff4b1354454b5b9f130f59dd553"
+  },
   "typoscript": {
     "revision": "43b221c0b76e77244efdaa9963e402a17c930fbc"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2181,6 +2181,14 @@ list.typescript = {
   maintainers = { "@steelsojka" },
 }
 
+list.typespec = {
+  install_info = {
+    url = "https://github.com/happenslol/tree-sitter-typespec",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@happenslol" },
+}
+
 list.typoscript = {
   install_info = {
     url = "https://github.com/Teddytrombone/tree-sitter-typoscript",

--- a/queries/typespec/highlights.scm
+++ b/queries/typespec/highlights.scm
@@ -1,0 +1,135 @@
+(identifier_or_member_expression) @type
+
+[
+  "is"
+  "extends"
+  "valueof"
+] @keyword.operator
+
+[
+  "namespace"
+  "model"
+  "scalar"
+  "interface"
+  "enum"
+  "union"
+  "alias"
+] @keyword.type
+
+[
+  "op"
+  "fn"
+  "dec"
+] @keyword.function
+
+"extern" @keyword.modifier
+
+[
+  "import"
+  "using"
+] @keyword.import
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "<"
+  ">"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ","
+  ";"
+  "."
+  ":"
+] @punctuation.delimiter
+
+[
+  "|"
+  "&"
+  "="
+  "..."
+] @operator
+
+"?" @punctuation.special
+
+[
+  (single_line_comment)
+  (multi_line_comment)
+] @comment @spell
+
+[
+  (quoted_string_literal)
+  (triple_quoted_string_literal)
+] @string
+
+(boolean_literal) @boolean
+
+[
+  (decimal_literal)
+  (hex_integer_literal)
+  (binary_integer_literal)
+] @number
+
+(escape_sequence) @string.escape
+
+(builtin_type) @type.builtin
+
+(decorator
+  "@" @attribute
+  name: (identifier_or_member_expression) @attribute)
+
+(augment_decorator_statement
+  name: (identifier_or_member_expression) @attribute)
+
+(using_statement
+  module: (identifier_or_member_expression) @module)
+
+(namespace_statement
+  name: (identifier_or_member_expression) @module)
+
+(model_statement
+  name: (identifier) @type)
+
+(model_property
+  name: (identifier) @variable.member)
+
+(union_statement
+  name: (identifier) @type)
+
+(union_variant
+  name: (identifier) @variable.member)
+
+(scalar_statement
+  name: (identifier) @type)
+
+(interface_statement
+  name: (identifier) @type)
+
+(enum_statement
+  name: (identifier) @type)
+
+(enum_member
+  name: (identifier) @constant)
+
+(operation_statement
+  name: (identifier) @function)
+
+(template_parameter
+  name: (identifier) @type)
+
+(alias_statement
+  name: (identifier) @type)
+
+(decorator_declaration_statement
+  name: (identifier) @attribute)
+
+(function_parameter
+  name: (identifier) @variable.parameter)
+
+(operation_arguments
+  (model_property
+    name: (identifier) @variable.parameter))

--- a/queries/typespec/indents.scm
+++ b/queries/typespec/indents.scm
@@ -1,0 +1,18 @@
+[
+  (model_expression)
+  (tuple_expression)
+  (namespace_body)
+  (interface_body)
+  (union_body)
+  (enum_body)
+  (template_arguments)
+  (template_parameters)
+  (operation_arguments)
+] @indent.begin
+
+[
+  "}"
+  ")"
+  ">"
+  "]"
+] @indent.end

--- a/queries/typespec/injections.scm
+++ b/queries/typespec/injections.scm
@@ -1,0 +1,5 @@
+([
+  (single_line_comment)
+  (multi_line_comment)
+] @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
This adds support for the [typespec](https://typespec.io/) language with [happenslol/tree-sitter-typespec](https://github.com/happenslol/tree-sitter-typespec).

I've been using this for a few weeks through `TSInstallGrammar` and linking the queries manually into my nvim config, so I can confirm this to be working correctly. I haven't added any folds yet, I hope it's alright if I amend that at a later date.

I've tried to keep to the best practices listed in the contribution guidelines, but this is my first time working with treesitter so I'm open to any suggestions.