### PR TITLE
Fix/leo highlight highlight for casting, record initialization and indents

### DIFF
--- a/queries/leo/highlights.scm
+++ b/queries/leo/highlights.scm
@@ -17,7 +17,10 @@
   "struct"
 ] @keyword.type
 
-"in" @keyword.operator
+[
+  "in"
+  "as"
+] @keyword.operator
 
 [
   "constant"
@@ -133,7 +136,23 @@
 (struct_component_declaration
   (identifier) @variable.member)
 
-(type) @type
+(struct_expression
+  (identifier) @type.definition)
+
+(struct_component_initializer
+  (identifier) @variable.member)
+
+[
+  (type)
+  (boolean_type)
+  (integer_type)
+  (field_type)
+  (group_type)
+  (scalar_type)
+  (address_type)
+  (signature_type)
+  (string_type)
+] @type
 
 [
   (block_height)

--- a/queries/leo/indents.scm
+++ b/queries/leo/indents.scm
@@ -1,32 +1,46 @@
 [
-  (record_declaration)
-  (struct_declaration)
-  (mapping_declaration)
-  (constant_declaration)
-  (return_statement)
-  (expression_statement)
-  (variable_declaration)
-  (loop_statement)
-  (assignment_statement)
-  (assert_statement)
-  (struct_expression)
   (array_expression)
-  (tuple_expression)
-  (parenthesized_expression)
-  (items_block)
+  (assert_statement)
+  (assignment_statement)
   (block)
+  (constant_declaration)
+  (expression_statement)
+  (items_block)
+  (loop_statement)
+  (mapping_declaration)
+  (parenthesized_expression)
+  (record_declaration)
+  (return_statement)
+  (struct_declaration)
+  (struct_expression)
+  (tuple_expression)
+  (variable_declaration)
 ] @indent.begin
-
-; if "if" statement and conditional statement are in separate lines
-; conditional should be indented and when the conditional block
-; starts dedented
-(branch
-  (block
-    "{" @indent.end)) @indent.begin
 
 ((function_parameters) @indent.align
   (#set! indent.open_delimiter "(")
   (#set! indent.close_delimiter ")"))
+
+(record_declaration
+  "}" @indent.branch)
+
+(struct_declaration
+  "}" @indent.branch)
+
+(struct_expression
+  "}" @indent.branch)
+
+(array_expression
+  "}" @indent.branch)
+
+(tuple_expression
+  "}" @indent.branch)
+
+(items_block
+  "}" @indent.branch)
+
+(block
+  "}" @indent.branch)
 
 [
   (comment)


### PR DESCRIPTION
**highlights**:
Record assignment highlighting added
Casting expression highlighting added

**indents**:
Fixed indents as the "}" did not indent well before, now all perfect