### PR TITLE
fix(health): highlights legend label

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -157,7 +157,7 @@ function M.check()
     end
     health.info(vim.fn.trim(out, ' ', 2))
   end
-  health.start('  Legend: H[ighlight], L[ocals], F[olds], I[ndents], In[J]ections')
+  health.start('  Legend: H[ighlights], L[ocals], F[olds], I[ndents], In[J]ections')
 
   if #error_collection > 0 then
     health.start('The following errors have been detected in query files:')


### PR DESCRIPTION
This patch makes highlights legend label consistent with the other labels representing their `{query_name}` used in `vim.treesitter.query.get()`, `vim.treesitter.query.get_files()` and `vim.treesitter.query.set()` functions.