### PR TITLE
fix(formatter): increase match limit

### DIFF
--- a/runtime/queries/commonlisp/highlights.scm
+++ b/runtime/queries/commonlisp/highlights.scm
@@ -295,8 +295,7 @@
     "clear-output" "assoc-if" "string/=" "princ" "directory-namestring" "stream-error-stream"
     "array-element-type" "setq" "copy-seq" "time" "restart-case" "prog*" "shared-initialize"
     "array-total-size" "simple-bit-vector-p" "define-method-combination" "write-byte" "constantly"
-    "caddar" "print-object" "vector" "throw" "reverse" ">=" "upper-case-p" "nbutlast")
-  )
+    "caddar" "print-object" "vector" "throw" "reverse" ">=" "upper-case-p" "nbutlast"))
 
 (list_lit
   .

--- a/runtime/queries/racket/highlights.scm
+++ b/runtime/queries/racket/highlights.scm
@@ -140,8 +140,7 @@
     "unit/c" "unit/new-import-export" "unit/s" "unless" "unquote" "unquote-splicing" "unsyntax"
     "unsyntax-splicing" "values/drop" "when" "with-continuation-mark" "with-contract"
     "with-contract-continuation-mark" "with-handlers" "with-handlers*" "with-method" "with-syntax"
-    "~?" "~@" "λ")
-  )
+    "~?" "~@" "λ"))
 
 ; builtin procedures
 ((symbol) @function.builtin

--- a/scripts/format-queries.lua
+++ b/scripts/format-queries.lua
@@ -446,7 +446,7 @@ local function format(bufnr, queries)
   }
   local root = ts.get_parser(bufnr, 'query'):parse(true)[1]:root()
   local query = ts.query.parse('query', queries)
-  for id, node, metadata in query:iter_captures(root, bufnr) do
+  for id, node, metadata in query:iter_captures(root, bufnr, nil, nil, { match_limit = 1024 }) do
     if query.captures[id]:sub(1, 1) ~= '_' then
       map[query.captures[id]][node:id()] = metadata and (metadata[id] and metadata[id] or metadata)
         or {}


### PR DESCRIPTION
Problem: Some very long patterns were not formatted correctly.

Solution: Increase the match limit when iterating to 1024.
