### PR TITLE
fix(astro): highlight self-closing component tags

### DIFF
--- a/queries/astro/highlights.scm
+++ b/queries/astro/highlights.scm
@@ -20,6 +20,10 @@
   (tag_name) @type)
   (#lua-match? @type "^[A-Z]"))
 
+((self_closing_tag
+  (tag_name) @type)
+  (#lua-match? @type "^[A-Z]"))
+
 ((erroneous_end_tag
   (erroneous_end_tag_name) @type)
   (#lua-match? @type "^[A-Z]"))


### PR DESCRIPTION
For Astro, adds highlighting to self-closing custom component tags, e.g `<Navigation />`.

Before this would be highlighted like a regular HTML tag, unless it was not self closing.