### PR TITLE
fix(ruby): highlight "&." as `@punctuation.delimiter`

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -275,6 +275,7 @@
   ","
   ";"
   "."
+  "&."
 ] @punctuation.delimiter
 
 [


### PR DESCRIPTION
Highlight `&.` as `@punctuation.delimiter` in Ruby. Typescript highlights do the same thing for Javascript's safe navigation operator.
