### PR TITLE
feat(ecma): inject sql template methods

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -43,6 +43,26 @@
   (#set! injection.include-children)
   (#set! injection.language "html"))
 
+; Vercel PostgreSQL
+; foo.sql`...` or foo.sql(`...`)
+(call_expression
+  function: [
+    (await_expression
+      (member_expression
+        property: ((property_identifier) @injection.language)))
+    (member_expression
+      property: ((property_identifier) @injection.language)
+    )
+  ]
+  arguments: [
+    (arguments
+      (template_string) @injection.content)
+    (template_string) @injection.content
+  ]
+  (#eq? @injection.language "sql")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children))
+
 (call_expression
   function: [
     (await_expression

--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -49,10 +49,9 @@
   function: [
     (await_expression
       (member_expression
-        property: ((property_identifier) @injection.language)))
+        property: (property_identifier) @injection.language))
     (member_expression
-      property: ((property_identifier) @injection.language)
-    )
+      property: (property_identifier) @injection.language)
   ]
   arguments: [
     (arguments


### PR DESCRIPTION
Added injection into tagged templates for SQL method calls (e.g., `` client.sql`...` ``) in order to add compatibility with Vercel's PostgreSQL SDK.

This is a continuation of https://github.com/nvim-treesitter/nvim-treesitter/pull/6555 which I inadvertently closed. That was originally opened to address the issue raised in mentioned in https://github.com/nvim-treesitter/nvim-treesitter/pull/6550.