### PR TITLE
fix(julia): misc fixes to type highlighting

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -71,7 +71,16 @@
   (identifier) @type .)
 
 (where_expression
-  (_) @type .)
+  [
+    (curly_expression
+      (_) @type)
+    (_) @type
+  ] .)
+
+(unary_expression
+  (operator) @operator
+  (_) @type
+  (#any-of? @operator "<:" ">:"))
 
 (binary_expression
   (_) @type


### PR DESCRIPTION
This patch fixes two issues related to `@type` capturing (split out from
https://github.com/nvim-treesitter/nvim-treesitter/pull/7392):

 - Capture the RHS of `<:` and `>:` as `@type` in `(unary_expression)`s
   similarly to what is already done for `(binary_expression)`s with
   these operators.
 - Capture children of `(curly_expression)`s inside of
   `(where_expression)`s as `@type` similarly how they are handled in
   `(parametrized_type_expression)`.
