### PR TITLE
feat(install): allow pass callback to `update()`

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -455,8 +455,8 @@ end, 3)
 
 ---@param languages? string[]|string
 ---@param _options? UpdateOptions
----@param _callback function
-M.update = a.sync(function(languages, _options, _callback)
+---@param callback function
+M.update = a.sync(function(languages, _options, callback)
   reload_parsers()
   if not languages or #languages == 0 then
     languages = 'all'
@@ -465,7 +465,7 @@ M.update = a.sync(function(languages, _options, _callback)
   languages = vim.tbl_filter(needs_update, languages) ---@type string[]
 
   if #languages > 0 then
-    install(languages, { force = true })
+    install(languages, { force = true }, callback)
   else
     log.info('All parsers are up-to-date')
   end


### PR DESCRIPTION
Problem: cannot run `:TSUpdate synchronously`

Solution: pass callback used after exiting jobs
(like in `install-parsers`).