### PR TITLE
fix(install): don't print operation summary by default

### DIFF
--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -125,16 +125,21 @@ install({languages} [, {opts}])                      *nvim-treesitter.install()*
                      compiling.
                    • {max_jobs} (`integer?`) limit parallel tasks (useful in
                      combination with {generate} on memory-limited systems).
+                   • {summary} (`boolean?`, default `false`) print summary of
+                     successful and total operations for multiple languages.
 
-uninstall({languages})                             *nvim-treesitter.uninstall()*
+uninstall({languages} [, {opts}])                  *nvim-treesitter.uninstall()*
 
     Remove the parser and queries for the specified language(s).
 
     Parameters: ~
     • {languages}  `(string[]|string)` (List of) languages or tiers (`stable`,
                    `unstable`) to update.
+    • {opts}       `(table?)` Optional parameters:
+                   • {summary} (`boolean?`, default `false`) print summary of
+                     successful and total operations for multiple languages.
 
-update([{languages}])                                 *nvim-treesitter.update()*
+update([{languages}, {opts}])                         *nvim-treesitter.update()*
 
     Update the parsers and queries if older than the revision specified in the
     manifest.
@@ -147,6 +152,11 @@ update([{languages}])                                 *nvim-treesitter.update()*
     Parameters: ~
     • {languages}  `(string[]|string)?` (List of) languages or tiers to update
                    (default: all installed).
+    • {opts}       `(table?)` Optional parameters:
+                   • {max_jobs} (`integer?`) limit parallel tasks (useful in
+                     combination with {generate} on memory-limited systems).
+                   • {summary} (`boolean?`, default `false`) print summary of
+                     successful and total operations for multiple languages.
 
 indentexpr()                                      *nvim-treesitter.indentexpr()*
 
@@ -165,6 +175,12 @@ get_installed([{type}])                        *nvim-treesitter.get_installed()*
 
     Return list of languages installed via `nvim-treesitter`.
 
+    Note: This only searches `nvim-treesitter`'s (configured or default)
+    installation directory; parsers and queries from other sources can be
+    placed anywhere on 'runtimepath' and are not included. To list all, e.g.,
+    parsers that are installed from any source, use >lua
+        vim.api.nvim_get_runtime_file('parser/*', true)
+<
     Parameters: ~
     • {type}  `('queries'|parsers'?)` If specified, only show languages with
               installed queries or parsers, respectively.

--- a/plugin/nvim-treesitter.lua
+++ b/plugin/nvim-treesitter.lua
@@ -27,7 +27,7 @@ end
 
 -- create user commands
 api.nvim_create_user_command('TSInstall', function(args)
-  require('nvim-treesitter.install').install(args.fargs, { force = args.bang })
+  require('nvim-treesitter.install').install(args.fargs, { force = args.bang, summary = true })
 end, {
   nargs = '+',
   bang = true,
@@ -39,6 +39,7 @@ end, {
 api.nvim_create_user_command('TSInstallFromGrammar', function(args)
   require('nvim-treesitter.install').install(args.fargs, {
     generate = true,
+    summary = true,
     force = args.bang,
   })
 end, {
@@ -50,7 +51,7 @@ end, {
 })
 
 api.nvim_create_user_command('TSUpdate', function(args)
-  require('nvim-treesitter.install').update(args.fargs)
+  require('nvim-treesitter.install').update(args.fargs, { summary = true })
 end, {
   nargs = '*',
   bar = true,
@@ -59,7 +60,7 @@ end, {
 })
 
 api.nvim_create_user_command('TSUninstall', function(args)
-  require('nvim-treesitter.install').uninstall(args.fargs)
+  require('nvim-treesitter.install').uninstall(args.fargs, { summary = true })
 end, {
   nargs = '+',
   bar = true,

--- a/scripts/install-parsers.lua
+++ b/scripts/install-parsers.lua
@@ -19,10 +19,10 @@ end
 vim.opt.runtimepath:append('.')
 
 ---@type async.Task
-local task = update and require('nvim-treesitter').update('all')
+local task = update and require('nvim-treesitter').update('all', { summary = true })
   or require('nvim-treesitter').install(
     #parsers > 0 and parsers or 'all',
-    { force = true, generate = generate, max_jobs = max_jobs }
+    { force = true, summary = true, generate = generate, max_jobs = max_jobs }
   )
 
 local ok, err_or_ok = task:pwait(1800000) -- wait max. 30 minutes


### PR DESCRIPTION
Problem: People complain about noisy `install()`.

Solution: Gate operation summary behind `summary` install option
(default false, set to true for interactive `:TS*` commands).
