### PR TITLE
error reporting: say what query and language it was when failing to load queries

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -105,7 +105,12 @@ do
   ---@param query_name string
   function M.get_query(lang, query_name)
     if cache[lang][query_name] == nil then
-      cache[lang][query_name] = ts.get_query(lang, query_name)
+      local ok, err = pcall(function()
+        cache[lang][query_name] = ts.get_query(lang, query_name)
+      end)
+      if not ok then
+        error("Failed when loading query " .. query_name .. " for language " .. lang .. " error: \n" .. err)
+      end
     end
 
     return cache[lang][query_name]


### PR DESCRIPTION
This is the bare minimum to not make it exceedingly painful to debug query load failures.

Fixes: https://github.com/neovim/neovim/issues/33362