### PR TITLE
fix(fennel): highlight $ in multi-symbol context properly

### DIFF
--- a/runtime/queries/fennel/highlights.scm
+++ b/runtime/queries/fennel/highlights.scm
@@ -104,6 +104,9 @@
 ((symbol) @variable.parameter
   (#any-of? @variable.parameter "$" "$..."))
 
+((symbol_fragment) @variable.parameter
+  (#eq? @variable.parameter "$"))
+
 ((symbol) @variable.parameter
   (#lua-match? @variable.parameter "^%$[1-9]$"))
 


### PR DESCRIPTION
Highlights the dollar symbol properly in multi-symbol contexts like `$.some.properties`.