### PR TITLE
fix(php): properly highlight grouped imported functions and constants

### DIFF
--- a/queries/php_only/highlights.scm
+++ b/queries/php_only/highlights.scm
@@ -233,6 +233,17 @@
     alias: (name) @function
   ])
 
+(namespace_use_declaration
+  type: "function"
+  body: (namespace_use_group
+    (namespace_use_clause
+      [
+        (name) @function
+        (qualified_name
+          (name) @function)
+        alias: (name) @function
+      ])))
+
 (namespace_use_clause
   type: "const"
   [
@@ -241,6 +252,17 @@
       (name) @constant)
     alias: (name) @constant
   ])
+
+(namespace_use_declaration
+  type: "const"
+  body: (namespace_use_group
+    (namespace_use_clause
+      [
+        (name) @constant
+        (qualified_name
+          (name) @constant)
+        alias: (name) @constant
+      ])))
 
 (class_interface_clause
   [

--- a/tests/query/highlights/php/keywords.php
+++ b/tests/query/highlights/php/keywords.php
@@ -12,15 +12,27 @@ use Foo\Baz as Baaz;
 //          ^^ @keyword.operator
 //             ^^^^ @type.definition
 
+use Foo\Baz\{Foo, Bar};
+//           ^^^ @type
+//                ^^^ @type
+
 use function Foo\foo as fooo;
 //  ^^^^^^^^ @keyword.function
 //               ^^^ @function
 //                      ^^^^ @function
 
+use function Foo\{bar, baz};
+//                ^^^ @function
+//                     ^^^ @function
+
 use const Foo\FOO as FOOO;
 //  ^^^^^ @keyword.modifier
 //            ^^^ @constant
 //                   ^^^^ @constant
+
+use const Foo\{FOO, BAR};
+//             ^^^ @constant
+//                  ^^^ @constant
 
 use Foo\Baz\{
 //  ^^^ @module


### PR DESCRIPTION
Hello!

This fixes highlighting for grouped functions and constants like:


```php
use function Foo\{bar, baz};
use const Foo\{FOO, BAR};
```

Thanks!