### PR TITLE
fix(latex): capture nameless color change

### DIFF
--- a/queries/latex/highlights.scm
+++ b/queries/latex/highlights.scm
@@ -146,7 +146,7 @@
 (color_reference
   command: _ @function.macro
   name: (curly_group_text
-    (_) @markup.link))
+    (_) @markup.link)?)
 
 ; Sectioning
 (title_declaration


### PR DESCRIPTION
Color can be changed by directly passing color `model` and `spec`, so make the `name` field optional.

This is possible since https://github.com/latex-lsp/tree-sitter-latex/pull/151.