### PR TITLE
Bug-fix cmdpath function in shell_command_selectors.lua

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -7,7 +7,7 @@ local uv = vim.uv or vim.loop
 ---@param p string
 ---@return string
 local function cmdpath(p)
-  p = '\"' .. p .. '\"'
+  p = '"' .. p .. '"'
   if vim.opt.shellslash:get() then
     local r = p:gsub("/", "\\")
     return r


### PR DESCRIPTION
Surround all paths submitted to the command line with double-quotes so as to accommodate spaces in those paths.