### PR TITLE
feat(query): highlight supertype "/" delimiters

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -33,7 +33,10 @@
   ")"
 ] @punctuation.bracket
 
-":" @punctuation.delimiter
+[
+  ":"
+  "/"
+] @punctuation.delimiter
 
 [
   "@"


### PR DESCRIPTION
For something like `(supertype/regularnode) @cap`