### PR TITLE
feat(make): fold `define` statements.

### DIFF
--- a/queries/make/folds.scm
+++ b/queries/make/folds.scm
@@ -1,5 +1,6 @@
 ([
   (conditional)
   (rule)
+  (define_directive)
 ] @fold
   (#trim! @fold))


### PR DESCRIPTION
Makes `define`-statements in Makefiles fold. Previously they didn't, which made them stand out in between rule statements, requiring unnecessary amounts of scrolling.

## Before

![image](https://github.com/user-attachments/assets/c11e97c4-fc69-4ca9-9e10-20ac0c45912b)

## After

![image](https://github.com/user-attachments/assets/63b6842c-79d7-4b39-86d1-aedb070fbb57)
