### PR TITLE
feat(v): add shebang query

### DIFF
--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -1,3 +1,5 @@
+(shebang) @keyword.directive
+
 ; Includes
 [
   "import"


### PR DESCRIPTION
Adds the shebang line as `@keyword.directive`(the default used for shebang queries).

|Current|Updated|
|-|-|
|![Screenshot_20240626_095720](https://github.com/nvim-treesitter/nvim-treesitter/assets/34311583/f506d66f-dfd2-4f44-a1e9-411cd9c75bdb)|![Screenshot_20240626_095744](https://github.com/nvim-treesitter/nvim-treesitter/assets/34311583/a9068af6-1ac8-40aa-a3fc-79eaa2fcd597)|
