### PR TITLE
fix(markdown): broader link recognition

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -40,14 +40,12 @@
   (image_description)
 ] @markup.link.label
 
-(inline_link
-  (link_text) @_label
-  (link_destination) @_url
+((inline_link
+  (link_destination) @_url) @_label
   (#set! @_label url @_url))
 
-(image
-  (image_description) @_label
-  (link_destination) @_url
+((image
+  (link_destination) @_url) @_label
   (#set! @_label url @_url))
 
 ; Conceal image links


### PR DESCRIPTION
**Problem:** Neovim's `gx` will not work when the cursor is on the first `[` of an inline Markdown link.

**Solution:** Set the `url` metadata property on the link parent node, rather than just the link label node