### PR TITLE
fix(julia): fix incorrect documentation query

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -357,8 +357,12 @@
     (module_definition)
     (struct_definition)
     (call_expression)
-    (identifier)
   ])
+
+(source_file
+  (string_literal) @string.documentation
+  .
+  (identifier))
 
 [
   (line_comment)


### PR DESCRIPTION
This patch fixes an inprecise `@string.documentation` query introduced
in https://github.com/nvim-treesitter/nvim-treesitter/pull/7391.
Specifically, the pattern `(string_literal) . (identifier)` matches also
for example `"hello"` in

```julia
foo("hello", world)
@info "hello" world
```

To fix this, this patch limits the pattern to top-level statements.
