### PR TITLE
feat(latex): capture conditionals

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -238,6 +238,14 @@
     (_) @markup.strong))
   (#any-of? @_name "\\textbf" "\\mathbf"))
 
+(generic_command
+  (command_name) @keyword.conditional
+  (#lua-match? @keyword.conditional "^\\if[a-zA-Z@]+$"))
+
+(generic_command
+  (command_name) @keyword.conditional
+  (#any-of? @keyword.conditional "\\fi" "\\else"))
+
 ; File inclusion commands
 (class_include
   command: _ @keyword.import


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/97bb67ca-43ff-4bea-b48d-de1c91b73954)
After:
![image](https://github.com/user-attachments/assets/bc94ff13-8a97-4533-a257-3172b5900df0)

Can possibly capture commands which are not conditionals in the purest sense shown above, but generally it works pretty well. In case someone has macro/command starting on `if` which doesn't have anything with conditionals, and is bothered by such false positive capture, they are free to overwrite it with another tailor-made capture.