### PR TITLE
feat(gitcommit): remove overflow rule

### DIFF
--- a/queries/gitcommit/highlights.scm
+++ b/queries/gitcommit/highlights.scm
@@ -15,8 +15,6 @@
 
 (subject) @markup.heading @spell
 
-(overflow) @comment.warning @spell
-
 (subject
   (subject_prefix) @function @nospell)
 


### PR DESCRIPTION
This commit remove the highlight of the overflow node in gitcommit syntax introduced [by this PR](https://github.com/nvim-treesitter/nvim-treesitter/pull/6222). 
This node will be removed when [this PR](https://github.com/gbprod/tree-sitter-gitcommit/pull/68) will be merge.

I've tried to explain the reasons [here](https://github.com/gbprod/tree-sitter-gitcommit/pull/68#issue-2333012970).