### PR TITLE
feat(latex): set url attribute for hyperlinks

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -112,10 +112,11 @@
   command: _ @function.macro @nospell
   keys: (curly_group_text_list) @markup.link @nospell)
 
-(hyperlink
+((hyperlink
   command: _ @function @nospell
   uri: (curly_group_uri
-    (_) @markup.link.url @nospell))
+    (_) @markup.link.url @nospell)) @_hyperlink
+  (#set! @_hyperlink url @markup.link.url))
 
 (glossary_entry_definition
   command: _ @function.macro @nospell


### PR DESCRIPTION
Just a sidenote: after https://github.com/neovim/neovim/commit/9762c5e3406cab8152d8dd161c0178965d841676, using `gx` binding anywhere on `\href{URL}{description}` will open `URL`.