### PR TITLE
Update README.md | Update Auto-disable Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,15 @@ require'nvim-treesitter.configs'.setup {
     disable = { "c", "rust" },
     -- Or use a function for more flexibility, e.g. to disable slow treesitter highlight for large files
     disable = function(lang, buf)
-        local max_filesize = 100 * 1024 -- 100 KB
-        local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
-        if ok and stats and stats.size > max_filesize then
-            return true
-        end
+      local max_filesize = 100 * 1024 -- 100 KB
+      local filename = vim.api.nvim_buf_get_name(buf)
+      local file_size = vim.fn.getfsize(filename)
+
+      if file_size > max_filesize then
+        return true
+      end
     end,
+
 
     -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
     -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).


### PR DESCRIPTION
since `vim.loop` is deprecated, updated the function.
This is also more concise and easier to understand.

Written with help from chatGPT3.5 turbo