### PR TITLE
feat(julia): capture function definitions

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -33,6 +33,103 @@
   (identifier) @function.call
   (#any-of? @_pipe "|>" ".|>"))
 
+; Function definitions
+; function f()
+(function_definition
+  (signature
+    (call_expression
+      [
+        (identifier) @function
+        (field_expression
+          (identifier) @function .)
+      ])))
+
+; function f() where A
+(function_definition
+  (signature
+    (where_expression
+      .
+      (call_expression
+        [
+          (identifier) @function
+          (field_expression
+            (identifier) @function .)
+        ]))))
+
+; function f() where A where B
+(function_definition
+  (signature
+    (where_expression
+      .
+      (where_expression
+        .
+        (call_expression
+          [
+            (identifier) @function
+            (field_expression
+              (identifier) @function .)
+          ])))))
+
+; function f()::A
+(function_definition
+  (signature
+    (typed_expression
+      .
+      (call_expression
+        [
+          (identifier) @function
+          (field_expression
+            (identifier) @function .)
+        ]))))
+
+; function f(::A)::B where A
+(function_definition
+  (signature
+    (where_expression
+      .
+      (typed_expression
+        .
+        (call_expression
+          [
+            (identifier) @function
+            (field_expression
+              (identifier) @function .)
+          ])))))
+
+; f() = ...
+(assignment
+  .
+  (call_expression
+    [
+      (identifier) @function
+      (field_expression
+        (identifier) @function .)
+    ]))
+
+; f(::A) where A = ...
+(assignment
+  .
+  (where_expression
+    .
+    (call_expression
+      [
+        (identifier) @function
+        (field_expression
+          (identifier) @function .)
+      ])))
+
+; f()::A = ...
+(assignment
+  .
+  (typed_expression
+    .
+    (call_expression
+      [
+        (identifier) @function
+        (field_expression
+          (identifier) @function .)
+      ])))
+
 ; Macros
 (macro_identifier
   "@" @function.macro


### PR DESCRIPTION
This patch adds capturing of function definitions for julia. Function definition expressions in julia can become arbitrarily complicated (e.g. by nesting `where`). The queries included here tries to capture the most common patterns seen in the wild. Checking all function definitions in all packages in my local depot yields the following results:

| Signature                              |  Count |      % | Cumulative |
|----------------------------------------|-------:|-------:|-----------:|
| `f()`                                  | 498367 | 40.3 % |     40.3 % |
| `function f()`                         | 479445 | 38.7 % |     79.0 % |
| `function f() where A`                 | 133304 | 10.8 % |     89.8 % |
| `f() where A`                          | 117966 |  9.5 % |     99.3 % |
| `function f()::A`                      |   5341 |  0.4 % |     99.7 % |
| `f()::A`                               |   1635 |  0.1 % |     99.8 % |
| `function f() where A where B`         |   1152 |  0.1 % |     99.9 % |
| `function f()::T where A`              |   1033 |  0.1 % |    100.0 % |
| `f() where A where B`                  |    661 |  0.1 % |    100.0 % |
| `function f() where A where B where C` |     91 |  0.0 % |    100.0 % |
| `f() where A where B where C`          |     21 |  0.0 % |    100.0 % |
| `function f()::T where A where B`      |      1 |  0.0 % |    100.0 % |

With this patch all but the last three signatures are matched, resulting in 99.99% coverage.

Closes #7365.