### PR TITLE
fix(formatter): simplify code, remove odd line break

### DIFF
--- a/queries/gdscript/highlights.scm
+++ b/queries/gdscript/highlights.scm
@@ -302,8 +302,7 @@
     "var_to_str" "weakref" "wrap" "wrapf" "wrapi"
     ; from modules/gdscript/doc_classes/@GDScript.xml
     "Color8" "assert" "char" "convert" "dict_to_inst" "get_stack" "inst_to_dict" "is_instance_of"
-    "len" "load" "preload" "print_debug" "print_stack" "range" "type_exists")
-  )
+    "len" "load" "preload" "print_debug" "print_stack" "range" "type_exists"))
 
 ; Builtin Constants
 ((identifier) @constant.builtin

--- a/queries/helm/highlights.scm
+++ b/queries/helm/highlights.scm
@@ -29,8 +29,7 @@
     "mod" "mul" "max" "min" "len" "addf" "add1f" "subf" "divf" "mulf" "maxf" "minf" "floor" "ceil"
     "round" "getHostByName" "base" "dir" "clean" "ext" "isAbs" "kindOf" "kindIs" "typeOf" "typeIs"
     "typeIsLike" "deepequal" "semver" "semverCompare" "urlParse" "urlJoin" "urlquery" "lookup"
-    "include")
-  )
+    "include"))
 
 ; {{ .Values.test }}
 (selector_expression

--- a/queries/ispc/highlights.scm
+++ b/queries/ispc/highlights.scm
@@ -107,5 +107,4 @@
     "reduce_max" "reduce_min" "rotate" "round" "rsqrt" "rsqrt_fast" "saturating_add"
     "saturating_div" "saturating_mul" "saturating_sub" "seed_rng" "select" "shift" "shuffle"
     "signbits" "sign_extend" "sin" "sincos" "soa_to_aos2" "soa_to_aos3" "soa_to_aos4" "sqrt"
-    "streaming_load" "streaming_load_uniform" "streaming_store" "tan" "trunc")
-  )
+    "streaming_load" "streaming_load_uniform" "streaming_store" "tan" "trunc"))

--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -129,8 +129,7 @@
     "__currentSystem" "__hashFile" "__path" "__unsafeDiscardOutputDependency" "__currentTime"
     "__hashString" "__pathExists" "__unsafeDiscardStringContext" "__deepSeq" "__head" "__readDir"
     "__unsafeGetAttrPos" "__div" "__intersectAttrs" "__readFile" "__zipAttrsWith" "__elem"
-    "__isAttrs" "__replaceStrings" "__elemAt" "__isBool" "__seq" "__fetchurl" "__isFloat" "__sort")
-  )
+    "__isAttrs" "__replaceStrings" "__elemAt" "__isBool" "__seq" "__fetchurl" "__isFloat" "__sort"))
 
 ; constants
 (variable_expression

--- a/queries/powershell/highlights.scm
+++ b/queries/powershell/highlights.scm
@@ -239,8 +239,7 @@
     "System.Management.Automation.PSScriptCmdlet" "Management.Automation.ErrorRecord"
     "System.Management.Automation.ErrorRecord" "Management.Automation.PSCredential"
     "System.Management.Automation.PSCredential" "Management.Automation.PSMethod"
-    "System.Management.Automation.PSMethod")
-  )
+    "System.Management.Automation.PSMethod"))
 
 ; Function definitions
 ;---------------------

--- a/scripts/format-queries.lua
+++ b/scripts/format-queries.lua
@@ -36,6 +36,7 @@ end)
 
 --- Control the indent here. Change to \t if uses tab instead
 local indent_str = "  "
+local indent_width_plus_one = 3
 local textwidth = 100
 
 -- Query to control the formatter
