### PR TITLE
feat(java) mark instanceof pattern variables as @local.definition.var

### DIFF
--- a/queries/java/locals.scm
+++ b/queries/java/locals.scm
@@ -74,6 +74,10 @@
   ; for (var item : items) {
   name: (identifier) @local.definition.var)
 
+(instanceof_expression
+	; sup instanceof Sub sub
+  name: (identifier) @local.definition.var)
+
 (formal_parameter
   name: (identifier) @local.definition.parameter)
 


### PR DESCRIPTION
This addresses part of #7828. Specifically, it marks the variable declaration as such. But I did not manage to assign the correct scope.