### PR TITLE
improve statusline() implementation

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -549,8 +549,9 @@ Default options (lua syntax):
 >
   {
     indicator_size = 100,
-    type_patterns = {'class', 'function', 'method'},
-    transform_fn = function(line, _node) return line:gsub('%s*[%[%(%{]*%s*$', '') end,
+    type_patterns = {'namespace', 'class', 'struct', 'function', 'method'},
+    ignore_fields = {'body'}
+    transform_fn = function(line, _node) return line:gsub('%s*[%[%(%{]*%s*$', ''):gsub('%s+', ' ') end,
     separator = ' -> ',
     allow_duplicates = false
   }
@@ -558,8 +559,11 @@ Default options (lua syntax):
 - `indicator_size` - How long should the string be. If longer, it is cut from
   the beginning.
 - `type_patterns` - Which node type patterns to match.
+- `ignore_fields` - for a node that matches the type pattern, which fields to
+  ignore to extract a signature
 - `transform_fn` - Function used to transform the single item in line. By
-  default it removes opening brackets and spaces from end. Takes two arguments:
+  default it removes opening brackets and spaces from end, and replace
+  consecutive whitespaces with a single space. Takes two arguments:
   the text of the line in question, and the corresponding treesitter node.
 - `separator` - Separator between nodes.
 - `allow_duplicates` - Whether or not to remove duplicate components.

--- a/lua/nvim-treesitter/statusline.lua
+++ b/lua/nvim-treesitter/statusline.lua
@@ -3,9 +3,23 @@ local ts_utils = require "nvim-treesitter.ts_utils"
 
 local M = {}
 
--- Trim spaces and opening brackets from end
+local function is_statusline_scope(node, type_patterns)
+  if not node then
+    return false
+  end
+
+  local node_type = node:type()
+  for _, pattern in ipairs(type_patterns) do
+    if node_type:find(pattern) then
+      return true
+    end
+  end
+  return false
+end
+
+-- default post-processing: trim spaces, new lines, trailing braces
 local transform_line = function(line)
-  return line:gsub("%s*[%[%(%{]*%s*$", "")
+  return line:gsub("%s*[%[%(%{]*%s*$", ""):gsub("%s+", " ")
 end
 
 function M.statusline(opts)
@@ -18,7 +32,8 @@ function M.statusline(opts)
   end
   local bufnr = options.bufnr or 0
   local indicator_size = options.indicator_size or 100
-  local type_patterns = options.type_patterns or { "class", "function", "method" }
+  local type_patterns = options.type_patterns or { "namespace", "class", "struct", "function", "method" }
+  local ignore_fields = options.ignore_fields or { "body" }
   local transform_fn = options.transform_fn or transform_line
   local separator = options.separator or " -> "
   local allow_duplicates = options.allow_duplicates or false
@@ -30,14 +45,59 @@ function M.statusline(opts)
 
   local lines = {}
   local expr = current_node
+  local prev_expr = nil
+  local included_prev_expr = false
 
+  -- walk up the tree from the current node
   while expr do
-    local line = ts_utils._get_line_for_node(expr, type_patterns, transform_fn, bufnr)
-    if line ~= "" then
-      if allow_duplicates or not vim.tbl_contains(lines, line) then
-        table.insert(lines, 1, line)
+    local include_cur_expr = is_statusline_scope(expr, type_patterns)
+    if include_cur_expr then
+      local expr_lines = {}
+      -- extract signature from a node by filtering out children nodes that look like
+      -- implementation and concat the text for the rest of the nodes
+      for expr_child, field_name in expr:iter_children() do
+        if vim.tbl_contains(ignore_fields, field_name) then
+          -- found body, break instead of continue to handle cases like lua functions
+          -- function func()
+          --   <body>
+          -- end
+          -- where `end` after body is redundant
+          break
+        end
+
+        -- consider the tree for C++ code `int func2(){}`
+        --  (function_definition ; [0, 0] - [0, 13]
+        --    type: (primitive_type) ; [0, 0] - [0, 3]
+        --    declarator: (function_declarator ; [0, 4] - [0, 11]
+        --      declarator: (identifier) ; [0, 4] - [0, 9]
+        --      parameters: (parameter_list)) ; [0, 9] - [0, 11]
+        --    body: (compound_statement)) ; [0, 11] - [0, 13]
+        -- function_declarator is nested inside function_definition, and it would be hard
+        -- to reliably tell them part across languages. Instead of trying to ignore
+        -- function_declarator, merge the text for that node into current line
+        if prev_expr and expr_child:equal(prev_expr) and included_prev_expr then
+          table.insert(expr_lines, lines[1])
+        else
+          -- normal case
+          table.insert(expr_lines, vim.trim(vim.treesitter.get_node_text(expr_child, bufnr)))
+        end
+      end
+      local line = transform_fn(table.concat(expr_lines, " "))
+      if line ~= "" then
+        -- since we're traversing from smaller scope to larger, we want to insert into lines
+        -- in the opposite order so the largest scope comes first
+        if included_prev_expr then
+          -- the existing head of lines was already merged into expr_lines, so
+          -- replace the head instead of pushing onto lines
+          lines[1] = line
+        elseif allow_duplicates or not vim.tbl_contains(lines, line) then
+          -- normal case
+          table.insert(lines, 1, line)
+        end
       end
     end
