### PR TITLE
fix(log): use vim.notify for printing logs

### DIFF
--- a/lua/nvim-treesitter/log.lua
+++ b/lua/nvim-treesitter/log.lua
@@ -1,4 +1,5 @@
 local echo = vim.api.nvim_echo
+local notify = vim.notify
 
 -- TODO(lewis6991): write these out to a file
 local messages = {} --- @type {[1]: string, [2]: string?, [3]: string}[]
@@ -54,7 +55,7 @@ end
 function Logger:info(m, ...)
   local m1 = m:format(...)
   messages[#messages + 1] = { 'info', self.ctx, m1 }
-  echo({ { mkpfx(self.ctx) .. ': ' .. m1, sev_to_hl.info } }, true, {})
+  notify(mkpfx(self.ctx) .. ': ' .. m1, vim.log.levels.INFO)
 end
 
 ---@param m string
@@ -62,7 +63,7 @@ end
 function Logger:warn(m, ...)
   local m1 = m:format(...)
   messages[#messages + 1] = { 'warn', self.ctx, m1 }
-  echo({ { mkpfx(self.ctx) .. ' warning: ' .. m1, sev_to_hl.warn } }, true, {})
+  notify(mkpfx(self.ctx) .. ' warning: ' .. m1, vim.log.levels.WARN)
 end
 
 ---@param m string
@@ -71,7 +72,7 @@ end
 function Logger:error(m, ...)
   local m1 = m:format(...)
   messages[#messages + 1] = { 'error', self.ctx, m1 }
-  echo({ { mkpfx(self.ctx) .. ' error: ' .. m1, sev_to_hl.error } }, true, {})
+  notify(mkpfx(self.ctx) .. ' error: ' .. m1, vim.log.levels.ERROR)
   return m1
 end
 


### PR DESCRIPTION
Problem:

When using `vim.api.nvim_echo` for printing out information as part of `:TSUpdate` and when installing/uninstalling, it could prompt `Press ENTER or type command to continue` if the screen is not wide enough. This is super frustrating. This happens with me all the time if I am using it on my macbook 14 inch with a split screen. I have also had it happening by using it fullscreen on my mac

Solution:

Use `vim.notify` which can be overridden and can therefore remove the problem. It is for example possible to use plugins like https://github.com/j-hui/fidget.nvim or https://github.com/rcarriga/nvim-notify (or possibly others) to not get this `Press ENTER or type command to continue`