### PR TITLE
fix(zig): add some missing highlights

### DIFF
--- a/queries/zig/highlights.scm
+++ b/queries/zig/highlights.scm
@@ -52,13 +52,13 @@ exception: "!" @keyword.exception
 (PtrTypeStart
   "c" @variable.builtin)
 
-((ContainerDeclType
-  [
-    (ErrorUnionExpr)
-    "enum"
-  ])
+(ContainerDecl
+  (ContainerDeclType
+    "enum")
   (ContainerField
-    (IDENTIFIER) @constant))
+    (ErrorUnionExpr
+      (SuffixExpr
+        (IDENTIFIER) @constant))))
 
 field_constant: (IDENTIFIER) @constant
 
@@ -190,6 +190,7 @@ field_constant: (IDENTIFIER) @constant
   (AssignOp)
   (MultiplyOp)
   (PrefixOp)
+  "="
   "*"
   "**"
   "->"
@@ -227,6 +228,9 @@ field_constant: (IDENTIFIER) @constant
   "|" @punctuation.bracket)
 
 (PtrIndexPayload
+  "|" @punctuation.bracket)
+
+(PtrListPayload
   "|" @punctuation.bracket)
 
 (ParamType


### PR DESCRIPTION
Reference file:

```zig
pub const args = @import("clap/args.zig");
pub const parsers = @import("clap/parsers.zig");
pub const streaming = @import("clap/streaming.zig");

pub const Values = enum {
    none,
    one,
    many,
};

fn testParseParams(str: []const u8, expected_params: []const Param(Help)) !void {
    for (expected_params, 0..) |_, i|
        try expectParam(expected_params[i], actual_params[i]);
}
```
