### PR TITLE
feat(cpp): highlight template method call

### DIFF
--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -154,6 +154,11 @@
   (field_expression
     (field_identifier) @function.method.call))
 
+(call_expression
+  (field_expression
+    (template_method
+      (field_identifier) @function.method.call)))
+
 ; constructors
 ((function_declarator
   (qualified_identifier


### PR DESCRIPTION
Example: `method` in `stuff.method<X>(args)`