### PR TITLE
feat(cpp): Add highlights capture group for lambda brackets

### DIFF
--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -30,10 +30,10 @@
   declarator: (field_identifier) @function.method)
 
 ; lambdas
-((lambda_expression
+(lambda_expression
   captures: (lambda_capture_specifier
-        "[" @lambda.capture.bracket
-        "]" @lambda.capture.bracket)))
+    "[" @lambda.capture.bracket
+    "]" @lambda.capture.bracket))
 
 (concept_definition
   name: (identifier) @type.definition)

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -29,6 +29,12 @@
 (function_declarator
   declarator: (field_identifier) @function.method)
 
+; lambdas
+((lambda_expression
+  captures: (lambda_capture_specifier
+        "[" @lambda.capture.bracket
+        "]" @lambda.capture.bracket)))
+
 (concept_definition
   name: (identifier) @type.definition)
 


### PR DESCRIPTION
When creating a colortheme I noticed that there's no way to target lambda capture brackets in c++, so I added this capability under the @lambda.capture.bracket specifier.

This for example sets lambda capture brackets to orange:

```
    -- highlight lambda capture brackets
    vim.api.nvim_set_hl(0, "@lambda.capture.bracket", { fg = "#ff8400"})
```