### PR TITLE
feat(python): highlight special brackets in `format_expression`

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -247,6 +247,10 @@
   "{" @punctuation.special
   "}" @punctuation.special)
 
+(format_expression
+  "{" @punctuation.special
+  "}" @punctuation.special)
+
 (line_continuation) @punctuation.special
 
 (type_conversion) @function.macro


### PR DESCRIPTION
Before:
<img width="198" height="32" alt="image" src="https://github.com/user-attachments/assets/3d168104-40da-4c84-aebe-32413faa5505" />

After:
<img width="197" height="38" alt="image" src="https://github.com/user-attachments/assets/1f986da0-3db6-432b-99c6-a645b08c2aee" />