### PR TITLE
fix(python): reorder builtin functions after other function calls

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -35,19 +35,6 @@
     function: (identifier) @_func))
   (#any-of? @_func "TypeVar" "NewType"))
 
-; Builtin functions
-((call
-  function: (identifier) @function.builtin)
-  (#any-of? @function.builtin
-    "abs" "all" "any" "ascii" "bin" "bool" "breakpoint" "bytearray" "bytes" "callable" "chr"
-    "classmethod" "compile" "complex" "delattr" "dict" "dir" "divmod" "enumerate" "eval" "exec"
-    "filter" "float" "format" "frozenset" "getattr" "globals" "hasattr" "hash" "help" "hex" "id"
-    "input" "int" "isinstance" "issubclass" "iter" "len" "list" "locals" "map" "max" "memoryview"
-    "min" "next" "object" "oct" "open" "ord" "pow" "print" "property" "range" "repr" "reversed"
-    "round" "set" "setattr" "slice" "sorted" "staticmethod" "str" "sum" "super" "tuple" "type"
-    "vars" "zip" "__import__")
-  (#set! priority 102))
-
 ; Function definitions
 (function_definition
   name: (identifier) @function)
@@ -425,6 +412,18 @@
   function: (attribute
     attribute: (identifier) @constructor))
   (#lua-match? @constructor "^%u"))
+
+; Builtin functions
+((call
+  function: (identifier) @function.builtin)
+  (#any-of? @function.builtin
+    "abs" "all" "any" "ascii" "bin" "bool" "breakpoint" "bytearray" "bytes" "callable" "chr"
+    "classmethod" "compile" "complex" "delattr" "dict" "dir" "divmod" "enumerate" "eval" "exec"
+    "filter" "float" "format" "frozenset" "getattr" "globals" "hasattr" "hash" "help" "hex" "id"
+    "input" "int" "isinstance" "issubclass" "iter" "len" "list" "locals" "map" "max" "memoryview"
+    "min" "next" "object" "oct" "open" "ord" "pow" "print" "property" "range" "repr" "reversed"
+    "round" "set" "setattr" "slice" "sorted" "staticmethod" "str" "sum" "super" "tuple" "type"
+    "vars" "zip" "__import__"))
 
 ; Regex from the `re` module
 (call

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -45,7 +45,8 @@
     "input" "int" "isinstance" "issubclass" "iter" "len" "list" "locals" "map" "max" "memoryview"
     "min" "next" "object" "oct" "open" "ord" "pow" "print" "property" "range" "repr" "reversed"
     "round" "set" "setattr" "slice" "sorted" "staticmethod" "str" "sum" "super" "tuple" "type"
-    "vars" "zip" "__import__"))
+    "vars" "zip" "__import__")
+  (#set! priority 102))
 
 ; Function definitions
 (function_definition

--- a/tests/query/highlights/python/functions.py
+++ b/tests/query/highlights/python/functions.py
@@ -16,3 +16,6 @@ class Foo:
 
 Foo().method()
 #     ^^^^^^ @function.method.call
+
+print()
+# ^ @function.builtin


### PR DESCRIPTION
`@functon.method.call` currently overrides `@functon.builtin`.

Reorder builtin functions after other function calls.