### PR TITLE
feat(parsers)!: updated wit queries and grammar to v1.2.0

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -5,6 +5,7 @@ The following is a list of languages for which a parser can be installed through
 Legend:
 - **Tier:** _stable_ (updates follow semver releases), _unstable_ (updates follow HEAD), _unmaintained_ (no automatic updates), or _unsupported_ (known to be broken, cannot be installed)
 - **Queries** available for **H**ighlights, **I**ndents, **F**olds, In**J**ections, **L**ocals
+- **Node:** Parser requires `node` for installation
 - **Maintainer** of queries in nvim-treesitter (may be different from parser maintainer!)
 
 <!--This section of the README is automatically updated by a CI job-->
@@ -327,7 +328,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` | @steelsojka
 [wgsl](https://github.com/szebniok/tree-sitter-wgsl) | unstable | `HFIJ ` | @szebniok
 [wgsl_bevy](https://github.com/tree-sitter-grammars/tree-sitter-wgsl-bevy) | unstable | `HFI  ` | @theHamsta
 [wing](https://github.com/winglang/tree-sitter-wing) | unstable | `HF JL` | @gshpychka, @MarkMcCulloh
-[wit](https://github.com/bytecodealliance/tree-sitter-wit) | unstable | `HF J ` | @mkatychev
+[wit](https://github.com/bytecodealliance/tree-sitter-wit) | stable | `HF J ` | @mkatychev
 [wxml](https://github.com/BlockLune/tree-sitter-wxml) | unstable | `HFIJ ` | @BlockLune
 [xcompose](https://github.com/tree-sitter-grammars/tree-sitter-xcompose) | unstable | `H  JL` | @ObserverOfTime
 [xml](https://github.com/tree-sitter-grammars/tree-sitter-xml) | unstable | `HFIJL` | @ObserverOfTime

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2603,11 +2603,11 @@ return {
   },
   wit = {
     install_info = {
-      revision = '230984dfaf803a0ff8f77da5034361a62c326577',
+      revision = 'v1.2.0',
       url = 'https://github.com/bytecodealliance/tree-sitter-wit',
     },
     maintainers = { '@mkatychev' },
-    tier = 2,
+    tier = 1,
   },
   wxml = {
     install_info = {

--- a/runtime/queries/wit/highlights.scm
+++ b/runtime/queries/wit/highlights.scm
@@ -6,6 +6,32 @@
 
 (version) @string.special
 
+(use_path
+  [
+    "@"
+    "/"
+  ] @punctuation.delimiter)
+
+(package_decl
+  [
+    "@"
+    "/"
+  ] @punctuation.delimiter)
+
+; feature gates with leading `@`
+(_
+  .
+  "@" @punctuation.special
+  .
+  [
+    "since"
+    "unstable"
+    "deprecated"
+  ] @attribute.builtin)
+
+(unstable_gate
+  feature: (id) @string)
+
 (world_item
   name: (id) @module)
 
@@ -53,8 +79,7 @@
 (flags_items
   name: (id) @type)
 
-(body
-  (id) @variable.member)
+(flags_field) @variable.member
 
 (variant_items
   name: (id) @type)
@@ -65,8 +90,7 @@
 (enum_items
   name: (id) @type)
 
-(enum_case
-  name: (id) @constant)
+(enum_case) @constant
 
 (resource_item
   name: (id) @type)
@@ -89,6 +113,9 @@
 (use_path
   (id) @module)
 
+(alias_item
+  (id) @module)
+
 (use_names_item
   (id) @module)
 
@@ -108,11 +135,16 @@
 
 "static" @keyword.modifier
 
+"async" @keyword.coroutine
+
+(uint) @constant
+
 [
   "include"
   "import"
   "export"
   "as"
+  "with"
 ] @keyword.import
 
 [
@@ -129,26 +161,30 @@
   "char"
   "bool"
   "string"
+] @type.builtin
+
+[
   "tuple"
   "list"
   "option"
   "result"
   "borrow"
-] @type.builtin
+  "future"
+  "stream"
+] @type
+
+"_" @variable.parameter.builtin
 
 [
-  "@"
-  "_"
-] @punctuation.special
-
-[
-  "/"
   ";"
   ":"
   ","
   "."
   "->"
 ] @punctuation.delimiter
+
+(use_path
+  "/" @punctuation.delimiter)
 
 [
   "{"
@@ -158,6 +194,8 @@
   ">"
   "<"
 ] @punctuation.bracket
+
+"=" @operator
 
 [
   (line_comment)


### PR DESCRIPTION
Updated to match new GH release:
https://github.com/bytecodealliance/tree-sitter-wit/releases/tag/v1.2.0