### PR TITLE
feat(inko): highlight the "copy" keyword

### DIFF
--- a/queries/inko/highlights.scm
+++ b/queries/inko/highlights.scm
@@ -53,6 +53,7 @@
 ; Keywords
 [
   "as"
+  "copy"
   "for"
   "impl"
   "inline"


### PR DESCRIPTION
This keyword is added as part of the upcoming 0.18.0 release. The Tree sitter commit is already included as part of 3edea87978b2ee93b197513e5cdf86012d33b7fa.