### PR TITLE
feat(tmux)!: update parser and highlights

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2372,7 +2372,7 @@ return {
   },
   tmux = {
     install_info = {
-      revision = 'a2936cb2579f7723b5744563c45bcefabc42fe47',
+      revision = '72b42cd0307bdfe471fd151a0282d0d38e889944',
       url = 'https://github.com/Freed-Wu/tree-sitter-tmux',
     },
     maintainers = { '@Freed-Wu', '@stevenxxiu' },

--- a/runtime/queries/tmux/highlights.scm
+++ b/runtime/queries/tmux/highlights.scm
@@ -14,8 +14,7 @@
 
 [
   (option)
-  (variable_name)
-  (variable_name_short)
+  (name)
 ] @variable
 
 (command_line_option) @variable.builtin


### PR DESCRIPTION
Breaking changes:

- Nodes `(variable_name)`, `(expr_variable_name)`, `(variable_name_short)`, are exposed as `(name)`.