### PR TITLE
feat(install): Add a `quite` option to the `install()` method

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -431,6 +431,7 @@ end
 ---@field force? boolean
 ---@field generate? boolean
 ---@field max_jobs? integer
+---@field quiet? boolean
 
 --- Install a parser
 ---@async
@@ -461,7 +462,9 @@ local function install(languages, options)
   join(options and options.max_jobs or MAX_JOBS, task_funs)
   if #task_funs > 1 then
     a.schedule()
-    log.info('Installed %d/%d languages', done, #task_funs)
+    if not options.quiet then
+      log.info('Installing %d/%d languages', done, #task_funs)
+    end
   end
   return done == #task_funs
 end


### PR DESCRIPTION
This flag skips the "[nvim-treesitter]: Installed X/X languages" message.

fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/7872