### PR TITLE
fix(bash): offset injection content

### DIFF
--- a/queries/bash/injections.scm
+++ b/queries/bash/injections.scm
@@ -14,16 +14,16 @@
   name: (command_name) @_command
   .
   argument: [
-    (string
-      (string_content) @injection.content)
+    (string) @injection.content
     (concatenation
-      (string
-        (string_content) @injection.content))
+      (string) @injection.content)
     (raw_string) @injection.content
     (concatenation
       (raw_string) @injection.content)
   ])
   (#eq? @_command "printf")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
   (#set! injection.language "printf"))
 
 ; printf -v var 'format'
@@ -34,17 +34,17 @@
   (_)
   .
   argument: [
-    (string
-      (string_content) @injection.content)
+    (string) @injection.content
     (concatenation
-      (string
-        (string_content) @injection.content))
+      (string) @injection.content)
     (raw_string) @injection.content
     (concatenation
       (raw_string) @injection.content)
   ])
   (#eq? @_command "printf")
   (#eq? @_arg "-v")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
   (#set! injection.language "printf"))
 
 ; printf -- 'format'
@@ -53,17 +53,17 @@
   argument: (word) @_arg
   .
   argument: [
-    (string
-      (string_content) @injection.content)
+    (string) @injection.content
     (concatenation
-      (string
-        (string_content) @injection.content))
+      (string) @injection.content)
     (raw_string) @injection.content
     (concatenation
       (raw_string) @injection.content)
   ])
   (#eq? @_command "printf")
   (#eq? @_arg "--")
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
   (#set! injection.language "printf"))
 
 ((command


### PR DESCRIPTION
### Problem

`printf` injection includes raw string quotes from bash. Leads to incorrect highlighting for `%` at the end of the string.


### Solution

Capture both regular and raw strings with quotes and offset the range to remove them.

Before and after:

![image](https://github.com/user-attachments/assets/bd50e65b-c850-434a-82c3-407461ac1d89) ![image](https://github.com/user-attachments/assets/84005aa7-d312-4d5b-af50-7dbdf612a6e1)

<details>

<summary>minimal.lua</summary>

```lua
for name, url in pairs {
  nvim_treesitter = 'https://github.com/nvim-treesitter/nvim-treesitter.git',
} do
  local install_path = vim.fn.fnamemodify('nvim_issue/' .. name, ':p')
  if vim.fn.isdirectory(install_path) == 0 then
    vim.fn.system { 'git', 'clone', '--depth=1', url, install_path }
  end
  vim.opt.runtimepath:append(install_path)
end

require'nvim-treesitter.configs'.setup {
  sync_install = true,
  ensure_installed = { 'bash', 'printf' },
  highlight = { enable = true },
}

vim.api.nvim_set_hl(0, '@character.printf', { fg = 'red' })

vim.api.nvim_buf_set_lines(0, 0, -1, true, {
  [[printf '%']],
  [[printf "%"]],
  [[printf '%'"%"]],
  [[printf "%"'%']],
  [[printf '%d']],
  [[printf "%d"]],
  [[printf '%d'"%d"]],
  [[printf "%d"'%d']],
  '',
  [[printf -v var '%']],
  [[printf -v var "%"]],
  [[printf -v var '%'"%"]],
  [[printf -v var "%"'%']],
  [[printf -v var '%d']],
  [[printf -v var "%d"]],
  [[printf -v var '%d'"%d"]],
  [[printf -v var "%d"'%d']],
  '',
  [[printf -- '%']],
  [[printf -- "%"]],
  [[printf -- '%'"%"]],
  [[printf -- "%"'%']],
  [[printf -- '%d']],
  [[printf -- "%d"]],
  [[printf -- '%d'"%d"]],
  [[printf -- "%d"'%d']],
})

vim.schedule(function()
  vim.cmd('set ft=bash')
end)
```

</details>
