### PR TITLE
feat: Added Caddyfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [bp](https://github.com/ambroisie/tree-sitter-bp) (maintained by @ambroisie)
 - [x] [c](https://github.com/tree-sitter/tree-sitter-c) (maintained by @amaanq)
 - [x] [c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) (maintained by @amaanq)
+- [x] [caddy](https://github.com/opa-oz/tree-sitter-caddy) (maintained by @opa-oz)
 - [x] [cairo](https://github.com/amaanq/tree-sitter-cairo) (maintained by @amaanq)
 - [x] [capnp](https://github.com/amaanq/tree-sitter-capnp) (maintained by @amaanq)
 - [x] [chatito](https://github.com/ObserverOfTime/tree-sitter-chatito) (maintained by @ObserverOfTime)

--- a/lockfile.json
+++ b/lockfile.json
@@ -59,6 +59,9 @@
   "c_sharp": {
     "revision": "b5eb5742f6a7e9438bee22ce8026d6b927be2cd7"
   },
+  "caddy": {
+    "revision": "6f860e7c0527b293439f5f96a1adac043e3ec18e"
+  },
   "cairo": {
     "revision": "6238f609bea233040fe927858156dee5515a0745"
   },

--- a/lockfile.json
+++ b/lockfile.json
@@ -60,7 +60,7 @@
     "revision": "b5eb5742f6a7e9438bee22ce8026d6b927be2cd7"
   },
   "caddy": {
-    "revision": "6f860e7c0527b293439f5f96a1adac043e3ec18e"
+    "revision": "2686186edb61be47960431c93a204fb249681360"
   },
   "cairo": {
     "revision": "6238f609bea233040fe927858156dee5515a0745"

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -38,6 +38,12 @@ for ft, lang in pairs {
   ts.language.register(lang, ft)
 end
 
+vim.filetype.add {
+  filename = {
+    ["Caddyfile"] = "caddy",
+  },
+}
+
 ---@class InstallInfo
 ---@field url string
 ---@field branch string|nil
@@ -231,6 +237,14 @@ list.c_sharp = {
   },
   filetype = "cs",
   maintainers = { "@amaanq" },
+}
+
+list.caddy = {
+  install_info = {
+    url = "https://github.com/opa-oz/tree-sitter-caddy",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@opa-oz" },
 }
 
 list.cairo = {

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -38,12 +38,6 @@ for ft, lang in pairs {
   ts.language.register(lang, ft)
 end
 
-vim.filetype.add {
-  filename = {
-    ["Caddyfile"] = "caddy",
-  },
-}
-
 ---@class InstallInfo
 ---@field url string
 ---@field branch string|nil

--- a/queries/caddy/folds.scm
+++ b/queries/caddy/folds.scm
@@ -1,0 +1,2 @@
+(block) @fold
+

--- a/queries/caddy/folds.scm
+++ b/queries/caddy/folds.scm
@@ -1,2 +1,1 @@
 (block) @fold
-

--- a/queries/caddy/highlights.scm
+++ b/queries/caddy/highlights.scm
@@ -1,0 +1,52 @@
+(comment) @comment @spell
+
+[ 
+  (env)
+  (argv)
+  (block_variable)
+  (placeholder)
+] @constant
+
+(value) @variable
+(directive (keyword) @attribute)
+(global_options (option (keyword) @attribute))
+
+(keyword) @keyword
+
+(boolean) @boolean
+
+(placeholder
+  [
+    "{"
+    "}"
+  ] @punctuation.special)
+
+
+[
+  (auto)
+] @variable.builtin
+
+[
+  (string_literal)
+  (quoted_string_literal)
+  (address)
+] @string
+
+[ 
+  (matcher) 
+  (route)
+  (snippet_name)
+] @string.special
+
+[
+  (numeric_literal)
+  (time)
+  (size)
+  (ip_literal)
+] @number
+
+[
+  "{"
+  "}"
+] @punctuation.bracket
+

--- a/queries/caddy/highlights.scm
+++ b/queries/caddy/highlights.scm
@@ -51,3 +51,5 @@
   "{"
   "}"
 ] @punctuation.bracket
+
+"," @punctuation.delimiter

--- a/queries/caddy/highlights.scm
+++ b/queries/caddy/highlights.scm
@@ -1,6 +1,6 @@
 (comment) @comment @spell
 
-[ 
+[
   (env)
   (argv)
   (block_variable)
@@ -8,8 +8,13 @@
 ] @constant
 
 (value) @variable
-(directive (keyword) @attribute)
-(global_options (option (keyword) @attribute))
+
+(directive
+  (keyword) @attribute)
+
+(global_options
+  (option
+    (keyword) @attribute))
 
 (keyword) @keyword
 
@@ -21,10 +26,7 @@
     "}"
   ] @punctuation.special)
 
-
-[
-  (auto)
-] @variable.builtin
+(auto) @variable.builtin
 
 [
   (string_literal)
@@ -32,8 +34,8 @@
   (address)
 ] @string
 
-[ 
-  (matcher) 
+[
+  (matcher)
   (route)
   (snippet_name)
 ] @string.special
@@ -49,4 +51,3 @@
   "{"
   "}"
 ] @punctuation.bracket
-

--- a/queries/caddy/indents.scm
+++ b/queries/caddy/indents.scm
@@ -1,0 +1,11 @@
+[
+  (block)
+] @indent.begin
+
+(block
+  "}" @indent.branch)
+
+(comment) @indent.auto
+
+(ERROR) @indent.auto
+

--- a/queries/caddy/indents.scm
+++ b/queries/caddy/indents.scm
@@ -1,6 +1,4 @@
-[
-  (block)
-] @indent.begin
+(block) @indent.begin
 
 (block
   "}" @indent.branch)
@@ -8,4 +6,3 @@
 (comment) @indent.auto
 
 (ERROR) @indent.auto
-

--- a/queries/caddy/injections.scm
+++ b/queries/caddy/injections.scm
@@ -1,0 +1,3 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+

--- a/queries/caddy/injections.scm
+++ b/queries/caddy/injections.scm
@@ -1,3 +1,2 @@
 ((comment) @injection.content
   (#set! injection.language "comment"))
-


### PR DESCRIPTION
⚠️⚠️⚠️ This PR requires Vim PR to be merged, waiting for https://github.com/vim/vim/pull/16525

Helloooo! It's me again

Thanks to Caddy documentation, this was the easy one:
![Entities](https://caddyserver.com/old/resources/images/caddyfile-visual.png)

![Screenshot 2025-01-26 at 13 49 59](https://github.com/user-attachments/assets/6d3f6ea7-cf77-4ccb-9e2e-891cc16b98a6)
_Warning: Screenshot is an image_

## Checklist
- [x] `tree-sitter build`
![Screenshot 2025-01-26 at 13 43 20](https://github.com/user-attachments/assets/1359fafb-3186-4e2c-a9ca-cfd2fcb739da)

- [x] `TSInstallFromGrammar caddy`
![Screenshot 2025-01-26 at 13 43 54](https://github.com/user-attachments/assets/fa552507-3490-4023-b7e1-89b1ad1a224b)

- [x] Alphabetically sorted
- [x]  Injections & highlights in place
