### PR TITLE
feat(zine): add zine-ssg parsers and queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -886,5 +886,8 @@
   },
   "zig": {
     "revision": "21e2218e0ec7f4e3c0640d16bf8c67e6f0a61e18"
+  },
+  "ziggy": {
+    "revision": "c66f47bc632c66668d61fa06eda112b41d6e5130"
   }
 }

--- a/lockfile.json
+++ b/lockfile.json
@@ -725,6 +725,9 @@
   "supercollider": {
     "revision": "affa4389186b6939d89673e1e9d2b28364f5ca6f"
   },
+  "superhtml": {
+    "revision": "3edb67236291d45ba97a79cdac3b91692487a352"
+  },
   "supermd": {
     "revision": "df79b57df18a985b5e524d465361da9de39b1863"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -889,5 +889,8 @@
   },
   "ziggy": {
     "revision": "c66f47bc632c66668d61fa06eda112b41d6e5130"
+  },
+  "ziggy_schema": {
+    "revision": "c66f47bc632c66668d61fa06eda112b41d6e5130"
   }
 }

--- a/lockfile.json
+++ b/lockfile.json
@@ -725,6 +725,12 @@
   "supercollider": {
     "revision": "affa4389186b6939d89673e1e9d2b28364f5ca6f"
   },
