### PR TITLE
fix(lua): use @property for keys in table literals

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -162,7 +162,7 @@
 
 ; Tables
 (field
-  name: (identifier) @variable.member)
+  name: (identifier) @property)
 
 (dot_index_expression
   field: (identifier) @variable.member)


### PR DESCRIPTION
`@property` should be used for key-value pairs, while `@variable.member` is used for field-access/index-expressions. Using different captures also provides the benefit of allowing the two to be highlighted differently.