### PR TITLE
feat(regex): better count quantifier highlights

### DIFF
--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -21,6 +21,8 @@
 
 (class_character) @constant
 
+(decimal_digits) @number
+
 [
   (control_letter_escape)
   (character_class_escape)
@@ -42,6 +44,7 @@
 [
   (start_assertion)
   (end_assertion)
+  ","
 ] @punctuation.delimiter
 
 (any_character) @variable.builtin


### PR DESCRIPTION
Better highlights for count quantifiers, e.g. `asdf{1,2}`