### PR TITLE
fix(kdl): Highlight query order

### DIFF
--- a/queries/kdl/highlights.scm
+++ b/queries/kdl/highlights.scm
@@ -1,17 +1,18 @@
 ; Types
+; Variables
+(identifier) @variable
+
+; Nodes
 (node
+  (identifier) @tag)
+
+; Type annotation
+(type
   (identifier) @type)
-
-(type) @type
-
-(annotation_type) @type.builtin
 
 ; Properties
 (prop
   (identifier) @property)
-
-; Variables
-(identifier) @variable
 
 ; Operators
 [


### PR DESCRIPTION
Fixes the highlighting queries for KDL so everything isn't highlighted as a variable due to the order of the queries previously meaning several queries were ignored.

I also changed the node names to be highlighted as `@tag` since KDL is an xml-like format so @tag seemed more appropriate than `@type` and it differentiates it from the type annotations.

This does NOT update to the latest KDL version 2, that would need grammar changes. It does "mostly" work with
KDL 2 though (notably unquoted strings seem to throw the grammar off.).

## Before

(Everything that's white is `@variable` due to the broad `(identifier) @variable` that was after the queries that were targeting specific identifiers)
![Screenshot_20250226_134336](https://github.com/user-attachments/assets/df764501-24d2-468b-9bf0-401f49984763)


## After
![Screenshot_20250226_134612](https://github.com/user-attachments/assets/7973f05a-895e-4639-a70b-e2e695e9d28e)

