### PR TITLE
feat(css): highlight @keyframes name

### DIFF
--- a/queries/css/highlights.scm
+++ b/queries/css/highlights.scm
@@ -72,6 +72,8 @@
 
 (namespace_name) @module
 
+(keyframes_name) @variable
+
 ((property_name) @variable
   (#lua-match? @variable "^[-][-]"))
 


### PR DESCRIPTION
I'm not sure what the best capture would be here, I used `@variable` because it's the most generic capture for an identifier.