### PR TITLE
fix(v): use `source_file` as parent node for comment highlight query

### DIFF
--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -288,8 +288,9 @@
   (block_comment)
 ] @comment @spell
 
-(source_file
+(_
   (line_comment)+ @comment.documentation
+  .
   [
     (function_declaration)
     (type_declaration)

--- a/queries/v/highlights.scm
+++ b/queries/v/highlights.scm
@@ -288,7 +288,7 @@
   (block_comment)
 ] @comment @spell
 
-(_
+(source_file
   (line_comment)+ @comment.documentation
   [
     (function_declaration)


### PR DESCRIPTION
This PR fixes a huge performance impairment related to doc comments. This is particularly noticeable with larger files.

To give an example that can be locally tested: with the current highlight query it is barely possible to work in https://github.com/vlang/v/blob/094c30c34785597de7238e06895d153d8d121e4d/vlib/builtin/string.v - even on good machines. With the changes, things work smoothly.

The `source_file` parent node is what e.g. the Go queries use for doc comments too.

