### PR TITLE
feat(julia): Add syntax highlighting for markdown and bash `prefixed_string_literals`

### DIFF
--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -13,14 +13,27 @@
   (#set! injection.language "markdown")
   (#offset! @injection.content 0 3 0 -3))
 
+; Inject comments
 ([
   (line_comment)
   (block_comment)
 ] @injection.content
   (#set! injection.language "comment"))
 
+; Inject regex in r"hello\bworld"
 ((prefixed_string_literal
   prefix: (identifier) @_prefix) @injection.content
   (#eq? @_prefix "r")
   (#set! injection.language "regex")
   (#offset! @injection.content 0 2 0 -1))
+
+; Inject markdown in md"**Bold** and _Italics_"
+((prefixed_string_literal
+  prefix: (identifier) @_prefix) @injection.content
+  (#eq? @_prefix "md")
+  (#set! injection.language "markdown")
+  (#offset! @injection.content 0 3 0 -1))
+
+; Inject bash in `git add --help`
+((command_literal) @injection.content
+  (#set! injection.language "bash"))


### PR DESCRIPTION
This PR adds markdown syntax highlighting and bash command line syntax highlighting for the appropriate Julia expressions.

bash syntax highlighting:

![image](https://github.com/user-attachments/assets/5d7c7037-f67f-4307-91de-ae3b8a1679bc)

markdown syntax highlighting:

![image](https://github.com/user-attachments/assets/6558341f-df3e-439c-a245-6676e54e6d7f)

This PR also adds a comment for each injection.