### PR TITLE
docs: remove git option from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `nvim-treesitter` plugin provides
 ## Requirements
 
 - Neovim 0.10.0 or later (nightly)
-- `tar` and `curl` in your path (or alternatively `git`)
+- `tar` and `curl` in your path
 - [`tree-sitter`](https://github.com/tree-sitter/tree-sitter) CLI (0.22.6 or later)
 - a C compiler in your path (see <https://docs.rs/cc/latest/cc/#compile-time-requirements>)
 


### PR DESCRIPTION
Downloading via `git` is no longer available