### PR TITLE
Remove the "class" keyword

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -363,7 +363,7 @@
     "revision": "962568c9efa71d25720ab42c5d36e222626ef3a6"
   },
   "inko": {
-    "revision": "0b08a8f976456a9271f70d4682143328d7224115"
+    "revision": "4d057a5c24d715b211c3c82de2526f041b4af66f"
   },
   "ipkg": {
     "revision": "8d3e9782f2d091d0cd39c13bfb3068db0c675960"

--- a/queries/inko/highlights.scm
+++ b/queries/inko/highlights.scm
@@ -75,7 +75,6 @@
 ] @keyword.operator
 
 [
-  "class"
   "trait"
   "type"
 ] @keyword.type


### PR DESCRIPTION
This keyword is deprecated as of 0.18.1 (released on February 12, 2025) and is being removed as part of the upcoming 0.19.0 release.