### PR TITLE
Add snakemake rules to locals

### DIFF
--- a/queries/python/locals.scm
+++ b/queries/python/locals.scm
@@ -16,15 +16,15 @@
 
 ; Imports
 (aliased_import
-  alias: (identifier) @local.definition.import)
+  alias: (identifier) @local.definition.import) @local.scope
 
 (import_statement
   name: (dotted_name
-    (identifier) @local.definition.import))
+    (identifier) @local.definition.import)) @local.scope
 
 (import_from_statement
   name: (dotted_name
-    (identifier) @local.definition.import))
+    (identifier) @local.definition.import)) @local.scope
 
 ; Function with parameters, defines parameters
 (parameters

--- a/queries/snakemake/locals.scm
+++ b/queries/snakemake/locals.scm
@@ -1,1 +1,5 @@
 ; inherits: python
+
+(rule_definition
+  name: (identifier) @local.definition.type) @local.scope
+

--- a/queries/snakemake/locals.scm
+++ b/queries/snakemake/locals.scm
@@ -2,4 +2,3 @@
 
 (rule_definition
   name: (identifier) @local.definition.type) @local.scope
-


### PR DESCRIPTION
This enables fuzzy finder such as snacks.picker to match snakemake rules as treesitter symbols