### PR TITLE
fix(nu): highlight all occurrences of "use"

### DIFF
--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -38,7 +38,10 @@
   "error"
 ] @keyword.exception
 
-"module" @keyword.import
+[
+  "module"
+  "use"
+] @keyword.import
 
 [
   "alias"
@@ -67,7 +70,6 @@
   "new" @keyword.import)
 
 (overlay_use
-  "use" @keyword.import
   "as" @keyword)
 
 (ctrl_error


### PR DESCRIPTION
Currently it is not highlighted for e.g.

```nushell
# Activate the theme when sourced
use activate
```

I have checked the `grammar.js` and there are no other occurrences of `"use"` that could be incorrectly overridden by this change.