### PR TITLE
feat(ruby): detect shebang directive

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -208,6 +208,11 @@
 
 (comment) @comment @spell
 
+((program
+  .
+  (comment) @keyword.directive @nospell)
+  (#lua-match? @keyword.directive "^#!/"))
+
 (program
   (comment)+ @comment.documentation
   (class))


### PR DESCRIPTION
Detect the shebang directive similarly to what Bash [does](https://github.com/nvim-treesitter/nvim-treesitter/blob/b6a6d8997c46dc15682020ce4fddc5a89ee1ac0d/queries/bash/highlights.scm#L236-L239).