### PR TITLE
fix(zig): begin indent at `struct_declaration`

### DIFF
--- a/queries/zig/indents.scm
+++ b/queries/zig/indents.scm
@@ -1,5 +1,6 @@
 [
   (block)
+  (struct_declaration)
   (switch_expression)
   (initializer_list)
 ] @indent.begin


### PR DESCRIPTION
The curly braces contained in the `struct_declaration` are not included by the `block`. Indentation should also start here.

## Example:
![image](https://github.com/user-attachments/assets/542ac229-41c9-4f00-8189-a57d4781dbdc)

Before this PR:
![image](https://github.com/user-attachments/assets/ef3719f3-0ada-491e-b288-7e844fd9be66)

After this PR:
![image](https://github.com/user-attachments/assets/46e448d0-75fa-46e9-bb03-78b072869abb)
