### PR TITLE
feat(htmldjango): Highlight keyword arguments for `url` and `include`…

### DIFF
--- a/queries/htmldjango/highlights.scm
+++ b/queries/htmldjango/highlights.scm
@@ -22,6 +22,15 @@
 
 (variable_name) @variable
 
+(unpaired_statement
+  (tag_name)
+  (variable
+    (variable_name) @variable.parameter)
+  .
+  "="
+  .
+  (_))
+
 (filter_name) @function.method
 
 (filter_argument) @variable.parameter


### PR DESCRIPTION
… tags