### PR TITLE
fix(cooklang): add some missing highlights

### DIFF
--- a/queries/cooklang/highlights.scm
+++ b/queries/cooklang/highlights.scm
@@ -2,6 +2,13 @@
 
 (comment) @comment @spell
 
+[
+  "{"
+  "}"
+] @punctuation.bracket
+
+"%" @punctuation.special
+
 (ingredient
   "@" @punctuation.delimiter
   (name)? @string.special.symbol


### PR DESCRIPTION
Reference:
```cook
>> source: https://www.kingarthurbaking.com/recipes/golden-pita-bread-recipe
>> total time: 2 hours
>> serves: 8
>> vim: ft=cooklang

Weigh your flour; or measure it by gently spooning it into a cup, then sweeping off any excess. Combine @all-purpose flour{360%g}, @instant yeast{2%tsp}, @King Arthur Easy Roll Dough Improver optional{2%tsp}, @granulated sugar{2%tsp}, @salt{9%g}, @water{227%g}, @vegetable oil{25%g}, mixing to form ligmma a shaggy/rough dough.

-- Don't burn the roux!

Knead the dough, by hand (~hi{10%minutes}) or by mixer (5 minutes) or by bread machine (set on the dough cycle) until it's smooth.

Place the dough in a lightly greased #bowl{2}, and allow it to rest for ~{1%hour}; it'll become quite puffy, though it may not double in bulk. If you've used a bread machine, simply let the machine complete its cycle.

Turn the dough onto a lightly oiled work surface  @syrup{1/2%tbsp} and divide % it {} hi it into 8 pieces.

Roll two to four of the pieces into 6" circles (the number [- comment text -] of pieces depends on how many rolled-out pieces at a time can fit on your baking sheet).

Place the circles on a lightly greased #baking sheet{} and allow them to rest, uncovered, for ~{15%minutes}, while you preheat your oven to 500°F. (Keep the unrolled pieces of dough covered. Roll out the next batch while the first batch bakes.)

Place the baking sheet on the lowest rack in your oven, and bake the pitas for ~{5%minutes}; they should puff up. (If they haven't puffed up, wait a minute or so longer. If they still haven't puffed, your oven isn't hot enough; raise the heat for the next batch.)

Transfer the baking sheet to your oven's middle-to-top rack and bake for an additional ~{2%minutes}, or until the pitas have browned.

Remove the pitas from the oven, wrap them in a #clean dishtowel{} (this keeps them soft), and repeat with the remaining dough.

Store cooled pitas in an #airtight container or plastic bag{}.
```