### PR TITLE
fix(rbs): fix highlight queries of rbs that is missing some definitions

### DIFF
--- a/queries/rbs/highlights.scm
+++ b/queries/rbs/highlights.scm
@@ -54,9 +54,24 @@
   (method_name
     [
       (identifier)
+      (identifier_suffix)
       (constant)
+      (constant_suffix)
       (operator)
       (setter)
+      (constant_setter)
+    ] @function.method))
+
+(attribute_member
+  (method_name
+    [
+      (identifier)
+      (identifier_suffix)
+      (constant)
+      (constant_suffix)
+      (operator)
+      (setter)
+      (constant_setter)
     ] @function.method))
 
 [
@@ -114,6 +129,10 @@
 
 (type
   (integer_literal) @number)
+
+(type
+  (record_type
+    key: (record_key) @string.special.symbol))
 
 ; Operators
 [


### PR DESCRIPTION
Some rbs highlight definitions are missing.
This is reported by https://github.com/joker1007/tree-sitter-rbs/issues/15
I apply the fixes to this repository.