### PR TITLE
Improve parser build reliability

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -92,6 +92,7 @@ function M.select_compiler_args(repo, compiler)
       "/Isrc",
       repo.files,
       "-Os",
+      "/std:c11",
       "/utf-8",
       "/LD",
     }
@@ -105,6 +106,7 @@ function M.select_compiler_args(repo, compiler)
       "-Isrc",
       "-shared",
       "-Os",
+      "-std=c11",
     }
   else
     local args = {
@@ -113,6 +115,7 @@ function M.select_compiler_args(repo, compiler)
       "-I./src",
       repo.files,
       "-Os",
+      "-std=c11",
     }
     if fn.has "mac" == 1 then
       table.insert(args, "-bundle")

--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -353,9 +353,9 @@ end
 function M.make_directory_change_for_command(dir, command)
   if fn.has "win32" == 1 then
     if string.find(vim.o.shell, "cmd") ~= nil then
-      return string.format("pushd %s & %s & popd", cmdpath(dir), command)
+      return string.format("pushd %s & %s", cmdpath(dir), command)
     else
-      return string.format("pushd %s ; %s ; popd", cmdpath(dir), command)
+      return string.format("pushd %s ; %s", cmdpath(dir), command)
     end
   else
     return string.format("cd %s;\n%s", dir, command)


### PR DESCRIPTION
While tracking down the cause of Windows-specific CI failures on https://github.com/nvim-treesitter/nvim-treesitter/pull/7481, I found two improvements to make.

1. `:TSInstallSync` didn't report failures on Windows because it was checking the return code of `popd` instead of the actual command.
2. The root cause of the failure is a `_Static_assert` statement, which is a C11 feature. This project should set the C standard version to C11, since [tree-sitter always does that](https://github.com/tree-sitter/tree-sitter/blob/201b41cf11fb217a1f1ce03ea25b83e62b7b48cb/cli/loader/src/lib.rs#L821).