### PR TITLE
feat(typespec): update typespec highlights and indents, add folds

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -861,7 +861,7 @@
     "revision": "75b3874edb2dc714fb1fd77a32013d0f8699989f"
   },
   "typespec": {
-    "revision": "42fb163442ef2691b9b720fb4e4e846809415d18"
+    "revision": "0a0575a4754a089efdca4248a7c31bb7cfd77921"
   },
   "typoscript": {
     "revision": "5d8fde870b0ded1f429ba5bb249a9d9f8589ff5f"

--- a/queries/typespec/folds.scm
+++ b/queries/typespec/folds.scm
@@ -1,0 +1,8 @@
+[
+  (model_expression)
+  (namespace_statement)
+  (interface_statement)
+  (enum_statement)
+  (object_value)
+  (array_value)
+] @fold

--- a/queries/typespec/highlights.scm
+++ b/queries/typespec/highlights.scm
@@ -4,6 +4,7 @@
   "is"
   "extends"
   "valueof"
+  "typeof"
 ] @keyword.operator
 
 [
@@ -29,6 +30,8 @@
   "using"
 ] @keyword.import
 
+"const" @keyword
+
 [
   "("
   ")"
@@ -38,6 +41,8 @@
   ">"
   "["
   "]"
+  "#{"
+  "#["
 ] @punctuation.bracket
 
 [
@@ -109,6 +114,9 @@
 (interface_statement
   name: (identifier) @type)
 
+(interface_member
+  name: (identifier) @function.method)
+
 (enum_statement
   name: (identifier) @type)
 
@@ -133,3 +141,9 @@
 (operation_arguments
   (model_property
     name: (identifier) @variable.parameter))
+
+(const_statement
+  name: (identifier) @variable)
+
+(object_member
+  key: (identifier) @variable.member)

--- a/queries/typespec/indents.scm
+++ b/queries/typespec/indents.scm
@@ -8,6 +8,9 @@
   (template_arguments)
   (template_parameters)
   (operation_arguments)
+  (decorator_arguments)
+  (object_value)
+  (array_value)
 ] @indent.begin
 
 [


### PR DESCRIPTION
The language added values and a few other changes a while ago, and I just now got around to adding that to the parser. This also updates the revision, which I see is normally done by a bot, so tell me if I should handle that differently.

The updated highlights, indents and folds come directly from the `tree-sitter-typespec` repository itself.