### PR TITLE
feat(liquid): Add queries for front_matter

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -441,7 +441,7 @@
     "revision": "f99011a3554213b654985a4b0a65b3b032ec4621"
   },
   "liquid": {
-    "revision": "23ac814111e2b4b4b083e2c92219af2d5b74d13d"
+    "revision": "d68a255c393cfefa9d3185023e2f1684a52907ed"
   },
   "liquidsoap": {
     "revision": "8e51fa63ddb93ac179d4e34a311d3d3f03780b42"

--- a/queries/liquid/highlights.scm
+++ b/queries/liquid/highlights.scm
@@ -130,3 +130,5 @@
   ","
   "."
 ] @punctuation.delimiter
+
+(front_matter) @keyword.directive

--- a/queries/liquid/injections.scm
+++ b/queries/liquid/injections.scm
@@ -18,5 +18,10 @@
   (#set! injection.language "css")
   (#set! injection.combined))
 
+((front_matter) @injection.content
+  (#set! injection.language "yaml")
+  (#offset! @injection.content 1 0 -1 0)
+  (#set! injection.include-children))
+
 ((comment) @injection.content
   (#set! injection.language "comment"))


### PR DESCRIPTION
Adds highlights and injections for `front_matter` node.

Follows the same convention as the Markdown queries ([injections](https://github.com/nvim-treesitter/nvim-treesitter/blob/bf18d4dc8d9a7a61e855190bc154df12d6536741/queries/markdown/injections.scm#L12), [highlights](https://github.com/nvim-treesitter/nvim-treesitter/blob/bf18d4dc8d9a7a61e855190bc154df12d6536741/queries/markdown/highlights.scm#L108)), as this does more or less the same thing. 