### PR TITLE
fix(r): resolve highlight regressions

### DIFF
--- a/queries/r/highlights.scm
+++ b/queries/r/highlights.scm
@@ -51,6 +51,7 @@
   "$"
   "@"
   ":"
+  "!"
   "special"
 ] @operator
 
@@ -86,6 +87,12 @@
 (call
   function: (identifier) @function.call)
 
+(extract_operator
+  rhs: (identifier) @variable.member)
+
+function: (extract_operator
+  rhs: (identifier) @function.method.call)
+
 ; Parameters
 (parameters
   (parameter
@@ -110,12 +117,7 @@
 (function_definition
   name: "\\" @operator)
 
-[
-  "in"
-  (return)
-  (next)
-  (break)
-] @keyword
+(return) @keyword.return
 
 [
   "if"
@@ -126,6 +128,9 @@
   "while"
   "repeat"
   "for"
+  "in"
+  (break)
+  (next)
 ] @keyword.repeat
 
 [

--- a/tests/query/highlights/r/test.r
+++ b/tests/query/highlights/r/test.r
@@ -23,14 +23,14 @@ b <- list(name = "r", version = R.version$major)
 #          ^ @variable.parameter
 #                 ^ @string
 #                                        ^ @operator
-#                                           ^ @variable
+#                                           ^ @variable.member
 
 Lang$new(name = "r")$print()
-#     ^ @variable
+#     ^ @function.method.call
 
 for(i in 1:10) {
 # <- @keyword.repeat
-#      ^ @keyword
+#      ^ @keyword.repeat
 }
 
 add <- function(a, b = 1, ...) {
@@ -39,6 +39,7 @@ add <- function(a, b = 1, ...) {
 #                  ^ @variable.parameter
 #                         ^ @constant.builtin
   return(a + b)
+# ^ @keyword.return
 }
 
 base::letters


### PR DESCRIPTION
Reverts highlights to the state they were before the parser update, where accurate (at least in the context of the test and my own observations)