### PR TITLE
feat(gotmpl): highlight operator

### DIFF
--- a/queries/gotmpl/highlights.scm
+++ b/queries/gotmpl/highlights.scm
@@ -32,6 +32,7 @@
 ; Operators
 ([
   "|"
+  "="
   ":="
 ] @operator
   (#set! priority 110))


### PR DESCRIPTION
Hope the formatting is okay, because when trying to run the format queries script like so:
`./scripts/format-queries.lua queries/gotmpl/highlights.scm`

Outputs:

```
E5113: Error while calling lua chunk: .../nightly/share/nvim/runtime/lua/vim/treesitter/query.lua:317: Query error at 210:7. Impossible pattern:
      name: (string) .)
      ^

stack traceback:
        [C]: in function '_ts_parse_query'
        .../nightly/share/nvim/runtime/lua/vim/treesitter/query.lua:317: in function 'fn'
        ...bob/nightly/share/nvim/runtime/lua/vim/func/_memoize.lua:78: in function 'parse'
        ./scripts/format-queries.lua:414: in function 'format'
        ./scripts/format-queries.lua:429: in main chunk
Jan 13 21:06:12.079 ERROR Error: Process exited with error code 1
```
Is this only on my end?
