### PR TITLE
feat(roc): switch to active upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [pip requirements](https://github.com/ObserverOfTime/tree-sitter-requirements) (maintained by @ObserverOfTime)
 - [x] [rnoweb](https://github.com/bamonroe/tree-sitter-rnoweb) (maintained by @bamonroe)
 - [x] [robot](https://github.com/Hubro/tree-sitter-robot) (maintained by @Hubro)
-- [x] [roc](https://github.com/nat-418/tree-sitter-roc) (maintained by @nat-418)
+- [x] [roc](https://github.com/faldor20/tree-sitter-roc) (maintained by @nat-418)
 - [x] [ron](https://github.com/amaanq/tree-sitter-ron) (maintained by @amaanq)
 - [x] [rst](https://github.com/stsewd/tree-sitter-rst) (maintained by @stsewd)
 - [x] [ruby](https://github.com/tree-sitter/tree-sitter-ruby) (maintained by @TravonteD)

--- a/lockfile.json
+++ b/lockfile.json
@@ -609,7 +609,7 @@
     "revision": "322e4cc65754d2b3fdef4f2f8a71e0762e3d13af"
   },
   "roc": {
-    "revision": "7df2c0892e62efb81a7504d9799d4e0d0443d241"
+    "revision": "df46a85abda9f948d38f5d4e3684cec49c42fef2"
   },
   "ron": {
     "revision": "78938553b93075e638035f624973083451b29055"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1782,7 +1782,7 @@ list.robot = {
 
 list.roc = {
   install_info = {
-    url = "https://github.com/nat-418/tree-sitter-roc",
+    url = "https://github.com/faldor20/tree-sitter-roc",
     files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@nat-418" },

--- a/queries/roc/highlights.scm
+++ b/queries/roc/highlights.scm
@@ -79,29 +79,12 @@
 ] @keyword
 
 ;----headers-----
-(interface_header
-  (name) @type.definition)
-
-(imports
-  (imports_entry
-    (module) @module))
-
-(packages
-  (record_pattern
-    (record_field_pattern
-      (field_name) @module)))
-
-(app_name) @string.special
-
-(import_path) @string.special.path
-
 [
   "app"
-  "packages"
-  "provides"
-  "interface"
-  "exposes"
   "expect"
+  "module"
+  "package"
+  "import"
 ] @keyword
 
 [
@@ -184,6 +167,9 @@
   (float)
 ] @number.float
 
-(string) @string
+[
+  (string)
+  (multiline_string)
+] @string
 
 (char) @character

--- a/queries/roc/locals.scm
+++ b/queries/roc/locals.scm
@@ -8,6 +8,10 @@
 (exposes_list
   (ident) @local.reference)
 
+(import_expr
+  (as)
+  (module) @local.definition)
+
 (opaque_type_def
   (apply_type
     (concrete_type) @local.definition.type))
@@ -30,9 +34,6 @@
 
 (identifier_pattern
   (identifier) @local.definition)
-
-(exposes
-  (ident) @local.reference)
 
 (identifier) @local.reference
 


### PR DESCRIPTION
Upstream also does not contain symlinks which break unextracting on Windows.

@nat-418 