### PR TITLE
parsers.lua: use `main` branch

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1338,6 +1338,7 @@ list.lua = {
   install_info = {
     url = "https://github.com/MunifTanjim/tree-sitter-lua",
     files = { "src/parser.c", "src/scanner.c" },
+    branch = "main",
   },
   maintainers = { "@muniftanjim" },
 }


### PR DESCRIPTION
Upstream migrated the default branch.

Fixes: #7735

---
Cc: @Anderwafe