### PR TITLE
fix(python): don't highlight attribute name as builtin

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -25,7 +25,8 @@
 
 ((attribute
   attribute: (identifier) @variable.member)
-  (#lua-match? @variable.member "^[%l_].*$"))
+  (#lua-match? @variable.member "^[%l_].*$")
+  (#set! "priority" 101))
 
 ((assignment
   left: (identifier) @type.definition

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -23,11 +23,6 @@
 
 "_" @character.special ; match wildcard
 
-((attribute
-  attribute: (identifier) @variable.member)
-  (#lua-match? @variable.member "^[%l_].*$")
-  (#set! "priority" 101))
-
 ((assignment
   left: (identifier) @type.definition
   (type
@@ -396,44 +391,6 @@
   (ellipsis)
 ] @punctuation.delimiter
 
-; Class definitions
-(class_definition
-  name: (identifier) @type)
-
-(class_definition
-  body: (block
-    (function_definition
-      name: (identifier) @function.method)))
-
-(class_definition
-  superclasses: (argument_list
-    (identifier) @type))
-
-; Assign higher priority to @variable.member than @type.builtin
-; Reserved builtins (such as `type`) are valid as attribute name
-((class_definition
-  body: (block
-    (expression_statement
-      (assignment
-        left: (identifier) @variable.member))))
-  (#lua-match? @variable.member "^[%l_].*$")
-  (#set! "priority" 101))
-
-((class_definition
-  body: (block
-    (expression_statement
-      (assignment
-        left: (_
-          (identifier) @variable.member)))))
-  (#lua-match? @variable.member "^[%l_].*$")
-  (#set! "priority" 101))
-
-((class_definition
-  (block
-    (function_definition
-      name: (identifier) @constructor)))
-  (#any-of? @constructor "__new__" "__init__"))
-
 ((identifier) @type.builtin
   (#any-of? @type.builtin
     ; https://docs.python.org/3/library/exceptions.html
@@ -453,6 +410,46 @@
     ; https://docs.python.org/3/library/stdtypes.html
     "bool" "int" "float" "complex" "list" "tuple" "range" "str" "bytes" "bytearray" "memoryview"
     "set" "frozenset" "dict" "type" "object"))
+
+; After @type.builtin bacause builtins (such as `type`) are valid as attribute name
+((attribute
+  attribute: (identifier) @variable.member)
+  (#lua-match? @variable.member "^[%l_].*$"))
+
+; Class definitions
+(class_definition
+  name: (identifier) @type)
+
+(class_definition
+  body: (block
+    (function_definition
+      name: (identifier) @function.method)))
+
+(class_definition
+  superclasses: (argument_list
+    (identifier) @type))
+
+((class_definition
+  body: (block
+    (expression_statement
+      (assignment
+        left: (identifier) @variable.member))))
+  (#lua-match? @variable.member "^[%l_].*$"))
+
+((class_definition
+  body: (block
+    (expression_statement
+      (assignment
+        left: (_
+          (identifier) @variable.member)))))
+  (#lua-match? @variable.member "^[%l_].*$"))
+
+((class_definition
+  (block
+    (function_definition
+      name: (identifier) @constructor)))
+  (#any-of? @constructor "__new__" "__init__"))
+
 
 ; Regex from the `re` module
 (call

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -408,12 +408,15 @@
   superclasses: (argument_list
     (identifier) @type))
 
+; Assign higher priority to @variable.member than @type.builtin
+; Otherwise reserved builtins (such as `type`) are valid as attribute name
 ((class_definition
   body: (block
     (expression_statement
       (assignment
         left: (identifier) @variable.member))))
-  (#lua-match? @variable.member "^[%l_].*$"))
+  (#lua-match? @variable.member "^[%l_].*$")
+  (#set! "priority" 101))
 
 ((class_definition
   body: (block
@@ -421,7 +424,8 @@
       (assignment
         left: (_
           (identifier) @variable.member)))))
-  (#lua-match? @variable.member "^[%l_].*$"))
+  (#lua-match? @variable.member "^[%l_].*$")
+  (#set! "priority" 101))
 
 ((class_definition
   (block

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -410,7 +410,7 @@
     (identifier) @type))
 
 ; Assign higher priority to @variable.member than @type.builtin
-; Otherwise reserved builtins (such as `type`) are valid as attribute name
+; Reserved builtins (such as `type`) are valid as attribute name
 ((class_definition
   body: (block
     (expression_statement

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -450,7 +450,6 @@
       name: (identifier) @constructor)))
   (#any-of? @constructor "__new__" "__init__"))
 
-
 ; Regex from the `re` module
 (call
   function: (attribute

--- a/tests/query/highlights/python/fields.py
+++ b/tests/query/highlights/python/fields.py
@@ -4,6 +4,8 @@ class Fields:
 #                                            ^^^^ @constant.builtin
         self.fields = fields
 #            ^^^^^^ @variable.member
+        self.type = "foo"
+#            ^^^^ @variable.member
         self.__dunderfield__ = None
 #            ^^^^^^^^^^^^^^^ @variable.member
         self._FunKyFielD = 0

--- a/tests/query/highlights/python/fields.py
+++ b/tests/query/highlights/python/fields.py
@@ -1,4 +1,7 @@
 class Fields:
+    type: str
+#   ^^^^ @variable.member
+
     def __init__(self, fields: list[int]) -> None:
 #                                   ^^^ @type.builtin
 #                                            ^^^^ @constant.builtin


### PR DESCRIPTION
assigned higher highlight priority to `@variable.member` over `@type.builtin` to correctly highlight `type` since it is a regular attribute in this context

### Before
<img width="318" alt="screen 2025-03-07 at 09 28 41" src="https://github.com/user-attachments/assets/cf995bbb-81be-45a5-9550-b844a5383ab9" />

### After
<img width="317" alt="screen 2025-03-07 at 09 24 45" src="https://github.com/user-attachments/assets/5b3c44b7-48fb-4a1f-885c-04b3068d75fd" />