### PR TITLE
fix: declare fields of TSConfig optional

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -9,11 +9,11 @@ local caching = require "nvim-treesitter.caching"
 local M = {}
 
 ---@class TSConfig
----@field modules {[string]:TSModule}
----@field sync_install boolean
----@field ensure_installed string[]|string
----@field ignore_install string[]
----@field auto_install boolean
+---@field modules {[string]:TSModule}?
+---@field sync_install boolean?
+---@field ensure_installed string[]|string|nil
+---@field ignore_install string[]?
+---@field auto_install boolean?
 ---@field parser_install_dir string|nil
 
 ---@type TSConfig


### PR DESCRIPTION
Hi,
I propose to define all the fields of `TSConfig` as nillable to allow the user to not declare some of them without the LS freaking out.
Indeed, with the current trunk lua_ls displays a big diagnostics on the whole setup argument that hides all other possible information (more interesting diagnostics and syntactic coloration).