### PR TITLE
feat(http): switch to new parser version

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -315,7 +315,7 @@
     "revision": "ea71012d3fe14dd0b69f36be4f96bdfe9155ebae"
   },
   "http": {
-    "revision": "5ae6c7cfa62a7d7325c26171a1de4f6b866702b5"
+    "revision": "b88cd0c7dba0128b8f28fcb25cca13eea0d193b3"
   },
   "hurl": {
     "revision": "fba6ed8db3a009b9e7d656511931b181a3ee5b08"

--- a/queries/http/highlights.scm
+++ b/queries/http/highlights.scm
@@ -1,50 +1,36 @@
-; Keywords
-(scheme) @module
-
 ; Methods
 (method) @function.method
 
 ; Headers
 (header
-  name: (name) @constant)
+  name: (_) @constant)
 
 ; Variables
 (variable_declaration
   name: (identifier) @variable)
 
-; Fields
-(pair
-  name: (identifier) @variable.member)
-
-; URL / Host
-(host) @string.special.url
-
-(path
-  (identifier) @string.special.url)
-
-; Parameters
-(query_param
-  (key) @variable.parameter)
-
 ; Operators
-[
-  "="
-  "?"
-  "&"
-  "@"
-  "<"
-] @operator
+(comment
+  "=" @operator)
+
+(variable_declaration
+  "=" @operator)
+
+; keywords
+(comment
+  "@" @keyword
+  name: (_) @keyword)
 
 ; Literals
-(target_url) @string.special.url
+(request
+  url: (_) @string.special.url)
 
 (http_version) @constant
 
-(string) @string
+; Response
+(status_code) @number
 
-(number) @number
-
-(boolean) @boolean
+(status_text) @string
 
 ; Punctuation
 [
@@ -52,11 +38,15 @@
   "}}"
 ] @punctuation.bracket
 
-":" @punctuation.delimiter
+(header
+  ":" @punctuation.delimiter)
 
 ; external JSON body
 (external_body
-  file_path: (path) @string.special.path)
+  path: (_) @string.special.path)
 
 ; Comments
-(comment) @comment @spell
+[
+  (comment)
+  (request_separator)
+] @comment @spell

--- a/queries/http/injections.scm
+++ b/queries/http/injections.scm
@@ -19,10 +19,10 @@
 
 ; Script with other languages
 ((comment
-   name: (_) @_name
-   (#eq? @_name "lang")
-   value: (_) @injection.language)
- .
- (_
-   (script) @injection.content
-   (#offset! @injection.content 0 2 0 -2)))
+  name: (_) @_name
+  (#eq? @_name "lang")
+  value: (_) @injection.language)
+  .
+  (_
+    (script) @injection.content
+    (#offset! @injection.content 0 2 0 -2)))

--- a/queries/http/injections.scm
+++ b/queries/http/injections.scm
@@ -9,9 +9,20 @@
 ((xml_body) @injection.content
   (#set! injection.language "xml"))
 
-((graphql_body) @injection.content
+((graphql_data) @injection.content
   (#set! injection.language "graphql"))
 
-; Lua scripting
-((script_variable) @injection.content
-  (#set! injection.language "lua"))
+; Script (default to javascript)
+((script) @injection.content
+  (#offset! @injection.content 0 2 0 -2)
+  (#set! injection.language "javascript"))
+
+; Script with other languages
+((comment
+   name: (_) @_name
+   (#eq? @_name "lang")
+   value: (_) @injection.language)
+ .
+ (_
+   (script) @injection.content
+   (#offset! @injection.content 0 2 0 -2)))


### PR DESCRIPTION
The http parser suffered a complete spec refactor very recently. This PR is intended to update the parser here so that it works correctly.

The PR changes:
- Update `http` revision in the lockfile
- Update queries

---

#### Notes:
1. I don't know if the queries are formatted correctly like this. I recently moved to NixOS and I don't know if that's the reason, but when I run the script to format them it crashes with the error `fish: Job 1, './scripts/format-queries.lua qu…' terminated by signal SIGSEGV (Address boundary error)`. In case not, is it possible for you to run the script and push it to my branch before merging?