### PR TITLE
More bash injection support for Taskfile

### DIFF
--- a/queries/yaml/injections.scm
+++ b/queries/yaml/injections.scm
@@ -2,10 +2,10 @@
   (#set! injection.language "comment"))
 
 ; Github actions ("run") / Gitlab CI ("scripts")
-; Taskfile scripts ("cmds", "sh")
+; Taskfile scripts ("cmds", "cmd", "sh")
 (block_mapping_pair
   key: (flow_node) @_run
-  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "sh")
+  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "cmd" "sh")
   value: (flow_node
     (plain_scalar
       (string_scalar) @injection.content)
@@ -13,7 +13,7 @@
 
 (block_mapping_pair
   key: (flow_node) @_run
-  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "sh")
+  (#any-of? @_run "run" "script" "before_script" "after_script" "cmds" "cmd" "sh")
   value: (block_node
     (block_scalar) @injection.content
     (#set! injection.language "bash")

--- a/tests/query/injections/yaml/bash-on-taskfiles.yml
+++ b/tests/query/injections/yaml/bash-on-taskfiles.yml
@@ -13,3 +13,12 @@ tasks:
       - echo "{{.GREETING}}"
     #   ^ @bash
     silent: true
+  cmd:
+    cmd: echo "{{.GREETING}}"
+    #    ^ @bash
+    silent: true
+  cmd-block:
+    cmd: |
+      echo "{{.GREETING}}"
+    # ^ @bash
+    silent: true


### PR DESCRIPTION
This builds on the excellent addition bash injections in taskfiles in #7804 
I saw that `cmd` was missing both with and without multiline.

Before:
<img width="277" alt="Screenshot 2025-04-07 at 21 03 15" src="https://github.com/user-attachments/assets/5c5ba0d2-d21d-4a21-84ec-62a688cbcc5c" />

After:
<img width="306" alt="Screenshot 2025-04-07 at 21 02 03" src="https://github.com/user-attachments/assets/89b03546-4cb1-4056-b998-e418b1a6f00e" />
