### PR TITLE
fix(query): force all=false in add_{predicate,directive}

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -15,6 +15,9 @@ local non_filetype_match_injection_language_aliases = {
   ts = "typescript",
 }
 
+-- compatibility shim for breaking change on nightly/0.11
+local opts = vim.fn.has "nvim-0.10" == 1 and { force = true, all = false } or true
+
 local function get_parser_from_markdown_info_string(injection_alias)
   local match = vim.filetype.match { filename = "a." .. injection_alias }
   return match or non_filetype_match_injection_language_aliases[injection_alias] or injection_alias
@@ -57,7 +60,7 @@ query.add_predicate("nth?", function(match, _pattern, _bufnr, pred)
   end
 
   return false
-end, true)
+end, opts)
 
 ---@param match (TSNode|nil)[]
 ---@param _pattern string
@@ -91,9 +94,9 @@ local function has_ancestor(match, _pattern, _bufnr, pred)
   return false
 end
 
-query.add_predicate("has-ancestor?", has_ancestor, true)
+query.add_predicate("has-ancestor?", has_ancestor, opts)
 
-query.add_predicate("has-parent?", has_ancestor, true)
+query.add_predicate("has-parent?", has_ancestor, opts)
 
 ---@param match (TSNode|nil)[]
 ---@param _pattern string
@@ -117,7 +120,7 @@ query.add_predicate("is?", function(match, _pattern, bufnr, pred)
   local _, _, kind = locals.find_definition(node, bufnr)
 
   return vim.tbl_contains(types, kind)
-end, true)
+end, opts)
 
 ---@param match (TSNode|nil)[]
 ---@param _pattern string
@@ -137,7 +140,7 @@ query.add_predicate("kind-eq?", function(match, _pattern, _bufnr, pred)
   end
 
   return vim.tbl_contains(types, node:type())
-end, true)
+end, opts)
 
 ---@param match (TSNode|nil)[]
 ---@param _ string
@@ -158,7 +161,7 @@ query.add_directive("set-lang-from-mimetype!", function(match, _, bufnr, pred, m
     local parts = vim.split(type_attr_value, "/", {})
     metadata["injection.language"] = parts[#parts]
   end
-end, true)
+end, opts)
 
 ---@param match (TSNode|nil)[]
 ---@param _ string
@@ -173,10 +176,10 @@ query.add_directive("set-lang-from-info-string!", function(match, _, bufnr, pred
   end
   local injection_alias = vim.treesitter.get_node_text(node, bufnr):lower()
   metadata["injection.language"] = get_parser_from_markdown_info_string(injection_alias)
-end, true)
+end, opts)
 
 -- Just avoid some annoying warnings for this directive
-query.add_directive("make-range!", function() end, true)
+query.add_directive("make-range!", function() end, opts)
 
 --- transform node text to lower case (e.g., to make @injection.language case insensitive)
 ---
@@ -197,7 +200,7 @@ query.add_directive("downcase!", function(match, _, bufnr, pred, metadata)
     metadata[id] = {}
   end
   metadata[id].text = string.lower(text)
-end, true)
+end, opts)
 
 -- Trim blank lines from end of the region
 -- Arguments are the captures to trim.
@@ -235,4 +238,4 @@ query.add_directive("trim!", function(match, _, bufnr, pred, metadata)
       metadata[id].range = { start_row, start_col, end_row, end_col }
     end
   end
-end, true)
+end, opts)


### PR DESCRIPTION
This is a "fix" for the recent upstream change that makes `all=true` the default.

Backwards compatible using a shim (thanks @gpanders!)