### PR TITLE
regex failed to match last segment of url

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -260,7 +260,7 @@ local function do_download(logger, url, project_name, cache_dir, revision, outpu
 
   do -- Move tmp dir to output dir
     local dir_rev = revision:find('^v%d') and revision:sub(2) or revision
-    local repo_project_name = url:match('[^/]-$')
+    local repo_project_name = url:match('[^/]+$')
     local extracted = fs.joinpath(tmp, repo_project_name .. '-' .. dir_rev)
     logger:debug('Moving %s to %s/...', extracted, output_dir)
     local err = uv_rename(extracted, output_dir)


### PR DESCRIPTION
I tried to install a parser through a git url, and it failed with the following error.

`Could not rename temp: ENOENT no such file`

It tried to rename <repo_project_name ..  dir_rev> into <output_dir>, but the call to `match` before it returned nil, which is the value of repo_project_name that got turned into an empty string.

The changed regex now matches the last url segment.