### PR TITLE
feat(install): link queries with relative path

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -320,6 +320,21 @@ end
 ---@return string? err
 local function do_link_queries(logger, query_src, query_dir)
   uv_unlink(query_dir)
+
+  local install_dir = fs.dirname(query_dir)
+  if not fs.relpath(query_src, install_dir) then
+    local prefix = "../"
+    for dir in fs.parents(install_dir) do
+      local relpath = fs.relpath(dir, query_src)
+      local is_root = dir:match("^/$") or dir:match("^%a:/$")
+      if relpath and not is_root then
+        query_src = prefix .. relpath
+        break
+      end
+      prefix = "../" .. prefix
+    end
+  end
+
   local err = uv_symlink(query_src, query_dir, { dir = true, junction = true })
   a.schedule()
   if err then


### PR DESCRIPTION
The queries are linked with absolute paths. This makes the environment less portable. Therefore, I modified the `do_link_queries` to link with relative path in first priority. If the common base of `query_dir` and `query_src` is root ("/" or "%a:/"), use the absolute path as usual.

The fnamemodify() and vim.fs.relpath() cannot be directly used because the `query_src` is usually not the subdirectory of `query_dir`. Therefore, I used `vim.fs.parents()` to find the command base of these two directories.