### PR TITLE
feat(snakemake): update queries

### DIFF
--- a/runtime/queries/snakemake/highlights.scm
+++ b/runtime/queries/snakemake/highlights.scm
@@ -63,20 +63,20 @@ body: (_
 ; directive labels in wildcard context
 ((wildcard
   (identifier) @label)
-  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards"))
+  (#any-of? @label "input" "jobid" "log" "output" "params" "resources" "rule" "threads" "wildcards"))
 
 ((wildcard
   (attribute
     object: (identifier) @label))
-  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards"))
+  (#any-of? @label "input" "jobid" "log" "output" "params" "resources" "rule" "threads" "wildcards"))
 
 ((wildcard
   (subscript
     value: (identifier) @label))
-  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards"))
+  (#any-of? @label "input" "jobid" "log" "output" "params" "resources" "rule" "threads" "wildcards"))
 
 ; directive labels in block context (eg. within 'run:')
 ((identifier) @label
-  (#any-of? @label "input" "log" "output" "params" "resources" "threads" "wildcards")
+  (#any-of? @label "input" "jobid" "log" "output" "params" "resources" "rule" "threads" "wildcards")
   (#has-ancestor? @label "directive")
   (#has-ancestor? @label "block"))

--- a/runtime/queries/snakemake/indents.scm
+++ b/runtime/queries/snakemake/indents.scm
@@ -1,12 +1,12 @@
 ; inherits: python
 
-((rule_definition) @indent.begin
-  (#set! indent.immediate 1))
-
-((checkpoint_definition) @indent.begin
-  (#set! indent.immediate 1))
-
-((rule_inheritance) @indent.begin
+([
+  (rule_definition)
+  (checkpoint_definition)
+  (rule_inheritance)
+  (module_definition)
+  (directive)
+] @indent.begin
   (#set! indent.immediate 1))
 
 ((rule_import
@@ -14,12 +14,20 @@
   ":") @indent.begin
   (#set! indent.immediate 1))
 
-((module_definition) @indent.begin
-  (#set! indent.immediate 1))
-
-((directive) @indent.begin
-  (#set! indent.immediate 1))
-
-; end indentation after last parameter node (no following ',')
-(directive_parameters
-  (_) @indent.end .)
+; ; end indentation after last parameter node (no following ',')
+; ; accommodate different levels of nesting
+; ; see also queries/python/indents.scm: return_statement
+(directive
+  (directive_parameters
+    [
+      (_) @indent.dedent
+      (_
+        [
+          (_)
+          ")"
+          "}"
+          "]"
+        ] .) @indent.dedent
+    ]
+    . ; anchor at end: no subsequent ','
+    ))

--- a/runtime/queries/snakemake/locals.scm
+++ b/runtime/queries/snakemake/locals.scm
@@ -2,3 +2,39 @@
 
 (rule_definition
   name: (identifier) @local.definition.type) @local.scope
+
+(rule_inheritance
+  alias: (as_pattern_target) @local.definition.type) @local.scope
+
+(checkpoint_definition
+  name: (identifier) @local.definition.type) @local.scope
+
+(module_definition
+  name: (identifier) @local.definition.type) @local.scope
+
+; use rule A from X
+(rule_import
+  (rule_import_list
+    (identifier) @local.definition.import)
+  .
+  module_name: (identifier) .) @local.scope
+
+; use rule A from X as A_fromX
+; use rule A from X as *_fromX
+; use rule * from X as *_fromX
+(rule_import
+  alias: (as_pattern_target) @local.definition.import .) @local.scope
+
+; use rule A from X with:
+(rule_import
+  (rule_import_list
+    (identifier) @local.definition.type)
+  .
+  module_name: (identifier)
+  .
+  "with") @local.scope
+
+; use rule A from X as Y with:
+(rule_import
+  alias: (as_pattern_target) @local.definition.type
+  "with") @local.scope

--- a/tests/indent/snakemake/blocks.smk
+++ b/tests/indent/snakemake/blocks.smk
@@ -1,0 +1,22 @@
+rule A:
+    """doc"""
+
+if True:
+    rule B:
+        """doc"""
+
+use rule other from somewhere
+
+use rule other2 from somewhere as other_alias
+
+use rule other3 from somewhere with:
+    input: 2
+
+use rule other4 from somewhere as other_alias2 with:
+    input: 2
+
+checkpoint C:
+    input: "1"
+
+module A:
+    snakefile: "x.smk"

--- a/tests/indent/snakemake/directive_parameters.smk
+++ b/tests/indent/snakemake/directive_parameters.smk
@@ -1,0 +1,36 @@
+rule A:
+    input: a
+    output: b
+    params:
+        a = 1,
+        b = 2,
+        c = 3
+    shell:
+        """
+        touch {output}
+        """
+
+rule B:
+    input: a,
+    output: a,
+        b
+    params:
+
+rule C:
+    # test dedent after variably nested nodes
+    params:
+        1
+    params:
+        "1"
+    params:
+        a = 1
+    params:
+        a = "1"
+    params:
+        a = call(1)
+    params:
+        a = call("1")
+    params:
+        a = config["a"]
+    params:
+        b = call(config["a"])

--- a/tests/indent/snakemake_spec.lua
+++ b/tests/indent/snakemake_spec.lua
@@ -26,10 +26,22 @@ describe('indent Snakemake:', function()
     run:new_line('blocks.smk', { on_line = 15, text = 'pass', indent = 4 })
     run:new_line('directive_parameters.smk', { on_line = 4, text = 'before_a = 0,', indent = 8 })
     run:new_line('directive_parameters.smk', { on_line = 5, text = 'after_a = 1.1,', indent = 8 })
-    run:new_line('directive_parameters.smk', { on_line = 7, text = '"""dedent_after_last_param"""', indent = 4 })
-    run:new_line('directive_parameters.smk', { on_line = 14, text = 'b = "indent_after_param_with_comma"', indent = 8 })
-    run:new_line('directive_parameters.smk', { on_line = 15, text = 'b = "indent_after_param_with_comma"', indent = 8 })
-    run:new_line('directive_parameters.smk', { on_line = 17, text = 'b = "indent_after_opening"', indent = 8 })
+    run:new_line(
+      'directive_parameters.smk',
+      { on_line = 7, text = '"""dedent_after_last_param"""', indent = 4 }
+    )
+    run:new_line(
+      'directive_parameters.smk',
+      { on_line = 14, text = 'b = "indent_after_param_with_comma"', indent = 8 }
+    )
+    run:new_line(
+      'directive_parameters.smk',
+      { on_line = 15, text = 'b = "indent_after_param_with_comma"', indent = 8 }
+    )
+    run:new_line(
+      'directive_parameters.smk',
+      { on_line = 17, text = 'b = "indent_after_opening"', indent = 8 }
+    )
     for _, line in ipairs({ 22, 24, 26, 28, 30, 32, 34, 36 }) do
       run:new_line('directive_parameters.smk', { on_line = line, text = '"doc"', indent = 4 })
     end

--- a/tests/indent/snakemake_spec.lua
+++ b/tests/indent/snakemake_spec.lua
@@ -1,0 +1,37 @@
+local Runner = require('tests.indent.common').Runner
+local XFAIL = require('tests.indent.common').XFAIL
+
+local run = Runner:new(it, 'tests/indent/snakemake', {
+  tabstop = 4,
+  shiftwidth = 4,
+  softtabstop = 0,
+  expandtab = true,
+})
+
+describe('indent Snakemake:', function()
+  describe('whole file:', function()
+    run:whole_file('.', {
+      expected_failures = {},
+    })
+  end)
+
+  describe('new line:', function()
+    run:new_line('blocks.smk', { on_line = 1, text = 'input: 1', indent = 4 })
+    run:new_line('blocks.smk', { on_line = 2, text = 'input: 1', indent = 4 })
+    run:new_line('blocks.smk', { on_line = 5, text = 'input: 1', indent = 8 })
+    run:new_line('blocks.smk', { on_line = 6, text = 'input: 1', indent = 8 })
+    run:new_line('blocks.smk', { on_line = 8, text = 'pass', indent = 0 })
+    run:new_line('blocks.smk', { on_line = 10, text = 'pass', indent = 0 })
+    run:new_line('blocks.smk', { on_line = 12, text = 'pass', indent = 4 })
+    run:new_line('blocks.smk', { on_line = 15, text = 'pass', indent = 4 })
+    run:new_line('directive_parameters.smk', { on_line = 4, text = 'before_a = 0,', indent = 8 })
+    run:new_line('directive_parameters.smk', { on_line = 5, text = 'after_a = 1.1,', indent = 8 })
+    run:new_line('directive_parameters.smk', { on_line = 7, text = '"""dedent_after_last_param"""', indent = 4 })
+    run:new_line('directive_parameters.smk', { on_line = 14, text = 'b = "indent_after_param_with_comma"', indent = 8 })
+    run:new_line('directive_parameters.smk', { on_line = 15, text = 'b = "indent_after_param_with_comma"', indent = 8 })
+    run:new_line('directive_parameters.smk', { on_line = 17, text = 'b = "indent_after_opening"', indent = 8 })
+    for _, line in ipairs({ 22, 24, 26, 28, 30, 32, 34, 36 }) do
+      run:new_line('directive_parameters.smk', { on_line = line, text = '"doc"', indent = 4 })
+    end
+  end)
+end)


### PR DESCRIPTION
This PR updates indents, locals and highlights queries for snakemake, and adds tests for indent queries.

PS: To run tests for python/snakemake only, I deleted all *_spec.lua files except for snakemake_spec.lua via `find tests/ -depth -name '*python*' -prune -o -name '*_spec*' -print -delete`. Is there a less drastic way to select which tests to run via `make tests`?