### PR TITLE
fix(ecma): indent single-line if statements

### DIFF
--- a/queries/ecma/indents.scm
+++ b/queries/ecma/indents.scm
@@ -59,10 +59,11 @@
 (statement_block
   "{" @indent.branch)
 
-(parenthesized_expression
-  ("("
-    (_)
-    ")" @indent.end))
+((parenthesized_expression
+  "("
+  (_)
+  ")" @indent.end) @_outer
+  (#not-has-parent? @_outer if_statement))
 
 [
   "}"
@@ -75,3 +76,7 @@
   (comment)
   (ERROR)
 ] @indent.auto
+
+(if_statement
+  consequence: (_) @indent.dedent
+  (#not-kind-eq? @indent.dedent statement_block)) @indent.begin

--- a/tests/indent/ecma/if_else.js
+++ b/tests/indent/ecma/if_else.js
@@ -11,3 +11,9 @@ if (cond1) {
 } else {
   do_fallback()
 }
+
+if (true)
+  console.log('hi')
+console.log('hi')
+
+if (true)

--- a/tests/indent/javascript_spec.lua
+++ b/tests/indent/javascript_spec.lua
@@ -75,6 +75,8 @@ describe("indent JavaScript:", function()
       { 9, 2 },
       { 12, 2 },
       { 13, 0 },
+      { 16, 0 },
+      { 19, 2 },
     } do
       run:new_line("ecma/if_else.js", { on_line = info[1], text = "hello()", indent = info[2] }, info[3], info[4])
     end


### PR DESCRIPTION
Fixes #5898. Currently only works after-the-fact, i.e. indentation will not work with `o`.