### PR TITLE
feat(haskell) injections for inline-c-cpp quasiquotes

### DIFF
--- a/queries/haskell/injections.scm
+++ b/queries/haskell/injections.scm
@@ -82,3 +82,18 @@
   (quoter) @injection.language
   (#any-of? @injection.language "pymain" "pye" "py_" "pyf")
   (quasiquote_body) @injection.content)
+
+; -----------------------------------------------------------------------------
+; CPP
+; inline-c-cpp
+((quasiquote
+  (quoter
+    (qualified
+      module: (module (module_id) @_module)
+      id: (variable) @_id))
+  body: (quasiquote_body) @injection.content)
+ (#eq? @_module "C")
+ (#any-of? @_id "exp" "block")
+ (#set! injection.language "cpp")
+ (#set! injection.include-children)
+ (#set! injection.pattern "^\\$[a-zA-Z_][a-zA-Z0-9_]*:[a-zA-Z_][a-zA-Z0-9_]*$"))


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2c3d17ab-a4a5-4a1b-9f7e-88d24999834b)
the pattern for antiquotes ( `$solid:solid` `$pnt:p`) helps but for some reason antiquotes in the the first statement after `double {` are not highlighted in the same way and it seems like there are other errors though I don't know c++.