### PR TITLE
fix(install): clear status after install

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -456,7 +456,6 @@ local install_status = {} ---@type table<string,InstallStatus?>
 ---@return InstallStatus status
 local function install_lang(lang, cache_dir, install_dir, force, generate)
   if not force and vim.list_contains(config.get_installed(), lang) then
-    install_status[lang] = 'installed'
     return 'installed'
   end
 
@@ -475,6 +474,7 @@ local function install_lang(lang, cache_dir, install_dir, force, generate)
 
   local status = install_status[lang]
   assert(status and status ~= 'installing')
+  install_status[lang] = nil
   return status
 end
 
@@ -570,7 +570,6 @@ end)
 ---@return string? err
 local function uninstall_lang(logger, lang, parser, queries)
   logger:debug('Uninstalling ' .. lang)
-  install_status[lang] = nil
 
   if fn.filereadable(parser) == 1 then
     logger:debug('Unlinking ' .. parser)


### PR DESCRIPTION
## Details

Currently once the `install_status` is set for a language installing will never proceed, even when `force` is set. For my current setup this prevents updating, some info below in the `Updating` section if it matters.

Regardless of my specific issue I believe the notion of `force` should trigger an install / update when possible. To make this happen I've updated `install_status` so that it is only set for a language while an installation is in progress. After the task is completed `install_status` is cleared for the language. As a consequence of this `install_status` should really only be accessed in the `install_lang` function and can no longer be used to get the result of an installation.

### Updating

What I currently do is always trigger `install` for a list of languages in my config using:

```lua
require('nvim-treesitter').install({ ... })
```

This way if I add any new languages they are automatically installed. As a consequence of this all the languages end up with an `install_status` of `installed`.

After this I'll update my plugins using `lazy.nvim`, this triggers the `:TSUpdate` command, which will not actually update any languages (because of the `install_status`) but output a summary `Installed n/n languages`.