### PR TITLE
fix(gitcommit): correct the file path capture

### DIFF
--- a/queries/gitcommit/highlights.scm
+++ b/queries/gitcommit/highlights.scm
@@ -9,7 +9,7 @@
 
 (change) @keyword
 
-(filepath) @string.special.url
+(filepath) @string.special.path
 
 (arrow) @punctuation.delimiter
 


### PR DESCRIPTION
I think this is a leftover from the great capture migration, and there wasn't really a file path capture. Reference:

```gitcommit
feat(hi): msg right here
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch rust_und
# Changes to be committed:
#	renamed:    CONTRIBUTING.md -> CONTRIBUTING_HERE.md
#	modified:   LICENSE
#	new file:   hi.txt
#	modified:   queries/rust/highlights.scm
```