### PR TITLE
fix(query): properly apply predicate injections

### DIFF
--- a/queries/query/injections.scm
+++ b/queries/query/injections.scm
@@ -1,28 +1,28 @@
 ((predicate
   name: (identifier) @_name
   parameters: (parameters
-    (string) @injection.content))
+    (string
+      (string_content) @injection.content)))
   (#any-of? @_name "match" "not-match" "any-match" "vim-match" "not-vim-match" "any-vim-match")
-  (#set! injection.language "regex")
-  (#offset! @injection.content 0 1 0 -1))
+  (#set! injection.language "regex"))
 
 ((predicate
   name: (identifier) @_name
   parameters: (parameters
-    (string) @injection.content))
+    (string
+      (string_content) @injection.content)))
   (#any-of? @_name "lua-match" "not-lua-match" "any-lua-match")
-  (#set! injection.language "luap")
-  (#offset! @injection.content 0 1 0 -1))
+  (#set! injection.language "luap"))
 
 ((predicate
   name: (identifier) @_name
   parameters: (parameters
-    (string) @injection.content
+    (string
+      (string_content) @injection.content)
     .
     (string) .))
   (#any-of? @_name "gsub" "not-gsub")
-  (#set! injection.language "luap")
-  (#offset! @injection.content 0 1 0 -1))
+  (#set! injection.language "luap"))
 
 ((comment) @injection.content
   (#set! injection.language "comment"))

--- a/tests/query/injections/query/test-query-injections.scm
+++ b/tests/query/injections/query/test-query-injections.scm
@@ -1,0 +1,27 @@
+; vim: ft=query
+; format-ignore
+(((symbol) @constant
+  (#not-lua-match? @constant "^_*[A-Z][A-Z0-9_]*$"))
+;                             ^ @luap
+)
+
+; format-ignore
+(((tag
+  (attributes
+    (attribute
+      (attribute_name) @keyword)))
+  (#match? @keyword "^(:|v-bind|v-|\\@)"))
+;                    ^ @regex
+)
+
+((comment) @injection.language
+  .
+  [
+    (string_expression
+      (string_fragment) @injection.content)
+    (indented_string_expression
+      (string_fragment) @injection.content)
+  ]
+  (#gsub! @injection.language "#%s*([%w%p]+)%s*" "%1")
+  ;                            ^ @luap
+  (#set! injection.combined))


### PR DESCRIPTION
I think these have been broken since the query parser update. Basically the inner node for the string content was preventing injections because include-children was not set.