### PR TITLE
feat(inko): add support for array patterns

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1042,7 +1042,7 @@ return {
   },
   inko = {
     install_info = {
-      revision = 'f58a87ac4dc6a7955c64c9e4408fbd693e804686',
+      revision = '74cbd0f69053b4a9ad4fed8831dee983ec7e4990',
       url = 'https://github.com/inko-lang/tree-sitter-inko',
     },
     maintainers = { '@yorickpeterse' },

--- a/runtime/queries/inko/indents.scm
+++ b/runtime/queries/inko/indents.scm
@@ -27,6 +27,7 @@
   (trait)
   (tuple)
   (tuple_pattern)
+  (array_pattern)
   (type_arguments)
 ] @indent.begin
 


### PR DESCRIPTION
This updates the version of the Inko parser to the latest version and includes indent support for the new array pattern node.

Array patterns are added as part of https://github.com/inko-lang/inko/pull/891. While this PR is still a draft, the syntax is final and it's mostly a matter of runtime specifics (i.e. nothing that affects nvim-treesitter).