### PR TITLE
fix(install): skip duplicate dependencies

### DIFF
--- a/lua/nvim-treesitter/config.lua
+++ b/lua/nvim-treesitter/config.lua
@@ -164,7 +164,8 @@ function M.norm_languages(languages, skip)
     end
   end
 
-  return languages
+  table.sort(languages)
+  return vim.fn.uniq(languages) --[=[@as string[]]=]
 end
 
 return M


### PR DESCRIPTION
## Details

Follow up to: https://github.com/nvim-treesitter/nvim-treesitter/pull/8021

More info on why duplicate dependencies can cause problems: https://github.com/nvim-treesitter/nvim-treesitter/pull/8021#issuecomment-3114962375

Tests without `--max-jobs`:  https://github.com/nvim-treesitter/nvim-treesitter/actions/runs/16518667608