### PR TITLE
feat(formatter): support formatting missing nodes

### DIFF
--- a/scripts/format-queries.lua
+++ b/scripts/format-queries.lua
@@ -90,6 +90,7 @@ local format_queries = [[
     (grouping)
     (named_node)
     (anonymous_node)
+    (missing_node)
     (field_definition)
   ] @format.prepend-newline)
 
@@ -101,6 +102,7 @@ local format_queries = [[
     (grouping)
     (named_node)
     (anonymous_node)
+    (missing_node)
     (field_definition)
     (comment)
   ] @format.cancel-prepend
@@ -153,6 +155,7 @@ local format_queries = [[
     (named_node)        ; (foo (bar))
     (predicate)         ; (named_node (#set!))
     (anonymous_node)
+    (missing_node)
     "."
   ])
 ;; Honoring comment's position within a node
@@ -185,6 +188,7 @@ local format_queries = [[
     (named_node)
     (predicate)
     (anonymous_node)
+    (missing_node)
     "."
   ] @format.append-newline)
 
@@ -210,6 +214,7 @@ local format_queries = [[
     (named_node)                  ; ((foo))
     (list)                        ; ([foo] (...))
     (anonymous_node)              ; ("foo")
+    (missing_node)
     (grouping . (_))
   ] @format.indent.begin
   .
@@ -223,6 +228,7 @@ local format_queries = [[
   "("
   [
     (anonymous_node)
+    (missing_node)
     (named_node)
     (list)
     (predicate)
@@ -237,6 +243,8 @@ local format_queries = [[
   (#not-kind-eq? @format.cancel-append "comment"))
 (grouping
   (capture) @format.prepend-space)
+(missing_node
+  name: (_) @format.prepend-space)
 ;; Remove unnecessary parens
 (grouping
   "(" @format.remove
@@ -251,6 +259,8 @@ local format_queries = [[
     (grouping)
     (anonymous_node
       name: (string) .)
+    (missing_node
+      name: (_) .)
     (named_node
       [
         "_"
@@ -297,6 +307,7 @@ local format_queries = [[
     (grouping)
     (named_node)
     (anonymous_node)
+    (missing_node)
     (negated_field)
   ] @format.cancel-append
   .


### PR DESCRIPTION
This commit makes missing nodes take formatting identical to that of regular named nodes, with the only exception being that a newline will not be prepended to a node name. E.g. this pattern:

```query
(MISSING identifier)
```

will *not* be changed to:

```query
(MISSING
  (identifier))
```