### PR TITLE
fix(nu): add missing `ctrl_match` to query files

### DIFF
--- a/queries/nu/folds.scm
+++ b/queries/nu/folds.scm
@@ -2,6 +2,7 @@
   (attribute_list)
   (block)
   (command_list)
+  (ctrl_match)
   (parameter_bracks)
   (record_body)
   (val_list)

--- a/queries/nu/indents.scm
+++ b/queries/nu/indents.scm
@@ -2,6 +2,7 @@
 ; Copyright (c) 2019 - 2022 The Nushell Project Developers
 ; Licensed under the MIT license.
 [
+  (ctrl_match)
   (expr_parenthesized)
   (parameter_bracks)
   (val_record)


### PR DESCRIPTION
Fixes indents/folds for match statements, e.g.

```nushell
match $foo {
  true => 0
  _ => 1
}
```