### PR TITLE
fix(latex)!: label number and reference

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1240,7 +1240,7 @@ return {
   latex = {
     install_info = {
       generate = true,
-      revision = '7af2bf3addcab5ada8843cf08b857daf1799dbd4',
+      revision = '7e0ecdc02926c7b9b2e0c76003d4fe7b0944f957',
       url = 'https://github.com/latex-lsp/tree-sitter-latex',
     },
     maintainers = { '@theHamsta', '@clason' },

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -23,6 +23,9 @@
 (curly_group_spec
   (text) @variable.parameter)
 
+(curly_group_value
+  (value_literal) @constant)
+
 (brack_group_argc) @variable.parameter
 
 [
@@ -84,6 +87,54 @@
   command: _ @function.macro @nospell
   declaration: (curly_group_command_name
     (_) @function))
+
+(counter_declaration
+  command: _ @function.macro @nospell
+  counter: (curly_group_word
+    (word) @variable)
+  supercounter: (brack_group_word
+    (word) @variable)?)
+
+(counter_within_declaration
+  command: _ @function.macro @nospell
+  counter: (curly_group_word
+    (word) @variable)
+  supercounter: (curly_group_word
+    (word) @variable))
+
+(counter_without_declaration
+  command: _ @function.macro @nospell
+  counter: (curly_group_word
+    (word) @variable)
+  supercounter: (curly_group_word
+    (word) @variable))
+
+(counter_value
+  command: _ @function.macro @nospell
+  counter: (curly_group_word
+    (word) @variable))
+
+; The 'value' fields for the two following highlights
+; are handled by counter_value and curly_group_value.
+(counter_definition
+  command: _ @function.macro @nospell
+  counter: (curly_group_word
+    (word) @variable))
+
+(counter_addition
+  command: _ @function.macro @nospell
+  counter: (curly_group_word
+    (word) @variable))
+
+(counter_increment
+  command: _ @function.macro @nospell
+  counter: (curly_group_word
+    (word) @variable))
+
+(counter_typesetting
+  command: _ @function.macro @nospell
+  counter: (curly_group_word
+    (word) @variable))
 
 (label_definition
   command: _ @function.macro
@@ -298,6 +349,14 @@
 
 ; Turn spelling off for whole nodes
 [
+  (counter_declaration)
+  (counter_within_declaration)
+  (counter_without_declaration)
+  (counter_value)
+  (counter_definition)
+  (counter_addition)
+  (counter_increment)
+  (counter_typesetting)
   (label_reference)
   (label_reference_range)
   (label_number)


### PR DESCRIPTION
Note: this PR is the updated version of #8023 !

In accordance with latex-lsp/tree-sitter-latex#213, this updates the node types for label_reference_range and label_number nodes to use the curly_group_label nodes.

This also updates the revision of the parser to include those nodes.

A PR will be coming to include the newly-added counter-related nodes, see https://github.com/latex-lsp/tree-sitter-latex/pull/219.