### PR TITLE
fix(html): correct the link label highlight

### DIFF
--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -86,7 +86,7 @@
 ((element
   (start_tag
     (tag_name) @_tag)
-  (text) @string.special.url)
+  (text) @markup.link.label)
   (#eq? @_tag "a"))
 
 ((attribute


### PR DESCRIPTION
Unlike the `href` attribute, the inner text of the `a` tag is the label of the link, not the actual URL.