### PR TITLE
feat(sproto): add parser

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -269,6 +269,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` |   | @steelsojka
 [sosl](https://github.com/aheber/tree-sitter-sfapex) | unstable | `H    ` |   | @aheber, @xixiafinland
 [sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn) | unstable | `H  JL` |   | @Sarrus1
 [sparql](https://github.com/GordianDziwis/tree-sitter-sparql) | unstable | `HFIJL` |   | @GordianDziwis
+[sproto](https://github.com/hanxi/tree-sitter-sproto) | unstable | `HFIJ ` |   | @hanxi
 [sql](https://github.com/derekstride/tree-sitter-sql) | unstable | `HFIJ ` |   | @derekstride
 [squirrel](https://github.com/tree-sitter-grammars/tree-sitter-squirrel) | unstable | `HFIJL` |   | @amaanq
 [ssh_config](https://github.com/tree-sitter-grammars/tree-sitter-ssh-config) | unstable | `HFIJL` |   | @ObserverOfTime

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2115,6 +2115,14 @@ return {
     maintainers = { '@GordianDziwis' },
     tier = 2,
   },
+  sproto = {
+    install_info = {
+      revision = 'd554c1456e35e7b2690552d52921c987d0cf6799',
+      url = 'https://github.com/hanxi/tree-sitter-sproto',
+    },
+    maintainers = { '@hanxi' },
+    tier = 2,
+  },
   sql = {
     install_info = {
       branch = 'gh-pages',

--- a/runtime/queries/sproto/folds.scm
+++ b/runtime/queries/sproto/folds.scm
@@ -1,0 +1,6 @@
+[
+  (type_definition)
+  (protocol_definition)
+  (request_block)
+  (response_block)
+] @fold

--- a/runtime/queries/sproto/highlights.scm
+++ b/runtime/queries/sproto/highlights.scm
@@ -1,0 +1,47 @@
+(comment) @comment @spell
+
+[
+  "."
+  ":"
+] @punctuation.delimiter
+
+"*" @operator
+
+[
+  "request"
+  "response"
+] @keyword
+
+(type_definition
+  name: (identifier) @type)
+
+(nested_type_definition
+  name: (identifier) @type)
+
+(type_specifier) @type
+
+[
+  "integer"
+  "boolean"
+  "string"
+  "binary"
+  "double"
+] @type.builtin
+
+(protocol_definition
+  name: (identifier) @function)
+
+(field_definition
+  name: (identifier) @property)
+
+(map_specifier
+  key: (identifier) @property)
+
+(integer) @number
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+] @punctuation.bracket

--- a/runtime/queries/sproto/indents.scm
+++ b/runtime/queries/sproto/indents.scm
@@ -1,0 +1,10 @@
+[
+  (type_definition)
+  (protocol_definition)
+  (request_block)
+  (response_block)
+] @indent.begin
+
+"}" @indent.end @indent.branch
+
+(comment) @indent.auto

--- a/runtime/queries/sproto/injections.scm
+++ b/runtime/queries/sproto/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
<!-- 
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  Make sure to fill out all fields and read the checklist at the end.
-->

# sproto

<!-- Link to an official description of the language -->
https://github.com/cloudwu/sproto

<details>
<summary>Representative code sample</summary>

```sproto
# This is a comment.

.Person {	# . means a user defined type 
    name 0 : string	# string is a build-in type.
    id 1 : integer
    email 2 : string

    .PhoneNumber {	# user defined type can be nest.
        number 0 : string
        type 1 : integer
    }

    phone 3 : *PhoneNumber	# *PhoneNumber means an array of PhoneNumber.
    height 4 : integer(2)	# (2) means a 1/100 fixed-point number.
    data 5 : binary		# Some binary data
    weight 6 : double   # floating number
}

.AddressBook {
    person 0 : *Person(id)	# (id) is optional, means Person.id is main index.
}

