### PR TITLE
Update to Gleam latest version

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -255,7 +255,7 @@
     "revision": "f4685bf11ac466dd278449bcfe5fd014e94aa504"
   },
   "gleam": {
-    "revision": "99ec4101504452c488b7c835fb65cfef75b090b7"
+    "revision": "6ece453acf8b14568c10f629f8cd25d3dde3794f"
   },
   "glimmer": {
     "revision": "da605af8c5999b43e6839b575eae5e6cafabb06f"


### PR DESCRIPTION
The version previously locked to didn't support all Gleam syntax of Gleam v1.11.0.

I'm unfamiliar with this repo, so apologies if this isn't the correct process for updating this.