### PR TITLE
Adds a Tree-sitter parser for Seed7 and removes ada.

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -722,6 +722,9 @@
   "scss": {
     "revision": "c478c6868648eff49eb04a4df90d703dc45b312a"
   },
+  "seed7": {
+    "revision": "dd023d4247245aaa79fa58b1e9471fae0950d61d"
+  },
   "sflog": {
     "revision": "3597575a429766dd7ecce9f5bb97f6fec4419d5d"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2090,6 +2090,16 @@ list.scss = {
   maintainers = { "@elianiva" },
 }
 
+list.seed7 = {
+  install_info = {
+    url = "https://github.com/Aliqyan-21/tree-sitter-seed7",
+    branch = "main",
+    files = { "src/parser.c" },
+  },
+  filetype = "sd7",
+  maintainers = { "@aliqyan-21" },
+}
+
 list.sflog = {
   install_info = {
     url = "https://github.com/aheber/tree-sitter-sfapex",

--- a/queries/seed7/highlights.scm
+++ b/queries/seed7/highlights.scm
@@ -1,0 +1,68 @@
+; Keywords
+(kDollar) @keyword
+(kInclude) @keyword
+(kConst) @keyword
+(kVar) @keyword
+(kFunc) @keyword
+(kIs) @keyword
+(kLocal) @keyword
+(kBegin) @keyword
+(kEndFunc) @keyword
+(kIf) @keyword
+(kThen) @keyword
+(kElsif) @keyword
+(kElse) @keyword
+(kEndIf) @keyword
+(kFor) @keyword
+(kRange) @keyword
+(kTo) @keyword
+(kDo) @keyword
+(kEndFor) @keyword
+(kRepeat) @keyword
+(kUntil) @keyword
+(kWhile) @keyword
+(kEndWhile) @keyword
+(kCase) @keyword
+(kOf) @keyword
+(kWhen) @keyword ; New
+(kOtherwise) @keyword
+(kEndCase) @keyword
+; Identifiers
+(identifier) @variable
+(declVar (identifier) @variable)
+(declConst (identifier) @constant)
+(exprCall (identifier) @function)
+(stmtFor (identifier) @variable)
+(exprAssign (identifier) @variable)
+; Types
+(typeProc) @type
+(typeString) @type
+(typeInteger) @type
+; Literals
+(string) @string
+(integer) @number
+; Operators
+(kConcat) @operator
+(kEq) @operator
+(kNeq) @operator
+(kLt) @operator
+(kGt) @operator
+(kLeq) @operator
+(kGeq) @operator
+(kAssign) @operator
+(kPlus) @operator
+(kMinus) @operator
+(kMult) @operator
+(kDiv) @operator
+(kRangeOp) @operator ; New
+(kSetUnion) @operator ; New
+; Punctuation
+":" @punctuation.delimiter
+";" @punctuation.delimiter
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"{" @punctuation.bracket ; New
+"}" @punctuation.bracket ; New
+(kEndDot) @punctuation.delimiter
+; Comments
+(comment) @comment


### PR DESCRIPTION
- Parser: https://github.com/aliqyan-21/tree-sitter-seed7
- Features: Supports includes, constants, functions, variables, control structures (if, for, while, repeat, case with when), expressions (identifiers, strings, integers, function calls, concatenation, comparisons, assignments, arithmetic, set literals, ranges, set unions), types (proc, string, integer), and comments.
- Includes highlights.scm for Neovim syntax highlighting.
- Filetype: sd7