### PR TITLE
feat(bibtex): use better captures

### DIFF
--- a/queries/bibtex/highlights.scm
+++ b/queries/bibtex/highlights.scm
@@ -22,7 +22,7 @@
 (number) @number
 
 (field
-  name: (identifier) @variable.member)
+  name: (identifier) @property)
 
 (token
   (identifier) @variable.parameter)
@@ -35,7 +35,7 @@
 [
   (key_brace)
   (key_paren)
-] @string.special.symbol
+] @markup.link.label
 
 (string
   name: (identifier) @constant)


### PR DESCRIPTION
- I think `@property` fits better since those are key/value pairs.
- `@markup.link.label` fits with latex's captures for citations using `@markup.link`.