### PR TITLE
chore: bump Agda parser

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -3,7 +3,7 @@
     "revision": "e8e2515465cc2d7c444498e68bdb9f1d86767f95"
   },
   "agda": {
-    "revision": "b9b32fa042c2952a7bfca86847ea325e44ccc897"
+    "revision": "e8d47a6987effe34d5595baf321d82d3519a8527"
   },
   "angular": {
     "revision": "843525141575e397541e119698f0532755e959f6"


### PR DESCRIPTION
This includes a patch for the crash described in https://github.com/tree-sitter/tree-sitter-agda/issues/24.