### PR TITLE
fix(haskell): properly set inline-python injection language

### DIFF
--- a/runtime/queries/haskell/injections.scm
+++ b/runtime/queries/haskell/injections.scm
@@ -79,6 +79,7 @@
 ; Python
 ; inline-python
 (quasiquote
-  (quoter) @injection.language
-  (#any-of? @injection.language "pymain" "pye" "py_" "pyf")
-  (quasiquote_body) @injection.content)
+  (quoter) @_name
+  (#any-of? @_name "pymain" "pye" "py_" "pyf")
+  (quasiquote_body) @injection.content
+  (#set! injection.language "python"))


### PR DESCRIPTION
Supersedes #7895.