### PR TITLE
docs: Clarify tree-sitter-cli requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For details on these and how to help improving them, see [CONTRIBUTING.md](./CON
 
 - Neovim 0.11.0 or later (nightly)
 - `tar` and `curl` in your path
-- [`tree-sitter`](https://github.com/tree-sitter/tree-sitter) CLI (0.25.0 or later)
+- [`tree-sitter-cli`](https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md) (0.25.0 or later)
 - a C compiler in your path (see <https://docs.rs/cc/latest/cc/#compile-time-requirements>)
 - `Node` (23.0.0 or later) for some parsers (see the [list of supported languages](SUPPORTED_LANGUAGES.md))
 


### PR DESCRIPTION
Link to the tree-sitter-cli README directly, instead of the tree-sitter top-level README to avoid confusion.