### PR TITLE
feat(latex): parse ```math as LaTeX

### DIFF
--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -13,6 +13,7 @@ local non_filetype_match_injection_language_aliases = {
   sh = "bash",
   uxn = "uxntal",
   ts = "typescript",
+  math = "latex",
 }
 
 -- compatibility shim for breaking change on nightly/0.11


### PR DESCRIPTION
Thanks for making nvim-treesitter! I use it every day; it's very useful.

This change makes <code>```math</code> fenced code blocks render using LaTex syntax highlighting.

For context, GitHub-flavored Markdown renders <code>```math</code> fenced code blocks by first parsing them as LaTeX (c.f. <code>```latex</code> which will render as raw LaTeX source): https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions#writing-expressions-as-blocks

I've been using the following injection at `after/queries/markdown/injections.scm`:

```scm
; extends
; Use :Inspect, :InspectTree, and :EditQuery

; Highlight ```math fenced code blocks using the LaTeX highlighter.
(fenced_code_block
  (info_string (language) @_lang)
  (code_fence_content) @injection.content
  (#eq? @_lang "math")
  (#set! injection.language "latex"))
```

But I noticed that we use `#set-lang-from-info-string!` with some built-in aliases: https://github.com/nvim-treesitter/nvim-treesitter/blob/bfe74a4899882a4ef45abb80813f14644a110a34/queries/markdown/injections.scm#L5