### PR TITLE
feat(inko): highlight "inline" keyword

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -354,7 +354,7 @@
     "revision": "962568c9efa71d25720ab42c5d36e222626ef3a6"
   },
   "inko": {
-    "revision": "aecabede39b0db05678e2d4686258d4f71b00a51"
+    "revision": "a6fb0b0bfee5dede688968fd91282da799e5aa8e"
   },
   "ispc": {
     "revision": "9b2f9aec2106b94b4e099fe75e73ebd8ae707c04"

--- a/queries/inko/highlights.scm
+++ b/queries/inko/highlights.scm
@@ -55,12 +55,13 @@
   "as"
   "for"
   "impl"
+  "inline"
   "let"
+  "move"
   "mut"
+  "recover"
   "ref"
   "uni"
-  "move"
-  "recover"
 ] @keyword
 
 "fn" @keyword.function


### PR DESCRIPTION
The parser added support for the "inline" keyword in a few places. This ensures a highlight is present for the keyword.