### PR TITLE
fix(gleam): indent on unqualified imports rather than import

### DIFF
--- a/queries/gleam/indents.scm
+++ b/queries/gleam/indents.scm
@@ -7,7 +7,6 @@
   (constant)
   (external_function)
   (function)
-  (import)
   (let)
   (list)
   (constant)
@@ -16,6 +15,7 @@
   (type_alias)
   (todo)
   (tuple)
+  (unqualified_imports)
 ] @indent.begin
 
 [


### PR DESCRIPTION
The current `import` indent causes an indentation to trigger after a line with `import ...`.  I _think_ the more correct is to only begin indentation when doing an `unqualified_imports`, i.e. 

```gleam
// don't  indent from _just_ this
import my_library.{
  // but indent for this
  type Something
}
```

Obviously could very well be wrong about this, but I've been getting indentation bugs with what's on `master`.  It does
```gleam
import gleam/result
  |
```
which feels wrong.