### PR TITLE
feat: add enforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [elsa](https://github.com/glapa-grossklag/tree-sitter-elsa) (maintained by @glapa-grossklag, @amaanq)
 - [x] [elvish](https://github.com/elves/tree-sitter-elvish) (maintained by @elves)
 - [ ] [embedded_template](https://github.com/tree-sitter/tree-sitter-embedded-template)
+- [x] [enforce](https://github.com/simonvic/tree-sitter-enforce) (maintained by @simonvic)
 - [x] [erlang](https://github.com/WhatsApp/tree-sitter-erlang) (maintained by @filmor)
 - [x] [facility](https://github.com/FacilityApi/tree-sitter-facility) (maintained by @bryankenote)
 - [x] [faust](https://github.com/khiner/tree-sitter-faust) (maintained by @khiner)

--- a/lockfile.json
+++ b/lockfile.json
@@ -173,6 +173,9 @@
   "embedded_template": {
     "revision": "8495d106154741e6d35d37064f864758ece75de6"
   },
+  "enforce": {
+    "revision": "9db7a49f3d73222c05b75dcfa8892f5e93542d1e"
+  },
   "erlang": {
     "revision": "90f1fcb7a9c9fff2442c00d087368d5bc2c94407"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -549,6 +549,14 @@ list.embedded_template = {
   filetype = "eruby",
 }
 
+list.enforce = {
+  install_info = {
+    url = "https://github.com/simonvic/tree-sitter-enforce",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@simonvic" },
+}
+
 list.erlang = {
   install_info = {
     url = "https://github.com/WhatsApp/tree-sitter-erlang",

--- a/queries/enforce/folds.scm
+++ b/queries/enforce/folds.scm
@@ -1,0 +1,10 @@
+[
+  (block)
+  (switch)
+  (formal_parameters)
+  (actual_parameters)
+  (decl_class)
+  (decl_enum)
+  (comment_block)
+  (doc_block)
+] @fold

--- a/queries/enforce/highlights.scm
+++ b/queries/enforce/highlights.scm
@@ -1,27 +1,18 @@
-(comment_line) @comment @spell
-(comment_block) @comment.block @spell
+[
+ (comment_line)
+ (comment_block)
+ ] @comment @spell
 
-(doc_line) @comment.documentation @spell
-(doc_block) @comment.documentation.block @spell
+[
+ (doc_line)
+ (doc_block)
+ ] @comment.documentation @spell
 
 (literal_bool) @boolean
 (literal_int) @number
 (literal_float) @number.float
 (literal_string) @string
 (escape_sequence) @string.escape
-
-
-; vectors
-; TODO: what about arrays of vectors?
-(decl_variable
-  (type_vector)
-  (literal_string) @vector
-  )
-
-(formal_parameter
-  type: (type_vector)
-  default: (literal_string) @vector
-  )
 
 (identifier) @variable
 
@@ -118,34 +109,11 @@
 
 ; Constructor and deconstructor (function with same name of the class)
 (decl_class
-  typename: (identifier) @foo
+  typename: (identifier) @_classname
   body: (class_body
     (decl_method
-	    name: (identifier) @constructor
-	    (#eq? @constructor @foo)
+      name: (identifier) @constructor
+      (#eq? @constructor @_classname)
       )
     )
   )
-
-; TODO: mark invalid deconstructor as error?
-(decl_class
-  typename: (identifier) @foo
-  body: (class_body
-    (decl_method
-      "~"
-	    name: (identifier) @constructor.deconstructor
-	    (#eq? @constructor.deconstructor @foo)
-      )
-    )
-  )
-
-; Dead code
-(block
-  (_)*
-  (return)
-  (_)* @deadcode (#set! "priority" 110)
-  )
-
-(ERROR) @error
-
-; TODO: string and print format injection

--- a/queries/enforce/highlights.scm
+++ b/queries/enforce/highlights.scm
@@ -113,9 +113,9 @@
 ] @keyword
 
 [
- "new"
- "delete"
- ] @keyword.operator
+  "new"
+  "delete"
+] @keyword.operator
 
 "return" @keyword.return
 

--- a/queries/enforce/highlights.scm
+++ b/queries/enforce/highlights.scm
@@ -20,6 +20,9 @@
 
 (identifier) @variable
 
+(formal_parameter
+  name: (identifier) @variable.parameter)
+
 ((identifier) @constant
   (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
 
@@ -104,41 +107,37 @@
   ";"
 ] @punctuation.delimiter
 
-(literal_string
-  [
-    "\""
-    "\""
-  ] @punctuation.delimiter)
-
 [
-  "continue"
-  "break"
-  "switch"
-  "case"
-  "typedef"
-  "delete"
   "default"
   "extends"
-  "new" ; TODO: is it operator?
-  "auto" ; TODO: is it type?
 ] @keyword
+
+[
+ "new"
+ "delete"
+ ] @keyword.operator
 
 "return" @keyword.return
 
 [
   "if"
   "else"
+  "switch"
+  "case"
 ] @keyword.conditional
 
 [
   "while"
   "for"
   "foreach"
+  "continue"
+  "break"
 ] @keyword.repeat
 
 [
   "enum"
   "class"
+  "typedef"
 ] @keyword.type
 
 [
@@ -154,19 +153,27 @@
 (decl_class
   typename: (identifier) @type)
 
+(decl_class
+  superclass: (superclass
+    typename: (identifier) @type))
+
 (decl_enum
   typename: (identifier) @type)
 
 (type_identifier
   (identifier) @type)
 
-(type_primitive) @type.builtin
+[
+  "auto"
+  (type_primitive)
+] @type.builtin
 
 [
   (super)
   (this)
-  (literal_null)
 ] @variable.builtin
+
+(literal_null) @constant.builtin
 
 (decl_method
   name: (identifier) @function.method)

--- a/queries/enforce/highlights.scm
+++ b/queries/enforce/highlights.scm
@@ -83,8 +83,6 @@
  "auto" ; TODO: is it type?
  ] @keyword
 
-; ["thread"] @keyword.coroutine
-
 ["return"] @keyword.return
 ["if" "else"] @keyword.conditional
 ["while" "for" "foreach"] @keyword.repeat
@@ -140,30 +138,6 @@
       )
     )
   )
-
-; Constant fields
-; (decl_field
-;   ((field_modifier) @_modifier (#eq? @_modifier "const"))
-;   (_)
-;   (identifier) @constant
-;   )
-
-; TODO: mark assignment to const as error?
-
-; Constant parameters and local variables referencing to it
-; (decl_method
-;   (formal_parameters
-;   	(formal_parameter
-;   	  ((formal_parameter_modifier) @_modifier (#eq? @_modifier "const"))
-;   	  name: (identifier) @_constantParam @constant
-;   	  )
-;   	)
-;   body: (block
-;   	(_
-;   	  ((identifier) @constant (#eq? @constant @_constantParam))
-;   	  )
-;   	)
-;   )
 
 ; Dead code
 (block

--- a/queries/enforce/highlights.scm
+++ b/queries/enforce/highlights.scm
@@ -1,111 +1,178 @@
 [
- (comment_line)
- (comment_block)
- ] @comment @spell
+  (comment_line)
+  (comment_block)
+] @comment @spell
 
 [
- (doc_line)
- (doc_block)
- ] @comment.documentation @spell
+  (doc_line)
+  (doc_block)
+] @comment.documentation @spell
 
 (literal_bool) @boolean
+
 (literal_int) @number
+
 (literal_float) @number.float
+
 (literal_string) @string
+
 (escape_sequence) @string.escape
 
 (identifier) @variable
 
-((identifier) @constant (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
+((identifier) @constant
+  (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
 
 ; Preprocessor directives
 [
- (include)
- (define)
- (ifdef)
- (ifndef)
- (else)
- (endif)
- ] @keyword.directive
+  (include)
+  (define)
+  (ifdef)
+  (ifndef)
+  (else)
+  (endif)
+] @keyword.directive
 
 (preproc_const) @constant.macro
 
 ; Constant fields
 (decl_field
-  ((field_modifier) @_modifier (#eq? @_modifier "const"))
+  ((field_modifier) @_modifier
+    (#eq? @_modifier "const"))
   type: (_)
-  name: (identifier) @constant
-  )
+  name: (identifier) @constant)
 
-(enum_member name: (identifier) @constant)
-
-[
- "+" "-" "*" "/" "%" "^"
- "++" "--"
- "=" "+=" "-=" "*=" "/=" "&=" "^=" "|=" "<<=" ">>="
- "<" "<=" ">=" ">"
- "==" "!="
- "!" "&&" "||" ">>" "<<" "&" "|" "^" "~"
- ] @operator
+(enum_member
+  name: (identifier) @constant)
 
 [
- "(" ")"
- "[" "]"
- "{" "}"
- ] @punctuation.bracket
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "^"
+  "++"
+  "--"
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
+  "&="
+  "^="
+  "|="
+  "<<="
+  ">>="
+  "<"
+  "<="
+  ">="
+  ">"
+  "=="
+  "!="
+  "!"
+  "&&"
+  "||"
+  ">>"
+  "<<"
+  "&"
+  "|"
+  "^"
+  "~"
+] @operator
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
 
 ; TODO: <> in decl_class
-(types [ "<" ">" ] @punctuation.bracket)
+(types
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
 
 [
- "," "." ":" ";"
- ] @punctuation.delimiter
+  ","
+  "."
+  ":"
+  ";"
+] @punctuation.delimiter
 
-(literal_string ["\"" "\""] @punctuation.delimiter)
+(literal_string
+  [
+    "\""
+    "\""
+  ] @punctuation.delimiter)
 
 [
- "continue" "break"
- "switch" "case"
- "typedef"
- "delete"
- "default"
- "extends"
- "new" ; TODO: is it operator?
- "auto" ; TODO: is it type?
- ] @keyword
+  "continue"
+  "break"
+  "switch"
+  "case"
+  "typedef"
+  "delete"
+  "default"
+  "extends"
+  "new" ; TODO: is it operator?
+  "auto" ; TODO: is it type?
+] @keyword
 
-["return"] @keyword.return
-["if" "else"] @keyword.conditional
-["while" "for" "foreach"] @keyword.repeat
-["enum" "class"] @keyword.type
+"return" @keyword.return
+
 [
- (variable_modifier)
- (method_modifier)
- (class_modifier)
- (field_modifier)
- (formal_parameter_modifier)
- ] @keyword.modifier
+  "if"
+  "else"
+] @keyword.conditional
 
-["ref"] @type
-(decl_class typename: (identifier) @type)
-(decl_enum typename: (identifier) @type)
-(type_identifier (identifier) @type)
+[
+  "while"
+  "for"
+  "foreach"
+] @keyword.repeat
+
+[
+  "enum"
+  "class"
+] @keyword.type
+
+[
+  (variable_modifier)
+  (method_modifier)
+  (class_modifier)
+  (field_modifier)
+  (formal_parameter_modifier)
+] @keyword.modifier
+
+"ref" @type
+
+(decl_class
+  typename: (identifier) @type)
+
+(decl_enum
+  typename: (identifier) @type)
+
+(type_identifier
+  (identifier) @type)
 
 (type_primitive) @type.builtin
 
 [
- (super)
- (this)
- (literal_null)
- ] @variable.builtin
+  (super)
+  (this)
+  (literal_null)
+] @variable.builtin
 
 (decl_method
-  name: (identifier) @function.method
- )
+  name: (identifier) @function.method)
 
 (invokation
-  invoked: (identifier) @function.method.call
-  )
+  invoked: (identifier) @function.method.call)
 
 ; Constructor and deconstructor (function with same name of the class)
 (decl_class
@@ -113,7 +180,4 @@
   body: (class_body
     (decl_method
       name: (identifier) @constructor
-      (#eq? @constructor @_classname)
-      )
-    )
-  )
+      (#eq? @constructor @_classname))))

--- a/queries/enforce/highlights.scm
+++ b/queries/enforce/highlights.scm
@@ -1,0 +1,177 @@
+(comment_line) @comment @spell
+(comment_block) @comment.block @spell
+
+(doc_line) @comment.documentation @spell
+(doc_block) @comment.documentation.block @spell
+
+(literal_bool) @boolean
+(literal_int) @number
+(literal_float) @number.float
+(literal_string) @string
+(escape_sequence) @string.escape
+
+
+; vectors
+; TODO: what about arrays of vectors?
+(decl_variable
+  (type_vector)
+  (literal_string) @vector
+  )
+
+(formal_parameter
+  type: (type_vector)
+  default: (literal_string) @vector
+  )
+
+(identifier) @variable
+
+((identifier) @constant (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
+
+; Preprocessor directives
+[
+ (include)
+ (define)
+ (ifdef)
+ (ifndef)
+ (else)
+ (endif)
+ ] @keyword.directive
+
+(preproc_const) @constant.macro
+
+; Constant fields
+(decl_field
+  ((field_modifier) @_modifier (#eq? @_modifier "const"))
+  type: (_)
+  name: (identifier) @constant
+  )
+
+(enum_member name: (identifier) @constant)
+
+[
+ "+" "-" "*" "/" "%" "^"
+ "++" "--"
+ "=" "+=" "-=" "*=" "/=" "&=" "^=" "|=" "<<=" ">>="
+ "<" "<=" ">=" ">"
+ "==" "!="
+ "!" "&&" "||" ">>" "<<" "&" "|" "^" "~"
+ ] @operator
+
+[
+ "(" ")"
+ "[" "]"
+ "{" "}"
+ ] @punctuation.bracket
+
+; TODO: <> in decl_class
+(types [ "<" ">" ] @punctuation.bracket)
+
+[
+ "," "." ":" ";"
+ ] @punctuation.delimiter
+
+(literal_string ["\"" "\""] @punctuation.delimiter)
+
+[
+ "continue" "break"
+ "switch" "case"
+ "typedef"
+ "delete"
+ "default"
+ "extends"
+ "new" ; TODO: is it operator?
+ "auto" ; TODO: is it type?
+ ] @keyword
+
+; ["thread"] @keyword.coroutine
+
+["return"] @keyword.return
+["if" "else"] @keyword.conditional
+["while" "for" "foreach"] @keyword.repeat
+["enum" "class"] @keyword.type
+[
+ (variable_modifier)
+ (method_modifier)
+ (class_modifier)
+ (field_modifier)
+ (formal_parameter_modifier)
+ ] @keyword.modifier
+
+["ref"] @type
+(decl_class typename: (identifier) @type)
+(decl_enum typename: (identifier) @type)
+(type_identifier (identifier) @type)
+
+(type_primitive) @type.builtin
+
+[
+ (super)
+ (this)
+ (literal_null)
+ ] @variable.builtin
+
+(decl_method
+  name: (identifier) @function.method
+ )
+
+(invokation
+  invoked: (identifier) @function.method.call
+  )
+
+; Constructor and deconstructor (function with same name of the class)
+(decl_class
+  typename: (identifier) @foo
+  body: (class_body
+    (decl_method
+	    name: (identifier) @constructor
+	    (#eq? @constructor @foo)
+      )
+    )
+  )
+
+; TODO: mark invalid deconstructor as error?
+(decl_class
+  typename: (identifier) @foo
+  body: (class_body
+    (decl_method
+      "~"
+	    name: (identifier) @constructor.deconstructor
+	    (#eq? @constructor.deconstructor @foo)
+      )
+    )
+  )
+
+; Constant fields
+; (decl_field
+;   ((field_modifier) @_modifier (#eq? @_modifier "const"))
+;   (_)
+;   (identifier) @constant
+;   )
+
+; TODO: mark assignment to const as error?
+
+; Constant parameters and local variables referencing to it
+; (decl_method
+;   (formal_parameters
+;   	(formal_parameter
+;   	  ((formal_parameter_modifier) @_modifier (#eq? @_modifier "const"))
+;   	  name: (identifier) @_constantParam @constant
+;   	  )
+;   	)
+;   body: (block
+;   	(_
+;   	  ((identifier) @constant (#eq? @constant @_constantParam))
+;   	  )
+;   	)
+;   )
+
+; Dead code
+(block
+  (_)*
+  (return)
+  (_)* @deadcode (#set! "priority" 110)
+  )
+
+(ERROR) @error
+
+; TODO: string and print format injection

--- a/queries/enforce/indents.scm
+++ b/queries/enforce/indents.scm
@@ -8,15 +8,18 @@
 ] @indent.begin
 
 [
-  "(" ")"
-  "[" "]"
-  "{" "}"
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
 ] @indent.branch
 
 [
- ")"
- "]"
- "}"
+  ")"
+  "]"
+  "}"
 ] @indent.end
 
 (comment_line) @indent.ignore

--- a/queries/enforce/indents.scm
+++ b/queries/enforce/indents.scm
@@ -1,8 +1,9 @@
 [
   (block)
-  (decl_class)
-  (decl_enum)
-  (switch)
+  (class_body)
+  (enum_body)
+  (switch_body)
+  (array_creation)
   (formal_parameters)
   (actual_parameters)
 ] @indent.begin
@@ -12,7 +13,6 @@
   ")"
   "["
   "]"
-  "{"
   "}"
 ] @indent.branch
 

--- a/queries/enforce/indents.scm
+++ b/queries/enforce/indents.scm
@@ -1,0 +1,27 @@
+[
+  (block)
+  (decl_class)
+  (decl_enum)
+  (switch)
+  (formal_parameters)
+  (actual_parameters)
+] @indent.begin
+
+[
+  "(" ")"
+  "[" "]"
+  "{" "}"
+] @indent.branch
+
+[
+ ")"
+ "]"
+ "}"
+] @indent.end
+
+(comment_line) @indent.ignore
+
+[
+  (ERROR)
+  (comment_block)
+] @indent.auto

--- a/queries/enforce/injections.scm
+++ b/queries/enforce/injections.scm
@@ -10,18 +10,4 @@
   ] @injection.content
  (#set! injection.language "doxygen"))
 
-; TODO: can't use printf language, we need numbered format
-; (invokation
-;   (member_access
-;     accessed: ((type_primitive) @_accessed (#eq? @_accessed "string"))
-;   	member: (identifier) @_method
-;   	)
-;   (actual_parameters
-;   	(actual_parameter
-;   	  (literal_string) @injection.content
-;   	  )
-;   	(actual_parameter)*
-;   	)
-;   (#eq? @_method "Format")
-;   (#set! injection.language "printf")
-;   )
+; TODO: string and print (numbered) format injection

--- a/queries/enforce/injections.scm
+++ b/queries/enforce/injections.scm
@@ -1,0 +1,27 @@
+([
+  (comment_block)
+  (comment_line)
+  ] @injection.content
+ (#set! injection.language "comment"))
+
+([
+  (doc_block)
+  (doc_line)
+  ] @injection.content
+ (#set! injection.language "doxygen"))
+
+; TODO: can't use printf language, we need numbered format
+; (invokation
+;   (member_access
+;     accessed: ((type_primitive) @_accessed (#eq? @_accessed "string"))
+;   	member: (identifier) @_method
+;   	)
+;   (actual_parameters
+;   	(actual_parameter
+;   	  (literal_string) @injection.content
+;   	  )
+;   	(actual_parameter)*
+;   	)
+;   (#eq? @_method "Format")
+;   (#set! injection.language "printf")
+;   )

--- a/queries/enforce/injections.scm
+++ b/queries/enforce/injections.scm
@@ -1,13 +1,13 @@
 ([
   (comment_block)
   (comment_line)
-  ] @injection.content
- (#set! injection.language "comment"))
+] @injection.content
+  (#set! injection.language "comment"))
 
 ([
   (doc_block)
   (doc_line)
-  ] @injection.content
- (#set! injection.language "doxygen"))
+] @injection.content
+  (#set! injection.language "doxygen"))
 
 ; TODO: string and print (numbered) format injection

--- a/queries/enforce/locals.scm
+++ b/queries/enforce/locals.scm
@@ -1,20 +1,40 @@
 ; Scopes
 (compilation_unit) @local.scope
-(decl_class body: (_) @local.scope)
-(decl_enum body: (_) @local.scope)
+
+(decl_class
+  body: (_) @local.scope)
+
+(decl_enum
+  body: (_) @local.scope)
+
 (decl_method) @local.scope
+
 (block) @local.scope
+
 (if) @local.scope
+
 (for) @local.scope
+
 (foreach) @local.scope
+
 (while) @local.scope
 
 ; Definitions
-(decl_class typename: (identifier) @local.definition.type)
-(decl_enum typename: (identifier) @local.definition.enum)
-(decl_method name: (identifier) @local.definition.method)
-(decl_variable (_)* (identifier) @local.definition.var)
+(decl_class
+  typename: (identifier) @local.definition.type)
+
+(decl_enum
+  typename: (identifier) @local.definition.enum)
+
+(decl_method
+  name: (identifier) @local.definition.method)
+
+(decl_variable
+  (_)*
+  (identifier) @local.definition.var)
 
 ; References
 (identifier) @local.reference
-(type_identifier (identifier) @local.reference)
+
+(type_identifier
+  (identifier) @local.reference)

--- a/queries/enforce/locals.scm
+++ b/queries/enforce/locals.scm
@@ -1,0 +1,20 @@
+; Scopes
+(compilation_unit) @local.scope
+(decl_class body: (_) @local.scope)
+(decl_enum body: (_) @local.scope)
+(decl_method) @local.scope
+(block) @local.scope
+(if) @local.scope
+(for) @local.scope
+(foreach) @local.scope
+(while) @local.scope
+
+; Definitions
+(decl_class typename: (identifier) @local.definition.type)
+(decl_enum typename: (identifier) @local.definition.enum)
+(decl_method name: (identifier) @local.definition.method)
+(decl_variable (_)* (identifier) @local.definition.var)
+
+; References
+(identifier) @local.reference
+(type_identifier (identifier) @local.reference)


### PR DESCRIPTION
Add `enforce` parser.

> Enforce Script is the language that is used by the [Enfusion](https://community.bistudio.com/wiki/Enfusion) engine first introduced in [DayZ](https://community.bistudio.com/wiki/Category:DayZ) Standalone. It is a Object-Oriented Scripting Language (OOP) that works with objects and classes and is similar to C# programming language.

[Official documentation](https://community.bistudio.com/wiki/DayZ:Enforce_Script_Syntax)