### PR TITLE
Add extra highlights and fold patterns for recent additions to tree-sitter-perl

### DIFF
--- a/queries/perl/folds.scm
+++ b/queries/perl/folds.scm
@@ -2,19 +2,30 @@
 
 (pod) @fold
 
-; fold the block-typed package statements only
+; fold the block-typed package and class statements only
 (package_statement
+  (block)) @fold
+
+(class_statement
   (block)) @fold
 
 [
   (subroutine_declaration_statement)
+  (method_declaration_statement)
   (conditional_statement)
   (loop_statement)
   (for_statement)
   (cstyle_for_statement)
   (block_statement)
+  (defer_statement)
   (phaser_statement)
 ] @fold
+
+(try_statement
+  (block) @fold)
+
+(eval_expression
+  (block) @fold)
 
 (anonymous_subroutine_expression) @fold
 

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -32,9 +32,18 @@
 ("continue" @keyword.repeat
   (block))
 
+[
+  "try"
+  "catch"
+  "finally"
+] @keyword.exception
+
 "return" @keyword.return
 
-"sub" @keyword.function
+[
+  "sub"
+  "method"
+] @keyword.function
 
 [
   "map"
@@ -42,14 +51,20 @@
   "sort"
 ] @function.builtin
 
-"package" @keyword.import
+[
+  "package"
+  "class"
+] @keyword.import
 
 [
+  "defer"
   "do"
+  "eval"
   "my"
   "our"
   "local"
   "state"
+  "field"
   "last"
   "next"
   "redo"
@@ -129,10 +144,16 @@
 (package_statement
   (package) @type)
 
+(class_statement
+  (package) @type)
+
 (require_expression
   (bareword) @type)
 
 (subroutine_declaration_statement
+  name: (bareword) @function)
+
+(method_declaration_statement
   name: (bareword) @function)
 
 (attribute_name) @attribute


### PR DESCRIPTION
Adds highlights and fold patterns for the new `try/catch`, `defer` and `class` syntax now recognised by tree-sitter-perl. Also adds recognition of `eval` which we somehow missed doing last time.