### PR TITLE
fix(rust): inject html and json in macro invocations

### DIFF
--- a/queries/rust/injections.scm
+++ b/queries/rust/injections.scm
@@ -5,7 +5,7 @@
     (identifier) @_macro_name
   ]
   (token_tree) @injection.content
-  (#not-eq? @_macro_name "slint")
+  (#not-any-of? @_macro_name "slint" "html" "json")
   (#set! injection.language "rust")
   (#set! injection.include-children))
 
@@ -19,6 +19,17 @@
   (#eq? @_macro_name "slint")
   (#offset! @injection.content 0 1 0 -1)
   (#set! injection.language "slint")
+  (#set! injection.include-children))
+
+(macro_invocation
+  macro: [
+    (scoped_identifier
+      name: (_) @injection.language)
+    (identifier) @injection.language
+  ]
+  (token_tree) @injection.content
+  (#any-of? @injection.language "html" "json")
+  (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children))
 
 (macro_definition
@@ -36,11 +47,6 @@
   (block_comment)
 ] @injection.content
   (#set! injection.language "comment"))
-
-((macro_invocation
-  macro: (identifier) @injection.language
-  (token_tree) @injection.content)
-  (#any-of? @injection.language "html" "json"))
 
 (call_expression
   function: (scoped_identifier

--- a/queries/rust/injections.scm
+++ b/queries/rust/injections.scm
@@ -12,23 +12,11 @@
 (macro_invocation
   macro: [
     (scoped_identifier
-      name: (_) @_macro_name)
-    (identifier) @_macro_name
-  ]
-  (token_tree) @injection.content
-  (#eq? @_macro_name "slint")
-  (#offset! @injection.content 0 1 0 -1)
-  (#set! injection.language "slint")
-  (#set! injection.include-children))
-
-(macro_invocation
-  macro: [
-    (scoped_identifier
       name: (_) @injection.language)
     (identifier) @injection.language
   ]
   (token_tree) @injection.content
-  (#any-of? @injection.language "html" "json")
+  (#any-of? @injection.language "slint" "html" "json")
   (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children))
 


### PR DESCRIPTION
This properly injects html and json in `json!`, `serde_json::json!` and `html!` etc. macro invocations. Before rust was being injected at the same time which caused the injection to break.

Before:
![rust macro invocations with improper injection highlighting](https://github.com/user-attachments/assets/db17de89-2bb6-477a-bbd2-c04b913f91b7)

After:
![rust macro invocations with working injection highlighting](https://github.com/user-attachments/assets/370509db-27b2-4bd9-bb9a-9cd9427a95d4)