### PR TITLE
feat(javadoc): add parser and queries

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -380,6 +380,9 @@
   "java": {
     "revision": "a7db5227ec40fcfe94489559d8c9bc7c8181e25a"
   },
+  "javadoc": {
+    "revision": "8089a905454cbb7eac4ba6ec5495338169c60a56"
+  },
   "javascript": {
     "revision": "6fbef40512dcd9f0a61ce03a4c9ae7597b36ab5c"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1127,6 +1127,14 @@ list.java = {
   maintainers = { "@p00f" },
 }
 
+list.javadoc = {
+  install_info = {
+    url = "https://github.com/rmuir/tree-sitter-javadoc",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@rmuir" },
+}
+
 list.javascript = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-javascript",

--- a/queries/java/injections.scm
+++ b/queries/java/injections.scm
@@ -5,20 +5,13 @@
   (#set! injection.language "comment"))
 
 ((block_comment) @injection.content
-  (#lua-match? @injection.content "/[*][!<*][^a-zA-Z]")
-  (#set! injection.language "doxygen"))
+  (#lua-match? @injection.content "/[*][*][%s]")
+  (#set! injection.language "javadoc"))
 
-; markdown-style javadocs: https://openjdk.org/jeps/467
+; markdown-style javadocs https://openjdk.org/jeps/467
 ((line_comment) @injection.content
   (#lua-match? @injection.content "^///%s")
-  (#offset! @injection.content 0 4 0 0)
-  (#set! injection.language "markdown_inline"))
-
-; markdown-style javadocs: https://openjdk.org/jeps/467
-((line_comment) @injection.content
-  (#lua-match? @injection.content "^///%s+[@]")
-  (#offset! @injection.content 0 4 0 0)
-  (#set! injection.language "doxygen"))
+  (#set! injection.language "javadoc"))
 
 ((method_invocation
   name: (identifier) @_method

--- a/queries/javadoc/highlights.scm
+++ b/queries/javadoc/highlights.scm
@@ -1,0 +1,98 @@
+[
+ (tag_name)
+ "include"
+ "exclude"
+] @nospell @keyword
+
+(identifier) @nospell @variable
+
+(fragment) @nospell @variable.member
+
+(parameter
+  name: (identifier) @variable.parameter)
+
+(param_tag
+  parameter_name: (identifier) @variable.parameter)
+
+[
+ (boolean_type)
+ (integral_type)
+ (floating_point_type)
+] @nospell @type.builtin
+
+(module
+  (identifier) @module)
+
+(type
+  (identifier) @type)
+
+(type_parameter
+  (identifier) @type)
+
+(method
+  (identifier) @function)
+
+(((method
+    (identifier) @constructor)
+    (#match? @constructor "^[A-Z]")))
+
+(member
+  (identifier) @variable.member)
+
+((member
+  (identifier) @constant)
+  (#match? @constant "^[A-Z_][A-Z0-9_]+$"))
+
+((member
+  (identifier) @type)
+  (#match? @type "^[A-Z].*[a-z]"))
+
+[
+  (string_literal)
+  (indexword)
+] @nospell @string
+
+[
+  (bare_format_string)
+  (literal_format_string)
+] @nospell @string.special
+
+(url) @nospell @markup.link.url
+
+(attribute
+  name: (identifier) @nospell @property)
+
+(system_property) @nospell @property
+
+(unsigned_integer) @number
+
+(code) @nospell @markup.raw
+
+[
+  "="
+  ":"
+] @operator
+
+[
+  "/"
+  "."
+  ","
+  "..."
+  "#"
+  "##"
+] @punctuation.delimiter
+
+[
+  "{"
+  "}"
+  "("
+  ")"
+  "["
+  "]"
+] @punctuation.bracket
+
+(param_tag
+  [
+   "<"
+   ">"
+  ] @punctuation.bracket)

--- a/queries/javadoc/injections.scm
+++ b/queries/javadoc/injections.scm
@@ -1,0 +1,29 @@
+;; @value tags without double-quotes
+((bare_format_string) @injection.content
+                      (#set! injection.language "printf"))
+
+;; @value tags with double quotes
+((literal_format_string) @injection.content
+                         (#offset! @injection.content 0 1 0 -1)
+                         (#set! injection.language "printf"))
+
+;; injected code snippets
+((snippet_tag
+   (attributes
+     (attribute
+       name: (identifier) @_attribute_key
+       value: (attribute_value [
+         (identifier) @injection.language
+         (string_literal
+           (quoted_value) @injection.language)
+       ])))
+   body: (description) @injection.content)
+ (#eq? @_attribute_key "lang"))
+
+;; html content
+((description) @injection.content
+  (#set! injection.language "html"))
+
+;; markdown content
+((markdown_description) @injection.content
+  (#set! injection.language "markdown_inline"))


### PR DESCRIPTION
Previously java was configured to use doxygen parser for documentation comments, but javadocs are not doxygen. Inline tags have a different syntax, block tags are not recognized, and doxygen creates a lot of errors during highlighting.

Add parser for javadoc comments, with queries for highlights and injections.