### PR TITLE
feat(liquid): add highlight

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -399,7 +399,7 @@
     "revision": "f99011a3554213b654985a4b0a65b3b032ec4621"
   },
   "liquid": {
-    "revision": "5f131f9b77370119ba5d799dfd8946e5f9411738"
+    "revision": "f84c94a4c0e93fe1231f6cda9c3a14df9c839ab2"
   },
   "liquidsoap": {
     "revision": "14feafa91630afb1ab9988cf9b738b7ea29f3f89"

--- a/lockfile.json
+++ b/lockfile.json
@@ -399,7 +399,7 @@
     "revision": "f99011a3554213b654985a4b0a65b3b032ec4621"
   },
   "liquid": {
-    "revision": "7862a3424832c3a9d45eb21143b375837bd6573b"
+    "revision": "5f131f9b77370119ba5d799dfd8946e5f9411738"
   },
   "liquidsoap": {
     "revision": "14feafa91630afb1ab9988cf9b738b7ea29f3f89"

--- a/queries/liquid/highlights.scm
+++ b/queries/liquid/highlights.scm
@@ -25,6 +25,7 @@
   "as"
   "assign"
   "capture"
+  (custom_unpaired_statement)
   "decrement"
   "echo"
   "endcapture"

--- a/queries/liquid/highlights.scm
+++ b/queries/liquid/highlights.scm
@@ -95,6 +95,7 @@
 
 [
   "include"
+  "include_relative"
   "render"
   "section"
   "sections"


### PR DESCRIPTION
Adding highlight for `custom_upaired_statement` keyword re: [this update](https://github.com/hankthetank27/tree-sitter-liquid/commit/4f1b43625924c11ec99d79a0f2ddbb94c4e393d7)

Edit: forgot to add the highlight for `include_relative` keyword as part of the initial commit, which was part of the same updates (adding support for some Jekyll specific syntax).