### PR TITLE
fix(markdown): don't set link metadata twice

### DIFF
--- a/queries/markdown_inline/highlights.scm
+++ b/queries/markdown_inline/highlights.scm
@@ -91,9 +91,6 @@
   (email_autolink)
 ] @markup.link.url @nospell
 
-((link_destination) @_url
-  (#set! @_url url @_url))
-
 ((uri_autolink) @_url
   (#offset! @_url 0 1 0 -1)
   (#set! @_url url @_url))


### PR DESCRIPTION
Otherwise the same link will be opened twice when the cursor is on the link text itself.

I checked `grammar.js` before this change to make sure there are no other instances of `link_destination` that would no longer be covered by this change