### PR TITLE
fix(latex): make sure math_environment does not get double capture

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -53,14 +53,12 @@
 (begin
   command: _ @module
   name: (curly_group_text
-    (text) @label @nospell)
-  (#not-has-ancestor? @label math_environment))
+    (text) @label @nospell))
 
 (end
   command: _ @module
   name: (curly_group_text
-    (text) @label @nospell)
-  (#not-has-ancestor? @label math_environment))
+    (text) @label @nospell))
 
 ; Definitions and references
 (new_command_definition
@@ -320,6 +318,14 @@
 
 (math_environment
   (_) @markup.math)
+
+(math_environment
+  begin: (begin
+    name: (curly_group_text
+      text: (text) @markup.math))
+  end: (end
+    name: (curly_group_text
+      text: (text) @markup.math)))
 
 ; Comments
 [

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -52,12 +52,14 @@
 ; General environments
 (begin
   command: _ @module
-  name: (curly_group_text (text) @label @nospell)
+  name: (curly_group_text
+    (text) @label @nospell)
   (#not-has-ancestor? @label math_environment))
 
 (end
   command: _ @module
-  name: (curly_group_text (text) @label @nospell)
+  name: (curly_group_text
+    (text) @label @nospell)
   (#not-has-ancestor? @label math_environment))
 
 ; Definitions and references

--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -52,13 +52,13 @@
 ; General environments
 (begin
   command: _ @module
-  name: (curly_group_text
-    (text) @label @nospell))
+  name: (curly_group_text (text) @label @nospell)
+  (#not-has-ancestor? @label math_environment))
 
 (end
   command: _ @module
-  name: (curly_group_text
-    (text) @label @nospell))
+  name: (curly_group_text (text) @label @nospell)
+  (#not-has-ancestor? @label math_environment))
 
 ; Definitions and references
 (new_command_definition


### PR DESCRIPTION
This PR is an adaptation to the way generic environments are captured in order to make sure math_envrironment do not get double captures, thus highlighting them differently. I think this improves the highlighting, since many engines follow a similar paradigm, like legacy vim syntax. Moreover, it indicates a core difference in the code, indicated by the grammar itself. 
Here are some before and after images to showcase the differences:
![2024-08-22-23:58:05](https://github.com/user-attachments/assets/0271a3bd-b1c0-483c-ad30-58f3531279a3)
![2024-08-22-23:57:16](https://github.com/user-attachments/assets/806f0ab8-b1dd-464d-956c-09372aea543e)
I am not sure if the default behavior is to be expected, if it is feel free to close this PR.
Keep up the great work and thanks for your contribution!