### PR TITLE
feat(snakemake): add wildcard flag

### DIFF
--- a/queries/snakemake/highlights.scm
+++ b/queries/snakemake/highlights.scm
@@ -44,7 +44,8 @@
 
 ; Wildcard names
 (wildcard
-  (identifier) @variable)
+  (identifier) @variable
+  (flag) @variable.parameter.builtin)
 
 ; builtin variables
 ((identifier) @variable.builtin


### PR DESCRIPTION
Wildcard interpolations support the `:q` flag to quote list/tuple elements with whitespace.

```snakemake
rule x:
    input: 
        "the first file.txt",
        "the second file.txt"
    output: "output.txt"
    shell:
       """
       cat {input:q} > {output}
       """
```

With `{input:q}`, this expands to `cat 'the first file.txt' 'the second file.txt' > output.txt`

With `{input}`, this expands to `cat the first file.txt the second file.txt > output.txt`

The `(wildcard (flag))` node was added in the latest version of the `snakemake` parser.
