### PR TITLE
fix: align line continuation highlights 

### DIFF
--- a/runtime/queries/cylc/highlights.scm
+++ b/runtime/queries/cylc/highlights.scm
@@ -32,6 +32,8 @@
   (graph_parenthesis)
 ] @punctuation.bracket
 
+(line_continuation) @punctuation.special
+
 [
   "\""
   "\"\"\""

--- a/runtime/queries/earthfile/highlights.scm
+++ b/runtime/queries/earthfile/highlights.scm
@@ -126,4 +126,4 @@
 
 "=" @operator
 
-(line_continuation) @operator
+(line_continuation) @punctuation.special

--- a/runtime/queries/make/highlights.scm
+++ b/runtime/queries/make/highlights.scm
@@ -168,3 +168,5 @@
     "file"
     "value"
   ] @function.builtin)
+
+"\\" @punctuation.special

--- a/runtime/queries/matlab/highlights.scm
+++ b/runtime/queries/matlab/highlights.scm
@@ -211,10 +211,9 @@
   (#eq? @boolean "false"))
 
 ; Comments
-[
-  (comment)
-  (line_continuation)
-] @comment @spell
+(comment) @comment @spell
+
+(line_continuation) @punctuation.special
 
 ((comment) @keyword.directive
   (#lua-match? @keyword.directive "^%%%% "))

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -247,6 +247,8 @@
   "{" @punctuation.special
   "}" @punctuation.special)
 
+(line_continuation) @punctuation.special
+
 (type_conversion) @function.macro
 
 [


### PR DESCRIPTION
These should be `@punctuation.special`. Added the highlight for python, cylc, and make. Corrected it for earthfile and matlab.