### PR TITLE
changed the ordering of compilers on windows to something more sensib…

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -19,7 +19,7 @@ local lockfile = {}
 
 if fn.has "win32" == 1 then
   M.compilers = { vim.fn.getenv "CC", "cl", "clang", "cc", "gcc", "zig" }
-else 
+else
   M.compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
 end
 

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -17,7 +17,12 @@ local M = {}
 ---@type table<string, LockfileInfo>
 local lockfile = {}
 
-M.compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
+if fn.has "win32" == 1 then
+  M.compilers = { vim.fn.getenv "CC", "cl", "clang", "cc", "gcc", "zig" }
+else 
+  M.compilers = { vim.fn.getenv "CC", "cc", "gcc", "clang", "cl", "zig" }
+end
+
 M.prefer_git = fn.has "win32" == 1
 M.command_extra_args = {}
 M.ts_generate_args = nil


### PR DESCRIPTION
fixes #7499 in which the default C compiler was set to gcc due to having MYSY2/mingw installed and gcc in the path causing parsers to be compiled with gcc and causing crashes on the Windows version of neovim