### PR TITLE
feat(ruby): add highlights

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -127,7 +127,7 @@
 ((identifier) @keyword.function
   (#any-of? @keyword.function
     "include" "extend" "prepend" "attr_reader" "attr_writer" "attr_accessor" "module_function"
-    "refine" "using")))
+    "refine" "using"))
 
 ((identifier) @keyword.exception
   (#any-of? @keyword.exception "raise" "fail" "catch" "throw"))

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -124,8 +124,8 @@
   (#any-of? @constant.builtin
     "__callee__" "__dir__" "__id__" "__method__" "__send__" "__ENCODING__" "__FILE__" "__LINE__"))
 
-((identifier) @keyword.function
-  (#any-of? @keyword.function
+((identifier) @function.builtin
+  (#any-of? @function.builtin
     "include" "extend" "prepend" "attr_reader" "attr_writer" "attr_accessor" "module_function"
     "refine" "using"))
 

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -125,7 +125,9 @@
     "__callee__" "__dir__" "__id__" "__method__" "__send__" "__ENCODING__" "__FILE__" "__LINE__"))
 
 ((identifier) @keyword.function
-  (#any-of? @keyword.function "include"  "extend" "prepend" "attr_reader" "attr_writer" "attr_accessor" "module_function" "refine" "using"))
+  (#any-of? @keyword.function
+    "include" "extend" "prepend" "attr_reader" "attr_writer" "attr_accessor" "module_function"
+    "refine" "using")))
 
 ((identifier) @keyword.exception
   (#any-of? @keyword.exception "raise" "fail" "catch" "throw"))

--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -71,9 +71,6 @@
   "ensure"
 ] @keyword.exception
 
-((identifier) @keyword.exception
-  (#any-of? @keyword.exception "fail" "raise"))
-
 ; Function calls
 "defined?" @function
 
@@ -126,6 +123,12 @@
 ((identifier) @constant.builtin
   (#any-of? @constant.builtin
     "__callee__" "__dir__" "__id__" "__method__" "__send__" "__ENCODING__" "__FILE__" "__LINE__"))
+
+((identifier) @keyword.function
+  (#any-of? @keyword.function "include"  "extend" "prepend" "attr_reader" "attr_writer" "attr_accessor" "module_function" "refine" "using"))
+
+((identifier) @keyword.exception
+  (#any-of? @keyword.exception "raise" "fail" "catch" "throw"))
 
 ((constant) @type
   (#not-lua-match? @type "^[A-Z0-9_]+$"))


### PR DESCRIPTION
Add highlight groups for ruby special methods

Before
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/5418788/68bb9166-1d06-4dff-a4bb-9b86739b850a)
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/5418788/bb4d7acd-90fd-4201-896c-cd2c3ee64535)

After
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/5418788/754566cc-baff-467c-bb5a-90e4ee6eaa7c)
![image](https://github.com/nvim-treesitter/nvim-treesitter/assets/5418788/a60b9817-f928-4cb4-b1f7-52dacebb8771)

