### PR TITLE
fix(rst): adornment should be captured as @markup.heading

### DIFF
--- a/queries/rst/highlights.scm
+++ b/queries/rst/highlights.scm
@@ -9,10 +9,7 @@
   (transition)
 ] @punctuation.special
 
-[
-  "bullet"
-  "adornment"
-] @markup.list
+"bullet" @markup.list
 
 ; Resets for injection
 (doctest_block) @none
@@ -133,7 +130,10 @@
 ] @markup.link @nospell
 
 ; Others
-(title) @markup.heading
+[
+  (title)
+  "adornment"
+] @markup.heading
 
 (comment) @comment @spell
 


### PR DESCRIPTION
Left: before, Right: after.

<image src="https://github.com/user-attachments/assets/1289ec04-4340-472f-be2c-19cd873cddac"  width="45%" />
<image src="https://github.com/user-attachments/assets/94d9f84b-2e6e-430a-a385-f4cf4e52d617"  width="45%" />



