### PR TITLE
fix(xml): properly indent closing tags

### DIFF
--- a/queries/xml/indents.scm
+++ b/queries/xml/indents.scm
@@ -6,7 +6,7 @@
   (contentspec)
 ] @indent.align
 
-(ETag) @indent.dedent
+(ETag) @indent.branch
 
 (doctypedecl) @indent.ignore
 


### PR DESCRIPTION
Confusing as it is, https://github.com/heurist/nvim-treesitter/blob/master/CONTRIBUTING.md?plain=1#L394 says:

```query
@indent.dedent      ; dedent children when matching this node
@indent.branch      ; dedent itself when matching this node
```

@indent.branch is therefore the appropriate choice for de-indenting.