### PR TITLE
feat(python): Improved python indentation

### DIFF
--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -8,6 +8,7 @@
   (list_pattern)
   (binary_operator)
   (lambda)
+  (concatenated_string)
 ] @indent.begin
 
 ((list) @indent.align
@@ -125,6 +126,10 @@
 ((parameters) @indent.align
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")"))
+
+((parameters) @indent.align
+  (#lua-match? @indent.align "[^\n ]%)$")
+  (#set! indent.avoid_last_matching_next 1))
 
 ((tuple) @indent.align
   (#set! indent.open_delimiter "(")

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -125,6 +125,8 @@
 
 ((parameters) @indent.align
   (#lua-match? @indent.align "[^\n ]%)$")
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
   (#set! indent.avoid_last_matching_next 1))
 
 ((tuple) @indent.align

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -70,12 +70,11 @@
 ((case_clause) @indent.begin
   (#set! indent.immediate 1))
 
-;; if (cond1
-;;     or cond2
-;;         or cond3):
-;;     pass
-;;
-
+; if (cond1
+;     or cond2
+;         or cond3):
+;     pass
+;
 (if_statement
   condition: (parenthesized_expression) @indent.align
   (#lua-match? @indent.align "^%([^\n]")
@@ -83,13 +82,12 @@
   (#set! indent.close_delimiter ")")
   (#set! indent.avoid_last_matching_next 1))
 
-;; while (
-;;     cond1
-;;     or cond2
-;;         or cond3):
-;;     pass
-;;
-
+; while (
+;     cond1
+;     or cond2
+;         or cond3):
+;     pass
+;
 (while_statement
   condition: (parenthesized_expression) @indent.align
   (#lua-match? @indent.align "[^\n ]%)$")
@@ -97,20 +95,18 @@
   (#set! indent.close_delimiter ")")
   (#set! indent.avoid_last_matching_next 1))
 
-;; if (
-;;     cond1
-;;     or cond2
-;;         or cond3):
-;;     pass
-;;
-
+; if (
+;     cond1
+;     or cond2
+;         or cond3):
+;     pass
+;
 (if_statement
   condition: (parenthesized_expression) @indent.align
   (#lua-match? @indent.align "[^\n ]%)$")
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")")
   (#set! indent.avoid_last_matching_next 1))
-
 
 (ERROR
   "(" @indent.align

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -1,6 +1,5 @@
 [
   (import_from_statement)
-  (parenthesized_expression)
   (generator_expression)
   (list_comprehension)
   (set_comprehension)
@@ -9,7 +8,6 @@
   (list_pattern)
   (binary_operator)
   (lambda)
-  (concatenated_string)
 ] @indent.begin
 
 ((list) @indent.align
@@ -69,12 +67,14 @@
 
 (if_statement
   condition: (parenthesized_expression) @indent.align
+  (#match? @indent.align "^\\([^\n]")
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")")
   (#set! indent.avoid_last_matching_next 1))
 
 (while_statement
   condition: (parenthesized_expression) @indent.align
+  (#match? @indent.align "^\\([^\n]")
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")")
   (#set! indent.avoid_last_matching_next 1))
@@ -92,8 +92,7 @@
 
 ((parameters) @indent.align
   (#set! indent.open_delimiter "(")
-  (#set! indent.close_delimiter ")")
-  (#set! indent.avoid_last_matching_next 1))
+  (#set! indent.close_delimiter ")"))
 
 ((tuple) @indent.align
   (#set! indent.open_delimiter "(")

--- a/queries/python/indents.scm
+++ b/queries/python/indents.scm
@@ -22,6 +22,10 @@
   (#set! indent.open_delimiter "{")
   (#set! indent.close_delimiter "}"))
 
+((parenthesized_expression) @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
 ((for_statement) @indent.begin
   (#set! indent.immediate 1))
 
@@ -65,19 +69,47 @@
 ((case_clause) @indent.begin
   (#set! indent.immediate 1))
 
+;; if (cond1
+;;     or cond2
+;;         or cond3):
+;;     pass
+;;
+
 (if_statement
   condition: (parenthesized_expression) @indent.align
-  (#match? @indent.align "^\\([^\n]")
+  (#lua-match? @indent.align "^%([^\n]")
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")")
   (#set! indent.avoid_last_matching_next 1))
 
+;; while (
+;;     cond1
+;;     or cond2
+;;         or cond3):
+;;     pass
+;;
+
 (while_statement
   condition: (parenthesized_expression) @indent.align
-  (#match? @indent.align "^\\([^\n]")
+  (#lua-match? @indent.align "[^\n ]%)$")
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")")
   (#set! indent.avoid_last_matching_next 1))
+
+;; if (
+;;     cond1
+;;     or cond2
+;;         or cond3):
+;;     pass
+;;
+
+(if_statement
+  condition: (parenthesized_expression) @indent.align
+  (#lua-match? @indent.align "[^\n ]%)$")
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")")
+  (#set! indent.avoid_last_matching_next 1))
+
 
 (ERROR
   "(" @indent.align
@@ -128,9 +160,6 @@
   ":"
   .
   (#lua-match? @indent.branch "^elif"))
-
-(parenthesized_expression
-  ")" @indent.end)
 
 (generator_expression
   ")" @indent.end)

--- a/tests/indent/python/aligned_indent.py
+++ b/tests/indent/python/aligned_indent.py
@@ -2,6 +2,12 @@ def aligned_indent(arg1,
                    arg2):
     pass
 
+def aligned_indent2(
+    arg1,
+    arg2
+):
+    pass
+
 aligned_indent(1,
                2)
 
@@ -9,6 +15,11 @@ aligned_indent(1,
 aligned_indent(1,
                2
                )
+
+aligned_indent(
+    1,
+    2
+)
 
 foodsadsa(sdada,
           2

--- a/tests/indent/python/parenthesized_conditions.py
+++ b/tests/indent/python/parenthesized_conditions.py
@@ -1,0 +1,35 @@
+if (
+    True
+    or 1
+    or False
+):
+    pass
+
+if (
+    True
+    or 1
+        or False):
+    pass
+
+if (True
+    or 1
+        or False):
+    pass
+
+while (
+    False
+    or 1
+    or False
+):
+    pass
+
+while (
+    False
+    or 1
+        or False):
+    pass
+
+while (False
+       or 1
+       or False):
+    pass


### PR DESCRIPTION
The existing python indentation query has a few quirks around parameter lists and parenthesized expressions.

Current behavior:
```python
def foo(
    a,
    b,
    c
    ):  # I think this is a bug in indent.avoid_last_matching_next, this line should not be indented.
    
    # Condition indented too far, flake8 wants the closing bracket to be
    # on the same indentation level as the if statement.
    if (
            True
            or 1
            or False
            ):
        pass

    # Indented too far
    if (
            True
            or 1
                or False):
        pass
```

Fixed indentation:
```python
def foo(
    a,
    b,
    c
):
    if (
        True
        or 1
        or False
    ):
        pass

    if (
        True
        or 1
            or False):
        pass

```