### PR TITLE
fix(git_config): match full-lowercase Git config variables

### DIFF
--- a/runtime/queries/git_config/highlights.scm
+++ b/runtime/queries/git_config/highlights.scm
@@ -7,7 +7,7 @@
 ((section_header
   (section_name) @keyword.import
   (subsection_name))
-  (#eq? @keyword.import "includeIf"))
+  (#any-of? @keyword.import "includeIf" "includeif"))
 
 (variable
   (name) @property)
@@ -47,7 +47,7 @@
 ((variable
   (name) @_name
   value: (string) @string.special.url)
-  (#eq? @_name "insteadOf"))
+  (#any-of? @_name "insteadOf" "insteadof"))
 
 ; Punctuation
 [

--- a/runtime/queries/git_config/injections.scm
+++ b/runtime/queries/git_config/injections.scm
@@ -4,7 +4,7 @@
 ((variable
   (name) @_name
   value: (string) @injection.content)
-  (#any-of? @_name "cmd" "command" "textconv" "sendmailCmd")
+  (#any-of? @_name "cmd" "command" "textconv" "sendmailCmd" "sendmailcmd")
   (#set! injection.language "bash"))
 
 (section
@@ -29,7 +29,7 @@
     (name) @_name
     value: (string) @injection.content)
   (#eq? @_interactive "interactive")
-  (#eq? @_name "diffFilter")
+  (#any-of? @_name "diffFilter" "difffilter")
   (#set! injection.language "bash"))
 
 ; https://github.com/git-lfs/git-lfs


### PR DESCRIPTION
Git config's sections, variable names, and (often) subsections are case-insensitive.

Source: https://github.com/git/git/blob/master/Documentation/config.adoc (`git help config`)

---

Instead of doing a full case-insensitive matching in the (few) places where we'd put the non-normalised variable names, I went for `#any-of?` because:
1. What are the chances anybody would use any casing other than `lowerCamelCase` or `lowercase`?
2. Nobody wants to read `(#lua-match? @keyword.import "^[iI][nN][cC][lL][uU][dD][eE][Ii][fF]$"))`
3. `#any-of` is generally cheaper (read: faster) to run

Oh, and it's a rule in the `CONTRIBUTING` guildelines!
I also ran `luacheck` and `stylua`.
