### PR TITLE
fix(rust): comment marker should not be `@operator`

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -214,16 +214,6 @@
     (identifier) @function.macro .))
 
 ; Literals
-[
-  (line_comment)
-  (block_comment)
-] @comment @spell
-
-(line_comment
-  (doc_comment)) @comment.documentation
-
-(block_comment
-  (doc_comment)) @comment.documentation
 
 (boolean_literal) @boolean
 
@@ -463,3 +453,17 @@
   macro: (identifier) @keyword.debug
   "!" @keyword.debug
   (#eq? @keyword.debug "dbg"))
+
+; Comments
+[
+  (line_comment)
+  (block_comment)
+  (outer_doc_comment_marker)
+  (inner_doc_comment_marker)
+] @comment @spell
+
+(line_comment
+  (doc_comment)) @comment.documentation
+
+(block_comment
+  (doc_comment)) @comment.documentation

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -214,7 +214,6 @@
     (identifier) @function.macro .))
 
 ; Literals
-
 (boolean_literal) @boolean
 
 (integer_literal) @number


### PR DESCRIPTION
Closes #7133