### PR TITLE
fix(install): add -std=c99 flag

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -126,6 +126,8 @@ function M.select_compiler_args(repo, compiler)
       end, repo.files) > 0
     then
       table.insert(args, "-lstdc++")
+    else
+      table.insert(args, "-std=c99")
     end
     if fn.has "win32" == 0 then
       table.insert(args, "-fPIC")


### PR DESCRIPTION
My gcc version is `gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)`. I can not compile parsers without `-std=c99` flag.