### PR TITLE
fix(query): parse before access trees

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -437,6 +437,7 @@ function M.get_capture_matches_recursively(bufnr, capture_or_fn, query_type)
   local matches = {}
 
   if parser then
+    parser:parse()
     parser:for_each_tree(function(tree, lang_tree)
       local lang = lang_tree:lang()
       local capture, type_ = type_fn(lang, tree, lang_tree)


### PR DESCRIPTION
When using [nvim-treesitter-textobjects-lsp-interop](https://github.com/nvim-treesitter/nvim-treesitter-textobjects?tab=readme-ov-file#textobjects-lsp-interop) to peek definition code, if the definition locate at a unopened file, `get_capture_matches_recursively` will return empty because the file have not been parse, and we can't get the range of the definition code. Add the missing `parse:parse()` to fix it.