### PR TITLE
fix(dhall): highlight several missing builtins

### DIFF
--- a/queries/dhall/highlights.scm
+++ b/queries/dhall/highlights.scm
@@ -1,4 +1,3 @@
-; Text
 ; Imports
 (missing_import) @keyword.import
 
@@ -12,6 +11,7 @@
 ] @string.special
 
 [
+  (import_as_bytes)
   (import_as_location)
   (import_as_text)
 ] @type
@@ -92,6 +92,7 @@
 
 (builtin
   [
+    "Bool"
     "Natural"
     "Natural/build"
     "Natural/fold"
@@ -121,8 +122,11 @@
     "Text/replace"
     "Optional"
     "Date"
+    "Date/show"
     "Time"
+    "Time/show"
     "TimeZone"
+    "TimeZone/show"
     "Type"
     "Kind"
     "Sort"
@@ -164,7 +168,10 @@
 ] @keyword.conditional
 
 ; Literals
-(text_literal) @string
+[
+  (text_literal)
+  (bytes_literal)
+] @string
 
 (interpolation
   "}" @string)


### PR DESCRIPTION
The dhall language `highlights.scm` queries are missing several builtins. I used the [language reference](https://docs.dhall-lang.org/references/Built-in-types.html) and the [treesitter implementation](https://github.com/jbellerb/tree-sitter-dhall/blob/master/queries/highlights.scm) as references:

- highlight builtin type [`Bool`](https://docs.dhall-lang.org/references/Built-in-types.html#bool)
- highlight import [`... as Bytes`](https://docs.dhall-lang.org/references/Built-in-types.html#keyword-as-bytes) and the bytes literal (ie. [`0x"deadbeef"`](https://docs.dhall-lang.org/references/Built-in-types.html#keyword-as-bytes))
- highlight builtin functions [`Date/show`](https://docs.dhall-lang.org/references/Built-in-types.html#function-date-show), [`Time/show`](https://docs.dhall-lang.org/references/Built-in-types.html#function-time-show), [`TimeZone/show`](https://docs.dhall-lang.org/references/Built-in-types.html#function-timezone-show)
