### PR TITLE
chore(jq): update builtin functions

### DIFF
--- a/queries/jq/highlights.scm
+++ b/queries/jq/highlights.scm
@@ -58,26 +58,25 @@
 ; jq -n 'builtins | map(split("/")[0]) | unique | .[]'
 ((funcname) @function.builtin
   (#any-of? @function.builtin
-    "IN" "INDEX" "JOIN" "acos" "acosh" "add" "all" "any" "arrays" "ascii_downcase" "ascii_upcase"
-    "asin" "asinh" "atan" "atan2" "atanh" "booleans" "bsearch" "builtins" "capture" "cbrt" "ceil"
-    "combinations" "contains" "copysign" "cos" "cosh" "debug" "del" "delpaths" "drem" "empty"
-    "endswith" "env" "erf" "erfc" "error" "exp" "exp10" "exp2" "explode" "expm1" "fabs" "fdim"
-    "finites" "first" "flatten" "floor" "fma" "fmax" "fmin" "fmod" "format" "frexp" "from_entries"
-    "fromdate" "fromdateiso8601" "fromjson" "fromstream" "gamma" "get_jq_origin" "get_prog_origin"
-    "get_search_list" "getpath" "gmtime" "group_by" "gsub" "halt" "halt_error" "has" "hypot"
-    "implode" "in" "index" "indices" "infinite" "input" "input_filename" "input_line_number"
-    "inputs" "inside" "isempty" "isfinite" "isinfinite" "isnan" "isnormal" "iterables" "j0" "j1"
-    "jn" "join" "keys" "keys_unsorted" "last" "ldexp" "leaf_paths" "length" "lgamma" "lgamma_r"
-    "limit" "localtime" "log" "log10" "log1p" "log2" "logb" "ltrimstr" "map" "map_values" "match"
-    "max" "max_by" "min" "min_by" "mktime" "modf" "modulemeta" "nan" "nearbyint" "nextafter"
-    "nexttoward" "normals" "not" "now" "nth" "nulls" "numbers" "objects" "path" "paths" "pow"
-    "pow10" "range" "recurse" "recurse_down" "remainder" "repeat" "reverse" "rindex" "rint" "round"
-    "rtrimstr" "scalars" "scalars_or_empty" "scalb" "scalbln" "scan" "select" "setpath"
-    "significand" "sin" "sinh" "sort" "sort_by" "split" "splits" "sqrt" "startswith" "stderr"
-    "strflocaltime" "strftime" "strings" "strptime" "sub" "tan" "tanh" "test" "tgamma" "to_entries"
-    "todate" "todateiso8601" "tojson" "tonumber" "tostream" "tostring" "transpose" "trunc"
-    "truncate_stream" "type" "unique" "unique_by" "until" "utf8bytelength" "values" "walk" "while"
-    "with_entries" "y0" "y1" "yn"))
+    "IN" "INDEX" "JOIN" "abs" "acos" "acosh" "add" "all" "any" "arrays" "ascii_downcase"
+    "ascii_upcase" "asin" "asinh" "atan" "atan2" "atanh" "booleans" "bsearch" "builtins" "capture"
+    "cbrt" "ceil" "combinations" "contains" "copysign" "cos" "cosh" "debug" "del" "delpaths" "drem"
+    "empty" "endswith" "env" "erf" "erfc" "error" "exp" "exp10" "exp2" "explode" "expm1" "fabs"
+    "fdim" "finites" "first" "flatten" "floor" "fma" "fmax" "fmin" "fmod" "format" "frexp"
+    "from_entries" "fromdate" "fromdateiso8601" "fromjson" "fromstream" "gamma" "get_jq_origin"
+    "get_prog_origin" "get_search_list" "getpath" "gmtime" "group_by" "gsub" "halt" "halt_error"
+    "has" "hypot" "implode" "in" "index" "indices" "infinite" "input" "input_filename"
+    "input_line_number" "inputs" "inside" "isempty" "isfinite" "isinfinite" "isnan" "isnormal"
+    "iterables" "j0" "j1" "jn" "join" "keys" "keys_unsorted" "last" "ldexp" "length" "lgamma"
+    "lgamma_r" "limit" "localtime" "log" "log10" "log1p" "log2" "logb" "ltrimstr" "map" "map_values"
+    "match" "max" "max_by" "min" "min_by" "mktime" "modf" "modulemeta" "nan" "nearbyint" "nextafter"
+    "nexttoward" "normals" "not" "now" "nth" "nulls" "numbers" "objects" "path" "paths" "pick" "pow"
+    "pow10" "range" "recurse" "remainder" "repeat" "reverse" "rindex" "rint" "round" "rtrimstr"
+    "scalars" "scalb" "scalbln" "scan" "select" "setpath" "significand" "sin" "sinh" "sort"
+    "sort_by" "split" "splits" "sqrt" "startswith" "stderr" "strflocaltime" "strftime" "strings"
+    "strptime" "sub" "tan" "tanh" "test" "tgamma" "to_entries" "todate" "todateiso8601" "tojson"
+    "tonumber" "tostream" "tostring" "transpose" "trunc" "truncate_stream" "type" "unique"
+    "unique_by" "until" "utf8bytelength" "values" "walk" "while" "with_entries" "y0" "y1" "yn"))
 
 ; Keywords
 [


### PR DESCRIPTION
This updates the list of known `@function.builtin` for the `jq` parser as some new functions have been added, and deprecated ones have been removed.

The list is generated with the command  `jq -n 'builtins | map(split("/")[0]) | unique | .[]'`

To compare before and after:

```
diff <(echo "IN" "INDEX" "JOIN" "abs" "acos" "acosh" "add" "all" "any" "arrays" "ascii_downcase" "ascii_upcase" "asin" "asinh" "atan" "atan2" "atanh" "booleans" "bsearch" "builtins" "capture" "cbrt" "ceil" "combinations" "contains" "copysign" "cos" "cosh" "debug" "del" "delpaths" "drem" "empty" "endswith" "env" "erf" "erfc" "error" "exp" "exp10" "exp2" "explode" "expm1" "fabs" "fdim" "finites" "first" "flatten" "floor" "fma" "fmax" "fmin" "fmod" "format" "frexp" "from_entries" "fromdate" "fromdateiso8601" "fromjson" "fromstream" "gamma" "get_jq_origin" "get_prog_origin" "get_search_list" "getpath" "gmtime" "group_by" "gsub" "halt" "halt_error" "has" "hypot" "implode" "in" "index" "indices" "infinite" "input" "input_filename" "input_line_number" "inputs" "inside" "isempty" "isfinite" "isinfinite" "isnan" "isnormal" "iterables" "j0" "j1" "jn" "join" "keys" "keys_unsorted" "last" "ldexp" "length" "lgamma" "lgamma_r" "limit" "localtime" "log" "log10" "log1p" "log2" "logb" "ltrimstr" "map" "map_values" "match" "max" "max_by" "min" "min_by" "mktime" "modf" "modulemeta" "nan" "nearbyint" "nextafter" "nexttoward" "normals" "not" "now" "nth" "nulls" "numbers" "objects" "path" "paths" "pick" "pow" "pow10" "range" "recurse" "remainder" "repeat" "reverse" "rindex" "rint" "round" "rtrimstr" "scalars" "scalb" "scalbln" "scan" "select" "setpath" "significand" "sin" "sinh" "sort" "sort_by" "split" "splits" "sqrt" "startswith" "stderr" "strflocaltime" "strftime" "strings" "strptime" "sub" "tan" "tanh" "test" "tgamma" "to_entries" "todate" "todateiso8601" "tojson" "tonumber" "tostream" "tostring" "transpose" "trunc" "truncate_stream" "type" "unique" "unique_by" "until" "utf8bytelength" "values" "walk" "while" "with_entries" "y0" "y1" "yn" | tr ' ' '\n' | sort) <(echo "IN" "INDEX" "JOIN" "acos" "acosh" "add" "all" "any" "arrays" "ascii_downcase" "ascii_upcase" "asin" "asinh" "atan" "atan2" "atanh" "booleans" "bsearch" "builtins" "capture" "cbrt" "ceil" "combinations" "contains" "copysign" "cos" "cosh" "debug" "del""delpaths" "drem" "empty" "endswith" "env" "erf" "erfc" "error" "exp" "exp10" "exp2" "explode" "expm1" "fabs" "fdim" "finites" "first" "flatten" "floor" "fma" "fmax" "fmin" "fmod" "format" "frexp" "from_entries" "fromdate" "fromdateiso8601" "fromjson" "fromstream" "gamma" "get_jq_origin" "get_prog_origin" "get_search_list" "getpath" "gmtime" "group_by" "gsub" "halt" "halt_error" "has" "hypot" "implode" "in" "index" "indices" "infinite" "input" "input_filename" "input_line_number" "inputs" "inside" "isempty" "isfinite" "isinfinite" "isnan" "isnormal" "iterables" "j0" "j1" "jn" "join" "keys" "keys_unsorted" "last" "ldexp" "leaf_paths" "length" "lgamma" "lgamma_r" "limit" "localtime" "log" "log10" "log1p" "log2" "logb" "ltrimstr" "map" "map_values" "match" "max" "max_by" "min" "min_by" "mktime" "modf" "modulemeta" "nan" "nearbyint" "nextafter" "nexttoward" "normals" "not" "now" "nth" "nulls" "numbers" "objects" "path" "paths" "pow" "pow10" "range" "recurse" "recurse_down" "remainder" "repeat" "reverse" "rindex" "rint" "round" "rtrimstr" "scalars" "scalars_or_empty" "scalb" "scalbln" "scan" "select" "setpath" "significand" "sin" "sinh" "sort" "sort_by" "split" "splits" "sqrt" "startswith" "stderr" "strflocaltime" "strftime" "strings" "strptime" "sub" "tan" "tanh" "test" "tgamma" "to_entries" "todate" "todateiso8601" "tojson" "tonumber" "tostream" "tostring" "transpose" "trunc" "truncate_stream" "type" "unique" "unique_by" "until" "utf8bytelength" "values" "walk" "while" "with_entries" "y0" "y1" "yn" | tr ' ' '\n' | sort)
```

```
< abs
96a96
> leaf_paths
131d130
< pick
135a135
> recurse_down
143a144
> scalars_or_empty
```

Looking through the [jq news file](https://github.com/jqlang/jq/blob/master/NEWS.md), can see items for `pick` and `abs` being added, and `leaf_paths`, `recurse_down` and `scalars_or_empty` have been removed.

Formatted the file using `./scripts/format-queries.lua` (just by having the file open and running `:source ../../scripts/format-queries.lua`, which seemed to work.