### PR TITLE
feat(fga): add FGA grammar

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -80,7 +80,7 @@ ecma (queries only)[^ecma] | unstable | `HFIJL` |   | @steelsojka
 [facility](https://github.com/FacilityApi/tree-sitter-facility) | unstable | `HFIJ ` |   | @bryankenote
 [faust](https://github.com/khiner/tree-sitter-faust) | unstable | `H  J ` |   | @khiner
 [fennel](https://github.com/alexmozaidze/tree-sitter-fennel) | unstable | `HF JL` |   | @alexmozaidze
-[fga](https://github.com/matoous/tree-sitter-fga) | unstable | `H    ` |   | @matoous
+[fga](https://github.com/matoous/tree-sitter-fga) | unstable | `H  J ` |   | @matoous
 [fidl](https://github.com/google/tree-sitter-fidl) | unstable | `HF J ` |   | @chaopeng
 [firrtl](https://github.com/tree-sitter-grammars/tree-sitter-firrtl) | unstable | `HFIJL` |   | @amaanq
 [fish](https://github.com/ram02z/tree-sitter-fish) | unstable | `HFIJL` |   | @ram02z

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -80,6 +80,7 @@ ecma (queries only)[^ecma] | unstable | `HFIJL` |   | @steelsojka
 [facility](https://github.com/FacilityApi/tree-sitter-facility) | unstable | `HFIJ ` |   | @bryankenote
 [faust](https://github.com/khiner/tree-sitter-faust) | unstable | `H  J ` |   | @khiner
 [fennel](https://github.com/alexmozaidze/tree-sitter-fennel) | unstable | `HF JL` |   | @alexmozaidze
+[fga](https://github.com/matoous/tree-sitter-fga) | unstable | `H    ` |   | @matoous
 [fidl](https://github.com/google/tree-sitter-fidl) | unstable | `HF J ` |   | @chaopeng
 [firrtl](https://github.com/tree-sitter-grammars/tree-sitter-firrtl) | unstable | `HFIJL` |   | @amaanq
 [fish](https://github.com/ram02z/tree-sitter-fish) | unstable | `HFIJL` |   | @ram02z

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -550,6 +550,14 @@ return {
     maintainers = { '@alexmozaidze' },
     tier = 2,
   },
+  fga = {
+    install_info = {
+      revision = '44bfe4e15dc11969f1a23e5f0fa9d8e961268721',
+      url = 'https://github.com/matoous/tree-sitter-fga',
+    },
+    maintainers = { '@matoous' },
+    tier = 2,
+  },
   fidl = {
     install_info = {
       revision = '0a8910f293268e27ff554357c229ba172b0eaed2',

--- a/runtime/queries/fga/highlights.scm
+++ b/runtime/queries/fga/highlights.scm
@@ -1,0 +1,50 @@
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (selector_expression
+    field: (identifier) @function.method))
+
+((type_identifier) @type.builtin
+  (#match? @type.builtin "^(string|int|map|uint|list|timestamp|bool|duration|double|ipaddress)$"))
+
+(condition_declaration
+  name: (identifier) @function)
+
+(version) @number
+
+[
+  "*"
+  "/"
+  "%"
+  ">>"
+  "<<"
+  "&"
+  "&^"
+] @operator
+
+[
+  "+"
+  "-"
+  "|"
+  "^"
+] @operator
+
+[
+  "or"
+  "and"
+  "but not"
+] @operator
+
+[
+  "model"
+  "schema"
+  "type"
+  "relations"
+  "define"
+  "from"
+] @keyword
+
+"condition" @keyword.function
+
+(comment) @comment

--- a/runtime/queries/fga/highlights.scm
+++ b/runtime/queries/fga/highlights.scm
@@ -6,7 +6,8 @@
     field: (identifier) @function.method))
 
 ((type_identifier) @type.builtin
-  (#match? @type.builtin "^(string|int|map|uint|list|timestamp|bool|duration|double|ipaddress)$"))
+  (#any-of? @type.builtin
+    "string" "int" "map" "uint" "list" "timestamp" "bool" "duration" "double" "ipaddress"))
 
 (condition_declaration
   name: (identifier) @function)
@@ -14,6 +15,17 @@
 (version) @number
 
 [
+  "("
+  ")"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  "+"
+  "-"
+  "|"
+  "^"
   "*"
   "/"
   "%"
@@ -21,30 +33,25 @@
   "<<"
   "&"
   "&^"
-] @operator
-
-[
-  "+"
-  "-"
-  "|"
-  "^"
-] @operator
+] @keyword.operator
 
 [
   "or"
   "and"
   "but not"
-] @operator
+] @keyword.operator
 
 [
   "model"
+  "module"
   "schema"
-  "type"
   "relations"
   "define"
   "from"
 ] @keyword
 
 "condition" @keyword.function
+
+"type" @keyword.operator
 
 (comment) @comment

--- a/runtime/queries/fga/injections.scm
+++ b/runtime/queries/fga/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
FGA is the DSL for [OpenFGA](https://openfga.dev/) authorization models - a zanzibar-like Role-Based Access Control system.

This PR adds the FGA grammar and highlight, which are the only supported queries for the FGA grammar at the moment.

# FGA

A grammer for [OpenFGA](https://github.com/openfga/), an authorization system inspired by Google's Zanzibar. The ANTLR Grammar for the OpenFGA DSL can be found at [openfga/language](https://github.com/openfga/language).

<details>

<summary>Representative code sample</summary>

```
model
  schema 1.1

type user

type organization
relations
  define member : [user]
  define ip_based_access_policy : [organization#member with in_company_network]

type document
relations
  define organization : [organization]      
  define viewer: [user]
  define can_view: viewer and ip_based_access_policy from organization

condition in_company_network(user_ip: ipaddress, cidr: string) {
  user_ip.in_cidr(cidr)
}
```

</details>

## Parser repo

https://github.com/matoous/tree-sitter-fga

<details>
<summary>Parsed tree for code sample</summary>

```
(source_file
  (model
    (schema
      (version)))
  (type_declaration
    (identifier))
  (type_declaration
    (identifier)
    (relations
      (definition
        (identifier)
        (relation_def
          (direct_relationship
            (identifier))))
      (definition
        (identifier)
        (relation_def
          (direct_relationship
            (relation_ref
              (identifier)
              (identifier))
            (conditional
              (identifier)))))))
  (type_declaration
    (identifier)
    (relations
      (definition
        (identifier)
        (relation_def
          (direct_relationship
            (identifier))))
      (definition
        (identifier)
        (relation_def
          (direct_relationship
            (identifier))))
      (definition
        (identifier)
        (relation_def
          (identifier)
          (operator)
          (indirect_relation
            (identifier)
            (identifier))))))
  (condition_declaration
    (identifier)
    (param
      (identifier)
      (type_identifier))
    (param
      (identifier)
      (type_identifier))
    (condition_body
      (call_expression
        (selector_expression
          (identifier)
          (identifier))
        (argument_list
          (identifier))))))
```

</details>

## Queries

Source of queries: https://github.com/matoous/tree-sitter-fga/blob/main/queries/highlights.scm

<details>

<summary>Screenshots of code sample</summary>

<img width="557" height="322" alt="Screenshot 2025-07-12 at 14 57 30" src="https://github.com/user-attachments/assets/6ad4416d-8a89-4768-a19f-006853032ab8" />

</details>


- [x] `./scripts/install-parsers.lua fga` works without warnings
- [x] `./scripts/install-parsers.lua --generate fga` works without warnings
- [ ] `make query` works without warning
- [x] `make docs` is run