+    included_prev_expr = include_cur_expr
+    prev_expr = expr
     expr = expr:parent()
   end
 

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -33,29 +33,6 @@ local function get_node_text(node, bufnr)
   end
 end
 
----@private
----@param node TSNode
----@param type_patterns string[]
----@param transform_fn fun(line: string): string
----@param bufnr integer
----@return string
-function M._get_line_for_node(node, type_patterns, transform_fn, bufnr)
-  local node_type = node:type()
-  local is_valid = false
-  for _, rgx in ipairs(type_patterns) do
-    if node_type:find(rgx) then
-      is_valid = true
-      break
-    end
-  end
-  if not is_valid then
-    return ""
-  end
-  local line = transform_fn(vim.trim(get_node_text(node, bufnr)[1] or ""), node)
-  -- Escape % to avoid statusline to evaluate content as expression
-  return line:gsub("%%", "%%%%")
-end
-
 -- Gets the actual text content of a node
 -- @deprecated Use vim.treesitter.query.get_node_text
 -- @param node the node to get the text from


### PR DESCRIPTION
Fixes #1931 
This PR contains three changes.
1. expand default `opt.type_patterns`: add `struct` and `namespace` as scopes.
2. Handle bug from false-positive node type:
Consider the following C++ code:
```
int f(int a, int b){
    return 1;
}
```
The above produces following `:InspectTree` output:
```
(function_definition ; [0, 0] - [2, 1]
  type: (primitive_type) ; [0, 0] - [0, 3]
  declarator: (function_declarator ; [0, 4] - [0, 12]
    declarator: (identifier) ; [0, 4] - [0, 5]
    parameters: (parameter_list ; [0, 5] - [0, 12]
      (parameter_declaration ; [0, 6] - [0, 11]
        type: (primitive_type) ; [0, 6] - [0, 9]
        declarator: (identifier)))) ; [0, 10] - [0, 11]
  body: (compound_statement ; [0, 12] - [2, 1]
    (return_statement ; [1, 4] - [1, 13]
      (number_literal)))) ; [1, 11] - [1, 12]
```
When the cursor is on the symbol `a`, the output of `nvim_treesitter#statusline()` is `int f(int a) -> f(int a)`. Looking at the tree, it's evident that this is because `opt.type_patterns` ends up matching both `function_definition` and `function_declarator`. When both a node and its parent matches the `type_pattern`, merge their text output.

3. More robust way of extracting signature from a node: The current implementation uses the first line in the range of a node as the signature of that node, which causes the problem demonstrated in #1931 
```
int
foo(very_long_parameter_type_that_takes_up_a_whole_line const& param){
    // statusline() here returns "int"
}
```
This new implementation extracts signature from a node by iterating over its children, filtering out the part that we don't want, and concatenating the text of the other nodes. The default option is to ignore the field named "body", which seems to work for C++, java, Python, C#, rust, lua, and is sufficiently flexible to customization. I also looked at using `@locals.scope` for this purpose, but the scope generally tags the function node instead of the function body node to include parameters.
Removed `@private` function `ts_utils._get_line_for_node()` which is currently only used by `statusline()`, but I didn't touch the `@deprecated` function `ts_utils.get_node_text()`.