### PR TITLE
feat(sparql): add regex injection

### DIFF
--- a/queries/sparql/injections.scm
+++ b/queries/sparql/injections.scm
@@ -1,2 +1,8 @@
 ((comment) @injection.content
   (#set! injection.language "comment"))
+
+(regex_expression
+  pattern: (rdf_literal
+    value: (string) @injection.content)
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.language "regex"))


### PR DESCRIPTION
This adds an injection for the `REGEX()` function documented [here](https://www.w3.org/TR/sparql11-query/#func-regex)

Before:
![imagen](https://github.com/user-attachments/assets/a5fb5b61-c8cf-454b-ad68-289ea5de1cc3)

After:
![imagen](https://github.com/user-attachments/assets/3d9e2c6c-cea6-473b-9dcb-479113233734)
