### PR TITLE
feat: Robots.txt support

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -608,6 +608,9 @@
   "robot": {
     "revision": "322e4cc65754d2b3fdef4f2f8a71e0762e3d13af"
   },
+  "robots": {
+    "revision": "8e3a4205b76236bb6dbebdbee5afc262ce38bb62"
+  },
   "roc": {
     "revision": "6ea64b6434a45472bd87b0772fd84a017de0a557"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1779,6 +1779,14 @@ list.robot = {
   maintainers = { "@Hubro" },
 }
 
+list.robots = {
+  install_info = {
+    url = "https://github.com/opa-oz/tree-sitter-robots-txt",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@opa-oz" },
+}
+
 list.roc = {
   install_info = {
     url = "https://github.com/faldor20/tree-sitter-roc",

--- a/queries/robots/highlights.scm
+++ b/queries/robots/highlights.scm
@@ -1,0 +1,9 @@
+(comment) @comment @spell
+
+(directive) @constant
+
+(unknownDirective) @attribute
+
+(value) @string
+
+":" @punctuation.delimiter

--- a/queries/robots/highlights.scm
+++ b/queries/robots/highlights.scm
@@ -1,8 +1,6 @@
 (comment) @comment @spell
 
-(directive) @constant
-
-(unknownDirective) @attribute
+(directive) @property
 
 (value) @string
 

--- a/queries/robots/injections.scm
+++ b/queries/robots/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
Hello, it's me again 🙇

Brought to you lang support for [robots.txt](https://en.wikipedia.org/wiki/Robots.txt)

**Before**
![Screenshot 2024-06-29 at 15 44 54](https://github.com/nvim-treesitter/nvim-treesitter/assets/34550675/dcbba98d-9397-47a2-82b2-08dcf0a2784c)

**After**
![Screenshot 2024-06-29 at 15 44 31](https://github.com/nvim-treesitter/nvim-treesitter/assets/34550675/3ca0bafc-fd1a-406d-8247-b0367de5151d)

- [x] `tree-sitter build`
![Screenshot 2024-06-29 at 15 45 47](https://github.com/nvim-treesitter/nvim-treesitter/assets/34550675/12cdfcb2-cc53-4c6e-93a8-69c7cb287b32)

- [x] `TSInstallFromGrammar robots`
![Screenshot 2024-06-29 at 15 46 07](https://github.com/nvim-treesitter/nvim-treesitter/assets/34550675/f9ae662d-7fdb-49ea-8b84-9d374a882f46)

- [x] Alphabetically sorted
- [x] Injections & highlights in place 