### PR TITLE
fix(verilog): fix some tpye.builtin highlights error

### DIFF
--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -75,6 +75,7 @@
   "global"
   "ref"
   "initial"
+  "string"
   (unique_priority)
   (bins_keyword)
   (always_keyword)
@@ -259,9 +260,13 @@
 
 [
   (net_type)
-  (data_type)
+  (integer_vector_type)
   (time_unit)
+  (integer_atom_type)
 ] @type.builtin
+
+(data_type
+  (simple_identifier) @type.builtin)
 
 ; variable
 (list_of_variable_decl_assignments
@@ -438,6 +443,9 @@ port_name: (simple_identifier) @variable
       (simple_identifier) @constructor)
   ]
   (simple_identifier)? @label)
+
+(generate_block
+  name: (simple_identifier) @label)
 
 ; function.call
 (method_call_body


### PR DESCRIPTION
1. Add "string" as a keyword
2. Fix issue where non-type.builtin fields are highlighted when using (data_type) as type.builtin
3. Add generate label
