### PR TITLE
fix(svelte): `else if` instruction is not properly highlighted

### DIFF
--- a/queries/svelte/highlights.scm
+++ b/queries/svelte/highlights.scm
@@ -14,6 +14,7 @@
 
 [
   "if"
+  "else if"
   "else"
   "then"
 ] @keyword.conditional


### PR DESCRIPTION
Currently, `else if` instruction in svelte is not highlighted (please see the screenshot). This pull request fixes the issue. Tested it locally and it works as expected.

![svelte](https://github.com/user-attachments/assets/cd5f4645-836b-4a04-933d-e22ff0ed8dff)