### PR TITLE
fix(r): adapt indent queries

### DIFF
--- a/queries/r/indents.scm
+++ b/queries/r/indents.scm
@@ -12,7 +12,8 @@
 ] @indent.begin
 
 (binary_operator
-  operator: (_)) @indent.begin
+  rhs: (_) @_no_indent
+  (#not-kind-eq? @_no_indent function_definition)) @indent.begin
 
 [
   "}"
@@ -20,6 +21,7 @@
 ] @indent.branch
 
 ((parameters
+  .
   (parameter
     name: (identifier))) @indent.align
   (#set! indent.open_delimiter "(")

--- a/tests/indent/r_spec.lua
+++ b/tests/indent/r_spec.lua
@@ -10,9 +10,7 @@ local run = Runner:new(it, "tests/indent/r", {
 
 describe("indent R:", function()
   describe("whole file:", function()
-    run:whole_file(".", {
-      expected_failures = { "./pipe.R" },
-    })
+    run:whole_file(".", {})
   end)
 
   describe("new line:", function()
@@ -34,9 +32,8 @@ describe("indent R:", function()
     run:new_line("loop.R", { on_line = 8, text = "x <- x + 1", indent = 2 })
     run:new_line("loop.R", { on_line = 14, text = "print('lol')", indent = 4 })
 
-    -- FIXME: |>, %>% indent broken after parser update
-    -- run:new_line("pipe.R", { on_line = 1, text = "head(n = 10L) |>", indent = 2 })
-    -- run:new_line("pipe.R", { on_line = 9, text = "head()", indent = 2 })
+    run:new_line("pipe.R", { on_line = 1, text = "head(n = 10L) |>", indent = 2 })
+    run:new_line("pipe.R", { on_line = 9, text = "head()", indent = 2 })
 
     run:new_line("aligned_indent.R", { on_line = 1, text = "z,", indent = 17 })
   end)


### PR DESCRIPTION
- Anchor parameter query. There's no need for multiple indent.align captures
- Narrow down binary_operator indent.begin. From tree-sitter-r corpus and highlight tests, this seems to be appropriate.