### PR TITLE
docs: recommending against starting treesitter for all parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ vim.api.nvim_create_autocmd('FileType', {
 })
 ```
 
+You may also want to enable treesitter highlighting for all languages. But removing the `pattern` option or using `pattern = '*'` will cause issues when opening buffers that cannot be parsed by treesitter (such as Telescope windows). To enable highlighting for all languages that nvim-treesitter can parse, you can use the following auto command anywhere **after** nvim-treesitter's `setup` function:
+
+```lua
+vim.api.nvim_create_autocmd("FileType", {
+  callback = function(opts)
+    local language = vim.treesitter.language.get_lang(opts.match)
+    if language == nil then
+      return
+    end
+    local parsers = vim.tbl_keys(require("nvim-treesitter.parsers"))
+    if vim.list_contains(parsers, language) then
+      vim.treesitter.start()
+    end
+  end,
+})
+```
+
 ## Folds
 
 Treesitter-based folding is provided by Neovim. To enable it, put the following in your `ftplugin` or `FileType` autocommand:

--- a/README.md
+++ b/README.md
@@ -94,22 +94,7 @@ vim.api.nvim_create_autocmd('FileType', {
 })
 ```
 
-You may also want to enable treesitter highlighting for all languages. But removing the `pattern` option or using `pattern = '*'` will cause issues when opening buffers that cannot be parsed by treesitter (such as Telescope windows). To enable highlighting for all languages that nvim-treesitter can parse, you can use the following auto command anywhere **after** nvim-treesitter's `setup` function:
-
-```lua
-vim.api.nvim_create_autocmd("FileType", {
-  callback = function(opts)
-    local language = vim.treesitter.language.get_lang(opts.match)
-    if language == nil then
-      return
-    end
-    local parsers = vim.tbl_keys(require("nvim-treesitter.parsers"))
-    if vim.list_contains(parsers, language) then
-      vim.treesitter.start()
-    end
-  end,
-})
-```
+**NOTE: We do not recommend implementing ways to run `vim.treesitter.start()` for every available parser / filetype. Enabling treesitter should be an explicit and deliberate action.**
 
 ## Folds
 


### PR DESCRIPTION
**NOTE: This is for the `main` branch**

I use a handy auto command in my own config which will enable treesitter highlighting for any language that nvim-treesitter can parse. Trying to enable treesitter on every `FileType` event with pattern `*` would cause a chain of errors when opening oil.nvim plugin windows, or Telescope windows -- so I needed a way to check if treesitter can actually parse the file type.

This auto command I've outlined in the README causes no errors for me and enables treesitter highlighting on all the languages I work with so far. Thought it would be good to document it there for others in the future since it's something I searched for but couldn't find any info on it, and I imagine many others would want this functionality too.