### PR TITLE
fix(install): early return if parser_info does not exist

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -91,6 +91,7 @@ local function get_parser_install_info(lang)
 
   if not parser_config then
     log.error('Parser not available for language "' .. lang .. '"')
+    return
   end
 
   return parser_config.install_info


### PR DESCRIPTION
Every now and then when a parser is renamed/removed or something, it will fail with `trying to index `parser_config` a nil value because we are not just continuing to execute even if it is nil or not