### PR TITLE
fix(parsers): adapt to upstream change in Nvim 0.11

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -58,12 +58,15 @@ end
 ---@field readme_name string|nil
 
 ---@type ParserInfo[]
-local list = setmetatable({}, {
-  __newindex = function(table, parsername, parserconfig)
-    rawset(table, parsername, parserconfig)
-    ts.language.register(parsername, parserconfig.filetype or parsername)
-  end,
-})
+local list = {}
+if vim.fn.has "nvim-0.11" == 0 then
+  setmetatable(list, {
+    __newindex = function(table, parsername, parserconfig)
+      rawset(table, parsername, parserconfig)
+      ts.language.register(parsername, parserconfig.filetype or parsername)
+    end,
+  })
+end
 
 list.ada = {
   install_info = {


### PR DESCRIPTION
In Nvim 0.11, `vim.treesitter.lang.get_lang(filetype)` falls back to `filetype` by default, so filetypes no longer have to be registered for languages with the same name.

https://github.com/neovim/neovim/pull/30379

Also, bye-bye metatable!
