### PR TITLE
feat(yaml): inject bash for Taskfiles

### DIFF
--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -2,9 +2,10 @@
   (#set! injection.language "comment"))
 
 ; Github actions ("run") / Gitlab CI ("scripts")
+; Taskfile scripts ("cmds", "sh")
 (block_mapping_pair
   key: (flow_node) @_run
-  (#any-of? @_run "run" "script" "before_script" "after_script")
+  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "sh")
   value: (flow_node
     (plain_scalar
       (string_scalar) @injection.content)
@@ -12,7 +13,7 @@
 
 (block_mapping_pair
   key: (flow_node) @_run
-  (#any-of? @_run "run" "script" "before_script" "after_script")
+  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "sh")
   value: (block_node
     (block_scalar) @injection.content
     (#set! injection.language "bash")
@@ -20,7 +21,7 @@
 
 (block_mapping_pair
   key: (flow_node) @_run
-  (#any-of? @_run "run" "script" "before_script" "after_script")
+  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "sh")
   value: (block_node
     (block_sequence
       (block_sequence_item
@@ -31,7 +32,7 @@
 
 (block_mapping_pair
   key: (flow_node) @_run
-  (#any-of? @_run "script" "before_script" "after_script")
+  (#any-of? @_run "script" "before_script" "after_script" "cmds" "sh")
   value: (block_node
     (block_sequence
       (block_sequence_item

--- a/tests/query/injections/yaml/bash-on-taskfiles.yml
+++ b/tests/query/injections/yaml/bash-on-taskfiles.yml
@@ -1,0 +1,15 @@
+# https://taskfile.dev
+
+version: '3'
+
+vars:
+  GREETING:
+    sh: echo "Hello, World!"
+    #   ^ @bash
+
+tasks:
+  default:
+    cmds:
+      - echo "{{.GREETING}}"
+    #   ^ @bash
+    silent: true


### PR DESCRIPTION
This change would inject bash for yaml [Taskfiles](https://taskfile.dev/) like is currently done for yaml Gitlab/Github pipeline configs. I found it helpful in my config so I thought it could be nice to share with others (especially since it's a simple change to the current injections).

Before:

<img width="519" alt="Screenshot 2025-04-06 at 7 05 08 PM" src="https://github.com/user-attachments/assets/413bfafc-ec19-4e70-8940-6acad2fcfbc7" />

After: 

<img width="519" alt="Screenshot 2025-04-06 at 7 03 23 PM" src="https://github.com/user-attachments/assets/6b47336d-0811-476c-9106-9a69ec105a19" />


