### PR TITLE
feat(inko): update parser for let pattern matching

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1041,7 +1041,7 @@ return {
   },
   inko = {
     install_info = {
-      revision = '080e957d94b330e3867f063b148a8050b0888f4e',
+      revision = '9d7ed4f6c0ea2a8f846f3bb00e33ab21ec9ca379',
       url = 'https://github.com/inko-lang/tree-sitter-inko',
     },
     maintainers = { '@yorickpeterse' },

--- a/runtime/queries/inko/locals.scm
+++ b/runtime/queries/inko/locals.scm
@@ -13,7 +13,7 @@
 (argument
   name: _ @local.definition.parameter)
 
-(define_variable
+(identifier_pattern
   name: _ @local.definition.var)
 
 (define_constant


### PR DESCRIPTION
Commit [9d7ed4](https://github.com/inko-lang/tree-sitter-inko/commit/9d7ed4f6c0ea2a8f846f3bb00e33ab21ec9ca379) of the Inko tree-sitter grammar introduces support for pattern matching in `let` expressions. This requires some corresponding changes to the "local" queries to correctly define local variables. This is done by simply defining locals for all "identifier_pattern" nodes, instead of only doing this for "define_variable" nodes.