### PR TITLE
feat(powershell): added data section name highlights

### DIFF
--- a/queries/powershell/highlights.scm
+++ b/queries/powershell/highlights.scm
@@ -143,6 +143,9 @@
 ((variable) @variable.builtin
   (#lua-match? @variable.builtin "^\$env:"))
 
+(data_name
+  (simple_name) @constant)
+
 (comment) @comment @spell
 
 ((program

--- a/queries/powershell/highlights.scm
+++ b/queries/powershell/highlights.scm
@@ -67,7 +67,10 @@
   "enum"
 ] @keyword.type
 
-(class_attribute) @keyword.modifier
+[
+  "data"
+  (class_attribute)
+] @keyword.modifier
 
 [
   "throw"
@@ -87,8 +90,6 @@
   "begin"
   "process"
   "end"
-  ; TODO: not supported by parser yet, can be used to declare constants
-  "data"
 ] @keyword
 
 ; Operators

--- a/queries/powershell/locals.scm
+++ b/queries/powershell/locals.scm
@@ -68,6 +68,10 @@
                           (unary_expression
                             (variable) @local.definition.var))))))))))))))
 
+; data sections
+(data_name
+  (simple_name) @local.definition.var)
+
 ; References
 ;-----------
 (variable) @local.reference


### PR DESCRIPTION
added highlight for variable name in data section definition

```powershell
Data TextMsgs {
 ^---- highlight "data" as @keyword.modifier
       ^---- highlights variable definition as @constant
  "Message"
  "Another message"
}
```


data sections can be used to isolate read-only data and text strings so I think `@constant` is most suitable tag for this

docs: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_data_sections?view=powershell-7.4