@@ -201,9 +202,6 @@ local format_queries = [[
 ;; All captures should be separated with a space
 (capture) @format.prepend-space
 
-;; Workaround to just use the string's content
-(anonymous_node (string) @format.keep)
-
 ; ( (_) ) handler
 (grouping
   "("
@@ -283,8 +281,6 @@ local format_queries = [[
     . (_) @format.prepend-space)
   (#set! lookahead-newline)
   (#set! conditional-newline))
-;; Workaround to keep the string's content
-(string) @format.keep
 
 ;; Comment related handlers
 (comment) @format.append-newline
@@ -325,25 +321,21 @@ end
 ---@param bufnr integer
 ---@param node TSNode
 ---@param lines string[]
----@param q table<string, TSMetadata>
+---@param q table<string, vim.treesitter.query.TSMetadata>
 ---@param level integer
 local function iter(bufnr, node, lines, q, level)
   --- Sometimes 2 queries apply append twice. This is to prevent the case from happening
   local apply_newline = false
   for child, _ in node:iter_children() do
     local id = child:id()
-    repeat
-      if apply_newline then
-        apply_newline = false
-        lines[#lines + 1] = string.rep(indent_str, level)
-      end
-      if q["format.ignore"][id] then
-        local text = vim.split(get_node_text(child, bufnr):gsub("\r\n?", "\n"), "\n", { trimempty = true })
-        append_lines(lines, text)
-        break
-      elseif q["format.remove"][id] then
-        break
-      end
+    if apply_newline then
+      apply_newline = false
+      lines[#lines + 1] = string.rep(indent_str, level)
+    end
+    if q["format.ignore"][id] then
+      local text = vim.split(get_node_text(child, bufnr):gsub("\r\n?", "\n"), "\n", { trimempty = true })
+      append_lines(lines, text)
+    elseif not q["format.remove"][id] then
       if not q["format.cancel-prepend"][id] then
         if q["format.prepend-newline"][id] then
           lines[#lines + 1] = string.rep(indent_str, level)
@@ -359,7 +351,7 @@ local function iter(bufnr, node, lines, q, level)
             local _, _, byte_end = node:end_()
             if
               q["format.prepend-space"][id]["lookahead-newline"]
-              and textwidth - (byte_end - byte_start) - #lines[#lines] < 0
+              and (byte_end - byte_start) + #lines[#lines] > textwidth
             then
               lines[#lines + 1] = string.rep(indent_str, level)
             else
@@ -370,7 +362,11 @@ local function iter(bufnr, node, lines, q, level)
       end
       if q["format.replace"][id] then
         append_lines(lines, vim.split(q["format.replace"][id].text, "\n", { trimempty = true }))
-      elseif child:named_child_count() == 0 or q["format.keep"][id] then
+      elseif
+        child:named_child_count() == 0
+        -- Workaround to preserve string content
+        or child:type() == "string"
+      then
         append_lines(
           lines,
           vim.split(string.gsub(get_node_text(child, bufnr), "\r\n?", "\n"), "\n+", { trimempty = true })
@@ -381,33 +377,17 @@ local function iter(bufnr, node, lines, q, level)
       if q["format.indent.begin"][id] then
         level = level + 1
         apply_newline = true
-        break
+      elseif q["format.indent.dedent"][id] then
+        lines[#lines] = string.sub(lines[#lines], indent_width_plus_one)
       end
-      if q["format.indent.dedent"][id] then
-        if string.match(lines[#lines], "^%s*" .. get_node_text(child, bufnr)) then
-          lines[#lines] = string.sub(lines[#lines], 1 + #string.rep(indent_str, 1))
-        end
-      end
-      if q["format.indent.end"][id] then
-        level = math.max(level - 1, 0)
-        if string.match(lines[#lines], "^%s*" .. get_node_text(child, bufnr)) then
-          lines[#lines] = string.sub(lines[#lines], 1 + #string.rep(indent_str, 1))
-        end
-        break
-      end
-    until true
-    repeat
-      if q["format.cancel-append"][id] then
-        apply_newline = false
-      end
-      if not q["format.cancel-append"][id] then
-        if q["format.append-newline"][id] then
-          apply_newline = true
-        elseif q["format.append-space"][id] then
-          lines[#lines] = lines[#lines] .. " "
-        end
-      end
-    until true
+    end
+    if q["format.cancel-append"][id] then
+      apply_newline = false
+    elseif q["format.append-newline"][id] then
+      apply_newline = true
+    elseif q["format.append-space"][id] then
+      lines[#lines] = lines[#lines] .. " "
+    end
   end
 end
 
@@ -419,7 +399,6 @@ local function format(bufnr, queries)
   local map = {
     ['format.ignore'] = {},           -- Ignore the node and its children
     ['format.indent.begin'] = {},     -- +1 shiftwidth for all nodes after this
-    ['format.indent.end'] = {},       -- -1 shiftwidth for all nodes after this
     ['format.indent.dedent'] = {},    -- -1 shiftwidth for this line only
     ['format.prepend-space'] = {},    -- Prepend a space before inserting the node
     ['format.prepend-newline'] = {},  -- Prepend a \n before inserting the node
@@ -427,7 +406,6 @@ local function format(bufnr, queries)
     ['format.append-newline'] = {},   -- Append a newline after inserting the node
     ['format.cancel-append'] = {},    -- Cancel any `@format.append-*` applied to the node
     ['format.cancel-prepend'] = {},   -- Cancel any `@format.prepend-*` applied to the node
-    ['format.keep'] = {},             -- String content is not exposed as a syntax node. This is a workaround for it
     ['format.replace'] = {},          -- Dedicated capture used to store results of `(#gsub!)`
     ['format.remove'] = {},           -- Do not add the syntax node to the result, i.e. brackets [], parens ()
   }


### PR DESCRIPTION
This commit simplifies much of the formatter code, removing the need for break statements, removing some unused captures, and merging some redundant `if` cases. The formatter output is the same except in some cases where a (seemingly unintentional) line break is now no longer added.