### PR TITLE
Add glimmer_template to folds list for glimmer_javascript and glimmer_typescript

### DIFF
--- a/runtime/queries/glimmer_javascript/folds.scm
+++ b/runtime/queries/glimmer_javascript/folds.scm
@@ -1,1 +1,3 @@
 ; inherits: ecma
+
+(glimmer_template) @fold

--- a/runtime/queries/glimmer_typescript/folds.scm
+++ b/runtime/queries/glimmer_typescript/folds.scm
@@ -1,1 +1,3 @@
 ; inherits: typescript
+
+(glimmer_template) @fold


### PR DESCRIPTION
small one -- noticed I was missing a fold.

Preview:
<img width="592" height="913" alt="image" src="https://github.com/user-attachments/assets/bb2a60d1-7667-4851-8a51-9568b455000f" />
