### PR TITLE
feat(parser): add amber language

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -32,6 +32,7 @@ for ft, lang in pairs {
   py = "python",
   erl = "erlang",
   typ = "typst",
+  ab = "amber",
 } do
   ts.language.register(lang, ft)
 end
@@ -76,6 +77,16 @@ list.agda = {
     files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@Decodetalkers" },
+}
+
+list.amber = {
+  install_info = {
+    url = "https://github.com/amber-lang/tree-sitter-amber",
+    files = { "src/parser.c" },
+    generate_requires_npm = true,
+  },
+  filetype = "ab",
+  maintainers = { "@amber-lang" },
 }
 
 list.angular = {


### PR DESCRIPTION
The Amber language is quite new and we are working on that.

We have an experimental tree-sitter integration, so in the meantime we have this way to test it in neovim using my fork with that change.

https://github.com/amber-lang/tree-sitter-amber
https://docs.amber-lang.com