### PR TITLE
fix(jinja): assign highlights to all variables and functions

### DIFF
--- a/runtime/queries/jinja_inline/highlights.scm
+++ b/runtime/queries/jinja_inline/highlights.scm
@@ -71,11 +71,7 @@
   "as"
 ] @keyword.import
 
-(import_statement
-  (identifier) @variable)
-
-(import_as
-  (identifier) @variable)
+(identifier) @variable
 
 [
   "if"
@@ -109,11 +105,33 @@
 
 (expression
   "."
-  (expression)+ @variable.member)
+  (expression
+    (binary_expression
+      .
+      (unary_expression
+        (primary_expression
+          (identifier) @variable.member)))))
+
+(expression
+  "."
+  (expression
+    (binary_expression
+      (binary_expression
+        (unary_expression
+          (primary_expression
+            (identifier) @variable.member))))))
 
 (assignment_expression
   "."
   (identifier)+ @variable.member)
+
+; jinja filters
+(binary_expression
+  (binary_operator
+    "|")
+  (unary_expression
+    (primary_expression
+      (identifier) @function.call)))
 
 (inline_trans
   "_" @function.builtin)

--- a/tests/query/highlights/jinja/filters.jinja
+++ b/tests/query/highlights/jinja/filters.jinja
@@ -1,0 +1,19 @@
+{{ name|striptags|title }}
+{# ^^^^ @variable #}
+{#      ^^^^^ @function.call #}
+{#                ^^^^^ @function.call #}
+
+{{ listx|join(', ') }}
+{# ^^^^^ @variable #}
+{#       ^^^^ @function.call #}
+{#            ^^^^ @string #}
+
+{{ listx|join(str) }}
+{# ^^^^^ @variable #}
+{#       ^^^^ @function.call #}
+{#            ^^^ @variable.parameter #}
+
+{{ foo.bar|random }}
+{# ^^^ @variable #}
+{#     ^^^ @variable.member #}
+{#         ^^^^^^ @function.call #}

--- a/tests/query/highlights/jinja/tests.jinja
+++ b/tests/query/highlights/jinja/tests.jinja
@@ -1,0 +1,13 @@
+{% if loop.index is divisibleby 3 %}
+{#    ^^^^ @variable #}
+{#         ^^^^^ @variable.member #}
+{#                  ^^^^^^^^^^ @keyword.operator #}
+
+{% if loop.index is divisibleby(3) %}
+{#    ^^^^ @variable #}
+{#         ^^^^^ @variable.member #}
+
+{% if foo.bar.baz is divisibleby 3 %}
+{#    ^^^ @variable #}
+{#        ^^^ @variable.member #}
+{#            ^^^ @variable.member #}

--- a/tests/query/highlights/jinja/variables.jinja
+++ b/tests/query/highlights/jinja/variables.jinja
@@ -1,0 +1,21 @@
+{{ foo }}
+{# ^^^ @variable #}
+
+{{ foo.bar }}
+{# ^^^ @variable #}
+{#     ^^^ @variable.member #}
+
+{{ foo['bar'] }}
+{# ^^^ @variable #}
+{#     ^^^^^ @string #}
+
+{{ foo.bar.baz }}
+{# ^^^ @variable #}
+{#     ^^^ @variable.member #}
+{#         ^^^ @variable.member #}
+
+{{ foo.bar + baz.qux }}
+{# ^^^ @variable #}
+{#     ^^^ @variable.member #}
+{#           ^^^ @variable #}
+{#               ^^^ @variable.member #}


### PR DESCRIPTION
The majority of jinja variables aren't assigned any highlights at all. Assign `@variable` to all identifiers.

Jinja filters without parameters are not highlighted as functions: add a query for these.

Refine the existing `@variable.member` to only capture identifiers instead of broader nodes.

Background: I configure yaml to inject this parser for ansible highlighting. But due to the missing highlight captures, most jinja is instead highlighted as yaml string (green), which is confusing. Additionally you can see another bug `abc.list_two` with the overly broad `@variable.member` capture.

Before:
<img width="909" height="211" alt="jinja_before" src="https://github.com/user-attachments/assets/5a8dd5e5-efc3-471f-b037-07e2e5e5f546" />

After:
<img width="619" height="210" alt="jinja_after" src="https://github.com/user-attachments/assets/56ef606f-f335-429c-930e-866a166cf397" />

cc: @cathaysia (and thank you for this parser)
