### PR TITLE
more perl syntax

### DIFF
--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -243,70 +243,43 @@
   ; highlights punc vars and also numeric only like $11
   (#lua-match? @variable.builtin "^%A+$"))
 
-(scalar) @variable
-
-(scalar_deref_expression
-  [
-    "$"
-    "*"
-  ] @variable)
-
 [
+  (scalar)
   (array)
-  (arraylen)
+  (hash)
+  (glob)
+  ; arraylen's sigil is kinda special b/c it's not a data type
+  (arraylen
+    "$#" @operator)
 ] @variable
 
-(array_deref_expression
+; all post deref sigils highlighted as operators, and the unrolly star is a special char
+(postfix_deref
   [
+    "$"
     "@"
-    "*"
-  ] @variable)
-
-(arraylen_deref_expression
-  [
-    "$#"
-    "*"
-  ] @variable)
-
-(hash) @variable
-
-(hash_deref_expression
-  [
     "%"
     "*"
-  ] @variable)
+    "$#"
+  ] @operator
+  "*" @character.special)
 
+(slices
+  [
+    arrayref: _
+    hashref: _
+  ]
+  [
+    "@"
+    "%"
+  ] @operator)
+
+; except for subref deref, b/c that's actually a function call
 (amper_deref_expression
   [
     "&"
     "*"
-  ] @variable)
-
-(glob) @variable
-
-(glob_deref_expression
-  "*" @variable)
-
-(glob_slot_expression
-  "*" @variable)
-
-(array_element_expression
-  array: (_) @variable)
-
-(slice_expression
-  array: (_) @variable)
-
-(keyval_expression
-  array: (_) @variable)
-
-(hash_element_expression
-  hash: (_) @variable)
-
-(slice_expression
-  hash: (_) @variable)
-
-(keyval_expression
-  hash: (_) @variable)
+  ] @function.call)
 
 ; mark hash or glob keys that are any form of string in any form of access
 (_

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -278,13 +278,15 @@
 
 (amper_deref_expression
   [
-   "&"
-   "*"
-   ] @variable)
+    "&"
+    "*"
+  ] @variable)
 
 (glob) @variable
+
 (glob_deref_expression
   "*" @variable)
+
 (glob_slot_expression
   "*" @variable)
 

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -262,6 +262,12 @@
     "*"
   ] @variable)
 
+(arraylen_deref_expression
+  [
+    "$#"
+    "*"
+  ] @variable)
+
 (hash) @variable
 
 (hash_deref_expression
@@ -269,6 +275,18 @@
     "%"
     "*"
   ] @variable)
+
+(amper_deref_expression
+  [
+   "&"
+   "*"
+   ] @variable)
+
+(glob) @variable
+(glob_deref_expression
+  "*" @variable)
+(glob_slot_expression
+  "*" @variable)
 
 (array_element_expression
   array: (_) @variable)

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -308,6 +308,20 @@
 (keyval_expression
   hash: (_) @variable)
 
+; mark hash or glob keys that are any form of string in any form of access
+(_
+  "{"
+  [
+    (autoquoted_bareword)
+    (_
+      (string_content))
+  ] @variable.member
+  "}")
+
+; mark stringies on the LHS of a fat comma as a hash key, b/c that's usually what it
+; denotes somewhat
+(_ [(autoquoted_bareword) (_ (string_content))] @variable.member . "=>" (_))
+
 (comment) @comment @spell
 
 [

--- a/queries/perl/highlights.scm
+++ b/queries/perl/highlights.scm
@@ -320,7 +320,15 @@
 
 ; mark stringies on the LHS of a fat comma as a hash key, b/c that's usually what it
 ; denotes somewhat
-(_ [(autoquoted_bareword) (_ (string_content))] @variable.member . "=>" (_))
+(_
+  [
+    (autoquoted_bareword)
+    (_
+      (string_content))
+  ] @variable.member
+  .
+  "=>"
+  (_))
 
 (comment) @comment @spell
 

--- a/queries/perl/injections.scm
+++ b/queries/perl/injections.scm
@@ -11,4 +11,5 @@
   ; match if there's a single `e` in the modifiers list
   (#lua-match? @_modifiers "e")
   (#not-lua-match? @_modifiers "e.*e")
-  (#set! injection.language "perl"))
+  (#set! injection.language "perl")
+  (#set! injection.include-children))


### PR DESCRIPTION
- **feat(perl): highlight newer nodes**
- **fix(perl): injections for s///e should fully re-parse**
- **feat(perl): bump the parser**

This is bundled with some new features i just did for the parser. only open question i
have is if globs (`*foo{THING}`) which represent package tables should get the highlight
for `variable` or `module`, b/c it kinda is a namespace (tho pivoted from the usual
meaning). For now i was conservative and made it variable
