### PR TITLE
fix(julia): macro definition docstrings

### DIFF
--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -6,6 +6,7 @@
     (abstract_definition)
     (struct_definition)
     (function_definition)
+    (macro_definition)
     (assignment)
     (const_statement)
   ]


### PR DESCRIPTION
Inject markdown in macro definition docstrings.

---

Closes https://github.com/tree-sitter/tree-sitter-julia/issues/145