### PR TITLE
ci(test): throttle all install steps

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -33,7 +33,7 @@ jobs:
 
       - if: inputs.type == 'build'
         name: Compile parsers
-        run: $NVIM -l ./scripts/install-parsers.lua
+        run: $NVIM -l ./scripts/install-parsers.lua --max-jobs=10
 
       - if: inputs.type == 'generate'
         name: Generate and compile parsers


### PR DESCRIPTION
Poor Windows runners can't handle unthrottled parallel install 😞 