### PR TITLE
fix(julia): fix macro identifier highlight query

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -34,7 +34,9 @@
   (#any-of? @_pipe "|>" ".|>"))
 
 ; Macros
-(macro_identifier) @function.macro
+(macro_identifier
+  "@" @function.macro
+  (identifier) @function.macro)
 
 (macro_definition
   (signature


### PR DESCRIPTION
This fixes the macro identifier highlight query after the breaking
changes in https://github.com/tree-sitter/tree-sitter-julia/pull/153.
See also
https://github.com/tree-sitter/tree-sitter-julia/pull/158/commits/9f2fb3b9a8c73ef0d2ec005c97f91274b492d48d.
