### PR TITLE
Add check for locked parser on Windows

### DIFF
--- a/lua/nvim-treesitter/shell_command_selectors.lua
+++ b/lua/nvim-treesitter/shell_command_selectors.lua
@@ -200,6 +200,34 @@ function M.select_install_rm_cmd(cache_folder, project_name)
   end
 end
 
+-- Returns a table of commands to test if a folder is locked
+---@param cache_folder string
+---@param project_name string
+---@return Command
+function M.select_install_test_lock(cache_folder, project_name)
+  if fn.has "win32" == 1 then
+    local project_name_test = project_name .. "-tmp"
+    local dir = cache_folder .. "\\" .. project_name
+    local dir_test = cache_folder .. "\\" .. project_name_test
+    return {
+      {
+        cmd = "cmd",
+        opts = {
+          args = { "/C", "if", "exist", cmdpath(dir), "ren", cmdpath(dir), project_name_test },
+        },
+      },
+      {
+        cmd = "cmd",
+        opts = {
+          args = { "/C", "if", "exist", cmdpath(dir_test), "ren", cmdpath(dir_test), project_name },
+        },
+      },
+    }
+  else
+    return {}
+  end
+end
+
 -- Returns the move command based on the OS
 ---@param from string
 ---@param to string


### PR DESCRIPTION
On Windows, as soon as parsers are loaded into Neovim, a lock is placed on the folder containing the parser. Subsequent efforts to update the parser will delete the contents of the folder but will fail to delete the folder, leaving the parser unusable. The only way to release the locks is by closing all terminals used to run Neovim.

This change adds a simple mechanism to test if a parser folder is locked prior to performing the delete and install by attempting to rename the folder if it exists. If the rename fails, a warning is logged and the install is cancelled, leaving the parser in its current state.

- Implemented a check for locked folders on Windows in `run_install` function.
- Introduced `select_install_test_lock` function to generate commands for testing folder locks on Windows.
- Added optional `hide_errors` parameter to `iter_cmd_sync` function to allow suppressing error messages during lock tests.