### PR TITLE
fix(installer): remove deprecated `--no-bindings` cli flag

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -360,10 +360,17 @@ local function run_install(cache_folder, install_folder, lang, repo, with_sync, 
   else
     if not M.ts_generate_args then
       local ts_cli_version = utils.ts_cli_version()
-      if ts_cli_version and vim.split(ts_cli_version, " ")[1] > "0.20.2" then
-        M.ts_generate_args = { "generate", "--no-bindings", "--abi", vim.treesitter.language_version }
+      if ts_cli_version then
+        local version_str = vim.split(ts_cli_version, " ")[1]
+        if version_str > "0.24.7" then
+          M.ts_generate_args = { "generate", "--abi", vim.treesitter.language_version }
+        elseif version_str > "0.20.2" then
+          M.ts_generate_args = { "generate", "--no-bindings", "--abi", vim.treesitter.language_version }
+        else
+          M.ts_generate_args = { "generate", "--no-bindings" }
+        end
       else
-        M.ts_generate_args = { "generate", "--no-bindings" }
+        M.ts_generate_args = { "generate", "--no-bindings" }  -- Fallback
       end
     end
   end


### PR DESCRIPTION
See https://github.com/tree-sitter/tree-sitter/pull/4292

The flag will let the installation of latex parser error.

```plaintext
nvim-treesitter[latex]: Error during "tree-sitter generate"                                                            
The --no-bindings flag is no longer used and will be removed in v0.25.0thread 'main' panicked at /usr/share/cargo/regis
try/tree-sitter-generate-0.24.7/src/render.rs:1703:5:                                                                  
This version of Tree-sitter can only generate parsers with ABI version 13 - 14, not 15                                 
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
``` 