### PR TITLE
feat(typescript): don't highlight default values as parameters

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -145,10 +145,10 @@
 
 ; Parameters
 (required_parameter
-  (identifier) @variable.parameter)
+  pattern: (identifier) @variable.parameter)
 
 (optional_parameter
-  (identifier) @variable.parameter)
+  pattern: (identifier) @variable.parameter)
 
 (required_parameter
   (rest_pattern


### PR DESCRIPTION
Default values for parameters are being highlighted as parameters when the default value is an `identifier`, so use the field names to distinguish them and only highlight the parameter.

Test
```typescript
function foo(bar: Type = value) {}
function foo(bar?: Type = value) {}
``` 

Tree
```scheme
((program
  (function_declaration
    name: (identifier)
    parameters: (formal_parameters
      (required_parameter
        pattern: (identifier)
        type: (type_annotation
          (type_identifier))
        value: (identifier)))
    body: (statement_block))
  (function_declaration
    name: (identifier)
    parameters: (formal_parameters
      (optional_parameter
        pattern: (identifier)
        type: (type_annotation
          (type_identifier))
        value: (identifier)))
    body: (statement_block)))
```