### PR TITLE
feat(latex): command definition without curly braces

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -387,7 +387,7 @@
     "revision": "854a40e99f7c70258e522bdb8ab584ede6196e2e"
   },
   "latex": {
-    "revision": "d018f2e6620bbaee229cb31fc8b67fabd713d770"
+    "revision": "12523bd1ffd2c428b2dad177e2b4555574d90973"
   },
   "ledger": {
     "revision": "8a841fb20ce683bfbb3469e6ba67f2851cfdf94a"

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -52,10 +52,14 @@
     (text) @label))
 
 ; Definitions and references
+; Capture both \newcommand{\foo}{bar} and \newcommand\foo{bar}
 (new_command_definition
   command: _ @function.macro
-  declaration: (curly_group_command_name
-    (_) @function))
+  declaration: [
+    (curly_group_command_name
+      (_) @function)
+    (command_name) @function
+  ])
 
 (old_command_definition
   command: _ @function.macro


### PR DESCRIPTION
Support both
```latex
\newcommand\foo{bar}
```
and
```latex
\newcommand{\foo}{bar}
```