### PR TITLE
feat(nu): added some new operators, removed deprecated keyword `register`

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -510,7 +510,7 @@
     "revision": "14e6da1627aaef21d2b2aa0c37d04269766dcc1d"
   },
   "nu": {
-    "revision": "b51db01e154fac33eda5b289a6c7751c09568f6d"
+    "revision": "d0b26e45525016ef8e6f2ced05852437c06a00ca"
   },
   "objc": {
     "revision": "181a81b8f23a2d593e7ab4259981f50122909fda"

--- a/queries/nu/highlights.scm
+++ b/queries/nu/highlights.scm
@@ -9,7 +9,6 @@
   "source"
   "source-env"
   "overlay"
-  "register"
 ] @keyword
 
 [
@@ -169,6 +168,20 @@ file_path: (val_string) @variable.parameter
   "err+out>"
   "o+e>"
   "out+err>"
+  "o>>"
+  "out>>"
+  "e>>"
+  "err>>"
+  "e+o>>"
+  "err+out>>"
+  "o+e>>"
+  "out+err>>"
+  "e>|"
+  "err>|"
+  "e+o>|"
+  "err+out>|"
+  "o+e>|"
+  "out+err>|"
 ] @operator
 
 [
@@ -183,6 +196,8 @@ file_path: (val_string) @variable.parameter
   "bit-shr"
   "in"
   "not-in"
+  "has"
+  "not-has"
   "starts-with"
   "ends-with"
   "not"


### PR DESCRIPTION
The nu parser is about to make a [breaking change](https://github.com/nushell/tree-sitter-nu/pull/181).