### PR TITLE
Configuration fix/enhancement

### DIFF
--- a/lua/nvim-treesitter.lua
+++ b/lua/nvim-treesitter.lua
@@ -9,11 +9,13 @@ require "nvim-treesitter.query_predicates"
 
 local M = {}
 
-function M.setup()
+---@param opts? TSConfig # Optional config to pass to `configs.setup`. (If omitted or `nil`, `configs.setup` will not be called.)
+function M.setup(opts)
   utils.setup_commands("install", install.commands)
   utils.setup_commands("info", info.commands)
   utils.setup_commands("configs", configs.commands)
   configs.init()
+  if opts then configs.setup(opts) end
 end
 
 M.define_modules = configs.define_modules

--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -406,9 +406,9 @@ function M.is_enabled(mod, lang, bufnr)
 end
 
 ---Setup call for users to override module configurations.
----@param user_data TSConfig module overrides
+---@param user_data TSConfig General options and module overrides
 function M.setup(user_data)
-  config.modules = vim.tbl_deep_extend("force", config.modules, user_data)
+  config.modules = vim.tbl_deep_extend("force", config.modules, user_data.modules)
   config.ignore_install = user_data.ignore_install or {}
   config.parser_install_dir = user_data.parser_install_dir or nil
   if config.parser_install_dir then


### PR DESCRIPTION
# In `configs.setup` function
 
`tbl_deep_extend` `config.modules` with `user_data.modules` rather than with `user_data`. This not only avoids introducing unnecessary/non-module items into `config.modules`, but also correctly processes `user_data` tables that correctly follow the `TSConfig` type definition specified in the annotations.

# In `nvim-treesitter.setup` function

Added optional parameters to pass to `configs.setup()` so that `require"nvim-treesitter".setup(opts)` works as expected.