### PR TITLE
fix(julia): capture docstrings in more cases

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -328,6 +328,8 @@
     (macro_definition)
     (module_definition)
     (struct_definition)
+    (call_expression)
+    (identifier)
   ])
 
 [

--- a/queries/julia/injections.scm
+++ b/queries/julia/injections.scm
@@ -10,6 +10,8 @@
     (macro_definition)
     (assignment)
     (const_statement)
+    (call_expression)
+    (identifier)
   ]
   (#set! injection.language "markdown"))
 


### PR DESCRIPTION
This patch enables `@string.documentation` capturing, and markdown
injection, for strings attached to `(call_expression)` and
`(identifier)` nodes. For example

```julia
"docs"
foo(::Int, ::Float64)

"docs"
bar
```
