### PR TITLE
feat(yaml): add language injection from comments

### DIFF
--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -78,3 +78,25 @@
           (block_scalar) @injection.content
           (#set! injection.language "promql")
           (#offset! @injection.content 0 1 0 0))))))
+
+; Support Idea-style injection: # language=yaml
+; Inject language at toplevel yaml node
+((comment) @injection.language
+  (#gsub! @injection.language "#%s*language=%s*([%w%p]+)%s*" "%1")
+  .
+  (block_mapping_pair
+    value: (block_node
+      (block_scalar) @injection.content
+      (#offset! @injection.content 0 1 0 0))))
+
+; Inject language in yaml body
+(block_mapping_pair
+  (comment) @injection.language
+  (#gsub! @injection.language "#%s*language=%s*([%w%p]+)%s*" "%1")
+  value: (block_node
+    (block_mapping
+      .
+      (block_mapping_pair
+        value: (block_node
+          (block_scalar) @injection.content
+          (#offset! @injection.content 0 1 0 0))))))

--- a/tests/query/injections/yaml/dynamic-language-injection-from-comment.yaml
+++ b/tests/query/injections/yaml/dynamic-language-injection-from-comment.yaml
@@ -1,0 +1,20 @@
+foo: bar
+# language=yaml
+top_yaml: |
+  aaa: qqq
+# ^ yaml
+top_text: |
+  key: value
+# language=python
+python: |
+  foo = 'asdafsaa'
+  print(f'{foo}')
+# ^ python
+level1:
+  foo: bar
+  # language=yaml
+  levlel2_yaml: |
+    key: value
+  # ^ yaml
+  level2_text: |
+    key: value


### PR DESCRIPTION
Added dynamic injection from comment into yaml value in order to support compatible with [intellij language injection](https://www.jetbrains.com/help/idea/using-language-injections.html#use-language-injection-comments).

This feature usable for yaml config contain inline config.

For example
- Envoy proxy configuration may contain [lua code](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/lua_filter) 

- ArgoCD Application config can contain yaml [values for helm chart](https://argo-cd.readthedocs.io/en/latest/user-guide/application-specification/)