foobar 1 {	# define a new protocol (for RPC used) with tag 1
    request Person	# Associate the type Person with foobar.request
    response {	# define the foobar.response type
        ok 0 : boolean
    }
}
```

</details>

## Parser repo

https://github.com/hanxi/tree-sitter-sproto

<details>
<summary>Parsed tree for code sample</summary>

```
(source_file ; [0, 0] - [29, 0]
  (comment) ; [0, 0] - [0, 20]
  (type_definition ; [2, 0] - [16, 1]
    name: (identifier) ; [2, 1] - [2, 7]
    (comment) ; [2, 10] - [2, 40]
    (field_definition ; [3, 4] - [3, 19]
      name: (identifier) ; [3, 4] - [3, 8]
      tag: (integer) ; [3, 9] - [3, 10]
      type: (type_specifier)) ; [3, 13] - [3, 19]
    (comment) ; [3, 20] - [3, 48]
    (field_definition ; [4, 4] - [4, 18]
      name: (identifier) ; [4, 4] - [4, 6]
      tag: (integer) ; [4, 7] - [4, 8]
      type: (type_specifier)) ; [4, 11] - [4, 18]
    (field_definition ; [5, 4] - [5, 20]
      name: (identifier) ; [5, 4] - [5, 9]
      tag: (integer) ; [5, 10] - [5, 11]
      type: (type_specifier)) ; [5, 14] - [5, 20]
    (nested_type_definition ; [7, 4] - [10, 5]
      name: (identifier) ; [7, 5] - [7, 16]
      (comment) ; [7, 19] - [7, 51]
      (field_definition ; [8, 8] - [8, 25]
        name: (identifier) ; [8, 8] - [8, 14]
        tag: (integer) ; [8, 15] - [8, 16]
        type: (type_specifier)) ; [8, 19] - [8, 25]
      (field_definition ; [9, 8] - [9, 24]
        name: (identifier) ; [9, 8] - [9, 12]
        tag: (integer) ; [9, 13] - [9, 14]
        type: (type_specifier))) ; [9, 17] - [9, 24]
    (field_definition ; [12, 4] - [12, 26]
      name: (identifier) ; [12, 4] - [12, 9]
      tag: (integer) ; [12, 10] - [12, 11]
      type: (type_specifier ; [12, 15] - [12, 26]
        (identifier))) ; [12, 15] - [12, 26]
    (comment) ; [12, 27] - [12, 72]
    (field_definition ; [13, 4] - [13, 25]
      name: (identifier) ; [13, 4] - [13, 10]
      tag: (integer) ; [13, 11] - [13, 12]
      type: (type_specifier) ; [13, 15] - [13, 22]
      fixed_point: (fixed_point_specifier ; [13, 22] - [13, 25]
        precision: (integer))) ; [13, 23] - [13, 24]
    (comment) ; [13, 26] - [13, 65]
    (field_definition ; [14, 4] - [14, 19]
      name: (identifier) ; [14, 4] - [14, 8]
      tag: (integer) ; [14, 9] - [14, 10]
      type: (type_specifier)) ; [14, 13] - [14, 19]
    (comment) ; [14, 21] - [14, 39]
    (field_definition ; [15, 4] - [15, 21]
      name: (identifier) ; [15, 4] - [15, 10]
      tag: (integer) ; [15, 11] - [15, 12]
      type: (type_specifier)) ; [15, 15] - [15, 21]
    (comment)) ; [15, 24] - [15, 41]
  (type_definition ; [18, 0] - [20, 1]
    name: (identifier) ; [18, 1] - [18, 12]
    (field_definition ; [19, 4] - [19, 26]
      name: (identifier) ; [19, 4] - [19, 10]
      tag: (integer) ; [19, 11] - [19, 12]
      type: (type_specifier ; [19, 16] - [19, 22]
        (identifier)) ; [19, 16] - [19, 22]
      map_key_type: (map_specifier ; [19, 22] - [19, 26]
        key: (identifier))) ; [19, 23] - [19, 25]
    (comment)) ; [19, 27] - [19, 77]
  (protocol_definition ; [22, 0] - [27, 1]
    name: (identifier) ; [22, 0] - [22, 6]
    tag: (integer) ; [22, 7] - [22, 8]
    (comment) ; [22, 11] - [22, 60]
    (request_block ; [23, 4] - [23, 18]
      type: (type_specifier ; [23, 12] - [23, 18]
        (identifier))) ; [23, 12] - [23, 18]
    (comment) ; [23, 19] - [23, 66]
    (response_block ; [24, 4] - [26, 5]
      (comment) ; [24, 15] - [24, 48]
      (field_definition ; [25, 8] - [25, 22]
        name: (identifier) ; [25, 8] - [25, 10]
        tag: (integer) ; [25, 11] - [25, 12]
        type: (type_specifier))))) ; [25, 15] - [25, 22]
```
</details>

## Queries

Source of queries: [https://github.com/hanxi/tree-sitter-sproto/tree/main/queries](https://github.com/hanxi/tree-sitter-sproto/tree/main/queries)

<details>
<summary>Screenshots of code sample</summary>
<img width="1376" height="931" alt="image" src="https://github.com/user-attachments/assets/816eb415-3c12-4442-b4c0-1d845ae784af" />
</details>


<details>
<summary>lazy.nvim config sample</summary>

```lua
vim.api.nvim_create_autocmd('FileType', {
  pattern = { 'sproto' },
  callback = function() vim.treesitter.start() end,
})
vim.treesitter.language.register('sproto', { 'sproto' })

vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"

vim.filetype.add({
    extension = {
        sproto = "sproto",
    },
    pattern = {
        [".*/%.sproto$"] = "sproto",
    },
})

return {
        {
                "hanxi/nvim-treesitter",
                branch = 'main',
                lazy = false,
                build = ":TSUpdate",
                opts = {
                        ensure_installed = {
                                "sproto",
                        }
                }
        }
}
```

</details>

<details>
<summary>lazy.nvim config sample custom</summary>

```lua
return {
    "nvim-treesitter/nvim-treesitter",
    opts = function(_, opts)
        -- 1. 添加 sproto 到 `ensure_installed` 列表
        -- 这会让 nvim-treesitter 在启动时尝试安装 sproto
        if type(opts.ensure_installed) == "table" then
            vim.list_extend(opts.ensure_installed, { "sproto" })
        end

        -- 注册新的 parser
        if type(parsers) == "table" then
            vim.list_extend(parsers, { "sproto" })
        end

        -- 配置文件类型
        vim.filetype.add({
            extension = {
                sproto = "sproto",
            },
            pattern = {
                [".*/%.sproto$"] = "sproto",
            },
        })

        -- 2. 配置 sproto parser 的位置
        -- 这是最关键的一步
        local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
        parser_config.sproto = {
            install_info = {
                -- 指向你本地 parser 的路径
                url = "https://github.com/hanxi/tree-sitter-sproto",
                files = { "src/parser.c" },
                generate_requires_npm = false,
                requires_generate = false,
            },
            filetype = "sproto", -- 将此 parser 关联到 sproto 文件类型
            indent = { enable = true },
        }
    end,
}
```

</details>

<!--
CHECKLIST: _Before_ submitting, make sure

* `./scripts/install-parsers.lua <language>` works without warnings
* `./scripts/install-parsers.lua --generate <language>` works without warnings
* `make query` works without warning
* `make docs` is run
-->