### PR TITLE
feat(markdown): fold sublists

### DIFF
--- a/queries/markdown/folds.scm
+++ b/queries/markdown/folds.scm
@@ -1,7 +1,12 @@
 ([
   (fenced_code_block)
   (indented_code_block)
-  (list)
+  (list_item
+    (list))
   (section)
 ] @fold
+  (#trim! @fold))
+
+(section
+  (list) @fold
   (#trim! @fold))


### PR DESCRIPTION
Turns out we can use plain old `#trim!` here rather than `#trim! 1 1 1 1` due to the slight improvements to the default trim functionality on nightly

## Before (see foldcolumn)

![image](https://github.com/user-attachments/assets/71c05a86-f134-44f1-901d-b43bb2fbde45)


## After

![image](https://github.com/user-attachments/assets/173d4358-bc64-4405-9d19-7e49b823bb9e)

Supercedes #3442