### PR TITLE
fix(r): prevent double indent from pipes

### DIFF
--- a/queries/r/indents.scm
+++ b/queries/r/indents.scm
@@ -2,8 +2,6 @@
   (braced_expression)
   (parenthesized_expression)
   (call)
-  "special"
-  "|>"
   "if"
   "else"
   "while"

--- a/tests/indent/r/incomplete_pipe.R
+++ b/tests/indent/r/incomplete_pipe.R
@@ -1,0 +1,2 @@
+mtcars %>%
+  head() %>%

--- a/tests/indent/r_spec.lua
+++ b/tests/indent/r_spec.lua
@@ -35,6 +35,8 @@ describe("indent R:", function()
     run:new_line("pipe.R", { on_line = 1, text = "head(n = 10L) |>", indent = 2 })
     run:new_line("pipe.R", { on_line = 9, text = "head()", indent = 2 })
 
+    run:new_line("incomplete_pipe.R", { on_line = 2, text = "head %>%", indent = 2 })
+
     run:new_line("aligned_indent.R", { on_line = 1, text = "z,", indent = 17 })
   end)
 end)


### PR DESCRIPTION
`special` and `|>` are both binary operators, so `@indent.begin` is defined in two places for them.

This leads to a double indentation:

```r
mtcars %>%
   head() %>%
      tail() %>%
      head()
```


After the changes proposed in this pull request, this indents as:

```r
mtcars %>%
   head() %>%
   tail() %>%
   head()
```