### PR TITLE
feat(yaml): highlighting to help deal with yaml's Norway problem

### DIFF
--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -82,7 +82,7 @@
 ] @punctuation.special
 
 ; help deal with for yaml's norway problem https://www.bram.us/2022/01/11/yaml-the-norway-problem/
-; values based on https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy
+; only using `true` and `false`, since Treesitter parser targets YAML spec 1.2 https://github.com/nvim-treesitter/nvim-treesitter/pull/7512#issuecomment-2565397302
 (block_mapping_pair
   value: (block_node
     (block_sequence
@@ -90,14 +90,10 @@
         (flow_node
           (plain_scalar
             (string_scalar) @boolean
-            (#any-of? @boolean
-              "yes" "no" "YES" "NO" "Yes" "No" "on" "off" "ON" "OFF" "On" "Off" "TRUE" "FALSE"
-              "True" "False")))))))
+            (#any-of? @boolean "TRUE" "FALSE" "True" "False")))))))
 
 (block_mapping_pair
   value: (flow_node
     (plain_scalar
       (string_scalar) @boolean
-      (#any-of? @boolean
-        "yes" "no" "YES" "NO" "Yes" "No" "on" "off" "ON" "OFF" "On" "Off" "TRUE" "FALSE" "True"
-        "False"))))
+      (#any-of? @boolean "TRUE" "FALSE" "True" "False"))))

--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -80,3 +80,9 @@
   "---"
   "..."
 ] @punctuation.special
+
+; help deal with for yaml's norway problem https://www.bram.us/2022/01/11/yaml-the-norway-problem/
+; values based on https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy
+((string_scalar) @boolean
+  (#any-of? @boolean
+    "yes" "no" "YES" "NO" "Yes" "No" "on" "off" "ON" "OFF" "On" "Off" "TRUE" "FALSE" "True" "False"))

--- a/queries/yaml/highlights.scm
+++ b/queries/yaml/highlights.scm
@@ -83,6 +83,21 @@
 
 ; help deal with for yaml's norway problem https://www.bram.us/2022/01/11/yaml-the-norway-problem/
 ; values based on https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy
-((string_scalar) @boolean
-  (#any-of? @boolean
-    "yes" "no" "YES" "NO" "Yes" "No" "on" "off" "ON" "OFF" "On" "Off" "TRUE" "FALSE" "True" "False"))
+(block_mapping_pair
+  value: (block_node
+    (block_sequence
+      (block_sequence_item
+        (flow_node
+          (plain_scalar
+            (string_scalar) @boolean
+            (#any-of? @boolean
+              "yes" "no" "YES" "NO" "Yes" "No" "on" "off" "ON" "OFF" "On" "Off" "TRUE" "FALSE"
+              "True" "False")))))))
+
+(block_mapping_pair
+  value: (flow_node
+    (plain_scalar
+      (string_scalar) @boolean
+      (#any-of? @boolean
+        "yes" "no" "YES" "NO" "Yes" "No" "on" "off" "ON" "OFF" "On" "Off" "TRUE" "FALSE" "True"
+        "False"))))


### PR DESCRIPTION
**Problem**  
In yaml there are some strings that, when not unquoted, are evaluated as boolean values instead of strings, for example `off` or `no`. This is also known as [yaml's Norway problem](https://www.bram.us/2022/01/11/yaml-the-norway-problem/), and results in easy to overlook bugs since the syntax highlighting of those tokens as string is quite misleading.

**Solution**  
The PR changes the highlight group of those strings to `@boolean`. It does not affect quoted strings. The specific strings this highlight-group-change is triggered on are taken from [yamllint's related `truthy` rule](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy).

---

before
<img alt="Showcase" width=40% src="https://github.com/user-attachments/assets/c1a70ec3-1c32-4b5d-8619-762e8a541b5b">

after
<img alt="Showcase" width=40% src="https://github.com/user-attachments/assets/ec6c5e77-deba-4d43-ab17-76dcd42ceeab">
