### PR TITLE
Adding cedars policy language with queries

### DIFF
--- a/queries/cedar/folds.scm
+++ b/queries/cedar/folds.scm
@@ -1,0 +1,6 @@
+[
+  (policy)
+  (record_literal)
+  (set_literal)
+  (condition)
+] @fold

--- a/queries/cedar/highlights.scm
+++ b/queries/cedar/highlights.scm
@@ -1,0 +1,51 @@
+
+; Main policy structure
+(policy) @keyword
+(effect) @keyword
+(scope) @keyword
+
+; Expressions
+(binary_expression) @operator
+(unary_expression) @operator
+(call_expression) @function.call
+(ext_fun_call) @function.call
+(selector_expression) @property
+(has_expression) @operator
+(like_expression) @operator
+(contains_expression) @operator
+(contains_all_expression) @operator
+(is_expression) @operator
+
+; Literals
+(record_literal) @punctuation.bracket
+(set_literal) @punctuation.bracket
+(entity) @constant
+
+; Conditions
+(condition) @keyword
+
+; Annotations
+(annotation) @attribute
+
+; Constraints
+(principal_constraint) @variable.builtin
+(action_constraint) @variable.builtin
+(resource_constraint) @variable.builtin
+
+; Basic punctuation
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ","
+  ";"
+  "."
+  "::"
+  "@"
+] @punctuation.delimiter


### PR DESCRIPTION
Name of language
[cedars](https://www.cedarpolicy.com/)

Representative code sample
Parser repo
https://github.com/chrnorm/tree-sitter-cedar

Parsed tree for code sample
Queries
Source of queries: "written from scratch"

Screenshots of code sample

<img width="2792" height="1706" alt="Screenshot Treesitter Cedar" src="https://github.com/user-attachments/assets/f78c2cd1-413a-4c14-90d3-35d95cf49533" />
