### PR TITLE
feat(latex): simplify captures of font changing

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -239,13 +239,7 @@
   command: (command_name) @_name
   arg: (curly_group
     (_) @markup.italic))
-  (#eq? @_name "\\emph"))
-
-((generic_command
-  command: (command_name) @_name
-  arg: (curly_group
-    (_) @markup.italic))
-  (#any-of? @_name "\\textit" "\\mathit"))
+  (#any-of? @_name "\\emph" "\\textit" "\\mathit"))
 
 ((generic_command
   command: (command_name) @_name


### PR DESCRIPTION
Additionally, add `\bm` (bold symbols in maths mode).