### PR TITLE
feat(cpp): add export, import, module highlighting

### DIFF
--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -225,6 +225,12 @@
 ] @keyword.type
 
 [
+  "export"
+  "import"
+  "module"
+] @keyword.import
+
+[
   "co_await"
   "co_yield"
   "co_return"


### PR DESCRIPTION
Adds highlighting for the C++20 `export`, `import`, and `module` keywords using the `@keyword.import` group. These keywords are parsed in the Treesitter grammar but were not previously captured for highlighting.

<small>_(Note: This is a resubmission because the original PR #7982 was based on the frozen master branch.)_</small>

## Comparisons
### Retrobox
 <table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/c7eab72d-c042-47fe-b936-fba224603ee0" alt="Before"></td>
    <td><img src="https://github.com/user-attachments/assets/7a0c61e0-29aa-414b-bb13-4ba90d42d4f5" alt="After"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/71d2a887-1f77-45ec-b03d-7a644391d32c" alt="Before"></td>
    <td><img src="https://github.com/user-attachments/assets/05ce07e9-f373-404c-b4a1-6663cea29552" alt="After"></td>
  </tr>
</table>

### Tokyo Night (Night Variant)
 <table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/76eb0be4-12b3-4cb1-bf2f-20c839678202" alt="Before"></td>
    <td><img src="https://github.com/user-attachments/assets/0ce61071-919a-4b71-82c4-bd2dc6cebda6" alt="After"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/efe845de-f62f-48bd-afd3-8ebe086bbe6f" alt="Before"></td>
    <td><img src="https://github.com/user-attachments/assets/8d290741-60d8-4bfd-a6d5-a2c2b9c72c30" alt="After"></td>
  </tr>
</table>


