### PR TITLE
feat: more comment injections

### DIFF
--- a/queries/ada/injections.scm
+++ b/queries/ada/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/agda/injections.scm
+++ b/queries/agda/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/apex/injections.scm
+++ b/queries/apex/injections.scm
@@ -1,0 +1,5 @@
+([
+  (line_comment)
+  (block_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/bibtex/injections.scm
+++ b/queries/bibtex/injections.scm
@@ -1,0 +1,2 @@
+((junk) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/blueprint/injections.scm
+++ b/queries/blueprint/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/cmake/injections.scm
+++ b/queries/cmake/injections.scm
@@ -1,0 +1,5 @@
+([
+  (bracket_comment)
+  (line_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/commonlisp/injections.scm
+++ b/queries/commonlisp/injections.scm
@@ -1,0 +1,5 @@
+([
+  (comment)
+  (block_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/cooklang/highlights.scm
+++ b/queries/cooklang/highlights.scm
@@ -1,5 +1,7 @@
 (metadata) @comment
 
+(comment) @comment @spell
+
 (ingredient
   "@" @punctuation.delimiter
   (name)? @string.special.symbol

--- a/queries/cooklang/injections.scm
+++ b/queries/cooklang/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/corn/injections.scm
+++ b/queries/corn/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/djot/injections.scm
+++ b/queries/djot/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 (code_block
   (language) @injection.language
   (code) @injection.content)

--- a/queries/ebnf/injections.scm
+++ b/queries/ebnf/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/erlang/injections.scm
+++ b/queries/erlang/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/foam/injections.scm
+++ b/queries/foam/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 ; Pass code blocks to Cpp highlighter
 (code
   (code_body) @injection.content

--- a/queries/fortran/injections.scm
+++ b/queries/fortran/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/fsh/injections.scm
+++ b/queries/fsh/injections.scm
@@ -1,0 +1,2 @@
+((fsh_comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/func/injections.scm
+++ b/queries/func/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/fusion/injections.scm
+++ b/queries/fusion/injections.scm
@@ -1,0 +1,5 @@
+([
+  (comment)
+  (afx_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/git_rebase/injections.scm
+++ b/queries/git_rebase/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 ((operation
   (command) @_command
   (message) @injection.content)

--- a/queries/gitignore/injections.scm
+++ b/queries/gitignore/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/glimmer/injections.scm
+++ b/queries/glimmer/injections.scm
@@ -1,0 +1,2 @@
+((comment_statement) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/hack/injections.scm
+++ b/queries/hack/injections.scm
@@ -1,0 +1,5 @@
+([
+  (comment)
+  (heredoc)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/hoon/highlights.scm
+++ b/queries/hoon/highlights.scm
@@ -20,7 +20,7 @@
 
 (aura) @constant.builtin
 
-(Gap) @comment
+(lineComment) @comment
 
 (boolean) @constant.builtin
 

--- a/queries/hoon/injections.scm
+++ b/queries/hoon/injections.scm
@@ -1,0 +1,2 @@
+((lineComment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/htmldjango/injections.scm
+++ b/queries/htmldjango/injections.scm
@@ -1,3 +1,9 @@
+([
+  (paired_comment)
+  (unpaired_comment)
+] @injection.content
+  (#set! injection.language "comment"))
+
 ((content) @injection.content
   (#set! injection.language "html")
   (#set! injection.combined))

--- a/queries/hurl/injections.scm
+++ b/queries/hurl/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 ; injections.scm
 ((json_value) @injection.content
   (#set! injection.language "json"))

--- a/queries/hyprlang/injections.scm
+++ b/queries/hyprlang/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 (exec
   (string) @injection.content
   (#set! injection.language "bash"))

--- a/queries/ini/injections.scm
+++ b/queries/ini/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/jsonnet/injections.scm
+++ b/queries/jsonnet/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/just/injections.scm
+++ b/queries/just/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 ; The right side of =~ literals
 (regex_literal
   (_) @injection.content

--- a/queries/liquidsoap/highlights.scm
+++ b/queries/liquidsoap/highlights.scm
@@ -104,7 +104,7 @@
 
 (bool) @boolean
 
-(comment) @comment
+(comment) @comment @spell
 
 (regexp) @string.regexp
 

--- a/queries/liquidsoap/injections.scm
+++ b/queries/liquidsoap/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/llvm/injections.scm
+++ b/queries/llvm/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/menhir/injections.scm
+++ b/queries/menhir/injections.scm
@@ -1,2 +1,9 @@
+([
+  (comment)
+  (line_comment)
+  (ocaml_comment)
+] @injection.content
+  (#set! injection.language "comment"))
+
 ((ocaml) @injection.content
   (#set! injection.language "ocaml"))

--- a/queries/mermaid/injections.scm
+++ b/queries/mermaid/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/mlir/injections.scm
+++ b/queries/mlir/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/nickel/injections.scm
+++ b/queries/nickel/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/ninja/injections.scm
+++ b/queries/ninja/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/prisma/injections.scm
+++ b/queries/prisma/injections.scm
@@ -1,0 +1,5 @@
+([
+  (comment)
+  (developer_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/promql/injections.scm
+++ b/queries/promql/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 ((label_value) @injection.content
   (#set! injection.language "regex")
   (#offset! @injection.content 0 1 0 -1))

--- a/queries/proto/injections.scm
+++ b/queries/proto/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/pug/injections.scm
+++ b/queries/pug/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 ((javascript) @injection.content
   (#set! injection.language "javascript"))
 

--- a/queries/robot/injections.scm
+++ b/queries/robot/injections.scm
@@ -1,0 +1,5 @@
+([
+  (comment)
+  (extra_text)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/scss/injections.scm
+++ b/queries/scss/injections.scm
@@ -1,0 +1,2 @@
+((single_line_comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/smithy/injections.scm
+++ b/queries/smithy/injections.scm
@@ -1,0 +1,5 @@
+([
+  (comment)
+  (documentation_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/solidity/injections.scm
+++ b/queries/solidity/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/swift/injections.scm
+++ b/queries/swift/injections.scm
@@ -1,0 +1,5 @@
+([
+  (comment)
+  (multiline_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/tcl/injections.scm
+++ b/queries/tcl/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/textproto/highlights.scm
+++ b/queries/textproto/highlights.scm
@@ -2,7 +2,7 @@
 
 (field_name) @variable.member
 
-(comment) @comment
+(comment) @comment @spell
 
 (number) @number
 

--- a/queries/textproto/injections.scm
+++ b/queries/textproto/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/twig/injections.scm
+++ b/queries/twig/injections.scm
@@ -1,3 +1,6 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
 ((content) @injection.content
   (#set! injection.language "html")
   (#set! injection.combined))

--- a/queries/usd/injections.scm
+++ b/queries/usd/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/vala/injections.scm
+++ b/queries/vala/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/vhs/injections.scm
+++ b/queries/vhs/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/wgsl/injections.scm
+++ b/queries/wgsl/injections.scm
@@ -1,0 +1,5 @@
+([
+  (line_comment)
+  (block_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/wing/injections.scm
+++ b/queries/wing/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Adds comment injections to parsers missing them (where appropriate). I also gave `@spell` captures to comments that were missing them, in parsers that I touched. Also the `hoon` comment node seemed inappropriate so I changed that one as well. Other than that, the rest of the changes are basically all the same