### PR TITLE
fix(brightscript): Updating parser filetype for brightscript: brs

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -221,6 +221,7 @@ list.brightscript = {
     url = "https://github.com/ajdelcimmuto/tree-sitter-brightscript",
     files = { "src/parser.c" },
   },
+  filetype = "brs",
   maintainers = { "@ajdelcimmuto" },
 }
 


### PR DESCRIPTION
After testing out the recently merged brightscript parser, I noticed I missed the specification of filetype. Filetypes for brightscript should be identified as `brs`. The parser / highlights was not working out of the box for me, and I had to set it explicitly in my lua config like this:
 `vim.treesitter.language.register('brightscript', 'brs')`
 
 I am hoping this change will allow for treesitter parser to work out of the box for `brs` filetype.