### PR TITLE
feat(markdown): Conceal backslashes in escape sequences

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -10,16 +10,19 @@
 (shortcut_link
   (link_text) @nospell)
 
-[
-  (backslash_escape)
-  (hard_line_break)
-] @string.escape
+(hard_line_break) @string.escape
+
+; Conceal backslashes in escape sequences
+(_
+  (backslash_escape) @string.escape
+  (#offset! @string.escape 0 0 0 -1)
+  (#set! conceal ""))
 
 ; Conceal codeblock and text style markers
 ([
   (code_span_delimiter)
   (emphasis_delimiter)
-] @conceal
+] @punctuation.delimiter
   (#set! conceal ""))
 
 ; Conceal inline links


### PR DESCRIPTION
| | `conceallevel=0` | `conceallevel=3` |
| ---:| --- | --- |
| **Before** | <img width="400" alt="Screenshot 2024-09-11 at 13 18 17" src="https://github.com/user-attachments/assets/dae02a16-aa7f-456d-b223-f29b88466d0e"> | <img width="400" alt="Screenshot 2024-09-11 at 13 18 30" src="https://github.com/user-attachments/assets/21f57f51-1c91-4427-8e89-2f50f6713a94"> |
| **After** | <img width="400" alt="Screenshot 2024-09-11 at 13 16 55" src="https://github.com/user-attachments/assets/8dc4164a-cfdb-4437-8421-e03eadbf107d"> | <img width="400" alt="Screenshot 2024-09-11 at 13 17 17" src="https://github.com/user-attachments/assets/8c403093-1b20-4b85-aa9b-c6dd2ade2cc4"> |

## Things to note
- For the conceal and offset to work, I needed to query for `(_ (backslash_escape))`; just querying for `backslash_escape` didn't work. I'm not sure why, but I'm guessing it might be something to do with whatever technical constraints require `markdown` and `markdown_inline` to be separate.
- I've made the slightly unorthodox move of not highlighting the escaped characters themselves, only the backslashes. The idea here is to use concealing as a simple "preview" mode, and in the final output, these escaped characters would appear as normal characters, so highlighting them felt a bit off to me. 
  - I also added `@punctuation.delimiter` to unescaped delimiters, which ends up with this easy distinction between unescaped and escaped delimiters:
    <img width="228" alt="image" src="https://github.com/user-attachments/assets/d2549f17-bea4-42ca-9200-42b2b77d41e5">
