### PR TITLE
fix(c, ecma): remove invalid predicate parameters

### DIFF
--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -149,7 +149,7 @@
 
 ((field_expression
   (field_identifier) @property) @_parent
-  (#not-has-parent? @_parent template_method function_declarator call_expression))
+  (#not-has-parent? @_parent function_declarator call_expression))
 
 (field_designator) @property
 

--- a/runtime/queries/ecma/indents.scm
+++ b/runtime/queries/ecma/indents.scm
@@ -33,11 +33,11 @@
 
 (assignment_expression
   right: (_) @_right
-  (#not-kind-eq? @_right "arrow_function" "function")) @indent.begin
+  (#not-kind-eq? @_right "arrow_function")) @indent.begin
 
 (variable_declarator
   value: (_) @_value
-  (#not-kind-eq? @_value "arrow_function" "call_expression" "function")) @indent.begin
+  (#not-kind-eq? @_value "arrow_function" "call_expression")) @indent.begin
 
 (arguments
   ")" @indent.end)


### PR DESCRIPTION
These are not valid named nodes in their respective languages.