### PR TITLE
feat(gomod): support `tool`

### DIFF
--- a/queries/gomod/highlights.scm
+++ b/queries/gomod/highlights.scm
@@ -14,6 +14,10 @@
 
 (module_path) @string.special.url
 
+(tool_directive) @keyword
+
+(tool) @string.special.url
+
 [
   (version)
   (go_version)

--- a/queries/gomod/highlights.scm
+++ b/queries/gomod/highlights.scm
@@ -14,7 +14,7 @@
 
 (module_path) @string.special.url
 
-(tool_directive) @keyword
+(tool_directive) @keyword.directive
 
 (tool) @string.special.url
 


### PR DESCRIPTION
New version of Go (1.24) introduces a new directive, `tool` into go.mod file: https://tip.golang.org/doc/modules/managing-dependencies#tools.
This PR adds the tool directive support to highlights for `gomod`.