### PR TITLE
feat(D): Add missing string highlights

### DIFF
--- a/queries/d/highlights.scm
+++ b/queries/d/highlights.scm
@@ -265,6 +265,9 @@
   (creal)
   (double)
   (cfloat)
+  (string)
+  (dstring)
+  (wstring)
 ] @type.builtin
 
 ; Functions


### PR DESCRIPTION
I merely copied the fix from https://github.com/gdamore/tree-sitter-d/issues/54 and applied it here so it will be available upstream.