### PR TITLE
feat(brightscript): Addition of brightscript parser and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [blade](https://github.com/EmranMR/tree-sitter-blade) (maintained by @calebdw)
 - [x] [blueprint](https://gitlab.com/gabmus/tree-sitter-blueprint.git) (experimental, maintained by @gabmus)
 - [x] [bp](https://github.com/ambroisie/tree-sitter-bp) (maintained by @ambroisie)
+- [x] [brightscript](https://github.com/ajdelcimmuto/tree-sitter-brightscript) (maintained by @ajdelcimmuto)
 - [x] [c](https://github.com/tree-sitter/tree-sitter-c) (maintained by @amaanq)
 - [x] [c_sharp](https://github.com/tree-sitter/tree-sitter-c-sharp) (maintained by @amaanq)
 - [x] [caddy](https://github.com/opa-oz/tree-sitter-caddy) (maintained by @opa-oz)

--- a/lockfile.json
+++ b/lockfile.json
@@ -54,7 +54,7 @@
     "revision": "16c43068ec30828c5aed11e87262c56f36782595"
   },
   "brightscript": {
-    "revision": "a5a68f3e4215c866659df7939fc4a6617d04341b"
+    "revision": "48ce1687125c6dfefcc7a1bef19fa0f0f00426cc"
   },
   "c": {
     "revision": "2a265d69a4caf57108a73ad2ed1e6922dd2f998c"

--- a/lockfile.json
+++ b/lockfile.json
@@ -53,6 +53,9 @@
   "bp": {
     "revision": "16c43068ec30828c5aed11e87262c56f36782595"
   },
+  "brightscript": {
+    "revision": "a5a68f3e4215c866659df7939fc4a6617d04341b"
+  },
   "c": {
     "revision": "2a265d69a4caf57108a73ad2ed1e6922dd2f998c"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -216,6 +216,14 @@ list.bp = {
   maintainers = { "@ambroisie" },
 }
 
+list.brightscript = {
+  install_info = {
+    url = "https://github.com/ajdelcimmuto/tree-sitter-brightscript",
+    files = { "src/parser.c" },
+  },
+  maintainers = { "@ajdelcimmuto" },
+}
+
 list.c = {
   install_info = {
     url = "https://github.com/tree-sitter/tree-sitter-c",

--- a/queries/brightscript/folds.scm
+++ b/queries/brightscript/folds.scm
@@ -1,0 +1,9 @@
+[
+  (function_statement)
+  (sub_statement)
+  (while_statement)
+  (for_statement)
+  (if_statement)
+  (try_statement)
+] @fold
+

--- a/queries/brightscript/folds.scm
+++ b/queries/brightscript/folds.scm
@@ -6,4 +6,3 @@
   (if_statement)
   (try_statement)
 ] @fold
-

--- a/queries/brightscript/highlights.scm
+++ b/queries/brightscript/highlights.scm
@@ -38,13 +38,13 @@
   (identifier) @property)
 
 ; Statements
-(if_statement) @conditional
-(conditional_compl) @conditional
-(for_statement) @repeat
-(while_statement) @repeat
-(try_statement) @exception
+(if_statement) @keyword.conditional
+(conditional_compl) @keyword.conditional
+(for_statement) @keyword.repeat
+(while_statement) @keyword.repeat
+(try_statement) @keyword.exception
 (return_statement) @keyword.return
-(throw_statement) @keyword.throw
+(throw_statement) @keyword.exception
 (assignment_statement) @operator
 (print_statement) @function.builtin
 (constant) @constant
@@ -94,9 +94,9 @@
 ["(" ")" "[" "]" "{" "}" "." "," "?." "?["] @punctuation.delimiter
 
 ; Special highlights for library statements
-(library_statement) @include
+(library_statement) @keyword.import
 (library_statement
-  path: (string) @string.special)
+  path: (string) @module)
 
 ; Array and associative array literals
 (array) @constructor

--- a/queries/brightscript/highlights.scm
+++ b/queries/brightscript/highlights.scm
@@ -102,7 +102,7 @@
 (invalid) @constant.builtin
 
 ; Comments
-(comment) @comment
+(comment) @comment @spell
 
 ; Punctuation
 [

--- a/queries/brightscript/highlights.scm
+++ b/queries/brightscript/highlights.scm
@@ -174,4 +174,4 @@
     ">="
   ] @operator)
 
-(as) @keyword
+(as) @keyword.operator

--- a/queries/brightscript/highlights.scm
+++ b/queries/brightscript/highlights.scm
@@ -1,9 +1,11 @@
 ; Identifiers
 (identifier) @variable
 
-; Function and sub declarations
+; Function declaration
 (function_statement
   name: (identifier) @function)
+
+; Sub declaration
 (sub_statement
   name: (identifier) @function)
 
@@ -39,14 +41,23 @@
 
 ; Statements
 (if_statement) @keyword.conditional
+
 (conditional_compl) @keyword.conditional
+
 (for_statement) @keyword.repeat
+
 (while_statement) @keyword.repeat
+
 (try_statement) @keyword.exception
+
 (return_statement) @keyword.return
+
 (throw_statement) @keyword.exception
+
 (assignment_statement) @operator
+
 (print_statement) @function.builtin
+
 (constant) @constant
 
 ; Keywords
@@ -83,24 +94,41 @@
 
 ; Literals
 (boolean) @boolean
+
 (number) @number
+
 (string) @string
+
 (invalid) @constant.builtin
 
 ; Comments
 (comment) @comment
 
 ; Punctuation
-["(" ")" "[" "]" "{" "}" "." "," "?." "?["] @punctuation.delimiter
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "."
+  ","
+  "?."
+  "?["
+] @punctuation.delimiter
 
 ; Special highlights for library statements
 (library_statement) @keyword.import
+
 (library_statement
   path: (string) @module)
 
 ; Array and associative array literals
 (array) @constructor
+
 (assoc_array) @constructor
+
 (assoc_array_element
   key: (identifier) @property)
 
@@ -135,7 +163,13 @@
 ] @keyword
 
 ; Special keywords (these might still need to be strings if not defined as separate nodes)
-["then" "else" "else if" "#else" "#else if"] @keyword
+[
+  "then"
+  "else"
+  "else if"
+  "#else"
+  "#else if"
+] @keyword
 
 ; Exit statements
 [

--- a/queries/brightscript/highlights.scm
+++ b/queries/brightscript/highlights.scm
@@ -1,0 +1,144 @@
+; Identifiers
+(identifier) @variable
+
+; Function and sub declarations
+(function_statement
+  name: (identifier) @function)
+(sub_statement
+  name: (identifier) @function)
+
+; Function calls
+(function_call
+  function: (prefix_exp
+    (identifier) @function.call))
+
+; Parameters
+(parameter
+  name: (identifier) @variable.parameter)
+
+; Types
+(type_specifier) @type
+
+; Variables
+(variable_declarator) @variable
+
+(multiplicative_expression
+  operator: (_) @keyword.operator)
+
+(logical_not_expression
+  operator: (_) @keyword.operator)
+
+(logical_expression
+  operator: (_) @keyword.operator)
+
+; Property access
+(prefix_exp
+  (prefix_exp
+    (identifier) @variable)
+  (identifier) @property)
+
+; Statements
+(if_statement) @conditional
+(conditional_compl) @conditional
+(for_statement) @repeat
+(while_statement) @repeat
+(try_statement) @exception
+(return_statement) @keyword.return
+(throw_statement) @keyword.throw
+(assignment_statement) @operator
+(print_statement) @function.builtin
+(constant) @constant
+
+; Keywords
+[
+  (function_start)
+  (sub_start)
+  (if_start)
+  (if_then)
+  (if_else)
+  (for_start)
+  (for_to)
+  (for_step)
+  (for_each)
+  (for_in)
+  (while_start)
+  (try_start)
+  (try_catch)
+  (as)
+] @keyword
+
+; Operators
+[
+  "="
+  "<>"
+  "<"
+  "<="
+  ">"
+  ">="
+  "+"
+  "-"
+  "*"
+  "/"
+] @operator
+
+; Literals
+(boolean) @boolean
+(number) @number
+(string) @string
+(invalid) @constant.builtin
+
+; Comments
+(comment) @comment
+
+; Punctuation
+["(" ")" "[" "]" "{" "}" "." "," "?." "?["] @punctuation.delimiter
+
+; Special highlights for library statements
+(library_statement) @include
+(library_statement
+  path: (string) @string.special)
+
+; Array and associative array literals
+(array) @constructor
+(assoc_array) @constructor
+(assoc_array_element
+  key: (identifier) @property)
+
+; Increment/decrement operators
+[
+  (prefix_increment_expression)
+  (prefix_decrement_expression)
+  (postfix_increment_expression)
+  (postfix_decrement_expression)
+] @operator
+
+; Comparison operators
+(comparison_expression
+  [
+    "="
+    "<>"
+    "<"
+    "<="
+    ">"
+    ">="
+  ] @operator)
+
+; End statements
+[
+  (end_sub)
+  (end_function)
+  (end_if)
+  (end_for)
+  (end_while)
+  (end_try)
+  (conditional_compl_end_if)
+] @keyword
+
+; Special keywords (these might still need to be strings if not defined as separate nodes)
+["then" "else" "else if" "#else" "#else if"] @keyword
+
+; Exit statements
+[
+  (exit_while_statement)
+  (exit_for_statement)
+] @keyword

--- a/queries/brightscript/highlights.scm
+++ b/queries/brightscript/highlights.scm
@@ -9,10 +9,12 @@
 (sub_statement
   name: (identifier) @function)
 
-; Function calls
-(function_call
-  function: (prefix_exp
-    (identifier) @function.call))
+[
+  (sub_start)
+  (function_start)
+  (end_sub)
+  (end_function)
+] @keyword.function
 
 ; Parameters
 (parameter
@@ -22,7 +24,16 @@
 (type_specifier) @type
 
 ; Variables
-(variable_declarator) @variable
+; Base variable in variable declarator (immediate child of prefix_exp)
+(variable_declarator
+  (prefix_exp
+    (identifier) @variable
+    (#not-has-ancestor? @variable prefix_exp)))
+
+; Properties in variable declarator
+(variable_declarator
+  (prefix_exp)
+  (identifier) @property)
 
 (multiplicative_expression
   operator: (_) @keyword.operator)
@@ -34,49 +45,61 @@
   operator: (_) @keyword.operator)
 
 ; Property access
+; First identifier in a chain (base variable)
 (prefix_exp
-  (prefix_exp
-    (identifier) @variable)
+  .
+  (identifier) @variable
+  (#not-has-ancestor? @variable prefix_exp))
+
+; All other identifiers in a chain (properties)
+(prefix_exp
+  (prefix_exp)
   (identifier) @property)
 
+; Function calls
+(function_call
+  function: (prefix_exp
+    (identifier) @function.call))
+
 ; Statements
-(if_statement) @keyword.conditional
+[
+  (if_start)
+  (else)
+  (else_if)
+  (end_if)
+  (then)
+  (conditional_compl_end_if)
+] @keyword.conditional
 
-(conditional_compl) @keyword.conditional
+[
+  (for_start)
+  (while_start)
+  (for_each)
+  (for_in)
+  (for_to)
+  (for_step)
+  (end_for)
+  (end_while)
+  (exit_while_statement)
+  (exit_for_statement)
+] @keyword.repeat
 
-(for_statement) @keyword.repeat
+; Statements
+[
+  (try_start)
+  (try_catch)
+  (throw)
+  (end_try)
+] @keyword.exception
 
-(while_statement) @keyword.repeat
+(return) @keyword.return
 
-(try_statement) @keyword.exception
-
-(return_statement) @keyword.return
-
-(throw_statement) @keyword.exception
-
-(assignment_statement) @operator
-
-(print_statement) @function.builtin
+(print) @function.builtin
 
 (constant) @constant
 
 ; Keywords
-[
-  (function_start)
-  (sub_start)
-  (if_start)
-  (if_then)
-  (if_else)
-  (for_start)
-  (for_to)
-  (for_step)
-  (for_each)
-  (for_in)
-  (while_start)
-  (try_start)
-  (try_catch)
-  (as)
-] @keyword
+(as) @keyword
 
 ; Operators
 [
@@ -102,7 +125,7 @@
 (invalid) @constant.builtin
 
 ; Comments
-(comment) @comment @spell
+(comment) @comment
 
 ; Punctuation
 [
@@ -151,28 +174,4 @@
     ">="
   ] @operator)
 
-; End statements
-[
-  (end_sub)
-  (end_function)
-  (end_if)
-  (end_for)
-  (end_while)
-  (end_try)
-  (conditional_compl_end_if)
-] @keyword
-
-; Special keywords (these might still need to be strings if not defined as separate nodes)
-[
-  "then"
-  "else"
-  "else if"
-  "#else"
-  "#else if"
-] @keyword
-
-; Exit statements
-[
-  (exit_while_statement)
-  (exit_for_statement)
-] @keyword
+(as) @keyword

--- a/queries/brightscript/highlights.scm
+++ b/queries/brightscript/highlights.scm
@@ -98,9 +98,6 @@
 
 (constant) @constant
 
-; Keywords
-(as) @keyword
-
 ; Operators
 [
   "="
@@ -125,7 +122,7 @@
 (invalid) @constant.builtin
 
 ; Comments
-(comment) @comment
+(comment) @comment @spell
 
 ; Punctuation
 [
@@ -135,10 +132,13 @@
   "]"
   "{"
   "}"
+  "?["
+] @punctuation.bracket
+
+[
   "."
   ","
   "?."
-  "?["
 ] @punctuation.delimiter
 
 ; Special highlights for library statements

--- a/queries/brightscript/indents.scm
+++ b/queries/brightscript/indents.scm
@@ -1,0 +1,39 @@
+; Start indentation for block-level constructs
+[
+  (sub_statement)
+  (function_statement)
+  (annonymous_sub)
+  (annonymous_function)
+  (conditional_compl)
+  (multi_line_if)
+  (for_statement)
+  (while_statement)
+  (try_statement)
+  (array)
+  (assoc_array)
+] @indent.begin
+
+; End indentation for all end statements
+[
+  (end_sub)
+  (end_function)
+  (end_if)
+  (end_for)
+  (end_while)
+  (end_try)
+  (conditional_compl_end_if)
+  "]"
+  "}"
+] @indent.branch @indent.end
+
+; Handle branching constructs
+[
+  (else_if_clause)
+  (else_clause)
+  (conditional_compl_else_if_clause)
+  (conditional_compl_else_clause)
+  (catch_clause)
+] @indent.branch
+
+; Ignore comments for indentation
+(comment) @indent.ignore

--- a/queries/brightscript/injections.scm
+++ b/queries/brightscript/injections.scm
@@ -1,0 +1,4 @@
+([
+  (comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/queries/brightscript/injections.scm
+++ b/queries/brightscript/injections.scm
@@ -1,4 +1,2 @@
-([
-  (comment)
-] @injection.content
+((comment) @injection.content
   (#set! injection.language "comment"))


### PR DESCRIPTION
[brightscript language reference](https://developer.roku.com/docs/references/brightscript/language/brightscript-language-reference.md)

> Roku BrightScript is a powerful scripting language that makes it easy and quick to build media and networked applications for embedded devices. 

I built this parser + queries largely last year, and have been using it myself for awhile now, and thought it might be time to make this the official brightscript language parser and queries for nvim-treesitter! The Roku dev community is quite small, but it does exist and I hope this parser can help those that want to use neovim for brightscript development!