### PR TITLE
feat(vue): add template commentstring metadata

### DIFF
--- a/runtime/queries/vue/highlights.scm
+++ b/runtime/queries/vue/highlights.scm
@@ -41,3 +41,6 @@
     (attribute_value) @none))
 
 (directive_modifier) @function.method
+
+((template_element) @_template
+  (#set! @_template bo.commentstring "<!-- %s -->"))


### PR DESCRIPTION
### Rational: 

I saw other queries setting the comment string (https://github.com/nvim-treesitter/nvim-treesitter/pull/7704)

Given that inside a <script> and <style> tag I can comment a line (I think this is due to @injection.language), I would expect the same to be applied to the vue file when commenting html.

IMO given that the default vue content is html this should be the default functionality. If there is a more correct approach please LMK.

See full context: https://github.com/nvim-treesitter/nvim-treesitter/pull/7954