### PR TITLE
feat(hyprlang): bash injections for exec keybindings

### DIFF
--- a/queries/hyprlang/injections.scm
+++ b/queries/hyprlang/injections.scm
@@ -4,3 +4,18 @@
 (exec
   (string) @injection.content
   (#set! injection.language "bash"))
+
+((keyword
+  (name) @_bind
+  (params
+    .
+    (_)
+    .
+    (_)
+    .
+    (string) @_exec
+    .
+    (string) @injection.content))
+  (#lua-match? @_bind "^bind")
+  (#lua-match? @_exec "^%s*exec%s*$")
+  (#set! injection.language "bash"))


### PR DESCRIPTION
Example:

```
bind = SHIFT, Print, exec, slurp | grim -g - - | wl-copy
bind = $mod, P, exec, uwsm app -- hyprpicker --autocopy --format=hex
```

Before:
![image](https://github.com/user-attachments/assets/e4eb0ebc-a06f-4569-a716-56f45814031d)


After:
![image](https://github.com/user-attachments/assets/1f2678c8-eca1-49f0-a19d-7d7d82c248da)
