### PR TITLE
fix(rust): inject regex into RegexBuilder instead of ByteRegexBuilder

### DIFF
--- a/queries/rust/injections.scm
+++ b/queries/rust/injections.scm
@@ -39,7 +39,7 @@
 (call_expression
   function: (scoped_identifier
     path: (identifier) @_regex
-    (#any-of? @_regex "Regex" "ByteRegexBuilder")
+    (#any-of? @_regex "Regex" "RegexBuilder")
     name: (identifier) @_new
     (#eq? @_new "new"))
   arguments: (arguments
@@ -51,7 +51,7 @@
   function: (scoped_identifier
     path: (scoped_identifier
       (identifier) @_regex
-      (#any-of? @_regex "Regex" "ByteRegexBuilder") .)
+      (#any-of? @_regex "Regex" "RegexBuilder") .)
     name: (identifier) @_new
     (#eq? @_new "new"))
   arguments: (arguments


### PR DESCRIPTION
inject regex into the [regex::RegexBuilder](https://docs.rs/regex/latest/regex/struct.RegexBuilder.html) and [regex::bytes::RegexBuilder](https://docs.rs/regex/latest/regex/bytes/struct.RegexBuilder.html) as i couldn't find any mention of a `ByteRegexBuilder` outside of this repo.

before:

![image](https://github.com/user-attachments/assets/0b5c0acf-26f8-4a3d-bb24-0efe1e9a851a)

after:

![image](https://github.com/user-attachments/assets/d2c30d3e-1f69-47b1-9180-f26e2e2a878c)