### PR TITLE
fix(markdown): capture entire heading line

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -8,28 +8,22 @@
   (setext_h2_underline) @markup.heading.2)
 
 (atx_heading
-  (atx_h1_marker) @markup.heading.1
-  (inline) @markup.heading.1)
+  (atx_h1_marker)) @markup.heading.1
 
 (atx_heading
-  (atx_h2_marker) @markup.heading.2
-  (inline) @markup.heading.2)
+  (atx_h2_marker)) @markup.heading.2
 
 (atx_heading
-  (atx_h3_marker) @markup.heading.3
-  (inline) @markup.heading.3)
+  (atx_h3_marker)) @markup.heading.3
 
 (atx_heading
-  (atx_h4_marker) @markup.heading.4
-  (inline) @markup.heading.4)
+  (atx_h4_marker)) @markup.heading.4
 
 (atx_heading
-  (atx_h5_marker) @markup.heading.5
-  (inline) @markup.heading.5)
+  (atx_h5_marker)) @markup.heading.5
 
 (atx_heading
-  (atx_h6_marker) @markup.heading.6
-  (inline) @markup.heading.6)
+  (atx_h6_marker)) @markup.heading.6
 
 (info_string) @label
 


### PR DESCRIPTION
Very small change that highlights the space(s) in-between the `#` and the heading content. Nice to have when captures are given a background color, underline, etc.