### PR TITLE
Allow specifying custom buffer number for `get_node_at_cursor`

### DIFF
--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -160,12 +160,12 @@ function M.get_named_children(node)
   return nodes
 end
 
-function M.get_node_at_cursor(winnr, ignore_injected_langs)
+function M.get_node_at_cursor(winnr, ignore_injected_langs, bufnr)
   winnr = winnr or 0
   local cursor = api.nvim_win_get_cursor(winnr)
   local cursor_range = { cursor[1] - 1, cursor[2] }
 
-  local buf = vim.api.nvim_win_get_buf(winnr)
+  local buf = bufnr or vim.api.nvim_win_get_buf(winnr)
   local root_lang_tree = parsers.get_parser(buf)
   if not root_lang_tree then
     return


### PR DESCRIPTION
So far `get_node_at_cursor` would always use the current buffer in a window (Neovim docs: https://neovim.io/doc/user/api.html#nvim_win_get_buf()). However, sometimes you do wanna use a custom buffer in a certain window, for example when dealing with [nvim-telescope](https://github.com/nvim-telescope/telescope.nvim). When there's a telescope opened, it's currently not possible to get the treesitter nodes of the buffer behind the telescope itself.

This PR adds an optional argument to allow the developer to specify a custom buf number.

There is no breaking change here. The new argument provides a default value, and since it's been placed at the end all current calls will continue to work.