### PR TITLE
feat(regex): highlights for lazy quantifiers, \k

### DIFF
--- a/queries/regex/highlights.scm
+++ b/queries/regex/highlights.scm
@@ -39,6 +39,8 @@
   "="
   "!"
   "-"
+  (backreference_escape)
+  (lazy)
 ] @operator
 
 [


### PR DESCRIPTION
Highlights the "?" following .* and the \k backreference operator in a
pattern like the following: title=(?<quote>["'])(.*?)\k<quote>