### PR TITLE
feat(make): highlight more special characters

### DIFF
--- a/queries/make/highlights.scm
+++ b/queries/make/highlights.scm
@@ -114,6 +114,22 @@
     ")"
   ] @operator)
 
+(automatic_variable
+  "$"
+  _ @character.special
+  (#set! priority 105))
+
+(automatic_variable
+  [
+    "$"
+    "("
+    ")"
+  ] @operator
+  (#set! priority 105))
+
+(recipe_line
+  "@" @character.special)
+
 (function_call
   [
     "subst"


### PR DESCRIPTION
Test text:
```make
lib/%.js.flow: src/%.js
	@echo "Building $(@)"
	@mkdir -p $(@D)
	@cp $(<) $(@)
```