### PR TITLE
fix(kitty): align line continuation highlights

### DIFF
--- a/runtime/queries/kitty/highlights.scm
+++ b/runtime/queries/kitty/highlights.scm
@@ -1,4 +1,4 @@
-(line_continuation) @comment
+(line_continuation) @punctuation.special
 
 (comment
   (comment_content) @spell) @comment


### PR DESCRIPTION
Changes them from `@comment` to `@punctuation.special`, which is how they are in other languages.