### PR TITLE
improve indent queries for zig

### DIFF
--- a/queries/zig/indents.scm
+++ b/queries/zig/indents.scm
@@ -1,7 +1,12 @@
 [
   (block)
   (struct_declaration)
+  (enum_declaration)
+  (union_declaration)
   (switch_expression)
+  (if_expression)
+  (while_expression)
+  (for_expression)
   (initializer_list)
 ] @indent.begin
 


### PR DESCRIPTION
This PR improves indentation for Zig.
* enum and union declarations are indented
* if, while, and for expressions are indented