### PR TITLE
Correct Godot Resources language name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [gnuplot](https://github.com/dpezto/tree-sitter-gnuplot) (maintained by @dpezto)
 - [x] [go](https://github.com/tree-sitter/tree-sitter-go) (maintained by @theHamsta, @WinWisely268)
 - [x] [goctl](https://github.com/chaozwn/tree-sitter-goctl) (maintained by @chaozwn)
-- [x] [Godot Resources (gdresource)](https://github.com/PrestonKnopp/tree-sitter-godot-resource) (maintained by @pierpo)
+- [x] [Godot Resources (godot_resource)](https://github.com/PrestonKnopp/tree-sitter-godot-resource) (maintained by @pierpo)
 - [x] [gomod](https://github.com/camdencheek/tree-sitter-go-mod) (maintained by @camdencheek)
 - [x] [gosum](https://github.com/amaanq/tree-sitter-go-sum) (maintained by @amaanq)
 - [x] [gotmpl](https://github.com/ngalaiko/tree-sitter-go-template) (maintained by @qvalentin)


### PR DESCRIPTION
Adjustment is to change the language name hint from `gdresource`, which is unrecognized, to `godot_resource`. Should save the next person some time looking up the appropriate name.