### PR TITLE
feat(markdown): completely conceal codeblock fences on nightly

### DIFF
--- a/queries/markdown/highlights.scm
+++ b/queries/markdown/highlights.scm
@@ -49,12 +49,14 @@
 
 (fenced_code_block
   (fenced_code_block_delimiter) @markup.raw.block
-  (#set! conceal ""))
+  (#set! conceal "")
+  (#set! conceal_lines ""))
 
 (fenced_code_block
   (info_string
     (language) @label
-    (#set! conceal "")))
+    (#set! conceal "")
+    (#set! conceal_lines "")))
 
 (link_destination) @markup.link.url
 


### PR DESCRIPTION
Required to make https://github.com/neovim/neovim/pull/31324 work with
nvim-treesitter.
