### PR TITLE
Fix typo in comment in shell_command_selectors.lua

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -292,7 +292,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
     -- Running `git clone` or `git checkout` while running under Git (such as
     -- editing a `git commit` message) will likely fail to install parsers
     -- (such as 'gitcommit') and can also corrupt the index file of the current
-    -- Git repository. Check for typical git environemnt variables and abort if found.
+    -- Git repository. Check for typical git environment variables and abort if found.
     for _, k in pairs {
       "GIT_ALTERNATE_OBJECT_DIRECTORIES",
       "GIT_CEILING_DIRECTORIES",


### PR DESCRIPTION
This is a small follow-up to https://github.com/nvim-treesitter/nvim-treesitter/pull/6960