### PR TITLE
feat(ruby): improve identifiers highlighting

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -125,9 +125,12 @@
     "__callee__" "__dir__" "__id__" "__method__" "__send__" "__ENCODING__" "__FILE__" "__LINE__"))
 
 ((identifier) @function.builtin
-  (#any-of? @function.builtin
-    "include" "extend" "prepend" "attr_reader" "attr_writer" "attr_accessor" "module_function"
-    "refine" "using"))
+  (#any-of? @function.builtin "attr_reader" "attr_writer" "attr_accessor" "module_function"))
+
+((call
+  !receiver
+  method: (identifier) @function.builtin)
+  (#any-of? @function.builtin "include" "extend" "prepend" "refine" "using"))
 
 ((identifier) @keyword.exception
   (#any-of? @keyword.exception "raise" "fail" "catch" "throw"))


### PR DESCRIPTION
Only highlight `include`, `extend`, `prepend`, `refine`, and `using` as built-ins if they are not called on an explicit object.

Before:

![before](https://github.com/user-attachments/assets/00ce881e-f5e4-40fc-bee8-872f64b199dd)

After:

![after](https://github.com/user-attachments/assets/c9ab24ef-dc8d-4c94-a70e-b177546beaef)