### PR TITLE
fix(http): prefer folding requests directly

### DIFF
--- a/runtime/queries/http/folds.scm
+++ b/runtime/queries/http/folds.scm
@@ -1,5 +1,5 @@
 [
-  (section)
+  (request)
   (json_body)
   (variable_declaration)+
 ] @fold


### PR DESCRIPTION
Folding sections is often "too much" and "lacks semantics", i.e., a section is a broad concept. Here's an example:

Original file:

![image](https://github.com/user-attachments/assets/779a93ae-e33a-496f-be21-ff9d070f8634)

Current behavior (zM):

![image](https://github.com/user-attachments/assets/c82f9bab-3a99-4784-8d45-0f575354d833)

New behavior (zM):

![image](https://github.com/user-attachments/assets/342e3963-2eba-45de-881c-a60167bb7eb7)


