### PR TITLE
Teach protobuf parser about editions

### DIFF
--- a/runtime/queries/proto/highlights.scm
+++ b/runtime/queries/proto/highlights.scm
@@ -15,6 +15,7 @@
   (identifier) @property)
 
 [
+  "edition"
   "extend"
   "extensions"
   "oneof"
@@ -63,6 +64,8 @@
 [
   "\"proto3\""
   "\"proto2\""
+  "\"2023\""
+  "\"2024\""
 ] @string.special
 
 (int_lit) @number


### PR DESCRIPTION
Handled similarly to `syntax = "proto{2,3}"` lines.

Ref: https://protobuf.dev/editions/overview/
Ref: https://buf.build/blog/protobuf-editions-are-here