### PR TITLE
fix: do not use flatten from neovim std

### DIFF
--- a/lua/nvim-treesitter/compat.lua
+++ b/lua/nvim-treesitter/compat.lua
@@ -28,12 +28,24 @@ function M.require_language(lang, opts)
   return (ts.language.add or ts.language.require_language)(lang, opts)
 end
 
-function M.flatten(t)
-  if vim.fn.has "nvim-0.11" == 1 then
-    return vim.iter(t):flatten():totable()
-  else
-    return vim.tbl_flatten(t)
+local insert = table.insert
+---@param list any[]
+---@return table Flattened
+local function flatten(list, l)
+  -- lua std does not using ipairs
+  for i = 1, #l do
+    local v = l[i]
+    if type(v) == "table" then
+      flatten(list, v)
+    else
+      insert(list, v)
+    end
   end
+  return list
+end
+
+function M.flatten(t)
+  return flatten({}, t)
 end
 
 return M


### PR DESCRIPTION
The last pr is closed, probably because I did something stupid.
I am sorry about that.
#6653

I open this pr because vim.iter():flatten() deprecated again.
Maybe it's better to write an own one.
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/32760059/773ce0c0-389c-42a3-aab7-af773072d9ee)
```
$ nvim --version
NVIM v0.11.0-dev-6+g06135cc21
Build type: RelWithDebInfo
LuaJIT 2.1.1713484068
Run "nvim -V1 -v" for more info
```