### PR TITLE
feat(htmldjango): improve punctuation highlighting

### DIFF
--- a/queries/htmldjango/highlights.scm
+++ b/queries/htmldjango/highlights.scm
@@ -10,7 +10,7 @@
   "{%"
   "%}"
   (end_paired_statement)
-] @punctuation.bracket
+] @punctuation.special
 
 (tag_name) @function
 
@@ -69,6 +69,5 @@
 
 [
   ":"
-  "'"
-  "\""
+  ","
 ] @punctuation.delimiter


### PR DESCRIPTION
In Django templates `{{` and `{%` are interpolations so they should be highlighted as `@punctuation.special`.

Don't highlight quotes as delimiters (consistency) and add missing comma delimiter.