### PR TITLE
feat(moonbit): add parsers and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [ ] [mermaid](https://github.com/monaqa/tree-sitter-mermaid) (experimental)
 - [x] [meson](https://github.com/Decodetalkers/tree-sitter-meson) (maintained by @Decodetalkers)
 - [x] [mlir](https://github.com/artagnon/tree-sitter-mlir) (experimental, maintained by @artagnon)
+- [x] [moonbit](https://github.com/moonbitlang/tree-sitter-moonbit) (experimental, maintained by @tonyfettes)
 - [x] [muttrc](https://github.com/neomutt/tree-sitter-muttrc) (maintained by @Freed-Wu)
 - [x] [nasm](https://github.com/naclsn/tree-sitter-nasm) (maintained by @ObserverOfTime)
 - [x] [nginx](https://github.com/opa-oz/tree-sitter-nginx) (maintained by @opa-oz)

--- a/lockfile.json
+++ b/lockfile.json
@@ -476,6 +476,9 @@
   "mlir": {
     "revision": "b5d5f238b371b7c9b764f6a053b045dda92bc836"
   },
+  "moonbit": {
+    "revision": "de40c86923fc456419085a70e1dc8aa92d20a3a1"
+  },
   "muttrc": {
     "revision": "173b0ab53a9c07962c9777189c4c70e90f1c1837"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1405,6 +1405,15 @@ list.mlir = {
   maintainers = { "@artagnon" },
 }
 
+list.moonbit = {
+  install_info = {
+    url = "https://github.com/moonbitlang/tree-sitter-moonbit",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  experimental = true,
+  maintainers = { "@tonyfettes" },
+}
+
 list.muttrc = {
   install_info = {
     url = "https://github.com/neomutt/tree-sitter-muttrc",

--- a/queries/moonbit/folds.scm
+++ b/queries/moonbit/folds.scm
@@ -1,0 +1,24 @@
+; Copyright 2025 International Digital Economy Academy
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+[
+  (block_expression)
+  (match_expression)
+  (nonempty_block_expression)
+  (struct_definition)
+  (enum_definition)
+  (function_definition)
+  (value_definition)
+  (if_expression)
+  (match_expression)
+] @fold

--- a/queries/moonbit/highlights.scm
+++ b/queries/moonbit/highlights.scm
@@ -1,0 +1,302 @@
+; Copyright 2025 International Digital Economy Academy
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+; Interpolation
+(interpolator) @none
+
+; Packages
+(package_identifier) @module
+
+; Variables
+; Variables
+(parameter
+  (parameter_label) @variable.parameter)
+
+(parameter
+  (lowercase_identifier) @variable.parameter)
+
+((parameter
+  (lowercase_identifier) @variable.builtin)
+  (#any-of? @variable.builtin "self"))
+
+(pattern
+  (simple_pattern
+    (lowercase_identifier) @variable))
+
+(qualified_identifier
+  (lowercase_identifier) @variable)
+
+((qualified_identifier
+  (lowercase_identifier) @variable.builtin)
+  (#any-of? @variable.builtin "self"))
+
+((qualified_identifier
+  (dot_identifier) @variable)
+  (#lua-match? @variable "^\.[^A-Z]"))
+
+(value_definition
+  (lowercase_identifier) @variable)
+
+(let_mut_expression
+  (lowercase_identifier) @variable)
+
+; Constants
+(const_definition
+  (uppercase_identifier) @constant)
+
+((qualified_identifier
+  (dot_identifier) @constant)
+  (#lua-match? @constant "^\.[A-Z]"))
+
+; Types
+; Type identifiers
+(type_identifier) @type
+
+(qualified_type_identifier) @type
+
+(constructor_expression
+  (uppercase_identifier) @type)
+
+; Type definitions
+(enum_definition
+  (identifier) @type.definition)
+
+(struct_definition
+  (identifier) @type.definition)
+
+(type_definition
+  (identifier) @type.definition)
+
+(trait_definition
+  (identifier) @type.definition)
+
+(type_alias_definition
+  (identifier) @type.definition)
+
+(error_type_definition
+  (identifier) @type.definition)
+
+; Builtin types
+((qualified_type_identifier) @type.builtin
+  (#any-of? @type.builtin
+    "Unit" "Bool" "Byte" "Int" "UInt" "Int64" "UInt64" "Float" "Double" "FixedArray" "Array" "Bytes"
+    "String" "Error" "Self"))
+
+; Constructors
+(enum_constructor) @constant
+
+(constructor_expression
+  (uppercase_identifier) @constant)
+
+; Fields
+(struct_field_declaration
+  (lowercase_identifier) @variable.member)
+
+(struct_field_expressions
+  (labeled_expression
+    (lowercase_identifier) @variable.member))
+
+(struct_field_expressions
+  (labeled_expression_pun
+    (lowercase_identifier) @variable.member))
+
+(struct_field_expression
+  (labeled_expression
+    (lowercase_identifier) @variable.member))
+
+(struct_field_expression
+  (labeled_expression_pun
+    (lowercase_identifier) @variable.member))
+
+(struct_field_pattern
+  (field_single_pattern
+    (labeled_pattern
+      (lowercase_identifier) @variable.member)))
+
+(struct_field_pattern
+  (field_single_pattern
+    (labeled_pattern_pun
+      (lowercase_identifier) @variable.member)))
+
+(access_expression
+  (accessor
+    (dot_identifier) @variable.member))
+
+; Functions
+; Function calls
+(apply_expression
+  (simple_expression
+    (qualified_identifier) @function.call))
+
+; Method calls
+(method_expression
+  (lowercase_identifier) @function.method.call)
+
+(dot_apply_expression
+  (dot_identifier) @function.method.call)
+
+; Function definitions
+(function_definition
+  (function_identifier
+    (lowercase_identifier) @function))
+
+(trait_method_declaration
+  (function_identifier) @function)
+
+(impl_definition
+  (function_identifier) @function)
+
+; Method definitions
+(function_definition
+  (function_identifier
+    (qualified_type_identifier)
+    (lowercase_identifier) @function.method))
+
+; Labels
+(loop_label) @label
+
+("continue"
+  (parameter_label) @label)
+
+("break"
+  (parameter_label) @label)
+
+; Operators
+[
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "="
+  "<"
+  ">"
+  ">="
+  "<="
+  "=="
+  "!="
+  "&&"
+  "||"
+  "=>"
+  "->"
+  "!"
+  "!!"
+] @operator
+
+; Keywords
+(mutability) @keyword.modifier
+
+[
+  "struct"
+  "enum"
+  "type"
+  "trait"
+  "typealias"
+] @keyword.type
+
+[
+  "pub"
+  "priv"
+  "readonly"
+  "all"
+  "open"
+  "extern"
+] @keyword.modifier
+
+[
+  "guard"
+  "let"
+  "mut"
+  "const"
+  "with"
+] @keyword
+
+(derive) @keyword
+
+[
+  "fn"
+  "test"
+  "impl"
+] @keyword.function
+
+"return" @keyword.return
+
+[
+  "while"
+  "loop"
+  "for"
+  "break"
+  "continue"
+  "in"
+] @keyword.repeat
+
+[
+  "if"
+  "else"
+  "match"
+] @keyword.conditional
+
+"async" @keyword.coroutine
+
+[
+  "try"
+  "raise"
+  "catch"
+] @keyword.exception
+
+; Delimiters
+[
+  ";"
+  ","
+] @punctuation.delimiter
+
+(colon) @punctuation.delimiter
+
+(colon_colon) @punctuation.delimiter
+
+(dot_operator) @punctuation.delimiter
+
+(dot_dot) @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+; Literals
+(string_interpolation) @string
+
+(string_literal) @string
+
+(multiline_string_literal) @string
+
+(escape_sequence) @string.escape
+
+(interpolator
+  "\\{" @punctuation.special
+  "}" @punctuation.special)
+
+(integer_literal) @number
+
+(float_literal) @number.float
+
+(boolean_literal) @boolean
+
+; Comments
+(comment) @comment @spell
+
+(docstring) @comment.documentation @spell

--- a/queries/moonbit/indents.scm
+++ b/queries/moonbit/indents.scm
@@ -1,0 +1,33 @@
+; Copyright 2025 Chung-Yu Chang (curist)
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+[
+  (block_expression)
+  (loop_expression)
+  (match_expression)
+  (nonempty_block_expression)
+  (struct_brace_expression)
+  (structure_item)
+] @indent.begin
+
+[
+  ")"
+  "}"
+  "]"
+] @indent.end
+
+[
+  ")"
+  "}"
+  "]"
+] @indent.branch

--- a/queries/moonbit/injections.scm
+++ b/queries/moonbit/injections.scm
@@ -1,0 +1,15 @@
+; Copyright 2025 International Digital Economy Academy
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/queries/moonbit/locals.scm
+++ b/queries/moonbit/locals.scm
@@ -1,0 +1,60 @@
+; Copyright 2025 International Digital Economy Academy
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+; Definitions
+; Functions
+(function_definition
+  (function_identifier) @local.definition.function)
+
+; Variables
+(value_definition
+  (lowercase_identifier) @local.definition.var)
+
+(parameter
+  (parameter_label) @local.definition.parameter)
+
+(let_expression
+  (pattern
+    (simple_pattern
+      (lowercase_identifier)) @local.definition.var))
+
+(let_mut_expression
+  (lowercase_identifier) @local.definition.var)
+
+; Types
+(struct_definition
+  (identifier) @local.definition.type)
+
+(enum_definition
+  (identifier) @local.definition.enum)
+
+(type_definition
+  (identifier) @local.definition.type)
+
+(type_identifier) @local.definition.type
+
+; References
+; Values
+(qualified_identifier) @local.reference
+
+; Types
+(qualified_type_identifier) @local.reference
+
+; Scopes
+[
+  (structure)
+  (function_definition)
+  (anonymous_lambda_expression)
+  (named_lambda_expression)
+  (block_expression)
+] @local.scope


### PR DESCRIPTION
This PR add parser configuration and queries for [moonbit](https://www.moonbitlang.com).

The parser is located at https://github.com/moonbitlang/tree-sitter-moonbit and is currently maintained by me.

The queries are copied from https://github.com/moonbit-community/moonbit.nvim . Note that all the queries comes with license header, but I'm not sure if this is OK or suitable for use within this repo.