### PR TITLE
feat(jsdoc): add missing highlights

### DIFF
--- a/queries/jsdoc/highlights.scm
+++ b/queries/jsdoc/highlights.scm
@@ -1,3 +1,40 @@
 (tag_name) @keyword @nospell
 
 (type) @type @nospell
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ":"
+  "/"
+  "."
+  "#"
+  "~"
+] @punctuation.delimiter
+
+(identifier) @variable
+
+(tag
+  (tag_name) @_name
+  (identifier) @function
+  (#any-of? @_name "@callback" "@function" "@func" "@method"))
+
+(tag
+  (tag_name) @_name
+  (identifier) @variable.parameter
+  (#any-of? @_name "@param" "@arg" "@argument"))
+
+(tag
+  (tag_name) @_name
+  (identifier) @property
+  (#any-of? @_name "@prop" "@property"))
+
+(tag
+  (tag_name) @_name
+  (identifier) @type
+  (#eq? @_name "@typedef"))


### PR DESCRIPTION
Some missing bracket and delimiter highlights, and nicer identifier highlights for certain tags. [Reference](https://jsdoc.app/)