### PR TITLE
feat(nix): Fix function highlights when part of a set

### DIFF
--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -88,7 +88,7 @@
     (select_expression
       attrpath: (attrpath
         (_)
-        attr: (identifier) @function.call))
+        attr: (identifier) @function.call .))
   ])
 
 ; basic identifiers

--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -79,6 +79,43 @@
   function: (variable_expression
     name: (identifier) @function.call))
 
+; basic identifiers
+(variable_expression) @variable
+
+(variable_expression
+  name: (identifier) @keyword.import
+  (#eq? @keyword.import "import"))
+
+(variable_expression
+  name: (identifier) @boolean
+  (#any-of? @boolean "true" "false"))
+
+; string interpolation (this was very annoying to get working properly)
+(interpolation
+  "${" @punctuation.special
+  (_)
+  "}" @punctuation.special) @none
+
+(select_expression
+  expression: (_) @_expr
+  attrpath: (attrpath
+    attr: (identifier) @variable.member)
+  (#not-eq? @_expr "builtins"))
+
+(attrset_expression
+  (binding_set
+    (binding
+      .
+      (attrpath
+        (identifier) @variable.member))))
+
+(rec_attrset_expression
+  (binding_set
+    (binding
+      .
+      (attrpath
+        (identifier) @variable.member))))
+
 (apply_expression
   function: [
     (select_expression
@@ -90,17 +127,6 @@
         (_)
         attr: (identifier) @function.call .))
   ])
-
-; basic identifiers
-(variable_expression) @variable
-
-(variable_expression
-  name: (identifier) @keyword.import
-  (#eq? @keyword.import "import"))
-
-(variable_expression
-  name: (identifier) @boolean
-  (#any-of? @boolean "true" "false"))
 
 ; builtin functions (with builtins prefix)
 (select_expression
@@ -149,32 +175,6 @@
   (#any-of? @constant.builtin
     ; nix eval --impure --expr 'with builtins; filter (x: !(isFunction builtins.${x} || isBool builtins.${x})) (attrNames builtins)'
     "builtins" "currentSystem" "currentTime" "langVersion" "nixPath" "nixVersion" "null" "storeDir"))
-
-; string interpolation (this was very annoying to get working properly)
-(interpolation
-  "${" @punctuation.special
-  (_)
-  "}" @punctuation.special) @none
-
-(select_expression
-  expression: (_) @_expr
-  attrpath: (attrpath
-    attr: (identifier) @variable.member)
-  (#not-eq? @_expr "builtins"))
-
-(attrset_expression
-  (binding_set
-    (binding
-      .
-      (attrpath
-        (identifier) @variable.member))))
-
-(rec_attrset_expression
-  (binding_set
-    (binding
-      .
-      (attrpath
-        (identifier) @variable.member))))
 
 ; function definition
 (binding

--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -79,6 +79,18 @@
   function: (variable_expression
     name: (identifier) @function.call))
 
+(apply_expression
+  function: [
+    (select_expression
+      attrpath: (attrpath
+        .
+        attr: (identifier) @function.call .))
+    (select_expression
+      attrpath: (attrpath
+        (_)
+        attr: (identifier) @function.call))
+  ])
+
 ; basic identifiers
 (variable_expression) @variable
 


### PR DESCRIPTION
Functions in Nix are only highlighted when they aren't part of a set. This may be intentional since GitHub highlights them the same way (see below), though.

```nix
# This gets highlighted as a function.
someFunc 32;

# These do not. 'someOtherFunc' gets highlighted with @variable.member.nix only.
lib.someOtherFunc 48;
lib.hello.someOtherFunc { };
```

There probably is a more efficient way to do this, but I don't know Scheme. More specifically, I couldn't figure out how to select the last node and had to write two different queries (one for `a.b.func` and one for `a.func`).