### PR TITLE
feat(latex): capture label_definition as label

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -86,6 +86,9 @@
     (_) @function))
 
 (label_definition
+  name: (curly_group_text) @label)
+
+(label_definition
   command: _ @function.macro
   name: (curly_group_text
     (_) @markup.link @nospell))


### PR DESCRIPTION
This PR attempts to enhance the highlighting of labels by capturing label_definition as a label. Here are some before and after:  
![2024-08-18-13:35:33](https://github.com/user-attachments/assets/ac250f41-ea0e-4485-8211-ac370b0c57b5)
![2024-08-18-13:34:38](https://github.com/user-attachments/assets/804215e0-5c23-49de-966f-14e8c7a3f28e)
The label capture does not fit the strict guidelines provided by the repo, but it is fitted in the context of LSP navigation. Please feel free to close this PR if it not fitted.
Thanks for your work and for your time reviewing :)