### PR TITLE
feat(angular)!: Change filetype of angular parser and add indentation queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -6,7 +6,7 @@
     "revision": "d3dc807692e6bca671d4491b3bf5c67eeca8c016"
   },
   "angular": {
-    "revision": "3d7f50e88acc34d7452d6fcec1b11b555da60f00"
+    "revision": "b96a0d1605da3492f6474245098b6f0c503e596d"
   },
   "apex": {
     "revision": "c99ad4b16d112fea91745e3f1b769754239fdaba"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -84,6 +84,7 @@ list.angular = {
     files = { "src/parser.c", "src/scanner.c" },
     generate_requires_npm = true,
   },
+  filetype = "htmlangular",
   maintainers = { "@dlvandenberg" },
   experimental = true,
 }

--- a/queries/angular/highlights.scm
+++ b/queries/angular/highlights.scm
@@ -92,13 +92,6 @@
   "{"
   "}"
   "@"
-  "} @"
-  (if_end_expression)
-  (for_end_expression)
-  (switch_end_expression)
-  (case_end_expression)
-  (default_end_expression)
-  (defer_end_expression)
 ] @punctuation.bracket
 
 (two_way_binding

--- a/queries/angular/indents.scm
+++ b/queries/angular/indents.scm
@@ -1,1 +1,16 @@
 ; inherits: html_tags
+
+[
+  (statement_block)
+  (switch_statement)
+] @indent.begin
+
+(statement_block
+  "{" @indent.branch)
+
+(statement_block
+  "}" @indent.end)
+
+"}" @indent.branch
+
+"}" @indent.end

--- a/tests/indent/angular/defer.html
+++ b/tests/indent/angular/defer.html
@@ -1,0 +1,9 @@
+@defer (on viewport) {
+  <calendar-cmp />
+} @placeholder (minimum 100ms) {
+  <small-component />
+} @loading (after 100s; minimum 200ms){
+  <loading-spinner />
+} @error {
+  <error-message />
+}

--- a/tests/indent/angular/for.html
+++ b/tests/indent/angular/for.html
@@ -1,0 +1,5 @@
+@for (item of items; track item.id) {
+  <li>{{ item.name }}</li>
+} @empty {
+  <p>No items</p>
+}

--- a/tests/indent/angular/if-else.html
+++ b/tests/indent/angular/if-else.html
@@ -1,0 +1,15 @@
+@if (someCondition) {
+  <p>someCondition is true</p>
+} @else {
+  <p>someCondition is false</p>
+}
+
+<div>
+  @if (someOther) {
+    <span>True</span>
+
+    @if (nestedCondition) {
+      <span>Nested</span>
+    }
+  }
+</div>

--- a/tests/indent/angular/switch-case.html
+++ b/tests/indent/angular/switch-case.html
@@ -1,0 +1,13 @@
+<div>
+  @switch (obj.property) {
+    @case (1) {
+      <p>Case 1</p>
+    }
+    @case (2) {
+      <p>Case 2</p>
+    }
+    @default {
+      <p>Default</p>
+    }
+  }
+</div>

--- a/tests/indent/angular_spec.lua
+++ b/tests/indent/angular_spec.lua
@@ -1,0 +1,70 @@
+local Runner = require("tests.indent.common").Runner
+local runner = Runner:new(it, "tests/indent/angular", {
+  tabstop = 2,
+  shiftwidth = 2,
+  expandtab = true,
+  filetype = "htmlangular",
+})
+
+describe("indent HTML Angular:", function()
+  describe("whole file:", function()
+    runner:whole_file "."
+  end)
+
+  describe("new line:", function()
+    for _, info in ipairs {
+      { 1, 2 },
+      { 2, 2 },
+      { 3, 2 },
+      { 4, 2 },
+      { 6, 0 },
+      { 7, 2 },
+      { 8, 4 },
+      { 10, 4 },
+      { 11, 6 },
+      { 12, 6 },
+      { 13, 4 },
+      { 14, 2 },
+    } do
+      runner:new_line("if-else.html", { on_line = info[1], text = "//", indent = info[2] })
+    end
+
+    for _, info in ipairs {
+      { 1, 2 },
+      { 2, 4 },
+      { 3, 6 },
+      { 4, 6 },
+      { 6, 6 },
+      { 7, 6 },
+      { 9, 6 },
+      { 10, 6 },
+      { 12, 2 },
+    } do
+      runner:new_line("switch-case.html", { on_line = info[1], text = "//", indent = info[2] })
+    end
+
+    for _, info in ipairs {
+      { 1, 2 },
+      { 2, 2 },
+      { 3, 2 },
+      { 4, 2 },
+      { 5, 0 },
+    } do
+      runner:new_line("for.html", { on_line = info[1], text = "//", indent = info[2] })
+    end
+
+    for _, info in ipairs {
+      { 1, 2 },
+      { 2, 2 },
+      { 3, 2 },
+      { 4, 2 },
+      { 5, 2 },
+      { 6, 2 },
+      { 7, 2 },
+      { 8, 2 },
+      { 9, 0 },
+    } do
+      runner:new_line("defer.html", { on_line = info[1], text = "//", indent = info[2] })
+    end
+  end)
+end)


### PR DESCRIPTION
Angular filetype detection has been added to [vim](https://github.com/vim/vim/commit/c03f631b7b01e672787b222a55898f8dcac8d859) and [neovim nightly](https://github.com/neovim/neovim/commit/afbe7736a4966f22146d857f246eac01cd080773)

So this PR changes the filetype of the Angular parser to `htmlangular`
It also updates the parser to a new version, with changed capture groups for Control Flow statements.
It also adds indentation queries (with tests)