### PR TITLE
feat(query): add exclusive make-range! variants

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -231,6 +231,14 @@ function M.insert_to_path(object, path, value)
   curr_obj[path[#path]] = value
 end
 
+---@type table<string, TSRangeFromNodesOpts>
+local range_directives = {
+  ["make-range!"] = {},
+  ["make-range-exclude-end!"] = { exclude_end = true },
+  ["make-range-exclude-start!"] = { exclude_start = true },
+  ["make-range-exclusive!"] = { exclude_start = true, exclude_end = true },
+}
+
 ---@param query Query
 ---@param bufnr integer
 ---@param start_row integer
@@ -275,11 +283,12 @@ function M.iter_prepared_matches(query, qnode, bufnr, start_row, end_row)
           if pred[1] == "set!" and type(pred[2]) == "string" then
             M.insert_to_path(prepared_match, split(pred[2]), pred[3])
           end
-          if pred[1] == "make-range!" and type(pred[2]) == "string" and #pred == 4 then
+          local range_opts = range_directives[pred[1]]
+          if range_opts and type(pred[2]) == "string" and #pred == 4 then
             M.insert_to_path(
               prepared_match,
               split(pred[2] .. ".node"),
-              tsrange.TSRange.from_nodes(bufnr, match[pred[3]], match[pred[4]])
+              tsrange.TSRange.from_nodes(bufnr, match[pred[3]], match[pred[4]], range_opts)
             )
           end
         end

--- a/lua/nvim-treesitter/query_predicates.lua
+++ b/lua/nvim-treesitter/query_predicates.lua
@@ -142,8 +142,15 @@ query.add_directive("set-lang-from-info-string!", function(match, _, bufnr, pred
   metadata["injection.language"] = get_parser_from_markdown_info_string(injection_alias)
 end, opts)
 
--- Just avoid some annoying warnings for this directive
-query.add_directive("make-range!", function() end, opts)
+-- Just avoid some annoying warnings for these directives
+for _, name in ipairs {
+  "make-range!",
+  "make-range-exclude-end!",
+  "make-range-exclude-start!",
+  "make-range-exclusive!",
+} do
+  query.add_directive(name, function() end, opts)
+end
 
 --- transform node text to lower case (e.g., to make @injection.language case insensitive)
 ---

--- a/lua/nvim-treesitter/tsrange.lua
+++ b/lua/nvim-treesitter/tsrange.lua
@@ -22,10 +22,21 @@ function TSRange.new(buf, start_row, start_col, end_row, end_col)
   }, TSRange)
 end
 
-function TSRange.from_nodes(buf, start_node, end_node)
+---@class TSRangeFromNodesOpts
+---@field exclude_start? boolean
+---@field exclude_end? boolean
+
+---@param buf integer
+---@param start_node TSNode|nil
+---@param end_node TSNode|nil
+---@param opts? TSRangeFromNodesOpts
+function TSRange.from_nodes(buf, start_node, end_node, opts)
   TSRange.__index = TSRange
-  local start_pos = start_node and { start_node:start() } or { end_node:start() }
-  local end_pos = end_node and { end_node:end_() } or { start_node:end_() }
+  opts = opts or {}
+  local start_pos = start_node and (opts.exclude_start and { start_node:end_() } or { start_node:start() })
+    or { end_node:start() }
+  local end_pos = end_node and (opts.exclude_end and { end_node:start() } or { end_node:end_() })
+    or { start_node:end_() }
   return setmetatable({
     start_pos = { start_pos[1], start_pos[2], start_pos[3] },
     end_pos = { end_pos[1], end_pos[2], end_pos[3] },

--- a/tests/unit/queries_spec.lua
+++ b/tests/unit/queries_spec.lua
@@ -1,0 +1,267 @@
+local query = require "nvim-treesitter.query"
+
+local function get_matching_nodes(case)
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, case.lines)
+  local lang_query = vim.treesitter.query.parse(case.lang, case.query)
+  local parser = vim.treesitter.get_parser(0, case.lang)
+  local tree = parser:parse()[1]
+  local root = tree:root()
+  local range = { root:range() }
+  local nodes = {}
+  for match in query.iter_prepared_matches(lang_query, root, 0, range[1], range[3] + 1) do
+    local capture = match[case.capture]
+    if capture ~= nil then
+      local node = capture.node
+      table.insert(nodes, { vim.treesitter.get_node_text(node, 0), { node:range() } })
+    end
+  end
+  return nodes
+end
+
+describe("make-range", function()
+  it("handles full match", function()
+    assert.same(
+      { { "int argc, char *argv[]", { 0, 9, 0, 31 } } },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration) @_start
+            .
+            (parameter_declaration) @_end)
+            (#make-range! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+
+  it("handles optional start", function()
+    assert.same(
+      {
+        { "int argc", { 0, 9, 0, 17 } },
+        { "int argc, char *argv[]", { 0, 9, 0, 31 } },
+      },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration)? @_start
+            .
+            (parameter_declaration)  @_end)
+            (#make-range! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+
+  it("handles optional end", function()
+    assert.same(
+      {
+        { "int argc, char *argv[]", { 0, 9, 0, 31 } },
+        { "char *argv[]", { 0, 19, 0, 31 } },
+      },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration) @_start
+            .
+            (parameter_declaration)? @_end)
+            (#make-range! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+end)
+
+describe("make-range-exclude-start", function()
+  it("handles full match", function()
+    assert.same(
+      { { ", char *argv[]", { 0, 17, 0, 31 } } },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration) @_start
+            .
+            (parameter_declaration) @_end)
+            (#make-range-exclude-start! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+
+  it("handles optional start", function()
+    assert.same(
+      {
+        { "int argc", { 0, 9, 0, 17 } },
+        { ", char *argv[]", { 0, 17, 0, 31 } },
+      },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration)? @_start
+            .
+            (parameter_declaration)  @_end)
+            (#make-range-exclude-start! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+
+  it("handles optional end", function()
+    assert.same(
+      {
+        { ", char *argv[]", { 0, 17, 0, 31 } },
+        { "", { 0, 31, 0, 31 } },
+      },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration) @_start
+            .
+            (parameter_declaration)? @_end)
+            (#make-range-exclude-start! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+end)
+
+describe("make-range-exclude-end", function()
+  it("handles full match", function()
+    assert.same(
+      { { "int argc, ", { 0, 9, 0, 19 } } },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration) @_start
+            .
+            (parameter_declaration) @_end)
+            (#make-range-exclude-end! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+
+  it("handles optional start", function()
+    assert.same(
+      {
+        { "", { 0, 9, 0, 9 } },
+        { "int argc, ", { 0, 9, 0, 19 } },
+      },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration)? @_start
+            .
+            (parameter_declaration)  @_end)
+            (#make-range-exclude-end! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+
+  it("handles optional end", function()
+    assert.same(
+      {
+        { "int argc, ", { 0, 9, 0, 19 } },
+        { "char *argv[]", { 0, 19, 0, 31 } },
+      },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration) @_start
+            .
+            (parameter_declaration)? @_end)
+            (#make-range-exclude-end! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+end)
+
+describe("make-range-exclusive", function()
+  it("handles full match", function()
+    assert.same(
+      { { ", ", { 0, 17, 0, 19 } } },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration) @_start
+            .
+            (parameter_declaration) @_end)
+            (#make-range-exclusive! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+
+  it("handles optional start", function()
+    assert.same(
+      {
+        { "", { 0, 9, 0, 9 } },
+        { ", ", { 0, 17, 0, 19 } },
+      },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration)? @_start
+            .
+            (parameter_declaration)  @_end)
+            (#make-range-exclusive! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+
+  it("handles optional end", function()
+    assert.same(
+      {
+        { ", ", { 0, 17, 0, 19 } },
+        { "", { 0, 31, 0, 31 } },
+      },
+      get_matching_nodes {
+        lang = "c",
+        lines = { "int main(int argc, char *argv[]) { return 0; }" },
+        capture = "@target",
+        query = [[
+          ((parameter_list
+            (parameter_declaration) @_start
+            .
+            (parameter_declaration)? @_end)
+            (#make-range-exclusive! "@target" @_start @_end))
+        ]],
+      }
+    )
+  end)
+end)


### PR DESCRIPTION
Related: #1622

## Motivation

I'd like to write a textobject query to match inside html tags. I'm able to get most of the way there with this query:

```query
(element
  (start_tag)
  .
  (_) @_start
  (_)? @_end
  .
  (end_tag)
  (#make-range! "tag.inner" @_start @_end))
```

But it doesn't match empty tags, as there are no inner nodes:

```html
<div></div>
```
Having a `make-range-exclusive!` directive would make this possible.

```query
(element
  (start_tag) @_start
  (end_tag) @_end
  (#make-range-exclusive! "tag.inner" @_start @_end))
```

## API

I'm not set on the exact naming/API. Alternatives:

- Add optional parameter(s) to the existing `make-range!` directive:
  ```query
  (#make-range! "@capture" @_start @end "[)") ; include start, exclude end
  ```
- Use [mathematical terminology](https://en.wikipedia.org/wiki/Interval_%28mathematics%29#Definitions_and_terminology)
  - make-range-open
  - make-range-left-open
  - make-range-right-open
