### PR TITLE
fix: retain nonbreaking spaces as spaces when concealed

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -93,7 +93,7 @@
 ; Replace common HTML entities.
 ((entity_reference) @character.special
   (#eq? @character.special "&nbsp;")
-  (#set! conceal ""))
+  (#set! conceal " "))
 
 ((entity_reference) @character.special
   (#eq? @character.special "&lt;")


### PR DESCRIPTION
This fixes indentations being lost in hover documentation that use the html entity `nbsp` when they are concealed by nvim (https://github.com/neovim/neovim/blob/20a7eebec086129e605041d32916f36df50890de/runtime/lua/vim/lsp/util.lua#L1638)