### PR TITLE
feat(inko): highlight the "type" keyword

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -357,7 +357,7 @@
     "revision": "962568c9efa71d25720ab42c5d36e222626ef3a6"
   },
   "inko": {
-    "revision": "1419efb8e7e140c30632cb0a2bef84e0d48a6fc5"
+    "revision": "0b08a8f976456a9271f70d4682143328d7224115"
   },
   "ispc": {
     "revision": "9b2f9aec2106b94b4e099fe75e73ebd8ae707c04"

--- a/queries/inko/highlights.scm
+++ b/queries/inko/highlights.scm
@@ -77,6 +77,7 @@
 [
   "class"
   "trait"
+  "type"
 ] @keyword.type
 
 [


### PR DESCRIPTION
This keyword will be released in 0.18.0 and deprecate the "class" keyword, which in turn will be removed in 0.19.0.