### PR TITLE
fix(razor): mark `npm` as required for generating from source

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1891,6 +1891,7 @@ list.razor = {
   install_info = {
     url = "https://github.com/tris203/tree-sitter-razor",
     files = { "src/parser.c", "src/scanner.c" },
+    generate_requires_npm = true,
   },
   maintainers = { "@tris203" },
 }


### PR DESCRIPTION
See https://github.com/tree-sitter/tree-sitter/actions/runs/13217922261/job/36899406179#step:10:588

The razor grammar has a dependency on the c-sharp grammar, so npm is required to generate this from source.