### PR TITLE
fix(gitignore): hl/capture non-special pattern chars

### DIFF
--- a/queries/gitignore/highlights.scm
+++ b/queries/gitignore/highlights.scm
@@ -1,5 +1,7 @@
 (comment) @comment @spell
 
+(pattern_char) @string.special.path
+
 [
   (directory_separator)
   (directory_separator_escaped)
@@ -9,15 +11,16 @@
   (wildcard_char_single)
   (wildcard_chars)
   (wildcard_chars_allow_slash)
-  (bracket_negation)
-] @operator
-
-(negation) @punctuation.special
+] @character.special
 
 [
   (pattern_char_escaped)
   (bracket_char_escaped)
 ] @string.escape
+
+(negation) @punctuation.special
+
+(bracket_negation) @operator
 
 ; bracket expressions
 [


### PR DESCRIPTION
Capture regular, non-special characters (as `@string.special.path`) allowing them to be highlighted.