### PR TITLE
feat(install)!: drop support for git

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -67,20 +67,19 @@ local function install_health()
     end
   end
 
-  do -- curl+tar or git check
+  do -- curl+tar check
     local curl = check_exe('curl')
-    local tar = check_exe('tar')
-
-    if curl and tar and vim.uv.os_uname().sysname ~= 'Windows_NT' then
-      health.ok(string.format('tar %s (%s)', tar.version, tar.path))
+    if curl then
       health.ok(string.format('curl %s (%s)\n%s', curl.version, curl.path, curl.out))
     else
-      local git = check_exe('git')
-      if git then
-        health.ok(string.format('git %s (%s)', git.version, git.path))
-      else
-        health.error('Either curl and tar or git must be installed and on `$PATH`')
-      end
+      health.error('curl not found')
+    end
+
+    local tar = check_exe('tar')
+    if tar then
+      health.ok(string.format('tar %s (%s)', tar.version, tar.path))
+    else
+      health.error('tar not found')
     end
   end
 

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -39,8 +39,6 @@ local function system(cmd, opts)
   return r
 end
 
-local iswin = uv.os_uname().sysname == 'Windows_NT'
-
 local M = {}
 
 ---
@@ -92,12 +90,6 @@ end
 --- PARSER MANAGEMENT FUNCTIONS
 ---
 
---- @param x string
---- @return boolean
-local function executable(x)
-  return fn.executable(x) == 1
-end
-
 --- @param logger Logger
 --- @param repo InstallInfo
 --- @param compile_location string
@@ -130,12 +122,12 @@ end
 ---@param revision string
 ---@param project_dir string
 ---@return string? err
-local function do_download_tar(logger, repo, project_name, cache_dir, revision, project_dir)
-  local is_github = repo.url:find('github.com', 1, true)
+local function do_download(logger, repo, project_name, cache_dir, revision, project_dir)
+  local is_gitlab = repo.url:find('gitlab.com', 1, true)
   local url = repo.url:gsub('.git$', '')
 
   local dir_rev = revision
-  if is_github and revision:find('^v%d') then
+  if revision:find('^v%d') then
     dir_rev = revision:sub(2)
   end
 
@@ -144,8 +136,9 @@ local function do_download_tar(logger, repo, project_name, cache_dir, revision, 
   util.delete(temp_dir)
 
   logger:info('Downloading ' .. project_name .. '...')
-  local target = is_github and url .. '/archive/' .. revision .. '.tar.gz'
-    or url .. '/-/archive/' .. revision .. '/' .. project_name .. '-' .. revision .. '.tar.gz'
+  local target = is_gitlab
+      and url .. '/-/archive/' .. revision .. '/' .. project_name .. '-' .. revision .. '.tar.gz'
+    or url .. '/archive/' .. revision .. '.tar.gz'
 
   local r = system({
     'curl',
@@ -204,53 +197,6 @@ local function do_download_tar(logger, repo, project_name, cache_dir, revision, 
 end
 
 ---@param logger Logger
----@param repo InstallInfo
----@param project_name string
----@param cache_dir string
----@param revision string
----@param project_dir string
----@return string? err
-local function do_download_git(logger, repo, project_name, cache_dir, revision, project_dir)
-  logger:info('Downloading ' .. project_name .. '...')
-
-  local r = system({
-    'git',
-    'clone',
-    '--filter=blob:none',
-    repo.url,
-    project_name,
-  }, {
-    cwd = cache_dir,
-  })
-
-  if r.code > 0 then
-    return logger:error('Error during download, please verify your internet connection: ', r.stderr)
-  end
-
-  logger:info('Checking out locked revision')
-  r = system({
-    'git',
-    'checkout',
-    revision,
-  }, {
-    cwd = project_dir,
-  })
-
-  if r.code > 0 then
-    return logger:error('Error while checking out revision: %s', r.stderr)
-  end
-end
-
----@param repo InstallInfo
----@return boolean
-local function can_download_tar(repo)
-  local can_use_tar = executable('tar') and executable('curl')
-  local is_github = repo.url:find('github.com', 1, true) ~= nil
-  local is_gitlab = repo.url:find('gitlab.com', 1, true) ~= nil
-  return can_use_tar and (is_github or is_gitlab) and not iswin
-end
-
----@param logger Logger
 ---@param compile_location string
 ---@return string? err
 local function do_compile(logger, compile_location)
@@ -274,7 +220,7 @@ end
 local function do_install(logger, compile_location, target_location)
   logger:info(string.format('Installing parser'))
 
-  if iswin then -- why can't you just be normal?!
+  if uv.os_uname().sysname == 'Windows_NT' then -- why can't you just be normal?!
     local tempfile = target_location .. tostring(uv.hrtime())
     uv_rename(target_location, tempfile) -- parser may be in use: rename...
     uv_unlink(tempfile) -- ...and mark for garbage collection
@@ -310,7 +256,6 @@ local function install_lang0(lang, cache_dir, install_dir, generate)
 
       revision = revision or repo.branch or 'main'
 
-      local do_download = can_download_tar(repo) and do_download_tar or do_download_git
       local err = do_download(logger, repo, project_name, cache_dir, revision, project_dir)
       if err then
         return err


### PR DESCRIPTION
Problem: Using git for installing parsers can lead to data loss if in a
git commit buffer.

Solution: Only support downloading via curl+tar, which are installed on
all supported platforms (since Windows 10). Curl will also be required
for WASM parsers (and for `vim.net.download()`).
