### PR TITLE
feat(snakemake): add rule_inheritance to folds

### DIFF
--- a/queries/snakemake/folds.scm
+++ b/queries/snakemake/folds.scm
@@ -2,6 +2,7 @@
 
 [
   (rule_definition)
+  (rule_inheritance)
   (module_definition)
   (checkpoint_definition)
 ] @fold


### PR DESCRIPTION
A `rule_inheritance` is on the same hierarchical level as a `rule_definition`.
I forgot to add it before.