### PR TITLE
feat(python): inject regex when concatenating strings

### DIFF
--- a/queries/python/injections.scm
+++ b/queries/python/injections.scm
@@ -3,8 +3,13 @@
     object: (identifier) @_re)
   arguments: (argument_list
     .
-    (string
-      (string_content) @injection.content))
+    [
+      (string
+        (string_content) @injection.content)
+      (concatenated_string
+        (string
+          (string_content) @injection.content))
+    ])
   (#eq? @_re "re")
   (#set! injection.language "regex"))
 


### PR DESCRIPTION
Sometimes if you're compiling a long regular expression in Python, you concatenate multiple strings to do it, like so:

### Before
<img width="253" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/9437625/b5ea8f2c-0fcf-4514-b8e6-e310917ae9ed">

### After
<img width="253" alt="image" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/9437625/e2a9e653-ff13-4862-a9e1-5b1f2aeb5c7b">
