### PR TITLE
feat(vim): highlight "trim" in script heredocs

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2499,7 +2499,7 @@ return {
   },
   vim = {
     install_info = {
-      revision = 'ccc312e878aa84f32d180b8528a3585c7b86a545',
+      revision = 'a93e834bea0975ec0ccb3f6d18540e9bd8170a4d',
       url = 'https://github.com/tree-sitter-grammars/tree-sitter-vim',
     },
     maintainers = { '@clason' },

--- a/runtime/queries/vim/highlights.scm
+++ b/runtime/queries/vim/highlights.scm
@@ -253,6 +253,9 @@
 (heredoc
   (parameter) @keyword)
 
+(script
+  (parameter) @keyword)
+
 [
   (marker_definition)
   (endmarker)


### PR DESCRIPTION
Allow the optional "trim", as documented in ":help :lua-heredoc".
