### PR TITLE
ci(tests): run tests on v0.10.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install and prepare Neovim
         env:
-          NVIM_TAG: stable
+          NVIM_TAG: v0.10.4
         run: |
           bash ./scripts/ci-install.sh
 


### PR DESCRIPTION
plenary.busted seems to be broken (you could even say... "busted" 😬 ) on Nvim 0.11, so stick with v0.10.4 on `master`.