### PR TITLE
fix(python): Highlight all types of docstrings

### DIFF
--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -80,27 +80,10 @@
 ] @string.escape
 
 ; doc-strings
-(module
-  .
-  (comment)*
-  .
-  (expression_statement
-    (string
-      (string_content) @spell) @string.documentation))
+(expression_statement
+  (string
+    (string_content) @spell) @string.documentation)
 
-(class_definition
-  body: (block
-    .
-    (expression_statement
-      (string
-        (string_content) @spell) @string.documentation)))
-
-(function_definition
-  body: (block
-    .
-    (expression_statement
-      (string
-        (string_content) @spell) @string.documentation)))
 
 ; Tokens
 [

--- a/queries/python/highlights.scm
+++ b/queries/python/highlights.scm
@@ -84,7 +84,6 @@
   (string
     (string_content) @spell) @string.documentation)
 
-
 ; Tokens
 [
   "-"

--- a/tests/query/highlights/python/docstrings.py
+++ b/tests/query/highlights/python/docstrings.py
@@ -1,0 +1,111 @@
+# Docstrings according to PEP 257 (https://peps.python.org/pep-0257/)
+# <- @comment
+
+"""Module docstring assigned to `__doc__`..."""
+# <- @string.documentation
+"""
+... with an addtional docstring, not part of `__doc__`.
+"""
+# <- @string.documentation
+
+"""
+Some random docstring in the middle if nowhere...
+"""
+# <- @string.documentation
+"""
+... also with not one ...
+"""
+# <- @string.documentation
+"""
+... but two addtional docstrings.
+"""
+# <- @string.documentation
+
+oneline_string_assignment = "not detected as docstring"
+#                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ @string
+#                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ !@string.documentation
+"""Module attribute docstring."""
+# <- @string.documentation
+
+multiline_string_assignment = """
+                              also not detected as docstring
+                              """
+#                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ @string
+#                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !@string.documentation
+
+multiline_string_in_brackets = (
+    "not "
+    # <- @string
+    # <- !@string.documentation
+    "detected "
+    # <- @string
+    # <- !@string.documentation
+    "as docstring, "
+    # <- @string
+    # <- !@string.documentation
+    "either."
+    # <- @string
+    # <- !@string.documentation
+)
+
+
+class A:
+    """
+    Class docstring, assigned to `__doc__`.
+    """
+    # <- @string.documentation
+
+    """
+    Some random docstring again, ...
+    """
+    # <- @string.documentation
+    """
+    ... with an "additional" docstring. Again.
+    """
+    # <- @string.documentation
+
+    foo = "class attribute"
+    #     ^^^^^^^^^^^^^^^^^ @string
+    #     ^^^^^^^^^^^^^^^^^ !@string.documentation
+    """
+    Class attribute docstring, but an attribute 
+    does not have a `__doc__` attribute itself.
+    """
+    # <- @string.documentation
+
+    bar: int
+    """Class attribute docstring, type annotation only."""
+    # <- @string.documentation
+
+    baz: str = "type annotated class attribute"
+    #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ @string
+    #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !@string.documentation
+    """Class attribute docstring, type annotation and assignment."""
+    # <- @string.documentation
+
+    def __init__(self):
+        """Method docstring."""
+        # <- @string.documentation
+
+        self.quux = "instance attribute"
+        #           ^^^^^^^^^^^^^^^^^^^^ @string
+        #           ^^^^^^^^^^^^^^^^^^^^ !@string.documentation
+        """Instance attribute docstring."""
+        # <- @string.documentation
+
+
+def f(x):
+    """Function docstring."""
+    # <- @string.documentation
+    """Addtional function docstring."""
+    # <- @string.documentation
+    return x**2
+
+
+f.a = 1
+"""Function attribute docstring."""
+# <- @string.documentation
+
+
+"Random docstring with single quotes - legal, but far off standard and confusing."
+# <- @string.documentation

--- a/tests/query/highlights/python/docstrings.py
+++ b/tests/query/highlights/python/docstrings.py
@@ -33,7 +33,12 @@ multiline_string_assignment = """
 #                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ @string
 #                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !@string.documentation
 
-multiline_string_in_brackets = (
+looks_like_implicit_string_concatenation = "abc"
+#                                          ^^^^^ @string 
+"def"
+# <- @string.documentation
+
+real_implicit_string_concatenation = (
     "not "
     # <- @string
     # <- !@string.documentation

--- a/tests/query/highlights/python/docstrings.py
+++ b/tests/query/highlights/python/docstrings.py
@@ -38,7 +38,12 @@ looks_like_implicit_string_concatenation = "abc"
 "def"
 # <- @string.documentation
 
-real_implicit_string_concatenation = (
+single_line_implicit_string_concatenation = "abc" "def"
+#                                           ^^^^^ @string 
+#                                                 ^^^^^ @string 
+#                                                 ^^^^^ !@string.documentation 
+
+multiline_implicit_string_concatenation = (
     "not "
     # <- @string
     # <- !@string.documentation


### PR DESCRIPTION
I read [PEP 257](https://peps.python.org/pep-0257/#what-is-a-docstring) again. It says:

> A docstring is a string literal that occurs as the first statement in a module, function, class, or method definition. Such a docstring becomes the `__doc__` special attribute of that object.

but also in the paragraph after the next:

> String literals occurring elsewhere in Python code may also act as documentation.

So, *every* string literal can be treated as a docstring (and is valid for Python as long as the indentation is correct), even with single quotes.

Since we are not distinguishing between
- docstrings that become the `__doc__` special attribute,
- package / module / class / function / attribute docstrings and 
- additional docstrings,

my suggestions is to just say: Every standalone string in a Python script is a documenting string (but not necessarily *the* docstring).

The highlight query then just boils down to

```
(expression_statement
  (string
    (string_content) @spell) @string.documentation)
```

If one would want to distinguish between the different types of docstrings, then this is obviously not sufficient, but I personally cannot imagine how one would benefit from that.
Differentiating between comments and docstrings, yes, sure, but not between types of docstrings.

Fixes #7786 