### PR TITLE
Update injections.scm

### DIFF
--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -21,7 +21,7 @@
 (sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content
-  (#match? @_sigil_name "^(H|LVN)$")
+  (#any-of? @_sigil_name "H" "LVN")
   (#set! injection.language "heex"))
 
 ; Surface

--- a/queries/elixir/injections.scm
+++ b/queries/elixir/injections.scm
@@ -21,7 +21,7 @@
 (sigil
   (sigil_name) @_sigil_name
   (quoted_content) @injection.content
-  (#eq? @_sigil_name "H")
+  (#match? @_sigil_name "^(H|LVN)$")
   (#set! injection.language "heex"))
 
 ; Surface


### PR DESCRIPTION
Match the Elixir treesitter updates for LVN sigil support: https://github.com/elixir-lang/tree-sitter-elixir/commit/53458546e3bb717beee1d15df30724c81eb41d1c

If possible to also bump up the heex treesitter packaged. 0.7.0 was recently released and that adds file alias support for neex -> HEEX syntax highlighting: https://github.com/phoenixframework/tree-sitter-heex/commit/9359017bd0dc6b023044713aa215544885663637

If you ned a PR for that I can do it, just not sure where to add the extension alias