### PR TITLE
fix(julia): treat :: as operator

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -281,6 +281,14 @@
   "::"
 ] @punctuation.delimiter
 
+; Treat `::` as operator in type contexts, see
+; https://github.com/nvim-treesitter/nvim-treesitter/pull/7392
+(typed_expression
+  "::" @operator)
+
+(unary_typed_expression
+  "::" @operator)
+
 [
   "("
   ")"

--- a/tests/query/highlights/julia/test.jl
+++ b/tests/query/highlights/julia/test.jl
@@ -2,13 +2,13 @@ function load_data(::Symbol; ::Int) :: Tuple
 # <- @keyword.function
 #        ^ @function.call
 #                 ^ @punctuation.bracket
-#                  ^^ @punctuation.delimiter
+#                  ^^ @operator
 #                    ^ @type.builtin
 #                          ^ @punctuation.delimiter
-#                            ^^ @punctuation.delimiter
+#                            ^^ @operator
 #                              ^^^ @type.builtin
 #                                 ^ @punctuation.bracket
-#                                   ^^ @punctuation.delimiter
+#                                   ^^ @operator
 #                                      ^ @type.builtin
     dataset = CIFAR10(; Tx = Float32, split = split)
 #   ^^^^^^^ @variable


### PR DESCRIPTION
This patch removes `::` from `@punctuation.delimiter` and instead treat
it as `@operator` within `(unary_typed_expression)` and
`(typed_expression)`. I believe these are the only places where `::` can
show up, so maybe it is simpler to just capture it as `@operator`
globally `::`. (Note that `<:` and `>:` already are `@operator`s
globally since they are parsed into the `(operator)` node.)

Edit: I split out the non-controversial parts into #7396 