### PR TITLE
feat(promql): do not use regex for string labels

### DIFF
--- a/queries/promql/highlights.scm
+++ b/queries/promql/highlights.scm
@@ -36,7 +36,23 @@
 
 (label_name) @variable.member
 
-(label_value) @string.regexp
+(
+  (label_name)
+  [
+    "=~"
+    "!~"
+  ]
+  (label_value) @string.regexp
+)
+
+(
+  (label_name)
+  [
+    "="
+    "!="
+  ]
+  (label_value) @string
+)
 
 (function_name) @function.call
 

--- a/queries/promql/highlights.scm
+++ b/queries/promql/highlights.scm
@@ -36,23 +36,19 @@
 
 (label_name) @variable.member
 
-(
-  (label_name)
+((label_name)
   [
     "=~"
     "!~"
   ]
-  (label_value) @string.regexp
-)
+  (label_value) @string.regexp)
 
-(
-  (label_name)
+((label_name)
   [
     "="
     "!="
   ]
-  (label_value) @string
-)
+  (label_value) @string)
 
 (function_name) @function.call
 

--- a/queries/promql/injections.scm
+++ b/queries/promql/injections.scm
@@ -1,13 +1,11 @@
 ((comment) @injection.content
   (#set! injection.language "comment"))
 
-(
-  (label_name)
+((label_name)
   [
     "=~"
     "!~"
   ]
   (label_value) @injection.content
   (#set! injection.language "regex")
-  (#offset! @injection.content 0 1 0 -1)
-)
+  (#offset! @injection.content 0 1 0 -1))

--- a/queries/promql/injections.scm
+++ b/queries/promql/injections.scm
@@ -1,6 +1,13 @@
 ((comment) @injection.content
   (#set! injection.language "comment"))
 
-((label_value) @injection.content
+(
+  (label_name)
+  [
+    "=~"
+    "!~"
+  ]
+  (label_value) @injection.content
   (#set! injection.language "regex")
-  (#offset! @injection.content 0 1 0 -1))
+  (#offset! @injection.content 0 1 0 -1)
+)

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -13,7 +13,6 @@ vim.filetype.add {
     usda = "usd",
     wgsl = "wgsl",
     w = "wing",
-    promql = "promql",
   },
 }
 

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -13,6 +13,7 @@ vim.filetype.add {
     usda = "usd",
     wgsl = "wgsl",
     w = "wing",
+    promql = "promql",
   },
 }
 

--- a/tests/query/highlights/promql/regex.promql
+++ b/tests/query/highlights/promql/regex.promql
@@ -1,0 +1,8 @@
+foo{path=~"^foo$"}[5m] or
+#          ^ @string.regexp
+foo{path!~"[a-zA-Z0-9]{1,3}"}[5m] or
+#          ^ @string.regexp
+foo{path="/api/users/{userId}"}[5m] or
+#         ^ @string
+foo{path!="/api/users/{userId}"}[5m]
+#          ^ @string

--- a/tests/query/highlights/promql/regex.promql
+++ b/tests/query/highlights/promql/regex.promql
@@ -1,4 +1,3 @@
-# vim: ft=promql
 foo{path=~"^foo$"}[5m] or
 #          ^ @string.regexp
 foo{path!~"[a-zA-Z0-9]{1,3}"}[5m] or
@@ -7,3 +6,5 @@ foo{path="/api/users/{userId}"}[5m] or
 #         ^ @string
 foo{path!="/api/users/{userId}"}[5m]
 #          ^ @string
+
+# vim: ft=promql

--- a/tests/query/highlights/promql/regex.promql
+++ b/tests/query/highlights/promql/regex.promql
@@ -1,3 +1,4 @@
+# vim: ft=promql
 foo{path=~"^foo$"}[5m] or
 #          ^ @string.regexp
 foo{path!~"[a-zA-Z0-9]{1,3}"}[5m] or

--- a/tests/query/highlights/yaml/promql-on-prometheus-rules.yaml
+++ b/tests/query/highlights/yaml/promql-on-prometheus-rules.yaml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: Node down
     expr: up{job="node_exporter"} == 0
-    #     ^ @promql
+    #     ^ @type
     for: 3m
     labels:
       severity: warning
@@ -13,18 +13,18 @@ groups:
   - alert: Node down
     expr: |
       up{job="node_exporter"} == 0
-    # ^ @promql
+    # ^ @type
     for: 3m
     labels:
       severity: warning
   - alert: Regex and String matching
     expr: |
       foo{path=~"^foo$"}[5m] or foo{path!~"[a-zA-Z0-9]{1,3}"}[5m] or foo{path="/api/users/{userId}"}[5m] or foo{path!="/api/users/{userId}"}[5m]
-    # ^ @promql
-    #            ^ @regex
-    #                                      ^ @regex
-    #                                                                          ^ @!regex
-    #                                                                                                                  ^ @!regex
+    # ^ @type
+    #            ^ @string.regexp
+    #                                      ^ @string.regexp
+    #                                                                          ^ @string
+    #                                                                                                                  ^ @string
     for: 3m
     labels:
       severity: warning

--- a/tests/query/injections/promql/regex.promql
+++ b/tests/query/injections/promql/regex.promql
@@ -1,4 +1,3 @@
-# vim: ft=promql
 foo{path=~"^foo$"}[5m] or
 #          ^ @regex
 foo{path!~"[a-zA-Z0-9]{1,3}"}[5m] or
@@ -7,3 +6,5 @@ foo{path="/api/users/{userId}"}[5m] or
 #         ^ @!regex
 foo{path!="/api/users/{userId}"}[5m]
 #          ^ @!regex
+
+# vim: ft=promql

--- a/tests/query/injections/promql/regex.promql
+++ b/tests/query/injections/promql/regex.promql
@@ -1,0 +1,8 @@
+foo{path=~"^foo$"}[5m] or
+#          ^ @regex
+foo{path!~"[a-zA-Z0-9]{1,3}"}[5m] or
+#          ^ @regex
+foo{path="/api/users/{userId}"}[5m] or
+#         ^ @!regex
+foo{path!="/api/users/{userId}"}[5m]
+#          ^ @!regex

--- a/tests/query/injections/promql/regex.promql
+++ b/tests/query/injections/promql/regex.promql
@@ -1,3 +1,4 @@
+# vim: ft=promql
 foo{path=~"^foo$"}[5m] or
 #          ^ @regex
 foo{path!~"[a-zA-Z0-9]{1,3}"}[5m] or


### PR DESCRIPTION
In Prometheus, label values are treated as strings when used with the `=` and `!=` operators, and as regular expressions when used with the `=~` and `!~` operators.

Injecting and then highlighting all label values as regex leads to a situation where entirely valid **string** label values containing regex special characters are mistakenly parsed and highlighted as regex. This results in syntax errors, causing labels to be highlighted incorrectly.

For example, in `foo{bar=~"[a-z]{1,3}"}`, `{` and `}` are regex special characters, so regex highlighting is expected. However, in `foo{path="/foo/{id}"}`, `{` and `}` are just part of the string and have no special meaning, so the whole value should be highlighted as a string.

---

Before:

![before](https://github.com/user-attachments/assets/7c7c8036-900c-4ac4-ae67-777d52dbd865)

After:

![after](https://github.com/user-attachments/assets/bd64d1f5-7644-4d59-b2dd-d11756d003ee)
