### PR TITLE
feat(matlab): capture comment sections

### DIFF
--- a/queries/matlab/highlights.scm
+++ b/queries/matlab/highlights.scm
@@ -211,3 +211,6 @@
   (comment)
   (line_continuation)
 ] @comment @spell
+
+((comment) @keyword.directive
+  (#lua-match? @keyword.directive "^%%%% "))


### PR DESCRIPTION
This PR capture the "section" comments of matlab, a way to define code sections to run separately, for more info [see](https://www.mathworks.com/help/matlab/matlab_prog/create-and-run-sections.html). The sections are captured as keyword.directive since they provide some kind of preprocessing command. Before and after images:

 
![2024-08-25-23:19:45](https://github.com/user-attachments/assets/71988434-1113-492c-bf58-2ed6b1627d07)
![2024-08-25-23:19:12](https://github.com/user-attachments/assets/eec023a5-4b73-4885-8112-ca24cd86594b)

Thank you for your contribution!