### PR TITLE
feat(query): highlights for dot-prefixed predicates

### DIFF
--- a/queries/query/highlights.scm
+++ b/queries/query/highlights.scm
@@ -46,6 +46,9 @@
   "#"
 ] @punctuation.special
 
+(predicate
+  "." @punctuation.special)
+
 "_" @character.special
 
 "MISSING" @keyword


### PR DESCRIPTION
Predicates can also take the form `(.eq? ...` according to `query.c`, and the parser now reflects that