### PR TITLE
fix(apex): highlights: change the constant variable order to recognize it correctly

### DIFF
--- a/queries/apex/highlights.scm
+++ b/queries/apex/highlights.scm
@@ -152,6 +152,9 @@
   field: (identifier) @variable.member)
 
 ; Variables
+(variable_declarator
+  (identifier) @property)
+
 (field_declaration
   (modifiers
     (modifier
@@ -166,9 +169,6 @@
       ]))
   (variable_declarator
     name: (identifier) @constant))
-
-(variable_declarator
-  (identifier) @property)
 
 ((identifier) @constant
   (#lua-match? @constant "^[A-Z][A-Z0-9_]+$")) ; SCREAM SNAKE CASE


### PR DESCRIPTION
This changes the order of how the constant variable is recognized. Without this, it applies property highlights to constant types. 

Kindly review & share the feedback.