### PR TITLE
feat(inko): add highlight for boolean patterns

### DIFF
--- a/queries/inko/highlights.scm
+++ b/queries/inko/highlights.scm
@@ -141,6 +141,8 @@
 
 (constant_pattern) @constant
 
+(boolean_pattern) @boolean
+
 ; Types
 (generic_type
   name: _ @type)


### PR DESCRIPTION
This query was missing, resulting in patterns such as `case Ok(true)` not being highlighted correctly.