### PR TITLE
fix(lua): remove duplicate ellipsis highlight

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -151,8 +151,6 @@
 ((identifier) @constant
   (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
 
-(vararg_expression) @constant
-
 (nil) @constant.builtin
 
 [


### PR DESCRIPTION
Already highlighted below as `@variable.parameter.builtin`