### PR TITLE
feat(jsx): commentstring query

### DIFF
--- a/queries/jsx/highlights.scm
+++ b/queries/jsx/highlights.scm
@@ -149,3 +149,9 @@
   (string
     (string_fragment) @string.special.url))
   (#any-of? @_attr "href" "src"))
+
+((jsx_element) @_jsx_element
+  (#set! @_jsx_element bo.commentstring "{/* %s */}"))
+
+((jsx_attribute) @_jsx_attribute
+  (#set! @_jsx_attribute bo.commentstring "// %s"))


### PR DESCRIPTION
References https://github.com/folke/ts-comments.nvim/blob/1bd9d0ba1d8b336c3db50692ffd0955fe1bb9f0c/lua/ts-comments/config.lua#L33; the `jsx_attribute` query is for the inside of tags, and works nicely in my testing