### PR TITLE
Remove incorrect builtin highlight for Gleam

### DIFF
--- a/queries/gleam/highlights.scm
+++ b/queries/gleam/highlights.scm
@@ -147,9 +147,6 @@
   (type_var)
 ] @type
 
-((type_identifier) @type.builtin
-  (#any-of? @type.builtin "Int" "Float" "String" "List"))
-
 ; Type Qualifiers
 [
   "const"

--- a/tests/query/highlights/gleam/function.gleam
+++ b/tests/query/highlights/gleam/function.gleam
@@ -5,14 +5,14 @@ pub fn add(x: Int, y: Int) -> Int {
 //        ^ @punctuation.bracket
 //         ^ @variable.parameter
 //          ^ @punctuation.delimiter
-//            ^^^ @type.builtin
+//            ^^^ @type
 //               ^ @punctuation.delimiter
 //                 ^ @variable.parameter
 //                  ^ @punctuation.delimiter
-//                    ^^^ @type.builtin
+//                    ^^^ @type
 //                       ^ @punctuation.bracket
 //                         ^ @punctuation.delimiter
-//                            ^^^ @type.builtin
+//                            ^^^ @type
 //                                ^ @punctuation.bracket
 }
 // <- @punctuation.bracket
@@ -50,7 +50,7 @@ fn list_of_two(my_value: a) -> List(a) {
 //                       ^ @type
 //                        ^ @punctuation.bracket
 //                          ^ @punctuation.delimiter
-//                             ^^^^ @type.builtin
+//                             ^^^^ @type
 //                                 ^ @punctuation.bracket
 //                                  ^ @type
 //                                   ^ @punctuation.bracket
@@ -66,19 +66,19 @@ fn replace(
   // <- @label
   // ^^^^^^ @variable.parameter
   //       ^ @punctuation.delimiter
-  //         ^^^^^^ @type.builtin
+  //         ^^^^^^ @type
   //               ^ @punctuation.delimiter
   each pattern: String,
   // <- @label
   //   ^^^^^^^ @variable.parameter
   //          ^ @punctuation.delimiter
-  //            ^^^^^^ @type.builtin
+  //            ^^^^^^ @type
   //                  ^ @punctuation.delimiter
   with replacement: String,
   // <- @label
   //   ^^^^^^^^^^^ @variable.parameter
   //              ^ @punctuation.delimiter
-  //                ^^^^^^ @type.builtin
+  //                ^^^^^^ @type
   //                      ^ @punctuation.delimiter
 ) {
   replace(in: "A,B,C", each: ",", with: " ")
@@ -107,7 +107,7 @@ pub external fn random_float() -> Float = "rand" "uniform"
 //                          ^ @punctuation.bracket
 //                           ^ @punctuation.bracket
 //                             ^^ @punctuation.delimiter
-//                                ^^^^^ @type.builtin
+//                                ^^^^^ @type
 //                                      ^ @operator
 //                                        ^^^^^^ @module
 //                                               ^^^^^^^^^ @function

--- a/tests/query/highlights/gleam/type.gleam
+++ b/tests/query/highlights/gleam/type.gleam
@@ -8,11 +8,11 @@ pub type Cat {
   // ^ @punctuation.bracket
   //  ^^^^ @variable.member
   //      ^ @punctuation.delimiter
-  //        ^^^^^^ @type.builtin
+  //        ^^^^^^ @type
   //              ^ @punctuation.delimiter
   //                ^^^^^^^^ @variable.member
   //                        ^ @punctuation.delimiter
-  //                          ^^^ @type.builtin
+  //                          ^^^ @type
   //                             ^ @punctuation.bracket
 }
 


### PR DESCRIPTION
Hello!

I'm the creator and lead developer of Gleam. Neovim has been highlighting Gleam types slightly incorrectly, and this has been identified as the issue.

I'm not very familiar with this configuration, so please do let me know if this is not the right way to correct this.

Thanks,
Louis