### PR TITLE
feat(bash): highlight variable argument for `printf -v`

### DIFF
--- a/queries/bash/highlights.scm
+++ b/queries/bash/highlights.scm
@@ -247,6 +247,17 @@
     "READLINE_ARGUMENT" "READLINE_LINE" "READLINE_MARK" "READLINE_POINT" "REPLY" "SECONDS" "SHELL"
     "SHELLOPTS" "SHLVL" "SRANDOM" "TIMEFORMAT" "TMOUT" "TMPDIR" "UID"))
 
+((command
+  name: (command_name
+    (word) @_printf)
+  .
+  argument: (word) @_v
+  .
+  argument: (word) @variable)
+  (#eq? @_printf "printf")
+  (#eq? @_v "-v")
+  (#lua-match? @variable "^[a-zA-Z_][a-zA-Z0-9_]*$"))
+
 (case_item
   value: (word) @variable.parameter)
 


### PR DESCRIPTION
Example:

```bash
printf -v var 'hello\nworld'
        # ^^^ this gets highlighted as @variable
```