### PR TITLE
fix(julia): fix injection queries

### DIFF
--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -1,5 +1,6 @@
 ; Inject markdown in docstrings
-((string_literal) @injection.content
+((string_literal
+  (content) @injection.content)
   .
   [
     (module_definition)
@@ -10,9 +11,7 @@
     (assignment)
     (const_statement)
   ]
-  (#lua-match? @injection.content "^\"\"\"")
-  (#set! injection.language "markdown")
-  (#offset! @injection.content 0 3 0 -3))
+  (#set! injection.language "markdown"))
 
 ; Inject comments
 ([
@@ -21,20 +20,21 @@
 ] @injection.content
   (#set! injection.language "comment"))
 
-; Inject regex in r"hello\bworld"
-((prefixed_string_literal
-  prefix: (identifier) @_prefix) @injection.content
+; Inject regex in r"..." and r"""...""" (e.g. r"hello\bworld")
+(prefixed_string_literal
+  prefix: (identifier) @_prefix
+  (content) @injection.content
   (#eq? @_prefix "r")
-  (#set! injection.language "regex")
-  (#offset! @injection.content 0 2 0 -1))
+  (#set! injection.language "regex"))
 
-; Inject markdown in md"**Bold** and _Italics_"
-((prefixed_string_literal
-  prefix: (identifier) @_prefix) @injection.content
+; Inject markdown in md"..." and md"""...""" (e.g. md"**Bold** and _Italics_")
+(prefixed_string_literal
+  prefix: (identifier) @_prefix
+  (content) @injection.content
   (#eq? @_prefix "md")
-  (#set! injection.language "markdown")
-  (#offset! @injection.content 0 3 0 -1))
+  (#set! injection.language "markdown"))
 
-; Inject bash in `git add --help`
-((command_literal) @injection.content
+; Inject bash in `...` and ```...``` (e.g. `git add --help`)
+(command_literal
+  (content) @injection.content
   (#set! injection.language "bash"))


### PR DESCRIPTION
This patch fixes the julia `(string_literal)` injection queries after
the breaking changes in
https://github.com/tree-sitter/tree-sitter-julia/pull/153. The queries
are simplified by the fact that string content is now directly available
as a separate `(content)` child node.
