### PR TITLE
feat(query): Highlight key in set! directive

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -12,7 +12,7 @@
   name: (identifier) @variable)
 
 (field_definition
-  name: (identifier) @property)
+  name: (identifier) @variable.member)
 
 (negated_field
   "!" @operator
@@ -62,6 +62,15 @@
 
 ((comment) @keyword.directive @nospell
   (#lua-match? @keyword.directive "^;+%s*format%-ignore%s*$"))
+
+((predicate
+  name: (identifier) @_name
+  parameters: (parameters
+    .
+    (capture)?
+    .
+    (identifier) @property))
+  (#eq? @_name "set"))
 
 ((predicate
   name: (identifier) @_name


### PR DESCRIPTION
Setting any property like `injection.language` or `injection.language` doesn't highlight it. This fixes it.