### PR TITLE
fix(python): correct highlighting of docstrings

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -80,7 +80,11 @@
 ] @string.escape
 
 ; doc-strings
-(expression_statement
+(module
+  (string
+    (string_content) @spell) @string.documentation)
+
+(block
   (string
     (string_content) @spell) @string.documentation)
 


### PR DESCRIPTION
The node `expression_statement` was changed to a supertype in the python parser, which caused a bug where the docstring query captures all strings as `@string.documentation`.
This commit restores the behavior as it was discussed in #7788.

I tested this visually (I don't know how to run the tests) with `tests/query/highlights/python/docstrings.py`.

Minimal reproduction:

```lua
vim.opt.runtimepath:append('.')
require('nvim-treesitter').setup({ install_dir = vim.fn.getcwd() .. '/site' })
require('nvim-treesitter').install({ 'python' }):wait()

vim.api.nvim_set_hl(0, '@string.documentation.python', { fg = '#FF0000' })

vim.api.nvim_create_autocmd('FileType', {
  pattern = 'python',
  callback = function()
    pcall(vim.treesitter.start)
  end,
})
```

Before this commit:
<img width="674" height="687" alt="image" src="https://github.com/user-attachments/assets/14c2389f-6f64-448e-98f1-d6c93333a596" />


After this commit:
<img width="708" height="690" alt="image" src="https://github.com/user-attachments/assets/f13939ef-8fe3-4ace-abcb-4d8df93f2028" />