### PR TITLE
feat: add terraform-vars parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -33,6 +33,7 @@ for ft, lang in pairs {
   sh = "bash",
   html_tags = "html",
   ["typescript.tsx"] = "tsx",
+  ["terraform-vars"] = "terraform",
   ["html.handlebars"] = "glimmer",
   pandoc = "markdown",
   rmd = "markdown",


### PR DESCRIPTION
Resolves #6465 

## Testing
I change nvim config to my repo:
```lua
return { "opa-oz/nvim-treesitter", branch = "feat/6465-add-tfvars", build = ":TSUpdate" }

```

Result:
<img width="545" alt="344018106-6badda85-38b4-4e0b-9ea9-fd0556032ddd" src="https://github.com/nvim-treesitter/nvim-treesitter/assets/34550675/4325620a-48ed-4bf6-918d-3bf4a9d1e0ea">

