### PR TITLE
fix(formatter): prefer #-prefixed predicates

### DIFF
--- a/scripts/format-queries.lua
+++ b/scripts/format-queries.lua
@@ -114,6 +114,9 @@ local format_queries = [[
   ":"
   "."
 ] @format.append-space
+(predicate
+  "." @format.cancel-append @format.replace
+  (#gsub! @format.replace "%." "#"))
 (
   "." @format.prepend-space @format.cancel-append
   .


### PR DESCRIPTION
This prevents the formatter for appending a space after the "." in a predicate prefix, and changes it to a "#" to match all other occurrences in the codebase.