### PR TITLE
feat(highlights): capture wildcard patterns as `@character.special`

### DIFF
--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -217,8 +217,9 @@
   "module"
   "this"
   "base"
-  (discard)
 ] @variable.builtin
+
+(discard) @character.special
 
 (constructor_declaration
   name: (identifier) @constructor)

--- a/queries/c_sharp/highlights.scm
+++ b/queries/c_sharp/highlights.scm
@@ -219,8 +219,6 @@
   "base"
 ] @variable.builtin
 
-(discard) @character.special
-
 (constructor_declaration
   name: (identifier) @constructor)
 
@@ -430,6 +428,11 @@
   "??="
   ".."
 ] @operator
+
+(list_pattern
+  ".." @character.special)
+
+(discard) @character.special
 
 [
   ";"

--- a/queries/elm/highlights.scm
+++ b/queries/elm/highlights.scm
@@ -67,7 +67,7 @@
   (lower_case_identifier) @variable)
 
 (anything_pattern
-  (underscore) @variable)
+  (underscore) @character.special)
 
 (record_base_identifier
   (lower_case_identifier) @variable)
@@ -88,7 +88,7 @@
 
 (function_declaration_left
   (anything_pattern
-    (underscore) @variable.parameter))
+    (underscore) @character.special))
 
 (function_declaration_left
   (lower_pattern

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -129,7 +129,7 @@
   (#eq? @keyword.operator "new"))
 
 ; Match Pattern
-(underscore) @constant ; The "_" pattern.
+(underscore) @character.special ; The "_" pattern.
 
 (pattern_open_ending) @operator ; The ".." pattern.
 

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -129,9 +129,11 @@
   (#eq? @keyword.operator "new"))
 
 ; Match Pattern
-(underscore) @character.special ; The "_" pattern.
+[
+  (underscore)
+  (pattern_open_ending)
+] @character.special
 
-(pattern_open_ending) @operator ; The ".." pattern.
 
 ; Alternations
 [

--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -134,7 +134,6 @@
   (pattern_open_ending)
 ] @character.special
 
-
 ; Alternations
 [
   "("

--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -91,8 +91,8 @@
 
 (wildcard
   [
-   ".."
-   "_"
+    ".."
+    "_"
   ] @character.special)
 
 (module

--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -4,8 +4,6 @@
 ; and don't override destructured parameters
 (variable) @variable
 
-(pattern/wildcard) @variable
-
 (decl/function
   patterns: (patterns
     (_) @variable.parameter))
@@ -78,7 +76,6 @@
   (operator)
   (constructor_operator)
   (all_names)
-  (wildcard)
   "."
   ".."
   "="
@@ -91,6 +88,12 @@
   "`"
   "@"
 ] @operator
+
+(wildcard
+  [
+   ".."
+   "_"
+  ] @character.special)
 
 (module
   (module_id) @module)

--- a/queries/haskell/highlights.scm
+++ b/queries/haskell/highlights.scm
@@ -89,11 +89,7 @@
   "@"
 ] @operator
 
-(wildcard
-  [
-    ".."
-    "_"
-  ] @character.special)
+(wildcard) @character.special
 
 (module
   (module_id) @module)

--- a/queries/java/highlights.scm
+++ b/queries/java/highlights.scm
@@ -2,6 +2,8 @@
 ; Variables
 (identifier) @variable
 
+(underscore_pattern) @character.special
+
 ; Methods
 (method_declaration
   name: (identifier) @function.method)

--- a/queries/menhir/highlights.scm
+++ b/queries/menhir/highlights.scm
@@ -27,10 +27,11 @@
 [
   "="
   "~"
-  "_"
 ] @operator
 
 (modifier) @operator
+
+"_" @character.special
 
 [
   "<"

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -275,6 +275,9 @@
   ".."
 ] @punctuation.delimiter
 
+(range_pattern
+  ".." @character.special)
+
 ; Operators
 ;----------
 [

--- a/queries/ocaml/highlights.scm
+++ b/queries/ocaml/highlights.scm
@@ -32,6 +32,9 @@
 
 (value_pattern) @variable.parameter
 
+((value_pattern) @character.special
+  (#eq? @character.special "_"))
+
 ; Functions
 ;----------
 (let_binding

--- a/queries/purescript/highlights.scm
+++ b/queries/purescript/highlights.scm
@@ -118,11 +118,12 @@
   "role" @keyword
   role: (type_role) @keyword.modifier)
 
-(hole) @character.special
-
 ; `_` wildcards in if-then-else and case-of expressions,
 ; as well as record updates and operator sections
-(wildcard) @variable.parameter
+[
+  "_"
+  (hole)
+] @character.special
 
 ; ----------------------------------------------------------------------------
 ; Functions and variables

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -21,7 +21,7 @@
     ; https://docs.python.org/3/library/constants.html
     "NotImplemented" "Ellipsis" "quit" "exit" "copyright" "credits" "license"))
 
-"_" @constant.builtin ; match wildcard
+"_" @character.special ; match wildcard
 
 ((attribute
   attribute: (identifier) @variable.member)

--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -43,7 +43,7 @@
   "#"
 ] @punctuation.special
 
-"_" @constant
+"_" @character.special
 
 ((parameters
   (identifier) @number)

--- a/queries/roc/highlights.scm
+++ b/queries/roc/highlights.scm
@@ -62,7 +62,7 @@
   (operator)
 ] @operator
 
-(wildcard_pattern) @constant.builtin
+(wildcard_pattern) @character.special
 
 [
   "if"

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -31,10 +31,9 @@
 (mod_item
   name: (identifier) @module)
 
-[
-  (self)
-  "_"
-] @variable.builtin
+(self) @variable.builtin
+
+"_" @character.special
 
 (label
   [

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -379,7 +379,11 @@
   ".." @character.special)
 
 (range_pattern
-  ".." @character.special)
+  [
+    ".."
+    "..="
+    "..."
+  ] @character.special)
 
 ; Punctuation
 [

--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -375,6 +375,12 @@
 (use_wildcard
   "*" @character.special)
 
+(remaining_field_pattern
+  ".." @character.special)
+
+(range_pattern
+  ".." @character.special)
+
 ; Punctuation
 [
   "("

--- a/queries/scala/highlights.scm
+++ b/queries/scala/highlights.scm
@@ -211,7 +211,8 @@
 
 (null_literal) @constant.builtin
 
-(wildcard) @variable.parameter
+(wildcard
+  "_") @character.special
 
 (namespace_wildcard
   [


### PR DESCRIPTION
Some languages use `_` as a wildcard pattern to match anything, which should be highlighted as `@character.special`. Is possible that other languages use a different character for the same purpose, but I don't know of any.

I got a list of grammars that use an underscore with this command:

```sh
rg '"_"|underscore' queries/
```
and just checked which ones use it for pattern matching, with the following results:

- [x] `elm`
- [x] `func`
- [x] `gdscript`
- [x] `haskell`
- [x] `menhir`
- [x] `ocaml`
- [x] `python`
- [x] `query`
- [ ] `racket`: It technically uses `_` for pattern matching but this is
  just a regular symbol in the grammar, so it would need a special and
  complicated query for highlighting.
- [x] `rust`
- [x] `scala`

Grammars that use `_` for other purposes:

- `blueprint`
- `cue`
- `elvish`
- `fish`
- `hare`
- `lalrpop`
- `latex`
- `perl`
- `uxntal`
- `wit`
- `zig`

Please tell me if I miss anything. 