### PR TITLE
feat(zig): add locals queries

### DIFF
--- a/queries/zig/locals.scm
+++ b/queries/zig/locals.scm
@@ -1,1 +1,64 @@
+(FnProto
+  function: (IDENTIFIER) @local.definition.function)
 
+(ParamDecl
+  parameter: (IDENTIFIER) @local.definition.parameter
+  (ParamType
+    (ErrorUnionExpr
+      (SuffixExpr
+        variable_type_function: (IDENTIFIER) @local.reference
+        (#set! reference.kind "type")))))
+
+(VarDecl
+  variable_type_function: (IDENTIFIER) @local.definition.var)
+
+(VarDecl
+  variable_type_function: (IDENTIFIER) @local.definition.type
+  (ErrorUnionExpr
+    (SuffixExpr
+      (ContainerDecl))))
+
+(ContainerField
+  (ErrorUnionExpr
+    (SuffixExpr
+      variable_type_function: (IDENTIFIER) @local.definition.var)))
+
+(ContainerField
+  field_member: (IDENTIFIER) @local.definition.field)
+
+
+(FieldInit
+  field_member: (IDENTIFIER) @local.definition.field)
+
+(FieldOrFnCall
+  function_call: (IDENTIFIER) @local.reference
+  (#set! reference.kind "function"))
+
+(FieldOrFnCall
+  field_access: (IDENTIFIER) @local.reference
+  (#set! reference.kind "field"))
+
+(SuffixExpr
+  field_constant: (IDENTIFIER) @local.reference
+  (#set! reference.kind "field"))
+
+(SuffixExpr
+  variable_type_function: (IDENTIFIER) @local.reference)
+
+
+(LabeledStatement
+  (BlockLabel
+    (IDENTIFIER) @local.definition))
+
+(BreakLabel
+  (IDENTIFIER) @local.reference)
+
+[
+  (ForStatement)
+  (IfStatement)
+  (WhileStatement)
+  (FnProto)
+  (Block)
+  (source_file)
+  (ContainerDecl )
+] @local.scope


### PR DESCRIPTION
I have very little experience with treesitter stuff so I'm glad about any kind of feedback.

I mainly oriented myself on the locals queries for c and this was enough for me to get https://github.com/theHamsta/nvim-dap-virtual-text to work in zig for me.

Hopefully I didn't forget anything but one thing I wanted to add was clearer type references but with current parser I don't think this is really possible?
```scheme
(_
  (ErrorUnionExpr
    (SuffixExpr
      variable_type_function: (IDENTIFIER) @local.reference
        (#set! reference.kind "type")))
  (InitList))
```
This breaks if there is another reference on the same line as the the type reference.

For example if I have a struct `Foo`, on this line it will also wrongly highlight the variable `bar`.

```zig
bar.baz = Foo{};
```

since the syntax tree looks likes this:

```scheme
      (Statement ; [116, 4] - [116, 22]
        (AssignExpr ; [116, 4] - [116, 21]
          (ErrorUnionExpr ; [116, 4] - [116, 11]
            (SuffixExpr ; [116, 4] - [116, 11]
              variable_type_function: (IDENTIFIER) ; [116, 4] - [116, 7]
              (FieldOrFnCall ; [116, 7] - [116, 11]
                field_access: (IDENTIFIER)))) ; [116, 8] - [116, 11]
          (AssignOp) ; [116, 12] - [116, 13]
          (ErrorUnionExpr ; [116, 14] - [116, 19]
            (SuffixExpr ; [116, 14] - [116, 19]
              variable_type_function: (IDENTIFIER))) ; [116, 14] - [116, 19]
          (InitList))) ; [116, 19] - [116, 21]
```

Not sure how relevant this is or if there is a trick but for me it seems to work without these extra tags so I don't think it'd be a blocker