### PR TITLE
feat(typst): highlight language name as @label

### DIFF
--- a/queries/typst/highlights.scm
+++ b/queries/typst/highlights.scm
@@ -114,6 +114,9 @@
 (raw_blck) @markup.raw
 
 (raw_blck
+  lang: (ident) @label)
+
+(raw_blck
   (blob) @markup.raw.block)
 
 ; refs and labels


### PR DESCRIPTION
Test code:

~~~typst
Adding `rbx` to `rcx` gives
the desired result.

What is ```rust fn main()``` in Rust
would be ```c int main()``` in C.

```rust
fn main() {
    println!("Hello World!");
}
```

This has ``` `backticks` ``` in it
(but the spaces are trimmed). And
``` here``` the leading space is
also trimmed.
~~~