### PR TITLE
feat(julia): highlight interpolation operator

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -298,6 +298,15 @@
   "}"
 ] @punctuation.bracket
 
+; Interpolation
+(string_interpolation
+  .
+  "$" @punctuation.special)
+
+(interpolation_expression
+  .
+  "$" @punctuation.special)
+
 ; Keyword operators
 ((operator) @keyword.operator
   (#any-of? @keyword.operator "in" "isa"))


### PR DESCRIPTION
This patch adds `$` to the `@punctuation.special` capture group. `$` is
used for string interpolation (`"hello $name"`) and expression
interpolation (`:(hello $name)`) and for both of these cases the
`@punctuation.special` category seem appropriate.
