### PR TITLE
feat(http): update injections queries

### DIFF
--- a/queries/http/injections.scm
+++ b/queries/http/injections.scm
@@ -13,28 +13,12 @@
   (#set! injection.language "graphql"))
 
 ; Script (default to javascript)
-((script) @injection.content
-  (#offset! @injection.content 0 2 0 -2)
-  (#set! injection.language "javascript"))
-
-; Script with other languages
-((comment
+((#set! injection.language "javascript")
+(comment
   name: (_) @_name
   (#eq? @_name "lang")
-  value: (_) @injection.language)
-  .
-  (_
-    (script) @injection.content
-    (#offset! @injection.content 0 2 0 -2)))
-
-; post-request scripts for requests without body
-((request
-  !body
-  (comment
-    name: (_) @_name
-    (#eq? @_name "lang")
-    value: (_) @injection.language) .)
-  .
-  (res_handler_script
-    (script) @injection.content
-    (#offset! @injection.content 0 2 0 -2)))
+  value: (_) @injection.language)?
+.
+(_
+  (script) @injection.content
+  (#offset! @injection.content 0 2 0 -2)))

--- a/queries/http/injections.scm
+++ b/queries/http/injections.scm
@@ -13,12 +13,12 @@
   (#set! injection.language "graphql"))
 
 ; Script (default to javascript)
-((#set! injection.language "javascript")
-(comment
+((comment
   name: (_) @_name
   (#eq? @_name "lang")
   value: (_) @injection.language)?
-.
-(_
-  (script) @injection.content
-  (#offset! @injection.content 0 2 0 -2)))
+  .
+  (_
+    (script) @injection.content
+    (#offset! @injection.content 0 2 0 -2))
+  (#set! injection.language "javascript"))

--- a/queries/http/injections.scm
+++ b/queries/http/injections.scm
@@ -26,3 +26,15 @@
   (_
     (script) @injection.content
     (#offset! @injection.content 0 2 0 -2)))
+
+; post-request scripts for requests without body
+((request
+  !body
+  (comment
+    name: (_) @_name
+    (#eq? @_name "lang")
+    value: (_) @injection.language) .)
+  .
+  (res_handler_script
+    (script) @injection.content
+    (#offset! @injection.content 0 2 0 -2)))


### PR DESCRIPTION
Updated `http/injections.scm` file following latest release of [tree-sitter-http](https://github.com/rest-nvim/tree-sitter-http).

This enables response handler script language injections for cases like:

```http
GET example.com

# @lang=lua
{%
-- lua code
%}
```
