### PR TITLE
feat(html): set url attribute for HTML URLs

### DIFF
--- a/queries/html_tags/highlights.scm
+++ b/queries/html_tags/highlights.scm
@@ -93,7 +93,8 @@
   (attribute_name) @_attr
   (quoted_attribute_value
     (attribute_value) @string.special.url))
-  (#any-of? @_attr "href" "src"))
+  (#any-of? @_attr "href" "src")
+  (#set! @string.special.url "url" @string.special.url))
 
 [
   "<"


### PR DESCRIPTION
See the justification in https://github.com/nvim-treesitter/nvim-treesitter/pull/6971:

>Setting the url attribute on actual URLs will cause Nvim to use the OSC 8 sequence on the entire URL, which enables terminal emulators to detect the URL even when it is wrapped.