### PR TITLE
feat(queries/nix): add support for pipe operator

### DIFF
--- a/queries/nix/highlights.scm
+++ b/queries/nix/highlights.scm
@@ -186,6 +186,8 @@ function: (select_expression
   "="
   "@"
   "?"
+  "<|"
+  "|>"
 ] @operator
 
 ; integers, also highlight a unary -


### PR DESCRIPTION
can be confirmed by enabling the experimental `pipe-operators` in nixos/nix and `pipe-operator` in lix.