### PR TITLE
fix(hurl): multiline injection query needs injection.combined

### DIFF
--- a/queries/hurl/injections.scm
+++ b/queries/hurl/injections.scm
@@ -11,4 +11,5 @@
 (multiline_string
   (multiline_string_type) @_lang
   (multiline_string_content) @injection.content
-  (#set-lang-from-info-string! @_lang))
+  (#set-lang-from-info-string! @_lang)
+  (#set! injection.combined))


### PR DESCRIPTION
This is a suggested fix for #6882 and https://github.com/pfeiferj/tree-sitter-hurl/issues/10.