### PR TITLE
fix(odin): highlight types with underscores

### DIFF
--- a/queries/odin/highlights.scm
+++ b/queries/odin/highlights.scm
@@ -192,7 +192,7 @@
   (identifier) @type)
 
 ((identifier) @type
-  (#lua-match? @type "^[A-Z][a-zA-Z0-9]*$")
+  (#lua-match? @type "^[_A-Z][_a-zA-Z0-9]*$")
   (#not-has-parent? @type parameter procedure_declaration call_expression))
 
 ; Fields


### PR DESCRIPTION
Odin's [naming convention](https://github.com/odin-lang/Odin/wiki/Naming-Convention) calls for types to be in Ada_Case. It therefore makes sense for types with underscores to also be highlighted as such.