### PR TITLE
feat(latex): capture left/right math delimiters

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -36,6 +36,12 @@
 
 (delimiter) @punctuation.delimiter
 
+(math_delimiter
+  left_command: _ @punctuation.delimiter
+  left_delimiter: _ @punctuation.delimiter
+  right_command: _ @punctuation.delimiter
+  right_delimiter: _ @punctuation.delimiter)
+
 [
   "["
   "]"


### PR DESCRIPTION
<del>
Capture math delimiter commands such as `\left` and `\right`.

Not sure wheter it should be `@function.macro` or `@function` or perhaps something else. I am open to suggestions.

Before:
![image](https://github.com/user-attachments/assets/c8004b3d-416d-4ad6-8f42-0111ff05c5c6)
After:
![image](https://github.com/user-attachments/assets/43948fc0-77bc-4043-a96d-279f1b39568b)

</del>

Edit:
Capture math delimiters provided by commands such as
`\left` and `\right`.