### PR TITLE
feat(groq): Add GROQ grammar

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -117,6 +117,7 @@ ecma (queries only)[^ecma] | unstable | `HFIJL` |   | @steelsojka
 [graphql](https://github.com/bkegley/tree-sitter-graphql) | unstable | `H IJ ` |   | @bkegley
 [gren](https://github.com/MaeBrooks/tree-sitter-gren) | unstable | `H  J ` |   | @MaeBrooks
 [groovy](https://github.com/murtaza64/tree-sitter-groovy) | unstable | `HFIJL` |   | @murtaza64
+[groq](https://github.com/ajrussellaudio/tree-sitter-groq) | unstable | `H    ` |   | @ajrussellaudio
 [gstlaunch](https://github.com/tree-sitter-grammars/tree-sitter-gstlaunch) | unstable | `H    ` |   | @theHamsta
 [hack](https://github.com/slackhq/tree-sitter-hack) | unstable | `H  J ` |   | 
 [hare](https://github.com/tree-sitter-grammars/tree-sitter-hare) | unstable | `HFIJL` |   | @amaanq

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -859,12 +859,8 @@ return {
   },
   groq = {
     install_info = {
-      path = '~/Documents/open-source/tree-sitter-groq',
-      revision = 'HEAD', -- commit hash for revision to check out; HEAD if missing
-      -- optional entries:
-      branch = 'main', -- only needed if different from default branch
-      generate = false, -- only needed if repo does not contain pre-generated `src/parser.c`
-      generate_from_json = false, -- only needed if repo does not contain `src/grammar.json` either
+      revision = '9959049ddeb4416101653a071ee923ba9f7a5cb1',
+      url = 'https://github.com/ajrussellaudio/tree-sitter-groq',
     },
     maintainers = { '@ajrussellaudio' },
     tier = 2,

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -857,6 +857,18 @@ return {
     maintainers = { '@murtaza64' },
     tier = 2,
   },
+  groq = {
+    install_info = {
+      path = '~/Documents/open-source/tree-sitter-groq',
+      revision = 'HEAD', -- commit hash for revision to check out; HEAD if missing
+      -- optional entries:
+      branch = 'main', -- only needed if different from default branch
+      generate = false, -- only needed if repo does not contain pre-generated `src/parser.c`
+      generate_from_json = false, -- only needed if repo does not contain `src/grammar.json` either
+    },
+    maintainers = { '@ajrussellaudio' },
+    tier = 2,
+  },
   gstlaunch = {
     install_info = {
       revision = '549aef253fd38a53995cda1bf55c501174372bf7',

--- a/plugin/filetypes.lua
+++ b/plugin/filetypes.lua
@@ -18,6 +18,7 @@ local filetypes = {
   git_rebase = { 'gitrebase' },
   glimmer = { 'handlebars', 'html.handlebars' },
   godot_resource = { 'gdresource' },
+  groq = { 'groq' },
   haskell = { 'hs' },
   haskell_persistent = { 'haskellpersistent' },
   idris = { 'idris2' },

--- a/runtime/queries/ecma/injections.scm
+++ b/runtime/queries/ecma/injections.scm
@@ -48,6 +48,17 @@
   (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children))
 
+; Sanity CMS GROQ query
+; defineQuery(`...`)
+(call_expression
+  function: (identifier) @_name
+  (#eq? @_name "defineQuery")
+  arguments: (arguments
+    (template_string) @injection.content)
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
+  (#set! injection.language "groq"))
+
 (call_expression
   function: (identifier) @_name
   (#eq? @_name "gql")

--- a/runtime/queries/groq/highlights.scm
+++ b/runtime/queries/groq/highlights.scm
@@ -1,0 +1,232 @@
+;; Tree-sitter highlights for GROQ language
+;; This file defines syntax highlighting for GROQ in Neovim
+
+;; Keywords
+"select" @keyword
+"asc" @keyword
+"desc" @keyword
+"in" @keyword.operator
+"match" @keyword.operator
+
+;; Operators
+"==" @operator
+"!=" @operator
+">" @operator
+">=" @operator
+"<" @operator
+"<=" @operator
+"&&" @operator
+"||" @operator
+"!" @operator
+"+" @operator
+"-" @operator
+"*" @operator
+"/" @operator
+"%" @operator
+"**" @operator
+".." @operator
+"..." @operator
+"=>" @operator
+"->" @operator
+"|" @operator
+
+;; Punctuation
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"," @punctuation.delimiter
+":" @punctuation.delimiter
+"." @punctuation.delimiter
+
+;; Literals
+(string) @string
+(number) @number
+(true) @boolean
+(false) @boolean
+(null) @constant.builtin
+
+;; Special references
+(star) @constant.builtin
+(parent) @constant.builtin
+(this) @constant.builtin
+
+;; Identifiers
+(identifier) @variable
+
+;; Parameters
+(parameter) @variable.parameter
+
+;; Function calls
+(function_call
+  (identifier) @function)
+
+(order_function
+  "order" @function.builtin)
+
+;; Comments
+(comment) @comment
+
+;; Projections and objects
+(projection
+  "{" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(object
+  "{" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+;; Conditional projections
+(conditional_projection
+  "=>" @operator)
+
+;; Select statements
+(select_statement
+  "..." @operator
+  "select" @keyword
+  "=>" @operator)
+
+;; Spread operators
+(spread_operator
+  "..." @operator)
+
+;; Array access
+(attribute_access
+  "." @punctuation.delimiter)
+
+;; String keys in projections/objects
+(pair
+  (literal (string) @property))
+
+;; Highlight field names in projections
+(projection (identifier) @property)
+
+;; Built-in functions (essential GROQ functions)
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "count"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "length"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "defined"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "references"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "now"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "dateTime"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "coalesce"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "unique"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "max"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "min"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "sum"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "avg"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "round"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "floor"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "ceil"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "abs"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "sqrt"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "upper"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "lower"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "string"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "number"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "boolean"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "array"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "object"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "type"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "global"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "sanity"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "path"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "delta"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "after"))
+
+(function_call
+  (identifier) @function.builtin
+  (#eq? @function.builtin "before"))
+
+;; Error highlighting
+(ERROR) @error

--- a/runtime/queries/groq/highlights.scm
+++ b/runtime/queries/groq/highlights.scm
@@ -1,75 +1,111 @@
-;; Tree-sitter highlights for GROQ language
-;; This file defines syntax highlighting for GROQ in Neovim
-
-;; Keywords
+; Tree-sitter highlights for GROQ language
+; This file defines syntax highlighting for GROQ in Neovim
+; Keywords
 "select" @keyword
+
 "asc" @keyword
+
 "desc" @keyword
+
 "in" @keyword.operator
+
 "match" @keyword.operator
 
-;; Operators
+; Operators
 "==" @operator
+
 "!=" @operator
+
 ">" @operator
+
 ">=" @operator
+
 "<" @operator
+
 "<=" @operator
+
 "&&" @operator
+
 "||" @operator
+
 "!" @operator
+
 "+" @operator
+
 "-" @operator
+
 "*" @operator
+
 "/" @operator
+
 "%" @operator
+
 "**" @operator
+
 ".." @operator
+
 "..." @operator
+
 "=>" @operator
+
 "->" @operator
+
 "|" @operator
 
-;; Punctuation
+; Punctuation
 "(" @punctuation.bracket
+
 ")" @punctuation.bracket
+
 "[" @punctuation.bracket
+
 "]" @punctuation.bracket
+
 "{" @punctuation.bracket
+
 "}" @punctuation.bracket
+
 "," @punctuation.delimiter
+
 ":" @punctuation.delimiter
+
 "." @punctuation.delimiter
 
-;; Literals
+; Literals
 (string) @string
+
 (number) @number
+
 (true) @boolean
+
 (false) @boolean
+
 (null) @constant.builtin
 
-;; Special references
+; Special references
 (star) @constant.builtin
+
 (parent) @constant.builtin
+
 (this) @constant.builtin
 
-;; Identifiers
+; Identifiers
 (identifier) @variable
 
-;; Parameters
+; Parameters
 (parameter) @variable.parameter
 
-;; Function calls
+; Function calls
 (function_call
   (identifier) @function)
 
 (order_function
   "order" @function.builtin)
 
-;; Comments
+; Comments
 (comment) @comment
 
-;; Projections and objects
+; Projections and objects
 (projection
   "{" @punctuation.bracket
   "}" @punctuation.bracket)
@@ -78,32 +114,34 @@
   "{" @punctuation.bracket
   "}" @punctuation.bracket)
 
-;; Conditional projections
+; Conditional projections
 (conditional_projection
   "=>" @operator)
 
-;; Select statements
+; Select statements
 (select_statement
   "..." @operator
   "select" @keyword
   "=>" @operator)
 
-;; Spread operators
+; Spread operators
 (spread_operator
   "..." @operator)
 
-;; Array access
+; Array access
 (attribute_access
   "." @punctuation.delimiter)
 
-;; String keys in projections/objects
+; String keys in projections/objects
 (pair
-  (literal (string) @property))
+  (literal
+    (string) @property))
 
-;; Highlight field names in projections
-(projection (identifier) @property)
+; Highlight field names in projections
+(projection
+  (identifier) @property)
 
-;; Built-in functions (essential GROQ functions)
+; Built-in functions (essential GROQ functions)
 (function_call
   (identifier) @function.builtin
   (#eq? @function.builtin "count"))

--- a/runtime/queries/groq/highlights.scm
+++ b/runtime/queries/groq/highlights.scm
@@ -227,6 +227,3 @@
 (function_call
   (identifier) @function.builtin
   (#eq? @function.builtin "before"))
-
-;; Error highlighting
-(ERROR) @error


### PR DESCRIPTION
<!-- 
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  Make sure to fill out all fields and read the checklist at the end.
-->

# GROQ

<!-- Link to an official description of the language -->
https://spec.groq.dev/GROQ-1.revision3/

<details>
<summary>Representative code sample</summary>
<pre>
*[_type == 'movie' && releaseYear >= 1979][0..12]{
  _id, title, releaseYear,
  director->{name},
  "posterImage": poster.asset->url,
  "cast": *[_type == "actor" && references(^._id)].name,
  "awards": count(awards[won == true]) > 0
}
</pre>
</details>

## Parser repo

https://github.com/ajrussellaudio/tree-sitter-groq

<details>
<summary>Parsed tree for code sample</summary>
<pre>
(source_file ; [0, 0] - [10, 0]
  (attribute_access ; [0, 0] - [6, 1]
    (expression ; [0, 0] - [0, 49]
      (attribute_access ; [0, 0] - [0, 49]
        (expression ; [0, 0] - [0, 42]
          (attribute_access ; [0, 0] - [0, 42]
            (expression ; [0, 0] - [0, 1]
              (star)) ; [0, 0] - [0, 1]
            (binary_expression ; [0, 2] - [0, 41]
              (expression ; [0, 2] - [0, 18]
                (binary_expression ; [0, 2] - [0, 18]
                  (expression ; [0, 2] - [0, 7]
                    (identifier)) ; [0, 2] - [0, 7]
                  (expression ; [0, 11] - [0, 18]
                    (literal ; [0, 11] - [0, 18]
                      (string))))) ; [0, 11] - [0, 18]
              (expression ; [0, 22] - [0, 41]
                (binary_expression ; [0, 22] - [0, 41]
                  (expression ; [0, 22] - [0, 33]
                    (identifier)) ; [0, 22] - [0, 33]
                  (expression ; [0, 37] - [0, 41]
                    (literal ; [0, 37] - [0, 41]
                      (number)))))))) ; [0, 37] - [0, 41]
        (binary_expression ; [0, 43] - [0, 48]
          (expression ; [0, 43] - [0, 44]
            (literal ; [0, 43] - [0, 44]
              (number))) ; [0, 43] - [0, 44]
          (expression ; [0, 46] - [0, 48]
            (literal ; [0, 46] - [0, 48]
              (number)))))) ; [0, 46] - [0, 48]
    (projection ; [0, 49] - [6, 1]
      (identifier) ; [1, 2] - [1, 5]
      (identifier) ; [1, 7] - [1, 12]
      (identifier) ; [1, 14] - [1, 25]
      (attribute_access ; [2, 2] - [2, 18]
        (expression ; [2, 2] - [2, 12]
          (attribute_access ; [2, 2] - [2, 12]
            (expression ; [2, 2] - [2, 10]
              (identifier)))) ; [2, 2] - [2, 10]
        (projection ; [2, 12] - [2, 18]
          (identifier))) ; [2, 13] - [2, 17]
      (pair ; [3, 2] - [3, 34]
        (literal ; [3, 2] - [3, 15]
          (string)) ; [3, 2] - [3, 15]
        (attribute_access ; [3, 17] - [3, 34]
          (expression ; [3, 17] - [3, 29]
            (attribute_access ; [3, 17] - [3, 29]
              (expression ; [3, 17] - [3, 23]
                (identifier)) ; [3, 17] - [3, 23]
              (identifier))) ; [3, 24] - [3, 29]
          (identifier))) ; [3, 31] - [3, 34]
      (pair ; [4, 2] - [4, 55]
        (literal ; [4, 2] - [4, 8]
          (string)) ; [4, 2] - [4, 8]
        (attribute_access ; [4, 10] - [4, 55]
          (expression ; [4, 10] - [4, 50]
            (attribute_access ; [4, 10] - [4, 50]
              (expression ; [4, 10] - [4, 11]
                (star)) ; [4, 10] - [4, 11]
              (binary_expression ; [4, 12] - [4, 49]
                (expression ; [4, 12] - [4, 28]
                  (binary_expression ; [4, 12] - [4, 28]
                    (expression ; [4, 12] - [4, 17]
                      (identifier)) ; [4, 12] - [4, 17]
                    (expression ; [4, 21] - [4, 28]
                      (literal ; [4, 21] - [4, 28]
                        (string))))) ; [4, 21] - [4, 28]
                (expression ; [4, 32] - [4, 49]
                  (function_call ; [4, 32] - [4, 49]
                    (identifier) ; [4, 32] - [4, 42]
                    (attribute_access ; [4, 43] - [4, 48]
                      (expression ; [4, 43] - [4, 44]
                        (parent)) ; [4, 43] - [4, 44]
                      (identifier))))))) ; [4, 45] - [4, 48]
          (identifier))) ; [4, 51] - [4, 55]
      (pair ; [5, 2] - [5, 42]
        (literal ; [5, 2] - [5, 10]
          (string)) ; [5, 2] - [5, 10]
        (binary_expression ; [5, 12] - [5, 42]
          (expression ; [5, 12] - [5, 38]
            (function_call ; [5, 12] - [5, 38]
              (identifier) ; [5, 12] - [5, 17]
              (attribute_access ; [5, 18] - [5, 37]
                (expression ; [5, 18] - [5, 24]
                  (identifier)) ; [5, 18] - [5, 24]
                (binary_expression ; [5, 25] - [5, 36]
                  (expression ; [5, 25] - [5, 28]
                    (identifier)) ; [5, 25] - [5, 28]
                  (expression ; [5, 32] - [5, 36]
                    (literal ; [5, 32] - [5, 36]
                      (true))))))) ; [5, 32] - [5, 36]
          (expression ; [5, 41] - [5, 42]
            (literal ; [5, 41] - [5, 42]
              (number)))))))) ; [5, 41] - [5, 42]</pre>
</details>

## Queries

Source of queries: written from scratch

<details>
<summary>Screenshots of code sample</summary>
<img width="510" height="133" alt="image" src="https://github.com/user-attachments/assets/5a947e7b-f20e-4fad-8a1a-6465afa4c15f" /></details>

- [x] `./scripts/install-parsers.lua <language>` works without warnings
- [x] `./scripts/install-parsers.lua --generate <language>` works without warnings
- [x] `make query` works without warning
- [x] `make docs` is run

## Note

This PR updates the JavaScript (`ecma`) injections. GROQ is usually passed as a string to a JS/TS function. There are [two ways of doing this](https://www.sanity.io/docs/apis-and-sdks/sanity-typegen#c3ef15d8ad39): as a template literal to a `groq` library function, which works out-of-the-box with existing JS injections; or as a string passed to `defineQuery`.

<details>
<summary>Screenshot of the code block from the docs above working with this parser in TypeScript</summary>
<img width="812" height="300" alt="image" src="https://github.com/user-attachments/assets/ef65da96-291e-4aad-a7a0-4aab7888c325" />
</details>