### PR TITLE
feat(koto)!: update parser and queries

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1215,7 +1215,7 @@ return {
   },
   koto = {
     install_info = {
-      revision = '2ffc77c14f0ac1674384ff629bfc207b9c57ed89',
+      revision = '633744bca404ae4edb961a3c2d7bc947a987afa4',
       url = 'https://github.com/koto-lang/tree-sitter-koto',
     },
     maintainers = { '@irh' },

--- a/runtime/queries/koto/highlights.scm
+++ b/runtime/queries/koto/highlights.scm
@@ -90,7 +90,8 @@
   (identifier) @module)
 
 (chain
-  lookup: (identifier) @variable.member)
+  (lookup
+    (identifier)) @variable.member)
 
 (chain
   start: (identifier) @function.call)


### PR DESCRIPTION
Breaking changes: `call`, `index`, `lookup` fields removed
