### PR TITLE
feat(indent): injected language shiftwidth

### DIFF
--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -189,6 +189,10 @@ function M.get_indent(lnum)
   if root_start ~= 0 then
     -- injected tree
     indent = vim.fn.indent(root:start() + 1)
+    -- With an injected tree, we have a different language than the filetype of the current buffer,
+    -- so it doesn't make sense to use the value of 'shiftwidth' for the current buffer. Instead, we
+    -- get the default 'shiftwidth' for this filetype!
+    indent_size = vim.api.nvim_get_option_value("shiftwidth", { filetype = lang_tree:lang() })
   end
 
   -- tracks to ensure multiple indent levels are not applied for same line

--- a/tests/indent/html/mixed_indent.html
+++ b/tests/indent/html/mixed_indent.html
@@ -1,0 +1,6 @@
+<body>
+  <script>
+  {
+  }
+  </script>
+</body>

--- a/tests/indent/html_spec.lua
+++ b/tests/indent/html_spec.lua
@@ -3,9 +3,25 @@ local runner = Runner:new(it, "tests/indent/html", {
   tabstop = 2,
   shiftwidth = 2,
   expandtab = true,
+  softtabstop = 0,
 })
 
 describe("indent HTML:", function()
+  local css_indent = vim.api.nvim_create_autocmd("FileType", {
+    pattern = "css",
+    callback = function()
+      vim.bo.tabstop = 2
+      vim.bo.shiftwidth = 2
+    end,
+  })
+  local js_indent = vim.api.nvim_create_autocmd("FileType", {
+    pattern = "javascript",
+    callback = function()
+      vim.bo.tabstop = 4
+      vim.bo.shiftwidth = 4
+    end,
+  })
+
   describe("whole file:", function()
     runner:whole_file "."
   end)
@@ -24,5 +40,9 @@ describe("indent HTML:", function()
     runner:new_line("script_style.html", { on_line = 6, text = "<div></div>", indent = 2 })
     runner:new_line("script_style.html", { on_line = 9, text = "const x = 1", indent = 2 })
     runner:new_line("script_style.html", { on_line = 11, text = "Text", indent = 2 })
+    runner:new_line("mixed_indent.html", { on_line = 3, text = "const x = 1;", indent = 6 })
   end)
+
+  vim.api.nvim_del_autocmd(js_indent)
+  vim.api.nvim_del_autocmd(css_indent)
 end)


### PR DESCRIPTION
This pull request changes the tab size for lines in injected trees to use `nvim_get_option_value()` to get the default shiftwidth for the language's filetype. 

### Context
Nvim-treesitter's indent module supports injected language trees, where one language is embedded within another language. However, the indent size is currently always calculated using the current buffer's `vim.bo.shiftwidth`. Within an injected tree, the language is different from the language of the outer buffer, so it doesn't make sense to use the buffer's value for 'shiftwidth'. In the future, it may be desirable to add more robust configuration for indent sizes, however I believe this is an improvement for the default indentation behavior.

Test case included.