### PR TITLE
feat(ruby): improve require highlighting

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -81,10 +81,10 @@
     (constant)
   ] @function.call)
 
-(program
-  (call
-    (identifier) @keyword.import)
-  (#any-of? @keyword.import "require" "require_relative" "load"))
+((call
+  !receiver
+  method: (identifier) @keyword.import)
+  (#any-of? @keyword.import "require" "require_relative" "load" "autoload" "gem"))
 
 ; Function definitions
 (alias


### PR DESCRIPTION
1. Highlight import (like `require`) when they are not top level.

    Before:

    ![before](https://github.com/user-attachments/assets/44784d96-e82a-4eb2-ad90-01d7c29f8efb)

    After:

    ![after](https://github.com/user-attachments/assets/a66cb0a2-2e72-4f14-ab3b-f43e0af5651d)

2. Add `autoload` and `gem` to the list of imports