### PR TITLE
Add highlight for non-integer type (real)

### DIFF
--- a/queries/verilog/highlights.scm
+++ b/queries/verilog/highlights.scm
@@ -263,6 +263,7 @@
   (integer_vector_type)
   (time_unit)
   (integer_atom_type)
+  (non_integer_type)
 ] @type.builtin
 
 (data_type


### PR DESCRIPTION
Add missing highlight for Verilog/SystemVerilog non-integer type like real to queries/verilog/highlights.scm