### PR TITLE
Feat: Pro(b)log support

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [pony](https://github.com/amaanq/tree-sitter-pony) (maintained by @amaanq, @mfelsche)
 - [x] [printf](https://github.com/ObserverOfTime/tree-sitter-printf) (maintained by @ObserverOfTime)
 - [x] [prisma](https://github.com/victorhqc/tree-sitter-prisma) (maintained by @elianiva)
+- [x] [problog](https://codeberg.org/foxy/tree-sitter-prolog) (maintained by @foxyseta)
+- [x] [prolog](https://codeberg.org/foxy/tree-sitter-prolog) (maintained by @foxyseta)
 - [x] [promql](https://github.com/MichaHoffmann/tree-sitter-promql) (maintained by @MichaHoffmann)
 - [x] [properties](https://github.com/tree-sitter-grammars/tree-sitter-properties) (maintained by @ObserverOfTime)
 - [x] [proto](https://github.com/treywood/tree-sitter-proto) (maintained by @treywood)

--- a/lockfile.json
+++ b/lockfile.json
@@ -530,6 +530,12 @@
   "prisma": {
     "revision": "eca2596a355b1a9952b4f80f8f9caed300a272b5"
   },
+  "problog": {
+    "revision": "d8bc22c007825d3af3d62b4326f9d8f9ca529974"
+  },
+  "prolog": {
+    "revision": "d8bc22c007825d3af3d62b4326f9d8f9ca529974"
+  },
   "promql": {
     "revision": "77625d78eebc3ffc44d114a07b2f348dff3061b0"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1564,6 +1564,24 @@ list.prisma = {
   maintainers = { "@elianiva" },
 }
 
+list.problog = {
+  install_info = {
+    url = "https://codeberg.org/foxy/tree-sitter-prolog",
+    files = { "src/parser.c" },
+    location = "grammars/problog",
+  },
+  maintainers = { "@foxyseta" },
+}
+
+list.prolog = {
+  install_info = {
+    url = "https://codeberg.org/foxy/tree-sitter-prolog",
+    files = { "src/parser.c" },
+    location = "grammars/prolog",
+  },
+  maintainers = { "@foxyseta" },
+}
+
 list.promql = {
   install_info = {
     url = "https://github.com/MichaHoffmann/tree-sitter-promql",

--- a/queries/problog/folds.scm
+++ b/queries/problog/folds.scm
@@ -1,0 +1,1 @@
+; inherits: prolog

--- a/queries/problog/highlights.scm
+++ b/queries/problog/highlights.scm
@@ -1,0 +1,4 @@
+; inherits: prolog
+
+(probability_label
+  _ @attribute)

--- a/queries/problog/indents.scm
+++ b/queries/problog/indents.scm
@@ -1,0 +1,1 @@
+; inherits: prolog

--- a/queries/problog/injections.scm
+++ b/queries/problog/injections.scm
@@ -1,0 +1,1 @@
+; inherits: prolog

--- a/queries/prolog/folds.scm
+++ b/queries/prolog/folds.scm
@@ -1,0 +1,6 @@
+[
+  (directive_term)
+  (clause_term)
+  (arg_list)
+  (list_notation)
+] @fold

--- a/queries/prolog/highlights.scm
+++ b/queries/prolog/highlights.scm
@@ -1,0 +1,43 @@
+(comment) @comment @spell
+
+(atom) @constant
+
+((atom) @boolean
+  (#any-of? @boolean "true" "false"))
+
+(functional_notation
+  function: (atom) @function.call)
+
+(integer) @number
+
+(float_number) @number.float
+
+(directive_head) @operator
+
+(operator_notation
+  operator: _ @operator)
+
+[
+  (open)
+  (open_ct)
+  (close)
+  (open_list)
+  "|"
+  (close_list)
+  (open_curly)
+  (close_curly)
+] @punctuation.bracket
+
+[
+  (arg_list_separator)
+  (comma)
+  (end)
+  (list_notation_separator)
+] @punctuation.delimiter
+
+(operator_notation
+  operator: (semicolon) @punctuation.delimiter)
+
+(double_quoted_list_notation) @string
+
+(variable_term) @variable

--- a/queries/prolog/indents.scm
+++ b/queries/prolog/indents.scm
@@ -1,0 +1,16 @@
+(directive_term) @indent.zero
+
+(clause_term) @indent.zero
+
+(functional_notation
+  (atom)
+  (open_ct) @indent.begin
+  (close) @indent.end)
+
+(list_notation
+  (open_list) @indent.begin
+  (close_list) @indent.end)
+
+(curly_bracketed_notation
+  (open_curly) @indent.begin
+  (close_curly) @indent.end)

--- a/queries/prolog/injections.scm
+++ b/queries/prolog/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Added Prolog and ProbLog parsers and queries. The two languages do not have proper scopes or injections, as far as I know (used the ISO standard to implement the parsers), so those queries are intentionally missing.