### PR TITLE
refactor(ecma): Exclude all-caps constants from `@type` highlight

### DIFF
--- a/queries/ecma/highlights.scm
+++ b/queries/ecma/highlights.scm
@@ -22,7 +22,7 @@
 ; Special identifiers
 ;--------------------
 ((identifier) @type
-  (#lua-match? @type "^[A-Z]"))
+  (#lua-match? @type "^[A-Z].+?[a-z]"))
 
 ((identifier) @constant
   (#lua-match? @constant "^_*[A-Z][A-Z%d_]*$"))


### PR DESCRIPTION
Part of #7304

It's a common convention in JS/TS/ecma to use screaming snake case (`FOO_BAR_BAZ`) for magic constants; for example, [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) from the language spec or [`IS_NON_DIMENSIONAL`](https://github.com/preactjs/preact/blob/07dc9f324e58569ce66634aa03fe8949b4190358/src/constants.js#L15) from this ecosystem project. These are not type definitions, but do start with a capital letter, and so get incorrectly caught by the regex pattern here.

What I propose is that the regex expand to check if there's also a lower-case letter somewhere within the identifier name and if not, it won't apply the `@type` highlight to the identifier.

This seems like the most efficient regex, but I'm no expert here. Hints/advice certainly appreciated if there's a better way to do this too.

I'd like to note, however, going from an identifier to a `@type` is fatally flawed -- it cannot be done per the language spec using such little context. Scope and preceding/following tokens are needed to do it right.