### PR TITLE
feat(streamdevice_proto): add parser and queries

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -275,6 +275,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` | @steelsojka
 [ssh_config](https://github.com/tree-sitter-grammars/tree-sitter-ssh-config) | unstable | `HFIJL` | @ObserverOfTime
 [starlark](https://github.com/tree-sitter-grammars/tree-sitter-starlark) | unstable | `HFIJL` | @amaanq
 [strace](https://github.com/sigmaSd/tree-sitter-strace) | unstable | `H  J ` | @amaanq
+[streamdevice_proto](https://github.com/minijackson/tree-sitter-streamdevice-proto)[^streamdevice_proto] | unstable | `H IJL` | @minijackson
 [styled](https://github.com/mskelton/tree-sitter-styled) | unstable | `HFIJ ` | @mskelton
 [supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) | unstable | `HFIJL` | @madskjeldgaard
 [superhtml](https://github.com/kristoff-it/superhtml) | unstable | `H  J ` | @rockorager
@@ -360,4 +361,5 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` | @steelsojka
 [^sflog]: Salesforce debug log
 [^slang]: Shader Slang
 [^snl]: EPICS Sequencer's SNL files
+[^streamdevice_proto]: EPICS StreamDevice .proto files
 <!--parserinfo-->

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2161,6 +2161,15 @@ return {
     maintainers = { '@amaanq' },
     tier = 2,
   },
