### PR TITLE
fix(swift): recognize shebang lines

### DIFF
--- a/queries/swift/highlights.scm
+++ b/queries/swift/highlights.scm
@@ -100,6 +100,8 @@
   (modify_specifier)
 ] @keyword
 
+(shebang_line) @keyword.directive
+
 (class_body
   (property_declaration
     (pattern


### PR DESCRIPTION
Did not recognize Shebang lines, added a highlight for them. Reference: 
```swift
#!/usr/bin/env swift

let args = CommandLine.arguments
var out = "y"
if args.count > 1 {
    out = args[1...args.count-1].joined(separator: " ")   
}
while true { print(out) }
```