### PR TITLE
fix(cooklang): apply correct filetype

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -288,6 +288,7 @@ list.cooklang = {
     files = { "src/parser.c", "src/scanner.c" },
   },
   maintainers = { "@addcninblue" },
+  filetype = "cook",
 }
 
 list.corn = {


### PR DESCRIPTION
`Cooklang` files are recognized as `cook` in vim. This prevents the parser from attaching since it is looking for `cooklang` files, so we have to specify the `filetype` here.