+  streamdevice_proto = {
+    install_info = {
+      revision = 'b638715ae8deb91c8bfedd7ff1fb27650f6e0309',
+      url = 'https://github.com/minijackson/tree-sitter-streamdevice-proto',
+    },
+    maintainers = { '@minijackson' },
+    readme_note = 'EPICS StreamDevice .proto files',
+    tier = 2,
+  },
   styled = {
     install_info = {
       revision = '319cdcaa0346ba6db668a222d938e5c3569e2a51',

--- a/runtime/queries/streamdevice_proto/highlights.scm
+++ b/runtime/queries/streamdevice_proto/highlights.scm
@@ -1,0 +1,90 @@
+(comment) @comment @spell
+
+(variable_name) @constant
+
+(enum_constant) @constant
+
+(ascii_name) @constant.builtin
+
+"=" @operator
+
+[
+  (function_name)
+  (command_name)
+  (handler_name)
+] @function
+
+((command_name) @function.builtin
+  (#any-of? @function.builtin "out" "in" "wait" "event" "exec" "disconnect" "connect"))
+
+((handler_name) @function.builtin
+  (#any-of? @function.builtin "mismatch" "writetimeout" "replytimeout" "readtimeout" "init"))
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+  "("
+  ")"
+  "<"
+  ">"
+] @punctuation.bracket
+
+[
+  "$"
+  "\\$"
+  "@"
+  "/"
+  "#/"
+] @punctuation.special
+
+(variable_expansion
+  [
+    "\\${"
+    "}"
+  ] @punctuation.special)
+
+(format_converter
+  [
+    "%"
+    "{"
+    "}"
+    "["
+    "]"
+    "("
+    ")"
+    "<"
+    ">"
+    "#/"
+    "/"
+  ] @punctuation.special)
+
+[
+  "|"
+  ";"
+  ","
+  "."
+] @punctuation.delimiter
+
+(quoted_literal) @string
+
+(escape_sequence) @string.escape
+
+(format_converter) @function.builtin
+
+(checksum_flag) @operator
+
+(checksum) @function
+
+(regex_pattern) @string.regexp
+
+(time_conversion_spec) @constant.builtin
+
+(keyword) @keyword
+
+(record_name) @constant
+
+(field_name) @variable.member
+
+(number) @number

--- a/runtime/queries/streamdevice_proto/indents.scm
+++ b/runtime/queries/streamdevice_proto/indents.scm
@@ -1,0 +1,21 @@
+[
+  (function)
+  (handler)
+] @indent.begin
+
+[
+  "{"
+  "}"
+  "("
+  ")"
+] @indent.branch
+
+[
+  "}"
+  ")"
+] @indent.end
+
+[
+  (comment)
+  (string)
+] @indent.auto

--- a/runtime/queries/streamdevice_proto/injections.scm
+++ b/runtime/queries/streamdevice_proto/injections.scm
@@ -1,0 +1,5 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))
+
+((regex_pattern) @injection.content
+  (#set! injection.language "regex"))

--- a/runtime/queries/streamdevice_proto/locals.scm
+++ b/runtime/queries/streamdevice_proto/locals.scm
@@ -1,0 +1,22 @@
+(source_file) @local.scope
+
+; The content of a function is a scope, not the whole function block.
+; Else, the function is defined inside itself
+(function
+  .
+  (function_name)
+  .
+  (_) @local.scope)
+
+(function
+  .
+  (function_name) @local.definition.function)
+
+(assignment
+  (variable_name) @local.definition.var)
+
+(variable_name) @local.reference
+
+((handler
+  (function_name) @local.reference)
+  (#set! reference.kind "call"))


### PR DESCRIPTION
<!-- 
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  Make sure to fill out all fields and read the checklist at the end.
-->

# Name of language

<!-- Link to an official description of the language -->
https://paulscherrerinstitute.github.io/StreamDevice/protocol.html

<details>
<summary>Representative code sample</summary>

```
# This is an example protocol file

Terminator = CR LF;

# Frequency is a float
# use ai and ao records

getFrequency {
    out "FREQ?"; in "%f";
}

setFrequency {
    out "FREQ %f";
    @init { getFrequency; }
}

# Switch is an enum, either OFF or ON
# use bi and bo records

getSwitch {
    out "SW?"; in "SW %{OFF|ON}";
}

setSwitch {
    out "SW %{OFF|ON}";
    @init { getSwitch; }
}

# Connect a stringout record to this to get
# a generic command interface.
# After processing finishes, the record contains the reply.

debug {
    ExtraInput = Ignore;
    out "%s"; in "%39c"
}
```

</details>

## Parser repo

https://github.com/minijackson/tree-sitter-streamdevice-proto/

<details>
<summary>Parsed tree for code sample</summary>

``` scheme
(source_file ; [0, 0] - [36, 0]
  (comment ; [0, 0] - [0, 34]
    (source)) ; [0, 0] - [0, 34]
  (assignment ; [2, 0] - [2, 18]
    (variable_name) ; [2, 0] - [2, 10]
    (string ; [2, 13] - [2, 18]
      (ascii_name) ; [2, 13] - [2, 15]
      (ascii_name))) ; [2, 16] - [2, 18]
  (comment ; [4, 0] - [4, 22]
    (source)) ; [4, 0] - [4, 22]
  (comment ; [5, 0] - [5, 23]
    (source)) ; [5, 0] - [5, 23]
  (function ; [7, 0] - [9, 1]
    (function_name) ; [7, 0] - [7, 12]
    (command ; [8, 4] - [8, 15]
      (command_name) ; [8, 4] - [8, 7]
      (string ; [8, 8] - [8, 15]
        (quoted_literal))) ; [8, 8] - [8, 15]
    (command ; [8, 17] - [8, 24]
      (command_name) ; [8, 17] - [8, 19]
      (string ; [8, 20] - [8, 24]
        (quoted_literal ; [8, 20] - [8, 24]
          (format_converter))))) ; [8, 21] - [8, 23]
  (function ; [11, 0] - [14, 1]
    (function_name) ; [11, 0] - [11, 12]
    (command ; [12, 4] - [12, 17]
      (command_name) ; [12, 4] - [12, 7]
      (string ; [12, 8] - [12, 17]
        (quoted_literal ; [12, 8] - [12, 17]
          (format_converter)))) ; [12, 14] - [12, 16]
    (handler ; [13, 4] - [13, 27]
      (handler_name) ; [13, 5] - [13, 9]
      (function_name))) ; [13, 12] - [13, 24]
  (comment ; [16, 0] - [16, 37]
    (source)) ; [16, 0] - [16, 37]
  (comment ; [17, 0] - [17, 23]
    (source)) ; [17, 0] - [17, 23]
  (function ; [19, 0] - [21, 1]
    (function_name) ; [19, 0] - [19, 9]
    (command ; [20, 4] - [20, 13]
      (command_name) ; [20, 4] - [20, 7]
      (string ; [20, 8] - [20, 13]
        (quoted_literal))) ; [20, 8] - [20, 13]
    (command ; [20, 15] - [20, 32]
      (command_name) ; [20, 15] - [20, 17]
      (string ; [20, 18] - [20, 32]
        (quoted_literal ; [20, 18] - [20, 32]
          (format_converter ; [20, 22] - [20, 31]
            (format_enum ; [20, 24] - [20, 30]
              (enum_specifier ; [20, 24] - [20, 27]
                (enum_constant)) ; [20, 24] - [20, 27]
              (enum_specifier ; [20, 28] - [20, 30]
                (enum_constant)))))))) ; [20, 28] - [20, 30]
  (function ; [23, 0] - [26, 1]
    (function_name) ; [23, 0] - [23, 9]
    (command ; [24, 4] - [24, 22]
      (command_name) ; [24, 4] - [24, 7]
      (string ; [24, 8] - [24, 22]
        (quoted_literal ; [24, 8] - [24, 22]
          (format_converter ; [24, 12] - [24, 21]
            (format_enum ; [24, 14] - [24, 20]
              (enum_specifier ; [24, 14] - [24, 17]
                (enum_constant)) ; [24, 14] - [24, 17]
              (enum_specifier ; [24, 18] - [24, 20]
                (enum_constant))))))) ; [24, 18] - [24, 20]
    (handler ; [25, 4] - [25, 24]
      (handler_name) ; [25, 5] - [25, 9]
      (function_name))) ; [25, 12] - [25, 21]
  (comment ; [28, 0] - [28, 43]
    (source)) ; [28, 0] - [28, 43]
  (comment ; [29, 0] - [29, 30]
    (source)) ; [29, 0] - [29, 30]
  (comment ; [30, 0] - [30, 59]
    (source)) ; [30, 0] - [30, 59]
  (function ; [32, 0] - [35, 1]
    (function_name) ; [32, 0] - [32, 5]
    (assignment ; [33, 4] - [33, 23]
      (variable_name) ; [33, 4] - [33, 14]
      (keyword)) ; [33, 17] - [33, 23]
    (command ; [34, 4] - [34, 12]
      (command_name) ; [34, 4] - [34, 7]
      (string ; [34, 8] - [34, 12]
        (quoted_literal ; [34, 8] - [34, 12]
          (format_converter)))) ; [34, 9] - [34, 11]
    (command ; [34, 14] - [34, 23]
      (command_name) ; [34, 14] - [34, 16]
      (string ; [34, 17] - [34, 23]
        (quoted_literal ; [34, 17] - [34, 23]
          (format_converter ; [34, 18] - [34, 22]
            width: (number))))))) ; [34, 19] - [34, 21]

```

</details>

## Queries

Source of queries: adapted from the tree-sitter grammar queries.

<details>
<summary>Screenshots of code sample</summary>

<img width="420" height="542" alt="image" src="https://github.com/user-attachments/assets/a4f8af0f-49c6-4d71-a50f-f6785b54f474" />


</details>

<!--
CHECKLIST: _Before_ submitting, make sure

* `./scripts/install-parsers.lua <language>` works without warnings
* `./scripts/install-parsers.lua --generate <language>` works without warnings
* `make query` works without warning
* `make docs` is run
-->