### PR TITLE
fix(verilog): various touch-ups

### DIFF
--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -22,7 +22,6 @@
   "localparam"
   "defparam"
   "assign"
-  "typedef"
   "modport"
   "fork"
   "join"
@@ -44,6 +43,7 @@
   "enum"
   "struct"
   "union"
+  "typedef"
 ] @keyword.type
 
 [
@@ -96,9 +96,6 @@
   (package_identifier
     (simple_identifier) @constant))
 
-(parameter_port_list
-  "#" @constructor)
-
 [
   "="
   "-"
@@ -110,12 +107,9 @@
   "|"
   "&&"
   "||"
-  ":"
-  "{"
-  "}"
-  "'{"
   "<="
   "@"
+  "@*"
   "=="
   "!="
   "==="
@@ -130,7 +124,11 @@
   "|="
   (unary_operator)
   (inc_or_dec_operator)
+  "#"
 ] @operator
+
+(parameter_port_list
+  "#" @constructor)
 
 [
   "or"
@@ -160,6 +158,8 @@
 [
   "signed"
   "unsigned"
+  "input"
+  "output"
 ] @keyword.modifier
 
 (data_type
@@ -197,9 +197,16 @@
 [
   ";"
   "::"
+  ":"
   ","
   "."
 ] @punctuation.delimiter
+
+(conditional_expression
+  [
+    "?"
+    ":"
+  ] @keyword.conditional.ternary)
 
 (default_nettype_compiler_directive
   (default_nettype_value) @string)
@@ -223,7 +230,7 @@
   (unbased_unsized_literal)
 ] @number
 
-(time_unit) @attribute
+(time_unit) @type.builtin
 
 (checker_instantiation
   (checker_identifier
@@ -307,4 +314,7 @@
   "]"
   "("
   ")"
+  "{"
+  "}"
+  "'{"
 ] @punctuation.bracket


### PR DESCRIPTION
Some fixes for verilog. Reference file:
```verilog
typedef enum {ONE, TWO, THREE} myenum;

typedef union packed
{
  my_opcode_struct_t opcode_s; // "fields view" to the struct
  logic[1:0][31:0] dword; // "dword view" to the struct
} my_opcode_union_t;

typedef struct packed
{
  my_opcode_t  opcode; // 16-bit opcode, enumerated type
  my_dest_t    dest; // 16-bit destination, enumerated type
  logic [15:0] opA;
  //logic [15:0] opB;
} my_opcode_struct_t;

class MyClass;
   int number;
   function new (int num = 0);
       number = num;
   endfunction

endclass

MyClass a_class = new();

module function_auto ();

  function automatic [7:0] factorial;
    input [7:0] i_Num;
    begin
      if (i_Num == 1)
        factorial = 1;
      else
        factorial = i_Num * factorial(i_Num-1);
    end
  endfunction

  initial
    begin
      $display("Factorial of 1 = %d", factorial(1));
      $display("Factorial of 2 = %d", factorial(2));
      $display("Factorial of 3 = %d", factorial(3));
      $display("Factorial of 4 = %d", factorial(4));
      $display("Factorial of 5 = %d", factorial(5));
    end
endmodule

module function_calling(a, b, c, d, e, f);
    input a, b, c, d, e ;
    output f;
    wire f;

    function  myfunction;
    input a, b, c, d;
    begin
        myfunction = ((a+b) + (c-d));
    end
    endfunction

    assign f =  (myfunction (a,b,c,d)) ? e :0;
endmodule
```