### PR TITLE
feat(latex): improve parameters

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -4,8 +4,6 @@
 (caption
   command: _ @function)
 
-(placeholder) @variable
-
 ; Turn spelling on for text
 (text) @spell
 
@@ -15,14 +13,17 @@
   content: (curly_group
     (_) @none @spell))
 
+; Variables, parameters
+(placeholder) @variable
+
 (key_value_pair
   key: (_) @variable.parameter @nospell
   value: (_))
 
-[
-  (brack_group)
-  (brack_group_argc)
-] @variable.parameter
+(curly_group_spec
+  (text) @variable.parameter)
+
+(brack_group_argc) @variable.parameter
 
 [
   (operator)


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/258d2896-5967-470e-b894-f0f6569f6feb)
After:
![image](https://github.com/user-attachments/assets/cc87e0d8-4d78-4a90-be0d-2d7e800c2e70)
Also, `(brack_group)` appeared in different contexts (optional arguments for environments), where it definitely wasn't `@variable.parameter`. What do you think?