### PR TITLE
Document setting foldmethod alongside foldexpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Treesitter-based folding is provided by Neovim. To enable it, put the following 
 
 ```lua
 vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+vim.wo.foldmethod = 'expr'
 ```
 
 ## Indentation

--- a/doc/nvim-treesitter.txt
+++ b/doc/nvim-treesitter.txt
@@ -45,6 +45,7 @@ Treesitter features for installed languages need to be enabled manually in a
       vim.treesitter.start()
       -- folds, provided by Neovim
       vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+      vim.wo.foldmethod = 'expr'
       -- indentation, provided by nvim-treesitter
       vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
     end,


### PR DESCRIPTION
`'foldexpr'` requires `'foldmethod'` to be set to `expr`, or it will have no effect. Document setting them together, so new users who are less familiar with these options won't be confused when `'foldexpr'` alone doesn't work.