### PR TITLE
feat(typst): add more folds

### DIFF
--- a/queries/typst/folds.scm
+++ b/queries/typst/folds.scm
@@ -4,4 +4,8 @@
   (show)
   (call)
   (section)
+  (for)
+  (branch)
+  (content)
+  (raw_blck)
 ] @fold


### PR DESCRIPTION
for 'for' blocks and 'if/else' expressions.

Actually I would like the folds to be more fine grained, but the treesitter grammar doesn't give me the information I need for that. I can't seem to make it fold individual if/else branches (see below, it folds the entire expression) nor can I distinguis multiline content blocks like this one:

```
#[
    Inlined content here
]
```

Perhaps I'll invest some time into that another day, but for the moment being able to fold large `for`/`if/else` expressions is a big win in my opinion.


## folds for `if/else`

![image](https://github.com/user-attachments/assets/0e0e96bc-4394-4243-b49c-2c27f7ac18a4)

## folds for `for`

![image](https://github.com/user-attachments/assets/01296f1b-1969-4fd9-b602-7eff06d605d1)
