### PR TITLE
fix(python): don't highlight parameter name as builtin

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -73,7 +73,6 @@
   (false)
 ] @boolean
 
-
 (integer) @number
 
 (float) @number.float

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -65,61 +65,6 @@
     (identifier) @type))
   (#eq? @_isinstance "isinstance"))
 
-; Normal parameters
-(parameters
-  (identifier) @variable.parameter)
-
-; Lambda parameters
-(lambda_parameters
-  (identifier) @variable.parameter)
-
-(lambda_parameters
-  (tuple_pattern
-    (identifier) @variable.parameter))
-
-; Default parameters
-(keyword_argument
-  name: (identifier) @variable.parameter)
-
-; Naming parameters on call-site
-(default_parameter
-  name: (identifier) @variable.parameter)
-
-(typed_parameter
-  (identifier) @variable.parameter)
-
-(typed_default_parameter
-  name: (identifier) @variable.parameter)
-
-; Variadic parameters *args, **kwargs
-(parameters
-  (list_splat_pattern ; *args
-    (identifier) @variable.parameter))
-
-(parameters
-  (dictionary_splat_pattern ; **kwargs
-    (identifier) @variable.parameter))
-
-; Typed variadic parameters
-(parameters
-  (typed_parameter
-    (list_splat_pattern ; *args: type
-      (identifier) @variable.parameter)))
-
-(parameters
-  (typed_parameter
-    (dictionary_splat_pattern ; *kwargs: type
-      (identifier) @variable.parameter)))
-
-; Lambda parameters
-(lambda_parameters
-  (list_splat_pattern
-    (identifier) @variable.parameter))
-
-(lambda_parameters
-  (dictionary_splat_pattern
-    (identifier) @variable.parameter))
-
 ; Literals
 (none) @constant.builtin
 
@@ -128,11 +73,6 @@
   (false)
 ] @boolean
 
-((identifier) @variable.builtin
-  (#eq? @variable.builtin "self"))
-
-((identifier) @variable.builtin
-  (#eq? @variable.builtin "cls"))
 
 (integer) @number
 
@@ -368,6 +308,67 @@
     ; https://docs.python.org/3/library/stdtypes.html
     "bool" "int" "float" "complex" "list" "tuple" "range" "str" "bytes" "bytearray" "memoryview"
     "set" "frozenset" "dict" "type" "object"))
+
+; Normal parameters
+(parameters
+  (identifier) @variable.parameter)
+
+; Lambda parameters
+(lambda_parameters
+  (identifier) @variable.parameter)
+
+(lambda_parameters
+  (tuple_pattern
+    (identifier) @variable.parameter))
+
+; Default parameters
+(keyword_argument
+  name: (identifier) @variable.parameter)
+
+; Naming parameters on call-site
+(default_parameter
+  name: (identifier) @variable.parameter)
+
+(typed_parameter
+  (identifier) @variable.parameter)
+
+(typed_default_parameter
+  name: (identifier) @variable.parameter)
+
+; Variadic parameters *args, **kwargs
+(parameters
+  (list_splat_pattern ; *args
+    (identifier) @variable.parameter))
+
+(parameters
+  (dictionary_splat_pattern ; **kwargs
+    (identifier) @variable.parameter))
+
+; Typed variadic parameters
+(parameters
+  (typed_parameter
+    (list_splat_pattern ; *args: type
+      (identifier) @variable.parameter)))
+
+(parameters
+  (typed_parameter
+    (dictionary_splat_pattern ; *kwargs: type
+      (identifier) @variable.parameter)))
+
+; Lambda parameters
+(lambda_parameters
+  (list_splat_pattern
+    (identifier) @variable.parameter))
+
+(lambda_parameters
+  (dictionary_splat_pattern
+    (identifier) @variable.parameter))
+
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "self"))
+
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "cls"))
 
 ; After @type.builtin bacause builtins (such as `type`) are valid as attribute name
 ((attribute

--- a/tests/query/highlights/python/fields.py
+++ b/tests/query/highlights/python/fields.py
@@ -15,3 +15,7 @@ class Fields:
 #            ^^^^^^^^^^^ @variable.member
         self.NOT_A_FIELD = "IM NOT A FIELD"
 #            ^^^^^^^^^^^ @constant
+
+Fields(type="schema", fields=["foo", "bar"])
+#      ^^^^ @variable.parameter
+#                     ^^^^^^ @variable.parameter

--- a/tests/query/highlights/python/fields.py
+++ b/tests/query/highlights/python/fields.py
@@ -2,12 +2,14 @@ class Fields:
     type: str
 #   ^^^^ @variable.member
 
-    def __init__(self, fields: list[int]) -> None:
-#                                   ^^^ @type.builtin
-#                                            ^^^^ @constant.builtin
+    def __init__(self, type: str, fields: list[int]) -> None:
+#                      ^^^^ @variable.parameter
+#                                 ^^^^^^ @variable.parameter
+#                                              ^^^ @type.builtin
+#                                                       ^^^^ @constant.builtin
         self.fields = fields
 #            ^^^^^^ @variable.member
-        self.type = "foo"
+        self.type = type  # this cannot be highlighted correctly by Treesitter
 #            ^^^^ @variable.member
         self.__dunderfield__ = None
 #            ^^^^^^^^^^^^^^^ @variable.member
@@ -16,6 +18,6 @@ class Fields:
         self.NOT_A_FIELD = "IM NOT A FIELD"
 #            ^^^^^^^^^^^ @constant
 
-Fields(type="schema", fields=["foo", "bar"])
+Fields(type="schema", fields=[0, 1])
 #      ^^^^ @variable.parameter
 #                     ^^^^^^ @variable.parameter

--- a/tests/query/highlights/python/fields.py
+++ b/tests/query/highlights/python/fields.py
@@ -3,6 +3,7 @@ class Fields:
 #   ^^^^ @variable.member
 
     def __init__(self, type: str, fields: list[int]) -> None:
+#                ^^^^ @variable.builtin
 #                      ^^^^ @variable.parameter
 #                                 ^^^^^^ @variable.parameter
 #                                              ^^^ @type.builtin

--- a/tests/query/highlights/python/functions.py
+++ b/tests/query/highlights/python/functions.py
@@ -12,7 +12,7 @@ class Foo:
 
     @classmethod
     def clsmethod(cls) -> None: ...
-#              ^^^ @variable.builtin
+#                 ^^^ @variable.builtin
 
 Foo().method()
 #     ^^^^^^ @function.method.call

--- a/tests/query/highlights/python/functions.py
+++ b/tests/query/highlights/python/functions.py
@@ -8,6 +8,11 @@ _ = func()
 
 class Foo:
     def method(self) -> None: ...
+#              ^^^^ @variable.builtin
+
+    @classmethod
+    def clsmethod(cls) -> None: ...
+#              ^^^ @variable.builtin
 
 Foo().method()
 #     ^^^^^^ @function.method.call


### PR DESCRIPTION
same as #7712 but for parameters
