### PR TITLE
Switch tree-sitter-t32 repository to GitHub

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -288,7 +288,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` |   | @steelsojka
 [sxhkdrc](https://github.com/RaafatTurki/tree-sitter-sxhkdrc) | unstable | `HF J ` |   | @RaafatTurki
 [systemtap](https://github.com/ok-ryoko/tree-sitter-systemtap) | unstable | `HF JL` |   | @ok-ryoko
 [systemverilog](https://github.com/gmlarumbe/tree-sitter-systemverilog) | unstable | `HF J ` |   | @zhangwwpeng
-[t32](https://gitlab.com/xasc/tree-sitter-t32) | unstable | `HFIJL` |   | @xasc
+[t32](https://github.com/xasc/tree-sitter-t32) | unstable | `HFIJL` |   | @xasc
 [tablegen](https://github.com/tree-sitter-grammars/tree-sitter-tablegen) | unstable | `HFIJL` |   | @amaanq
 [tact](https://github.com/tact-lang/tree-sitter-tact) | unstable | `HFIJL` |   | @novusnota
 [tcl](https://github.com/tree-sitter-grammars/tree-sitter-tcl) | unstable | `HFIJ ` |   | @lewis6991

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2274,7 +2274,7 @@ return {
   t32 = {
     install_info = {
       revision = 'd4e26ab7a730cfbe0cf84dba6ea3647989064839',
-      url = 'https://gitlab.com/xasc/tree-sitter-t32',
+      url = 'https://github.com/xasc/tree-sitter-t32',
     },
     maintainers = { '@xasc' },
     tier = 2,


### PR DESCRIPTION
Switches the grammar repository from GitLab to GitHub.


On a related note, I have a question about this part from *CONTRIBUTING.md*:

> - provide WASM release artifacts;

The WASM modules for *tree-sitter-t32* are currently in the [GitLab package registry](https://gitlab.com/xasc/tree-sitter-t32/-/releases). Do they need to move, too?

