### PR TITLE
fix(matlab): indentation of arguments statement

### DIFF
--- a/queries/matlab/indents.scm
+++ b/queries/matlab/indents.scm
@@ -1,6 +1,7 @@
 "end" @indent.end @indent.branch
 
 [
+  (arguments_statement)
   (if_statement)
   (for_statement)
   (while_statement)


### PR DESCRIPTION
Fixes https://github.com/acristoffers/tree-sitter-matlab/issues/19