+  "supermd": {
+    "revision": "df79b57df18a985b5e524d465361da9de39b1863"
+  },
+  "supermd_inline": {
+    "revision": "df79b57df18a985b5e524d465361da9de39b1863"
+  },
   "surface": {
     "revision": "f4586b35ac8548667a9aaa4eae44456c1f43d032"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2101,6 +2101,18 @@ list.supercollider = {
   maintainers = { "@madskjeldgaard" },
 }
 
+list.superhtml = {
+  install_info = {
+    url = "https://github.com/kristoff-it/superhtml",
+    files = {
+      "src/parser.c",
+      "src/scanner.c",
+    },
+    location = "tree-sitter-superhtml",
+  },
+  maintainers = { "@rockorager" },
+}
+
 list.supermd = {
   install_info = {
     url = "https://github.com/kristoff-it/supermd",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2101,6 +2101,30 @@ list.supercollider = {
   maintainers = { "@madskjeldgaard" },
 }
 
+list.supermd = {
+  install_info = {
+    url = "https://github.com/kristoff-it/supermd",
+    files = {
+      "src/parser.c",
+      "src/scanner.c",
+    },
+    location = "tree-sitter/supermd",
+  },
+  maintainers = { "@rockorager" },
+}
+
+list.supermd_inline = {
+  install_info = {
+    url = "https://github.com/kristoff-it/supermd",
+    files = {
+      "src/parser.c",
+      "src/scanner.c",
+    },
+    location = "tree-sitter/supermd-inline",
+  },
+  maintainers = { "@rockorager" },
+}
+
 list.surface = {
   install_info = {
     url = "https://github.com/connorlay/tree-sitter-surface",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2561,6 +2561,15 @@ list.ziggy = {
   maintainers = { "@rockorager" },
 }
 
+list.ziggy_schema = {
+  install_info = {
+    url = "https://github.com/kristoff-it/ziggy",
+    files = { "src/parser.c" },
+    location = "tree-sitter-ziggy-schema",
+  },
+  maintainers = { "@rockorager" },
+}
+
 list.templ = {
   install_info = {
     url = "https://github.com/vrischmann/tree-sitter-templ",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2552,6 +2552,15 @@ list.zig = {
   maintainers = { "@amaanq" },
 }
 
+list.ziggy = {
+  install_info = {
+    url = "https://github.com/kristoff-it/ziggy",
+    files = { "src/parser.c" },
+    location = "tree-sitter-ziggy",
+  },
+  maintainers = { "@rockorager" },
+}
+
 list.templ = {
   install_info = {
     url = "https://github.com/vrischmann/tree-sitter-templ",

--- a/queries/superhtml/highlights.scm
+++ b/queries/superhtml/highlights.scm
@@ -1,0 +1,47 @@
+(doctype) @constant
+
+(comment) @comment
+
+((tag_name) @string.special
+  (#any-of? @string.special "super" "extend"))
+
+(tag_name) @tag
+
+((element
+  (start_tag
+    (attribute
+      (attribute_name) @attribute
+      [
+        (attribute_value) @markup.link.url
+        (quoted_attribute_value
+          (attribute_value) @markup.link.url)
+      ]))
+  (element
+    (start_tag
+      (tag_name) @tag)))
+  (#eq? @tag "super")
+  (#eq? @attribute "id"))
+
+((element
+  (start_tag
+    (tag_name) @string.special
+    (attribute
+      (attribute_name) @attribute)+))
+  (#eq? @string.special "super"))
+
+(attribute_name) @attribute
+
+[
+  "\""
+  (attribute_value)
+] @string
+
+[
+  "<"
+  ">"
+  "</"
+  "/>"
+  "<!"
+] @punctuation.bracket
+
+"=" @punctuation.delimiter

--- a/queries/superhtml/injections.scm
+++ b/queries/superhtml/injections.scm
@@ -1,0 +1,7 @@
+((script_element
+  (raw_text) @injection.content)
+  (#set! injection.language "javascript"))
+
+((style_element
+  (raw_text) @injection.content)
+  (#set! injection.language "css"))

--- a/queries/supermd/highlights.scm
+++ b/queries/supermd/highlights.scm
@@ -1,0 +1,44 @@
+(atx_heading
+  (inline) @markup.heading)
+
+(setext_heading
+  (paragraph) @markup.heading)
+
+[
+  (atx_h1_marker)
+  (atx_h2_marker)
+  (atx_h3_marker)
+  (atx_h4_marker)
+  (atx_h5_marker)
+  (atx_h6_marker)
+  (setext_h1_underline)
+  (setext_h2_underline)
+] @punctuation.special
+
+[
+  (link_title)
+  (indented_code_block)
+  (fenced_code_block)
+] @markup.raw
+
+(fenced_code_block_delimiter) @punctuation.delimiter
+
+(link_destination) @markup.link.url
+
+(link_label) @markup.link.label
+
+[
+  (list_marker_plus)
+  (list_marker_minus)
+  (list_marker_star)
+  (list_marker_dot)
+  (list_marker_parenthesis)
+  (thematic_break)
+] @punctuation.special
+
+[
+  (block_continuation)
+  (block_quote_marker)
+] @punctuation.special
+
+(backslash_escape) @string.escape

--- a/queries/supermd/injections.scm
+++ b/queries/supermd/injections.scm
@@ -1,0 +1,22 @@
+(fenced_code_block
+  (info_string
+    (language) @injection.language)
+  (code_fence_content) @injection.content)
+
+((html_block) @injection.content
+  (#set! injection.language "html"))
+
+(document
+  .
+  (section
+    .
+    (thematic_break)
+    (_) @injection.content
+    (thematic_break))
+  (#set! injection.language "ziggy"))
+
+((minus_metadata) @injection.content
+  (#set! injection.language "ziggy"))
+
+((inline) @injection.content
+  (#set! injection.language "supermd_inline"))

--- a/queries/supermd_inline/highlights.scm
+++ b/queries/supermd_inline/highlights.scm
@@ -1,0 +1,52 @@
+[
+  (code_span)
+  (link_title)
+] @markup.raw
+
+[
+  (emphasis_delimiter)
+  (code_span_delimiter)
+] @punctuation.delimiter
+
+(emphasis) @markup.italic
+
+(strong_emphasis) @markup.strong
+
+[
+  (link_destination)
+  (uri_autolink)
+] @markup.link.url
+
+[
+  (link_label)
+  (link_text)
+  (image_description)
+] @markup.link.label
+
+[
+  (backslash_escape)
+  (hard_line_break)
+] @string.escape
+
+(image
+  [
+    "!"
+    "["
+    "]"
+    "("
+    ")"
+  ] @punctuation.delimiter)
+
+(inline_link
+  [
+    "["
+    "]"
+    "("
+    ")"
+  ] @punctuation.delimiter)
+
+(shortcut_link
+  [
+    "["
+    "]"
+  ] @punctuation.delimiter)

--- a/queries/supermd_inline/injections.scm
+++ b/queries/supermd_inline/injections.scm
@@ -1,0 +1,5 @@
+((html_tag) @injection.content
+  (#set! injection.language "html"))
+
+((latex_block) @injection.content
+  (#set! injection.language "latex"))

--- a/queries/ziggy/highlights.scm
+++ b/queries/ziggy/highlights.scm
@@ -1,0 +1,41 @@
+[
+  (true)
+  (false)
+] @constant.builtin
+
+(null) @constant.builtin
+
+[
+  (integer)
+  (float)
+] @number
+
+(struct_field
+  key: (_) @keyword)
+
+(struct
+  name: (_) @type)
+
+(tag) @function
+
+[
+  (string)
+  (line_string)*
+] @string
+
+(comment) @comment
+
+(escape_sequence) @string.escape
+
+"," @punctuation.delimiter
+
+[
+  "["
+  "]"
+  "{"
+  "}"
+  "("
+  ")"
+] @punctuation.bracket
+
+(top_comment) @comment

--- a/queries/ziggy/indents.scm
+++ b/queries/ziggy/indents.scm
@@ -1,0 +1,10 @@
+[
+  (struct)
+  (map)
+  (array)
+] @indent.begin
+
+[
+  "]"
+  "}"
+] @indent.end

--- a/queries/ziggy_schema/highlights.scm
+++ b/queries/ziggy_schema/highlights.scm
@@ -1,0 +1,38 @@
+(struct_field
+  key: (_) @keyword)
+
+(tag_name) @function
+
+[
+  "unknown"
+  "any"
+  "struct"
+  "root"
+  "enum"
+  "map"
+] @keyword
+
+(identifier) @type
+
+"?" @type
+
+[
+  "bool"
+  "bytes"
+  "int"
+  "float"
+] @constant.builtin
+
+(doc_comment) @comment.documentation
+
+[
+  ","
+  "|"
+] @punctuation.delimiter
+
+[
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket

--- a/queries/ziggy_schema/indents.scm
+++ b/queries/ziggy_schema/indents.scm
@@ -1,0 +1,3 @@
+(struct) @indent.begin
+
+"}" @indent.end


### PR DESCRIPTION
Add parsers and queries for filetypes used by the
[Zine](https://github.com/kristoff-it/zine) static site generator.

- [Ziggy](https://github.com/kristoff-it/ziggy)
- [SuperMD](https://github.com/kristoff-it/supermd)
- [SuperHTML](https://github.com/kristoff-it/superhtml)

The initial state of the queries are copies of those provided in the Zine repo.
