### PR TITLE
feat(java): add injections for markdown documentation comments

### DIFF
--- a/queries/java/injections.scm
+++ b/queries/java/injections.scm
@@ -8,6 +8,18 @@
   (#lua-match? @injection.content "/[*][!<*][^a-zA-Z]")
   (#set! injection.language "doxygen"))
 
+; markdown-style javadocs: https://openjdk.org/jeps/467
+((line_comment) @injection.content
+  (#lua-match? @injection.content "^///%s")
+  (#offset! @injection.content 0 4 0 0)
+  (#set! injection.language "markdown_inline"))
+
+; markdown-style javadocs: https://openjdk.org/jeps/467
+((line_comment) @injection.content
+  (#lua-match? @injection.content "^///%s+[@]")
+  (#offset! @injection.content 0 4 0 0)
+  (#set! injection.language "doxygen"))
+
 ((method_invocation
   name: (identifier) @_method
   arguments: (argument_list


### PR DESCRIPTION
Since Java 23, java documentation supports markdown.

It is supported by a `///` line comment followed by mandatory white space: https://openjdk.org/jeps/467

Before:
![markdown_before](https://github.com/user-attachments/assets/521edd51-4fc9-4227-85b4-9c9ebfef2ebb)

After:
![markdown_after](https://github.com/user-attachments/assets/299564d7-a4cf-4518-b6bf-4ea5ea21fbd1)

I wasn't able to figure out a way to use `injection.combined` alongside `#offset!` such that the prefix was removed from ALL lines in the "block" (not just the first one) to treat as one markdown document, which is what I wanted. As a workaround it uses `markdown_inline` for now, which seems ok a start. Any ideas?

Thank you for nvim-treesitter.
