### PR TITLE
fix(cpp): fix node type error.

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -230,7 +230,7 @@
   "private"
   "protected"
   "final"
-  "virtual"
+  (virtual)
 ] @keyword.modifier
 
 [


### PR DESCRIPTION
With neovim 0.10.1 and 0.10.2

Change in commit bfe74a4899882a4ef45abb80813f14644a110a34 results in following error:

Error in decoration provider treesitter/highlighter.win: Error executing lua: [snip]/treesitter/query.lua:252: Query error at 565:4. Invalid node type "virtual":
  "virtual"

Changing the string back to (virtual) at least gets rid of the error message.