### PR TITLE
fix(typst): code block injection now works correctly

### DIFF
--- a/queries/typst/injections.scm
+++ b/queries/typst/injections.scm
@@ -2,5 +2,6 @@
   (#set! injection.language "comment"))
 
 (raw_blck
-  (ident) @injection.language
-  (blob) @injection.content)
+  lang: (ident) @_lang
+  (blob) @injection.content
+  (#set-lang-from-info-string! @_lang))


### PR DESCRIPTION
Since this project has a separate `injections.scm` per language, this means that it is also have to be fixed. See https://github.com/uben0/tree-sitter-typst/issues/34.
