### PR TITLE
ci(install): adapt to new Neovim release artefact names

### DIFF
--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -3,7 +3,14 @@
 set -e
 
 os=$(uname -s)
-if [[ $os == Linux ]]; then
+if [[ $os == Linux ]] && [[ ${NVIM_TAG} == nightly ]]; then
+  wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux-x86_64.tar.gz
+  tar -zxf nvim-linux-x86_64.tar.gz
+  sudo ln -s "$PWD"/nvim-linux-x86_64/bin/nvim /usr/local/bin
+  rm -rf "$PWD"/nvim-linux-x86_64/lib/nvim/parser
+  mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
+  ln -s "$PWD" ~/.local/share/nvim/site/pack/nvim-treesitter/start
+elif [[ $os == Linux ]]; then
   wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux64.tar.gz
   tar -zxf nvim-linux64.tar.gz
   sudo ln -s "$PWD"/nvim-linux64/bin/nvim /usr/local/bin


### PR DESCRIPTION
Old name can be removed after 0.10.4 release
