### PR TITLE
Update branch info for parsers.

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -675,6 +675,7 @@ list.gitcommit = {
   install_info = {
     url = "https://github.com/gbprod/tree-sitter-gitcommit",
     files = { "src/parser.c", "src/scanner.c" },
+    branch = "main",
   },
   maintainers = { "@gbprod" },
 }
@@ -1194,6 +1195,7 @@ list.lua = {
   install_info = {
     url = "https://github.com/MunifTanjim/tree-sitter-lua",
     files = { "src/parser.c", "src/scanner.c" },
+    branch = {"main"},
   },
   maintainers = { "@muniftanjim" },
 }
@@ -1373,6 +1375,7 @@ list.norg = {
     files = { "src/parser.c", "src/scanner.cc" },
     cxx_standard = "c++14",
     use_makefile = true,
+    branch = "main",
   },
   maintainers = { "@JoeyGrajciar", "@vhyrro" },
 }
@@ -1689,6 +1692,7 @@ list.r = {
   install_info = {
     url = "https://github.com/r-lib/tree-sitter-r",
     files = { "src/parser.c", "src/scanner.c" },
+    branch = "main",
   },
   maintainers = { "@echasnovski" },
 }

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -693,6 +693,7 @@ list.gitignore = {
   install_info = {
     url = "https://github.com/shunsambongi/tree-sitter-gitignore",
     files = { "src/parser.c" },
+    branch = {"main"},
   },
   maintainers = { "@theHamsta" },
 }


### PR DESCRIPTION
# Issue:
Several parsers would not automatically install because the install defaults to the "master" branch. 
# Solution:
Update the parsers with correct branches. 

Updated gitcommit, gitignore, r, lua, norg. 

# New behavior:
parsers auto-install as desired.