### PR TITLE
refactor(jsdoc): Remove delimiter highlights

### DIFF
--- a/queries/jsdoc/highlights.scm
+++ b/queries/jsdoc/highlights.scm
@@ -9,14 +9,6 @@
   "]"
 ] @punctuation.bracket
 
-[
-  ":"
-  "/"
-  "."
-  "#"
-  "~"
-] @punctuation.delimiter
-
 (identifier) @variable @nospell
 
 (tag


### PR DESCRIPTION
As best as I can tell, none of these delimiter highlights work. I don't quite understand why, especially as the bracket highlights have no problem at all, but I haven't been able to get them to be picked up except where they shouldn't be (#7326).

```
/**
 * @param {string} [bar]
 *                 ^ Correctly picked up as @punctuation.bracket
 * @return {string}
 *         ^ Also picked up correct as @punctuation.bracket
 *
 *
 * None of the following, however, are picked up as @punctuation.delimiter
 * : / . # ~
 */
  ^ This is picked up as @punctuation.delimiter but it shouldn't be
```

Not quite sure if this wasn't tested, if something changed, or what, but given the circumstances this seemed like a reasonable suggestion?