### PR TITLE
fix(rust): regex injections, highlights

### DIFF
--- a/queries/rust/highlights.scm
+++ b/queries/rust/highlights.scm
@@ -475,3 +475,47 @@
 
 (block_comment
   (doc_comment)) @comment.documentation
+
+(call_expression
+  function: (scoped_identifier
+    path: (identifier) @_regex
+    (#any-of? @_regex "Regex" "ByteRegexBuilder")
+    name: (identifier) @_new
+    (#eq? @_new "new"))
+  arguments: (arguments
+    (raw_string_literal
+      (string_content) @string.regexp)))
+
+(call_expression
+  function: (scoped_identifier
+    path: (scoped_identifier
+      (identifier) @_regex
+      (#any-of? @_regex "Regex" "ByteRegexBuilder") .)
+    name: (identifier) @_new
+    (#eq? @_new "new"))
+  arguments: (arguments
+    (raw_string_literal
+      (string_content) @string.regexp)))
+
+(call_expression
+  function: (scoped_identifier
+    path: (identifier) @_regex
+    (#any-of? @_regex "RegexSet" "RegexSetBuilder")
+    name: (identifier) @_new
+    (#eq? @_new "new"))
+  arguments: (arguments
+    (array_expression
+      (raw_string_literal
+        (string_content) @string.regexp))))
+
+(call_expression
+  function: (scoped_identifier
+    path: (scoped_identifier
+      (identifier) @_regex
+      (#any-of? @_regex "RegexSet" "RegexSetBuilder") .)
+    name: (identifier) @_new
+    (#eq? @_new "new"))
+  arguments: (arguments
+    (array_expression
+      (raw_string_literal
+        (string_content) @string.regexp))))

--- a/queries/rust/injections.scm
+++ b/queries/rust/injections.scm
@@ -49,7 +49,8 @@
     name: (identifier) @_new
     (#eq? @_new "new"))
   arguments: (arguments
-    (raw_string_literal) @injection.content)
+    (raw_string_literal
+      (string_content) @injection.content))
   (#set! injection.language "regex"))
 
 (call_expression
@@ -60,7 +61,8 @@
     name: (identifier) @_new
     (#eq? @_new "new"))
   arguments: (arguments
-    (raw_string_literal) @injection.content)
+    (raw_string_literal
+      (string_content) @injection.content))
   (#set! injection.language "regex"))
 
 (call_expression
@@ -71,7 +73,8 @@
     (#eq? @_new "new"))
   arguments: (arguments
     (array_expression
-      (raw_string_literal) @injection.content))
+      (raw_string_literal
+        (string_content) @injection.content)))
   (#set! injection.language "regex"))
 
 (call_expression
@@ -83,7 +86,8 @@
     (#eq? @_new "new"))
   arguments: (arguments
     (array_expression
-      (raw_string_literal) @injection.content))
+      (raw_string_literal
+        (string_content) @injection.content)))
   (#set! injection.language "regex"))
 
 ((block_comment) @injection.content


### PR DESCRIPTION
**Problem:** Rust's regex injections were not applied since the string content is behind a `(string_content)` node, and the injections were applied to the parent node without the `include-children` directive.

**Solution:** Apply the injections to the string content. Also highlight them accordingly.