### PR TITLE
feat(markdown): set url attribute on plain URLs

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -88,6 +88,13 @@
   (email_autolink)
 ] @markup.link.url @nospell
 
+((link_destination) @_url
+  (#set! @_url "url" @_url))
+
+((uri_autolink) @_url
+  (#offset! @_url 0 1 0 -1)
+  (#set! @_url "url" @_url))
+
 (entity_reference) @nospell
 
 ; Replace common HTML entities.


### PR DESCRIPTION
Setting the url attribute on actual URLs will cause Nvim to use the OSC 8 sequence on the entire URL, which enables terminal emulators to detect the URL even when it is wrapped.

The (uri_autolink) node must use an #offset! directive to strip the surrounding <> characters from the URL.
