### PR TITLE
docs(readme): use vim.uv instead of vim.loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ require'nvim-treesitter.configs'.setup {
     -- Or use a function for more flexibility, e.g. to disable slow treesitter highlight for large files
     disable = function(lang, buf)
         local max_filesize = 100 * 1024 -- 100 KB
-        local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
+        local ok, stats = pcall(vim.uv.fs_stat, vim.api.nvim_buf_get_name(buf))
         if ok and stats and stats.size > max_filesize then
             return true
         end


### PR DESCRIPTION
While checking my config, I stumbled into a warning 

```lua
local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf)) -- Undefined field fs_stat
```

Looking into the Neovim help documentation (`:h vim.loop`), I found the following note:

```txt
• *vim.loop*				Use |vim.uv| instead.
```

This PR updates the README to reflect this change and encourage using `vim.uv` instead of the deprecated `vim.loop`.