### PR TITLE
refactor: replace vim.fn with alias fn for consistency

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local fn = vim.fn
 
 local queries = require "nvim-treesitter.query"
 local ts = require "nvim-treesitter.compat"
@@ -290,12 +291,12 @@ end
 ---@param lang string
 function M.edit_query_file_user_after(query_group, lang)
   lang = lang or parsers.get_buf_lang()
-  local folder = utils.join_path(vim.fn.stdpath "config", "after", "queries", lang)
+  local folder = utils.join_path(fn.stdpath "config", "after", "queries", lang)
   local file = utils.join_path(folder, query_group .. ".scm")
-  if vim.fn.isdirectory(folder) ~= 1 then
+  if fn.isdirectory(folder) ~= 1 then
     vim.ui.select({ "Yes", "No" }, { prompt = '"' .. folder .. '" does not exist. Create it?' }, function(choice)
       if choice == "Yes" then
-        vim.fn.mkdir(folder, "p", "0755")
+        fn.mkdir(folder, "p", "0755")
         vim.cmd(":edit " .. file)
       end
     end)
@@ -412,7 +413,7 @@ function M.setup(user_data)
   config.ignore_install = user_data.ignore_install or {}
   config.parser_install_dir = user_data.parser_install_dir or nil
   if config.parser_install_dir then
-    config.parser_install_dir = vim.fn.expand(config.parser_install_dir, ":p")
+    config.parser_install_dir = fn.expand(config.parser_install_dir, ":p")
   end
 
   config.auto_install = user_data.auto_install or false

--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -68,7 +68,7 @@ local function install_health()
         .. ' or set the environment variable CC or `require"nvim-treesitter.install".compilers` explicitly!',
     })
   else
