### PR TITLE
feat(fsharp): add parser and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [forth](https://github.com/AlexanderBrevig/tree-sitter-forth) (maintained by @amaanq)
 - [x] [fortran](https://github.com/stadelmanma/tree-sitter-fortran) (maintained by @amaanq)
 - [x] [fsh](https://github.com/mgramigna/tree-sitter-fsh) (maintained by @mgramigna)
+- [x] [fsharp](https://github.com/ionide/tree-sitter-fsharp) (maintained by @nsidorenco)
 - [x] [func](https://github.com/amaanq/tree-sitter-func) (maintained by @amaanq)
 - [x] [fusion](https://gitlab.com/jirgn/tree-sitter-fusion.git) (maintained by @jirgn)
 - [x] [GAP system](https://github.com/gap-system/tree-sitter-gap) (maintained by @reiniscirpons)

--- a/lockfile.json
+++ b/lockfile.json
@@ -198,7 +198,7 @@
     "revision": "fad2e175099a45efbc98f000cc196d3674cc45e0"
   },
   "fsharp": {
-    "revision": "dcbd07b8860fbde39f207dbc03b36a791986cd96"
+    "revision": "aa03beba6ba774f921d6e3ce2868d3846a1890a5"
   },
   "func": {
     "revision": "f780ca55e65e7d7360d0229331763e16c452fc98"

--- a/lockfile.json
+++ b/lockfile.json
@@ -197,6 +197,9 @@
   "fsh": {
     "revision": "fad2e175099a45efbc98f000cc196d3674cc45e0"
   },
+  "fsharp": {
+    "revision": "dcbd07b8860fbde39f207dbc03b36a791986cd96"
+  },
   "func": {
     "revision": "f780ca55e65e7d7360d0229331763e16c452fc98"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -198,7 +198,7 @@
     "revision": "fad2e175099a45efbc98f000cc196d3674cc45e0"
   },
   "fsharp": {
-    "revision": "aa03beba6ba774f921d6e3ce2868d3846a1890a5"
+    "revision": "f920105eec2d574eb911d7a25c81cdaa079a3f72"
   },
   "func": {
     "revision": "f780ca55e65e7d7360d0229331763e16c452fc98"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -617,6 +617,16 @@ list.fsh = {
   maintainers = { "@mgramigna" },
 }
 
+list.fsharp = {
+  install_info = {
+    url = "https://github.com/ionide/tree-sitter-fsharp",
+    files = { "src/parser.c", "src/scanner.c" },
+    branch = "main",
+    location = "fsharp",
+  },
+  maintainers = { "@nsidorenco" },
+}
+
 list.func = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-func",

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -621,7 +621,6 @@ list.fsharp = {
   install_info = {
     url = "https://github.com/ionide/tree-sitter-fsharp",
     files = { "src/parser.c", "src/scanner.c" },
-    branch = "main",
     location = "fsharp",
   },
   maintainers = { "@nsidorenco" },

--- a/queries/fsharp/highlights.scm
+++ b/queries/fsharp/highlights.scm
@@ -1,0 +1,372 @@
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell
+
+((line_comment) @comment.documentation @spell
+  (#match? @comment.documentation "^///"))
+
+(const
+  [
+    (_) @constant
+    (unit) @constant.builtin
+  ])
+
+(primary_constr_args
+  (_) @variable.parameter)
+
+(class_as_reference
+  (_) @variable.parameter.builtin)
+
+((argument_patterns
+  (long_identifier
+    (identifier) @character.special))
+  (#match? @character.special "^\_.*"))
+
+(wildcard_pattern) @character.special
+
+(type_name
+  type_name: (_) @type.definition)
+
+[
+  (_type)
+  (atomic_type)
+] @type
+
+(member_signature
+  .
+  (identifier) @function.method
+  (curried_spec
+    (arguments_spec
+      "*"* @operator
+      (argument_spec
+        (argument_name_spec
+          "?"? @character.special
+          name: (_) @variable.parameter)))))
+
+(union_type_case) @constant
+
+(rules
+  (rule
+    pattern: (_) @constant
+    block: (_)))
+
+(identifier_pattern
+  .
+  (_) @constant
+  .
+  (_) @variable)
+
+(optional_pattern
+  "?" @character.special)
+
+(fsi_directive_decl
+  .
+  (string) @module)
+
+(import_decl
+  .
+  (_) @module)
+
+(named_module
+  name: (_) @module)
+
+(namespace
+  name: (_) @module)
+
+(module_defn
+  .
+  (_) @module)
+
+(ce_expression
+  .
+  (_) @constant.macro)
+
+(field_initializer
+  field: (_) @property)
+
+(record_fields
+  (record_field
+    .
+    (identifier) @property))
+
+(dot_expression
+  base: (_)? @module)
+
+(value_declaration_left
+  .
+  (_) @variable)
+
+(function_declaration_left
+  .
+  (_) @function
+  .
+  (_)* @variable.parameter)
+
+(member_defn
+  (method_or_prop_defn
+    [
+      (property_or_ident) @function
+      (property_or_ident
+        instance: (identifier) @variable.parameter.builtin
+        method: (identifier) @function.method)
+    ]
+    args: (_)* @variable.parameter))
+
+(application_expression
+  .
+  (_) @function.call
+  .
+  (_) @variable)
+
+((infix_expression
+  .
+  (_)
+  .
+  (infix_op) @operator
+  .
+  (_) @function.call)
+  (#eq? @operator "|>"))
+
+((infix_expression
+  .
+  (_) @function.call
+  .
+  (infix_op) @operator
+  .
+  (_))
+  (#eq? @operator "<|"))
+
+[
+  (xint)
+  (int)
+  (int16)
+  (uint16)
+  (int32)
+  (uint32)
+  (int64)
+  (uint64)
+  (nativeint)
+  (unativeint)
+] @number
+
+[
+  (ieee32)
+  (ieee64)
+  (float)
+  (decimal)
+] @number.float
+
+(bool) @boolean
+
+[
+  (string)
+  (triple_quoted_string)
+  (verbatim_string)
+  (char)
+] @spell @string
+
+(compiler_directive_decl) @keyword.directive
+
+(preproc_line
+  "#line" @keyword.directive)
+
+(attribute) @attribute
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+  "[|"
+  "|]"
+  "{|"
+  "|}"
+] @punctuation.bracket
+
+[
+  "[<"
+  ">]"
+] @punctuation.special
+
+(format_string_eval
+  [
+    "{"
+    "}"
+  ] @punctuation.special)
+
+[
+  ","
+  ";"
+] @punctuation.delimiter
+
+[
+  "|"
+  "="
+  ">"
+  "<"
+  "-"
+  "~"
+  "->"
+  "<-"
+  "&&"
+  "||"
+  ":>"
+  ":?>"
+  (infix_op)
+  (prefix_op)
+] @operator
+
+[
+  "if"
+  "then"
+  "else"
+  "elif"
+  "when"
+  "match"
+  "match!"
+] @keyword.conditional
+
+[
+  "and"
+  "or"
+  "not"
+  "upcast"
+  "downcast"
+] @keyword.operator
+
+[
+  "return"
+  "return!"
+  "yield"
+  "yield!"
+] @keyword.return
+
+[
+  "for"
+  "while"
+  "downto"
+  "to"
+] @keyword.repeat
+
+[
+  "open"
+  "#r"
+  "#load"
+] @keyword.import
+
+[
+  "abstract"
+  "delegate"
+  "static"
+  "inline"
+  "mutable"
+  "override"
+  "rec"
+  "global"
+  (access_modifier)
+] @keyword.modifier
+
+[
+  "let"
+  "let!"
+  "use"
+  "use!"
+  "member"
+] @keyword.function
+
+[
+  "enum"
+  "type"
+  "inherit"
+  "interface"
+  "and"
+  "class"
+  "struct"
+] @keyword.type
+
+((identifier) @keyword.exception
+  (#any-of? @keyword.exception "failwith" "failwithf" "raise" "reraise"))
+
+[
+  "as"
+  "assert"
+  "begin"
+  "end"
+  "done"
+  "default"
+  "in"
+  "do"
+  "do!"
+  "event"
+  "field"
+  "fun"
+  "function"
+  "get"
+  "set"
+  "lazy"
+  "new"
+  "of"
+  "param"
+  "property"
+  "struct"
+  "val"
+  "module"
+  "namespace"
+  "with"
+] @keyword
+
+"null" @constant.builtin
+
+(match_expression
+  "with" @keyword.conditional)
+
+(try_expression
+  [
+    "try"
+    "with"
+    "finally"
+  ] @keyword.exception)
+
+((_type
+  (long_identifier
+    (identifier) @type.builtin))
+  (#any-of? @type.builtin
+    "bool" "byte" "sbyte" "int16" "uint16" "int" "uint" "int64" "uint64" "nativeint" "unativeint"
+    "decimal" "float" "double" "float32" "single" "char" "string" "unit"))
+
+(preproc_if
+  [
+    "#if" @keyword.directive
+    "#endif" @keyword.directive
+  ]
+  condition: (_)? @keyword.directive)
+
+(preproc_else
+  "#else" @keyword.directive)
+
+(long_identifier
+  (identifier)+ @module
+  .
+  (identifier))
+
+(op_identifier) @operator
+
+((identifier) @module.builtin
+  (#any-of? @module.builtin
+    "Array" "Async" "Directory" "File" "List" "Option" "Path" "Map" "Set" "Lazy" "Seq" "Task"
+    "String" "Result"))
+
+((value_declaration
+  (attributes
+    (attribute
+      (_type
+        (long_identifier
+          (identifier) @attribute))))
+  (function_or_value_defn
+    (value_declaration_left
+      .
+      (_) @constant)))
+  (#eq? @attribute "Literal"))

--- a/queries/fsharp/highlights.scm
+++ b/queries/fsharp/highlights.scm
@@ -4,7 +4,7 @@
 ] @comment @spell
 
 ((line_comment) @comment.documentation @spell
-  (#match? @comment.documentation "^///"))
+  (#lua-match? @comment.documentation "^///"))
 
 (const
   [
@@ -21,7 +21,7 @@
 ((argument_patterns
   (long_identifier
     (identifier) @character.special))
-  (#match? @character.special "^\_.*"))
+  (#lua-match? @character.special "^\_.*"))
 
 (wildcard_pattern) @character.special
 

--- a/queries/fsharp/highlights.scm
+++ b/queries/fsharp/highlights.scm
@@ -28,7 +28,7 @@
 
 (member_signature
   .
-  (identifier) @function.member)
+  (identifier) @function.method)
 
 (member_signature
   (curried_spec

--- a/queries/fsharp/highlights.scm
+++ b/queries/fsharp/highlights.scm
@@ -18,13 +18,6 @@
 (class_as_reference
   (_) @variable.parameter.builtin)
 
-((argument_patterns
-  (long_identifier
-    (identifier) @character.special))
-  (#lua-match? @character.special "^\_.*"))
-
-(wildcard_pattern) @character.special
-
 (type_name
   type_name: (_) @type.definition)
 
@@ -35,7 +28,9 @@
 
 (member_signature
   .
-  (identifier) @function.method
+  (identifier) @function.member)
+
+(member_signature
   (curried_spec
     (arguments_spec
       "*"* @operator
@@ -44,12 +39,15 @@
           "?"? @character.special
           name: (_) @variable.parameter)))))
 
-(union_type_case) @constant
+(union_type_case
+  (identifier) @constant)
 
 (rules
   (rule
     pattern: (_) @constant
     block: (_)))
+
+(wildcard_pattern) @character.special
 
 (identifier_pattern
   .
@@ -75,8 +73,7 @@
   name: (_) @module)
 
 (module_defn
-  .
-  (_) @module)
+  (identifier) @module)
 
 (ce_expression
   .
@@ -90,18 +87,44 @@
     .
     (identifier) @property))
 
-(dot_expression
-  base: (_)? @module)
-
 (value_declaration_left
   .
   (_) @variable)
 
 (function_declaration_left
   .
-  (_) @function
-  .
-  (_)* @variable.parameter)
+  (_) @function)
+
+(argument_patterns
+  [
+    (const)
+    (long_identifier)
+    (_pattern)
+  ] @variable.parameter)
+
+(argument_patterns
+  (typed_pattern
+    (_pattern) @variable.parameter
+    (_type) @type))
+
+(argument_patterns
+  (record_pattern
+    (field_pattern
+      .
+      (long_identifier) @variable.parameter)))
+
+(argument_patterns
+  (array_pattern
+    (_pattern)? @variable.parameter))
+
+(argument_patterns
+  (list_pattern
+    (_pattern)? @variable.parameter))
+
+((argument_patterns
+  (long_identifier
+    (identifier) @character.special))
+  (#lua-match? @character.special "^\_.*"))
 
 (member_defn
   (method_or_prop_defn
@@ -112,6 +135,12 @@
         method: (identifier) @function.method)
     ]
     args: (_)* @variable.parameter))
+
+(dot_expression
+  .
+  (_) @variable.member
+  .
+  (_))
 
 (application_expression
   .
@@ -171,13 +200,16 @@
 (preproc_line
   "#line" @keyword.directive)
 
-(attribute) @attribute
+(attribute
+  target: (identifier)? @keyword
+  (_type) @attribute)
 
 [
   "("
   ")"
   "{"
   "}"
+  ".["
   "["
   "]"
   "[|"
@@ -200,6 +232,8 @@
 [
   ","
   ";"
+  ":"
+  "."
 ] @punctuation.delimiter
 
 [
@@ -211,13 +245,23 @@
   "~"
   "->"
   "<-"
+  "&"
   "&&"
+  "|"
   "||"
   ":>"
   ":?>"
+  ".."
   (infix_op)
   (prefix_op)
+  (op_identifier)
 ] @operator
+
+(generic_type
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
 
 [
   "if"
@@ -300,8 +344,6 @@
   "in"
   "do"
   "do!"
-  "event"
-  "field"
   "fun"
   "function"
   "get"
@@ -309,8 +351,6 @@
   "lazy"
   "new"
   "of"
-  "param"
-  "property"
   "struct"
   "val"
   "module"
@@ -318,7 +358,10 @@
   "with"
 ] @keyword
 
-"null" @constant.builtin
+[
+  "null"
+  (unit)
+] @constant.builtin
 
 (match_expression
   "with" @keyword.conditional)
@@ -329,6 +372,9 @@
     "with"
     "finally"
   ] @keyword.exception)
+
+(application_expression
+  (unit) @function.call)
 
 ((_type
   (long_identifier
@@ -346,13 +392,6 @@
 
 (preproc_else
   "#else" @keyword.directive)
-
-(long_identifier
-  (identifier)+ @module
-  .
-  (identifier))
-
-(op_identifier) @operator
 
 ((identifier) @module.builtin
   (#any-of? @module.builtin

--- a/queries/fsharp/highlights.scm
+++ b/queries/fsharp/highlights.scm
@@ -33,7 +33,6 @@
 (member_signature
   (curried_spec
     (arguments_spec
-      "*"* @operator
       (argument_spec
         (argument_name_spec
           "?"? @character.special
@@ -252,6 +251,7 @@
   ":>"
   ":?>"
   ".."
+  "*"
   (infix_op)
   (prefix_op)
   (op_identifier)

--- a/queries/fsharp/injections.scm
+++ b/queries/fsharp/injections.scm
@@ -1,0 +1,11 @@
+([
+  (line_comment)
+  (block_comment_content)
+] @injection.content
+  (#set! injection.language "comment"))
+
+((line_comment) @injection.content
+  (#match? @injection.content "^///")
+  (#offset! @injection.content 0 3 0 0)
+  (#set! injection.language "xml")
+  (#set! injection.combined))

--- a/queries/fsharp/injections.scm
+++ b/queries/fsharp/injections.scm
@@ -5,7 +5,7 @@
   (#set! injection.language "comment"))
 
 ((line_comment) @injection.content
-  (#match? @injection.content "^///")
+  (#lua-match? @injection.content "^///")
   (#offset! @injection.content 0 3 0 0)
   (#set! injection.language "xml")
   (#set! injection.combined))


### PR DESCRIPTION
This adds support for the [fsharp parser](https://github.com/ionide/tree-sitter-fsharp) along with highlighting and injection queries. 

I have not been able to make satisfactory indentation queries so they are left out for now.