### PR TITLE
fix(latex)!: label number and reference

### DIFF
--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -92,9 +92,9 @@
 
 (label_reference_range
   command: _ @function.macro
-  from: (curly_group_text
+  from: (curly_group_label
     (_) @markup.link)
-  to: (curly_group_text
+  to: (curly_group_label
     (_) @markup.link))
 
 (label_reference
@@ -104,7 +104,7 @@
 
 (label_number
   command: _ @function.macro
-  name: (curly_group_text
+  name: (curly_group_label
     (_) @markup.link)
   number: (_) @markup.link)
 


### PR DESCRIPTION
In accordance with latex-lsp/tree-sitter-latex#213, this updates the node types for label_reference_range and label_number nodes to use the curly_group_label nodes.

This should thus be merged only when the upstream is :)