### PR TITLE
fix(bash): highlight shebang also when spaced

### DIFF
--- a/runtime/queries/bash/highlights.scm
+++ b/runtime/queries/bash/highlights.scm
@@ -269,4 +269,4 @@
 ((program
   .
   (comment) @keyword.directive @nospell)
-  (#lua-match? @keyword.directive "^#!/"))
+  (#lua-match? @keyword.directive "^#![ \t]*/"))


### PR DESCRIPTION
This commit aligns the shebang highlighting in bash syntax to what the Linux kernel will recognise as a valid shebang construct.

In summary, the kernel will accept both headers:

    #!/usr/bin/env lua
    #! /usr/bin/env lua

The second one is quite prominently used throughout documentation online, such as on Wikipedia's page for Shebang (Unix) [1].

Some sources are adamant it wouldn't be supported at a kernel level, but it looks to me, upon closer inspection of the current kernel code [2], that it is indeed quite evidently valid.  It'll simply skip over to the first character that's neither a space 0x20 nor a tab 0x09.

[1] https://en.wikipedia.org/wiki/Shebang_(Unix)
[2] https://github.com/torvalds/linux/blob/ec7714e4947909190ffb3041a03311a975350fe0/fs/binfmt_script.c#L44-L71