### PR TITLE
feat(predicates)!: rename `has-type` to `kind-eq` to align with Helix

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -124,7 +124,7 @@ end, true)
 ---@param _bufnr integer
 ---@param pred string[]
 ---@return boolean|nil
-query.add_predicate("has-type?", function(match, _pattern, _bufnr, pred)
+query.add_predicate("kind-eq?", function(match, _pattern, _bufnr, pred)
   if not valid_args(pred[1], pred, 2) then
     return
   end

--- a/queries/c/indents.scm
+++ b/queries/c/indents.scm
@@ -24,14 +24,14 @@
 
 ((for_statement
   body: (_) @_body) @indent.begin
-  (#not-has-type? @_body compound_statement))
+  (#not-kind-eq? @_body "compound_statement"))
 
 (while_statement
   condition: (_) @indent.begin)
 
 ((while_statement
   body: (_) @_body) @indent.begin
-  (#not-has-type? @_body compound_statement))
+  (#not-kind-eq? @_body "compound_statement"))
 
 ((if_statement)
   .
@@ -45,7 +45,7 @@
 (if_statement
   consequence: (_
     ";" @indent.end) @_consequence
-  (#not-has-type? @_consequence compound_statement)
+  (#not-kind-eq? @_consequence "compound_statement")
   alternative: (else_clause
     "else" @indent.branch
     [

--- a/queries/ecma/indents.scm
+++ b/queries/ecma/indents.scm
@@ -29,15 +29,15 @@
 
 (arrow_function
   body: (_) @_body
-  (#not-has-type? @_body statement_block)) @indent.begin
+  (#not-kind-eq? @_body "statement_block")) @indent.begin
 
 (assignment_expression
   right: (_) @_right
-  (#not-has-type? @_right arrow_function function)) @indent.begin
+  (#not-kind-eq? @_right "arrow_function" "function")) @indent.begin
 
 (variable_declarator
   value: (_) @_value
-  (#not-has-type? @_value arrow_function call_expression function)) @indent.begin
+  (#not-kind-eq? @_value "arrow_function" "call_expression" "function")) @indent.begin
 
 (arguments
   ")" @indent.end)

--- a/queries/groovy/indents.scm
+++ b/queries/groovy/indents.scm
@@ -19,7 +19,7 @@
 
 ((for_loop
   body: (_) @_body) @indent.begin
-  (#not-has-type? @_body closure))
+  (#not-kind-eq? @_body "closure"))
 
 ; TODO: while, try
 (list

--- a/queries/ispc/indents.scm
+++ b/queries/ispc/indents.scm
@@ -2,8 +2,8 @@
 
 ((foreach_statement
   body: (_) @_body) @indent.begin
-  (#not-has-type? @_body compound_statement))
+  (#not-kind-eq? @_body "compound_statement"))
 
 ((foreach_instance_statement
   body: (_) @_body) @indent.begin
-  (#not-has-type? @_body compound_statement))
+  (#not-kind-eq? @_body "compound_statement"))

--- a/queries/ocaml/indents.scm
+++ b/queries/ocaml/indents.scm
@@ -28,7 +28,7 @@
 
 ((else_clause
   (_) @_not_if) @indent.begin
-  (#not-has-type? @_not_if if_expression))
+  (#not-kind-eq? @_not_if "if_expression"))
 
 ((parameter) @indent.begin
   (#set! indent.start_at_same_line))

--- a/queries/swift/indents.scm
+++ b/queries/swift/indents.scm
@@ -66,7 +66,7 @@
     (_)* @indent.branch)
   .
   _ @indent.branch
-  (#not-has-type? @indent.branch type_parameters parameter))
+  (#not-kind-eq? @indent.branch "type_parameters" "parameter"))
 
 (ERROR
   [

--- a/scripts/format-queries.lua
+++ b/scripts/format-queries.lua
@@ -13,7 +13,7 @@ else
   files = vim.fn.split(vim.fn.glob(arg .. "/**/*.scm"))
 end
 
-ts.query.add_predicate("has-type?", function(match, _, _, pred)
+ts.query.add_predicate("kind-eq?", function(match, _, _, pred)
   local node = match[pred[2]]
   if not node then
     return true
@@ -132,7 +132,7 @@ local format_queries = [[
 ;; Append newlines for nodes inside the list
 (list
   (_) @format.append-newline
-  (#not-has-type? @format.append-newline capture quantifier))
+  (#not-kind-eq? @format.append-newline "capture" "quantifier"))
 
 ;; (_), "_" and _ handler
 ;; Start indents if it's one of these patterns
@@ -194,7 +194,7 @@ local format_queries = [[
   ] @format.cancel-append
   .
   ")"
-  (#not-has-type? @format.cancel-append comment))
+  (#not-kind-eq? @format.cancel-append "comment"))
 
 ;; All captures should be separated with a space
 (capture) @format.prepend-space
@@ -233,7 +233,7 @@ local format_queries = [[
 ;; Collapsing closing parens
 (grouping
   (_) @format.cancel-append . ")"
-  (#not-has-type? @format.cancel-append comment))
+  (#not-kind-eq? @format.cancel-append "comment"))
 (grouping
   (capture) @format.prepend-space)
 ;; Remove unnecessary parens


### PR DESCRIPTION
No point in having a different name for the same predicate.

(Helix uses quotes for the second argument even though those are not literals. I prefer that, to be honest.)