### PR TITLE
feat(python): revert breaking change

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -227,7 +227,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` |   | @steelsojka
 [puppet](https://github.com/tree-sitter-grammars/tree-sitter-puppet) | unstable | `HFIJL` |   | @amaanq
 [purescript](https://github.com/postsolar/tree-sitter-purescript) | unstable | `H  JL` |   | @postsolar
 [pymanifest](https://github.com/tree-sitter-grammars/tree-sitter-pymanifest) | unstable | `H  J ` |   | @ObserverOfTime
-[python](https://github.com/tree-sitter/tree-sitter-python) | unstable | `HFIJL` |   | @stsewd, @theHamsta
+[python](https://github.com/tree-sitter/tree-sitter-python) | stable | `HFIJL` |   | @stsewd, @theHamsta
 [ql](https://github.com/tree-sitter/tree-sitter-ql) | unstable | `HFIJL` |   | @pwntester
 [qmldir](https://github.com/tree-sitter-grammars/tree-sitter-qmldir) | unstable | `H  J ` |   | @amaanq
 [qmljs](https://github.com/yuja/tree-sitter-qmljs) | unstable | `HF J ` |   | @Decodetalkers

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1772,11 +1772,11 @@ return {
   },
   python = {
     install_info = {
-      revision = '26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64',
+      revision = 'v0.25.0',
       url = 'https://github.com/tree-sitter/tree-sitter-python',
     },
     maintainers = { '@stsewd', '@theHamsta' },
-    tier = 2,
+    tier = 1,
   },
   ql = {
     install_info = {

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -358,15 +358,17 @@
 
 ((class_definition
   body: (block
-    (assignment
-      left: (identifier) @variable.member)))
+    (expression_statement
+      (assignment
+        left: (identifier) @variable.member))))
   (#lua-match? @variable.member "^[%l_].*$"))
 
 ((class_definition
   body: (block
-    (assignment
-      left: (_
-        (identifier) @variable.member))))
+    (expression_statement
+      (assignment
+        left: (_
+          (identifier) @variable.member)))))
   (#lua-match? @variable.member "^[%l_].*$"))
 
 ((class_definition


### PR DESCRIPTION
This reverts the update in https://github.com/nvim-treesitter/nvim-treesitter/pull/8128 which turned out to have further breaking consequences.

Pin the parser to the last release (tier 1) to avoid pulling in more breaking changes.
