### PR TITLE
fix: use `@tag` for css universal selector

### DIFF
--- a/queries/css/highlights.scm
+++ b/queries/css/highlights.scm
@@ -27,10 +27,7 @@
   (feature_name)
 ] @property
 
-[
-  (nesting_selector)
-  (universal_selector)
-] @character.special
+(nesting_selector) @character.special
 
 (function_name) @function
 
@@ -57,6 +54,8 @@
 ] @keyword.operator
 
 (important) @keyword.modifier
+
+(universal_selector) @tag
 
 (attribute_selector
   (plain_value) @string)


### PR DESCRIPTION
Right now, the "*" `universal_selector` isn't actually even highlighted as `character.special`, but as `operator`, because the "*" a few lines below overrides it. I began to fix this by moving the line below the line setting * as operator, but then I thought that `tag` would make more sense as a capture than a special character. `tag` in CSS highlighting is almost the generic selector color and I think it is fitting, other uses of `character.special` (like for the `nesting_selector` feel different.