### PR TITLE
fix(typescript): support type param for styled components

### DIFF
--- a/runtime/queries/tsx/injections.scm
+++ b/runtime/queries/tsx/injections.scm
@@ -1,1 +1,1 @@
-; inherits: ecma,jsx
+; inherits: typescript,jsx

--- a/runtime/queries/typescript/injections.scm
+++ b/runtime/queries/typescript/injections.scm
@@ -1,1 +1,28 @@
 ; inherits: ecma
+
+; styled.div<{}>`<css>`
+(call_expression
+  function: (non_null_expression
+    (instantiation_expression
+      (member_expression
+        object: (identifier) @_name
+        (#eq? @_name "styled")
+        property: (property_identifier))
+      type_arguments: (type_arguments)))
+  arguments: ((template_string) @injection.content
+    (#offset! @injection.content 0 1 0 -1)
+    (#set! injection.include-children)
+    (#set! injection.language "styled")))
+
+; styled.div<T>`<css>`
+(binary_expression
+  left: (binary_expression
+    left: (member_expression
+      object: (identifier) @_name
+      (#eq? @_name "styled")
+      property: (property_identifier))
+    right: (identifier))
+  right: (template_string) @injection.content
+  (#offset! @injection.content 0 1 0 -1)
+  (#set! injection.include-children)
+  (#set! injection.language "styled"))


### PR DESCRIPTION
Added support for type arguments for styled components. Also inherit tsx injections from typescript. 
Seems like tests are failing in the `main` branch, so I skipped them.

| Before    | After |
| --------      | ------- |
| <img width="1224" height="962" alt="Screenshot_2025-08-10_19-09-43" src="https://github.com/user-attachments/assets/f2f706b4-fb33-488b-9ea6-76cf198fba82" />  | <img width="1154" height="956" alt="Screenshot_2025-08-10_19-10-32" src="https://github.com/user-attachments/assets/37724179-4c60-4782-9ec0-34f9acaf5f3e" />    |







