### PR TITLE
Fix get_capture_matches_recursively function

### DIFF
--- a/lua/nvim-treesitter/query.lua
+++ b/lua/nvim-treesitter/query.lua
@@ -437,6 +437,7 @@ function M.get_capture_matches_recursively(bufnr, capture_or_fn, query_type)
   local matches = {}
 
   if parser then
+    parser:parse(false)
     parser:for_each_tree(function(tree, lang_tree)
       local lang = lang_tree:lang()
       local capture, type_ = type_fn(lang, tree, lang_tree)


### PR DESCRIPTION
Hi! 

I think I found a bug.
I was using the `nvim-treesitter-textobjects` plugin and tried to set up the `lsp_interop` module, but no matter how I configured it, peeking at a definition would only show the first line.
After hours of print debugging, I think I finally managed to find a one-line solution to this issue.

I should mention that I've only been using Neovim for about two weeks and have never contributed to a plugin before. This is just a solution I came up with, and I'm not sure if it's the correct one.