### PR TITLE
fix(latex): environment name should be label

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -67,7 +67,7 @@
 (environment_definition
   command: _ @function.macro @nospell
   name: (curly_group_text
-    (_) @markup.link))
+    (_) @label @nospell))
 
 (theorem_definition
   command: _ @function.macro @nospell


### PR DESCRIPTION
Environment names are captured as `@label` in `(begin)` and `(end)` nodes, and so should they be when we are defining environments.

Before:
![image](https://github.com/user-attachments/assets/8dae4481-fd44-48fb-bca6-857092489238)
After:
![image](https://github.com/user-attachments/assets/5bf85f65-c351-4b9a-a16d-c9bc98585453)