### PR TITLE
fix(julia): fix incorrect documentation query

### DIFF
--- a/queries/julia/highlights.scm
+++ b/queries/julia/highlights.scm
@@ -356,13 +356,15 @@
     (macro_definition)
     (module_definition)
     (struct_definition)
-    (call_expression)
   ])
 
 (source_file
   (string_literal) @string.documentation
   .
-  (identifier))
+  [
+    (identifier)
+    (call_expression)
+  ])
 
 [
   (line_comment)


### PR DESCRIPTION
This patch fixes an inprecise `@string.documentation` query introduced
in https://github.com/nvim-treesitter/nvim-treesitter/pull/7391. The
pattern `(string_literal) . (call_expression)` matches also for example
`"hello"` in `foo("hello", bar())`. Similarly to
https://github.com/nvim-treesitter/nvim-treesitter/pull/7436, this patch
limits the pattern to top-level statements.
