### PR TITLE
feat(starlark): build targets as locals

### DIFF
--- a/.tsqueryrc.json
+++ b/.tsqueryrc.json
@@ -156,6 +156,7 @@
       "local.definition.namespace": "modules or namespaces",
       "local.definition.import": "imported names",
       "local.definition.associated": "the associated type of a variable",
+      "local.definition.target": "build targets",
       "local.scope": "scope block",
       "local.reference": "identifier reference"
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -494,6 +494,7 @@ are only provided for limited backwards compatibility.
 @local.definition.namespace  ; modules or namespaces
 @local.definition.import     ; imported names
 @local.definition.associated ; the associated type of a variable
+@local.definition.target     ; a build target (which may not be an identifier)
 
 @local.scope                 ; scope block
 @local.reference             ; identifier reference

--- a/runtime/queries/starlark/locals.scm
+++ b/runtime/queries/starlark/locals.scm
@@ -94,3 +94,14 @@
   arguments: (argument_list
     (string) @local.definition.import))
   (#eq? @_fn "load"))
+
+; Build target definitions
+((module
+  (expression_statement
+    (call
+      arguments: (argument_list
+        (keyword_argument
+          name: (identifier) @_name
+          value: (string
+            (string_content) @local.definition.target))))))
+  (#eq? @_name "name"))


### PR DESCRIPTION
Problem: I have very big BUILD files I want to navigate quickly. I have Telescope, so I can use `:Telescope treesitter` for an outline, but build targets aren't emitted as definitions.

Solution: Add a query that catches build targets.

One thing I'm unclear on is:
- I want to filter to just build targets.
- Build targets are absolutely not any of the mentioned types in the CONTRIBUTING file.
- Build targets do not actually create identifiers in buck2/bazel: they create objects which are observable to the outside world and which the user generally *cares* about, but they aren't in the same namespace as normal identifiers.

  This means that they *especially* don't fit into any of the existing categories.

I would like guidance as to whether this is the right approach or if I should call the capture group something else.