### PR TITLE
feat(query): highlights for missing nodes

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -11,6 +11,9 @@
 (named_node
   name: (identifier) @variable)
 
+(missing_node
+  name: (identifier) @variable)
+
 (field_definition
   name: (identifier) @variable.member)
 
@@ -44,6 +47,8 @@
 ] @punctuation.special
 
 "_" @character.special
+
+"MISSING" @keyword
 
 ((parameters
   (identifier) @number)


### PR DESCRIPTION
Highlight support for the new `MISSING` syntax