### PR TITLE
fix: formatter idempotency for nested groupings

### DIFF
--- a/scripts/format-queries.lua
+++ b/scripts/format-queries.lua
@@ -248,6 +248,7 @@ local format_queries = [[
   "(" @format.remove
   .
   [
+    (grouping)
     (anonymous_node
       name: (string) .)
     (named_node


### PR DESCRIPTION
Currently, for something like `(((((node))))) @cap`, the formatter will produce `((node)) @cap`, and then after another pass it will produce `(node) @cap`. This commit makes it so that all extraneous parentheses are removed on the first pass.