### PR TITLE
Fix missing format argument in shell_command_selectors

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -307,6 +307,7 @@ function M.select_download_commands(repo, project_name, cache_folder, revision, 
         vim.api.nvim_err_writeln(
           string.format(
             "Cannot install %s with git in an active git session. Exit the session and run ':TSInstall %s' manually",
+            project_name,
             project_name
           )
         )


### PR DESCRIPTION
Problem: [#6960](https://github.com/nvim-treesitter/nvim-treesitter/pull/6960) introduced a fix to bail installs if an active git session is detected. An error message is supposed to be printed using `string.format`. However, the error message has two placeholder %s args but only one provided argument. This causes a runtime error.

Solution: Add project_name again as a third argument to string.format to hydrate the second %s. This fixes the issue and the error message prints as-expected.