-    local version = vim.fn.systemlist(cc .. (cc == "cl" and "" or " --version"))[1]
+    local version = fn.systemlist(cc .. (cc == "cl" and "" or " --version"))[1]
     _ok(
       "`"
         .. cc
@@ -135,7 +135,7 @@ function M.check()
           table.insert(error_collection, { parser_name, query_group, err })
         end
       end
-      table.insert(parser_installation, vim.fn.trim(out, " ", 2))
+      table.insert(parser_installation, fn.trim(out, " ", 2))
     end
   end
   local legend = [[

--- a/lua/nvim-treesitter/incremental_selection.lua
+++ b/lua/nvim-treesitter/incremental_selection.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local fn = vim.fn
 
 local configs = require "nvim-treesitter.configs"
 local ts_utils = require "nvim-treesitter.ts_utils"
@@ -24,8 +25,8 @@ end
 -- The range starts with 1 and the ending is inclusive.
 ---@return integer, integer, integer, integer
 local function visual_selection_range()
-  local _, csrow, cscol, _ = unpack(vim.fn.getpos "v") ---@type integer, integer, integer, integer
-  local _, cerow, cecol, _ = unpack(vim.fn.getpos ".") ---@type integer, integer, integer, integer
+  local _, csrow, cscol, _ = unpack(fn.getpos "v") ---@type integer, integer, integer, integer
+  local _, cerow, cecol, _ = unpack(fn.getpos ".") ---@type integer, integer, integer, integer
 
   local start_row, start_col, end_row, end_col ---@type integer, integer, integer, integer
 

--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -1,3 +1,4 @@
+local fn = vim.fn
 local ts = vim.treesitter
 local parsers = require "nvim-treesitter.parsers"
 
@@ -131,7 +132,7 @@ function M.get_indent(lnum)
   -- some languages like Python will actually have worse results when re-parsing at opened new line
   if not M.avoid_force_reparsing[root_lang] then
     -- Reparse in case we got triggered by ":h indentkeys"
-    parser:parse { vim.fn.line "w0" - 1, vim.fn.line "w$" }
+    parser:parse { fn.line "w0" - 1, fn.line "w$" }
   end
 
   -- Get language tree with smallest range around node that's not a comment parser
@@ -158,7 +159,7 @@ function M.get_indent(lnum)
   local is_empty_line = string.match(getline(lnum), "^%s*$") ~= nil
   local node ---@type TSNode
   if is_empty_line then
-    local prevlnum = vim.fn.prevnonblank(lnum)
+    local prevlnum = fn.prevnonblank(lnum)
     local indentcols = get_indentcols_at_line(prevlnum)
     local prevline = vim.trim(getline(prevlnum))
     -- The final position can be trailing spaces, which should not affect indentation
@@ -183,12 +184,12 @@ function M.get_indent(lnum)
     node = get_first_node_at_line(root, lnum)
   end
 
-  local indent_size = vim.fn.shiftwidth()
+  local indent_size = fn.shiftwidth()
   local indent = 0
   local _, _, root_start = root:start()
   if root_start ~= 0 then
     -- injected tree
-    indent = vim.fn.indent(root:start() + 1)
+    indent = fn.indent(root:start() + 1)
   end
 
   -- tracks to ensure multiple indent levels are not applied for same line
@@ -328,7 +329,7 @@ function M.get_indent(lnum)
           -- it would be same indent as next line (we determine this as one
           -- width more than the open indent to avoid confusing with any
           -- hanging indents)
-          if indent <= vim.fn.indent(o_srow + 1) + indent_size then
+          if indent <= fn.indent(o_srow + 1) + indent_size then
             indent = indent + indent_size * 1
           else
             indent = indent

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -17,7 +17,7 @@ local M = {}
 ---@type table<string, LockfileInfo>
 local lockfile = {}
 
-M.compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
+M.compilers = { fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
 M.prefer_git = fn.has "win32" == 1
 M.command_extra_args = {}
 M.ts_generate_args = nil
@@ -101,7 +101,7 @@ end
 
 local function load_lockfile()
   local filename = utils.join_path(utils.get_package_path(), "lockfile.json")
-  lockfile = vim.fn.filereadable(filename) == 1 and vim.fn.json_decode(vim.fn.readfile(filename)) or {}
+  lockfile = fn.filereadable(filename) == 1 and fn.json_decode(fn.readfile(filename)) or {}
 end
 
 local function is_ignored_parser(lang)
@@ -129,8 +129,8 @@ end
 ---@return string|nil
 local function get_installed_revision(lang)
   local lang_file = utils.join_path(configs.get_parser_info_dir(), lang .. ".revision")
-  if vim.fn.filereadable(lang_file) == 1 then
-    return vim.fn.readfile(lang_file)[1]
+  if fn.filereadable(lang_file) == 1 then
+    return fn.readfile(lang_file)[1]
   end
 end
 
@@ -138,7 +138,7 @@ end
 ---@param input string
 ---@return string
 local function clean_path(input)
-  local pth = vim.fn.fnamemodify(input, ":p")
+  local pth = fn.fnamemodify(input, ":p")
   if fn.has "win32" == 1 then
     pth = pth:gsub("/", "\\")
   end
@@ -295,7 +295,7 @@ local function iter_cmd_sync(cmd_list)
     if type(cmd.cmd) == "function" then
       cmd.cmd()
     else
-      local ret = vim.fn.system(get_command(cmd))
+      local ret = fn.system(get_command(cmd))
       if vim.v.shell_error ~= 0 then
         print(ret)
         api.nvim_err_writeln(
@@ -321,8 +321,8 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
   local path_sep = utils.get_path_sep()
 
   local project_name = "tree-sitter-" .. lang
-  local maybe_local_path = vim.fn.expand(repo.url)
-  local from_local_path = vim.fn.isdirectory(maybe_local_path) == 1
+  local maybe_local_path = fn.expand(repo.url)
+  local from_local_path = fn.isdirectory(maybe_local_path) == 1
   if from_local_path then
     repo.url = maybe_local_path
   end
@@ -346,7 +346,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
 
   generate_from_grammar = repo.requires_generate_from_grammar or generate_from_grammar
 
-  if generate_from_grammar and vim.fn.executable "tree-sitter" ~= 1 then
+  if generate_from_grammar and fn.executable "tree-sitter" ~= 1 then
     api.nvim_err_writeln "tree-sitter CLI not found: `tree-sitter` is not executable!"
     if repo.requires_generate_from_grammar then
       api.nvim_err_writeln(
@@ -367,7 +367,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
       end
     end
   end
-  if generate_from_grammar and vim.fn.executable "node" ~= 1 then
+  if generate_from_grammar and fn.executable "node" ~= 1 then
     api.nvim_err_writeln "Node JS not found: `node` is not executable!"
     return
   end
@@ -408,7 +408,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
   end
   if generate_from_grammar then
     if repo.generate_requires_npm then
-      if vim.fn.executable "npm" ~= 1 then
+      if fn.executable "npm" ~= 1 then
         api.nvim_err_writeln("`" .. lang .. "` requires NPM to be installed from grammar.js")
         return
       end
@@ -426,7 +426,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
     end
     vim.list_extend(command_list, {
       {
-        cmd = vim.fn.exepath "tree-sitter",
+        cmd = fn.exepath "tree-sitter",
         info = "Generating source files from grammar.js...",
         err = 'Error during "tree-sitter generate"',
         opts = {
@@ -441,7 +441,7 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
     shell.select_mv_cmd("parser.so", parser_lib_name, compile_location),
     {
       cmd = function()
-        vim.fn.writefile({ revision or "" }, utils.join_path(configs.get_parser_info_dir() or "", lang .. ".revision"))
+        fn.writefile({ revision or "" }, utils.join_path(configs.get_parser_info_dir() or "", lang .. ".revision"))
       end,
     },
     { -- auto-attach modules after installation
@@ -637,7 +637,7 @@ function M.uninstall(...)
 
       local parser_lib = utils.join_path(install_dir, lang) .. ".so"
       local all_parsers = vim.api.nvim_get_runtime_file("parser/" .. lang .. ".so", true)
-      if vim.fn.filereadable(parser_lib) == 1 then
+      if fn.filereadable(parser_lib) == 1 then
         local command_list = {
           shell.select_rm_file_cmd(parser_lib, "Uninstalling parser for " .. lang),
           {
@@ -694,13 +694,13 @@ function M.write_lockfile(verbose, skip_langs)
       local sha ---@type string
       if v.parser.install_info.branch then
         sha = vim.split(
-          vim.fn.systemlist(
+          fn.systemlist(
             "git ls-remote " .. v.parser.install_info.url .. " | grep refs/heads/" .. v.parser.install_info.branch
           )[1],
           "\t"
         )[1]
       else
-        sha = vim.split(vim.fn.systemlist("git ls-remote " .. v.parser.install_info.url)[1], "\t")[1]
+        sha = vim.split(fn.systemlist("git ls-remote " .. v.parser.install_info.url)[1], "\t")[1]
       end
       lockfile[v.name] = { revision = sha }
       if verbose then
@@ -714,8 +714,8 @@ function M.write_lockfile(verbose, skip_langs)
   if verbose then
     print(vim.inspect(lockfile))
   end
-  vim.fn.writefile(
-    vim.fn.split(vim.fn.json_encode(lockfile), "\n"),
+  fn.writefile(
+    fn.split(fn.json_encode(lockfile), "\n"),
     utils.join_path(utils.get_package_path(), "lockfile.json")
   )
 end

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local fn = vim.fn
 local ts = vim.treesitter
 
 for ft, lang in pairs {
@@ -58,7 +59,7 @@ end
 local list = setmetatable({}, {
   __newindex = function(table, parsername, parserconfig)
     rawset(table, parsername, parserconfig)
-    if parserconfig.filetype or vim.fn.has "nvim-0.11" == 0 then
+    if parserconfig.filetype or fn.has "nvim-0.11" == 0 then
       ts.language.register(parsername, parserconfig.filetype or parsername)
     end
   end,
@@ -2617,7 +2618,7 @@ end
 function M.available_parsers()
   local parsers = vim.tbl_keys(M.list)
   table.sort(parsers)
-  if vim.fn.executable "tree-sitter" == 1 and vim.fn.executable "node" == 1 then
+  if fn.executable "tree-sitter" == 1 and fn.executable "node" == 1 then
     return parsers
   else
     return vim.tbl_filter(function(p) ---@param p string

--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local fnamemodify = vim.fn.fnamemodify
 local ts = require "nvim-treesitter.compat"
 local tsrange = require "nvim-treesitter.tsrange"
 local utils = require "nvim-treesitter.utils"
@@ -30,7 +31,7 @@ function M.available_query_groups()
   local query_files = api.nvim_get_runtime_file("queries/*/*.scm", true)
   local groups = {}
   for _, f in ipairs(query_files) do
-    groups[vim.fn.fnamemodify(f, ":t:r")] = true
+    groups[fnamemodify(f, ":t:r")] = true
   end
   local list = {}
   for k, _ in pairs(groups) do
@@ -145,7 +146,6 @@ end
 -- This function is meant for an autocommand and not to be used. Only use if file is a query file.
 ---@param fname string
 function M.invalidate_query_file(fname)
-  local fnamemodify = vim.fn.fnamemodify
   M.invalidate_query_cache(fnamemodify(fname, ":p:h:t"), fnamemodify(fname, ":t:r"))
 end
 

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -121,7 +121,7 @@ function M.select_compiler_args(repo, compiler)
     end
     if
       #vim.tbl_filter(function(file) ---@param file string
-        local ext = vim.fn.fnamemodify(file, ":e")
+        local ext = fn.fnamemodify(file, ":e")
         return ext == "cc" or ext == "cpp" or ext == "cxx"
       end, repo.files) > 0
     then
@@ -229,7 +229,7 @@ end
 ---@param prefer_git boolean
 ---@return table
 function M.select_download_commands(repo, project_name, cache_folder, revision, prefer_git)
-  local can_use_tar = vim.fn.executable "tar" == 1 and vim.fn.executable "curl" == 1
+  local can_use_tar = fn.executable "tar" == 1 and fn.executable "curl" == 1
   local is_github = repo.url:find("github.com", 1, true)
   local is_gitlab = repo.url:find("gitlab.com", 1, true)
 

--- a/lua/nvim-treesitter/ts_utils.lua
+++ b/lua/nvim-treesitter/ts_utils.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local fn = vim.fn
 
 local parsers = require "nvim-treesitter.parsers"
 local utils = require "nvim-treesitter.utils"
@@ -256,7 +257,7 @@ function M.get_vim_range(range, buf)
     -- Use the value of the last col of the previous row instead.
     erow = erow - 1
     if not buf or buf == 0 then
-      ecol = vim.fn.col { erow, "$" } - 1
+      ecol = fn.col { erow, "$" } - 1
     else
       ecol = #api.nvim_buf_get_lines(buf, erow - 1, erow, false)[1]
     end

--- a/lua/nvim-treesitter/tsrange.lua
+++ b/lua/nvim-treesitter/tsrange.lua
@@ -3,11 +3,12 @@ local TSRange = {}
 TSRange.__index = TSRange
 
 local api = vim.api
+local fn = vim.fn
 local ts_utils = require "nvim-treesitter.ts_utils"
 local parsers = require "nvim-treesitter.parsers"
 
 local function get_byte_offset(buf, row, col)
-  return api.nvim_buf_get_offset(buf, row) + vim.fn.byteidx(api.nvim_buf_get_lines(buf, row, row + 1, false)[1], col)
+  return api.nvim_buf_get_offset(buf, row) + fn.byteidx(api.nvim_buf_get_lines(buf, row, row + 1, false)[1], col)
 end
 
 function TSRange.new(buf, start_row, start_col, end_row, end_col)

--- a/lua/nvim-treesitter/utils.lua
+++ b/lua/nvim-treesitter/utils.lua
@@ -103,7 +103,7 @@ function M.create_or_reuse_writable_dir(dir, create_err, writeable_err)
   writeable_err = writeable_err or M.join_space("Invalid rights, '", dir, "' should be read/write")
   -- Try creating and using parser_dir if it doesn't exist
   if not luv.fs_stat(dir) then
-    local ok, error = pcall(vim.fn.mkdir, dir, "p", "0755")
+    local ok, error = pcall(fn.mkdir, dir, "p", "0755")
     if not ok then
       return nil, M.join_space(create_err, error)
     end


### PR DESCRIPTION
nvim-treesitter is aliasing `vim.fn` to `fn` as a local variable in many files. However, using vim.fn instead of fn in many places.

In this pr, I refactored for using fn.