### PR TITLE
feat(hyprlang): bash injection for bindings with descriptions

### DIFF
--- a/queries/hyprlang/injections.scm
+++ b/queries/hyprlang/injections.scm
@@ -13,6 +13,8 @@
     .
     (_)
     .
+    (_)?
+    .
     (string) @_exec
     .
     (string) @injection.content))


### PR DESCRIPTION
Fixes #7596 by adding an optional node. There is still an edge case if the keybind description is exactly `exec`, but I don't expect people to write their config like that. Solved by anchoring the injection injection to the last node.

```
# edge case
bindd = MODS, key, exec, exec, params
``` 