### PR TITLE
[injections/yaml]: bash injections in ansible files

### DIFF
--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -78,3 +78,56 @@
           (block_scalar) @injection.content
           (#set! injection.language "promql")
           (#offset! @injection.content 0 1 0 0))))))
+
+; Ansible ("command" / "shell")
+(block_sequence
+  (block_sequence_item
+    (_
+      (_
+        (block_mapping_pair
+          key: (flow_node
+            (plain_scalar
+              (string_scalar) @_command
+              (#any-of? @_command "command" "shell" "ansible.builtin.command"
+                "ansible.builtin.shell")))
+          value: (flow_node
+            (plain_scalar
+              (string_scalar) @injection.content
+              (#set! injection.language "bash"))))))))
+
+(block_sequence
+  (block_sequence_item
+    (_
+      (_
+        (block_mapping_pair
+          key: (flow_node
+            (plain_scalar
+              (string_scalar) @_command
+              (#any-of? @_command "command" "shell" "ansible.builtin.command"
+                "ansible.builtin.shell")))
+          value: (block_node
+            (block_scalar) @injection.content
+            (#set! injection.language "bash")
+            (#offset! @injection.content 0 1 0 0)))))))
+
+(block_sequence
+  (block_sequence_item
+    (_
+      (_
+        (block_mapping_pair
+          key: (flow_node
+            (plain_scalar
+              (string_scalar) @_command
+              (#any-of? @_command "command" "shell" "ansible.builtin.command"
+                "ansible.builtin.shell")))
+          value: (block_node
+            (block_mapping
+              (block_mapping_pair
+                key: (flow_node
+                  (plain_scalar
+                    (string_scalar) @_cmd
+                    (#eq? @_cmd "cmd")))
+                value: (flow_node
+                  (plain_scalar
+                    (string_scalar) @injection.content
+                    (#set! injection.language "bash")))))))))))

--- a/tests/query/injections/yaml/bash-on-ansible-tasks.yaml
+++ b/tests/query/injections/yaml/bash-on-ansible-tasks.yaml
@@ -1,0 +1,19 @@
+- name: Test1
+  command: echo "hello world!"
+  #        ^ @bash
+
+- name: Test2
+  ansible.builtin.shell: echo "hello world!" | cut -f1 -d" "
+  #                      ^ @bash
+
+- name: Test3
+  ansible.builtin.command:
+    cmd: echo 'Hello World'
+  #      ^ @bash
+
+- name: Test4
+  shell: |
+    echo Hello
+    echo World
+  # ^ @bash
+


### PR DESCRIPTION
Brings some color to Ansible's command/shell modules:

![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/7879747/3d0d5acf-2ba1-493e-9a26-d9d39f88e699)

...without polluting other modules.

I've added a tests file based on the others; though I'm not sure how it works - please let me know if I should do it differently 