### PR TITLE
feat(rust): add highlight for shorthand_field_identifier

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -23,6 +23,8 @@
 
 (field_identifier) @variable.member
 
+(shorthand_field_identifier) @variable.member
+
 (shorthand_field_initializer
   (identifier) @variable.member)
 


### PR DESCRIPTION
This highlights shorthand field identifiers in struct patterns like this:

```rs
    let lsp_types::InitializeParams {
        root_uri,
        capabilities,
        workspace_folders,
        initialization_options,
        client_info,
        ..
    } = from_json::<lsp_types::InitializeParams>("InitializeParams", &initialize_params)?;
```