### PR TITLE
fix(vue): `@character.special` highlights for `:`, `.`

### DIFF
--- a/runtime/queries/vue/highlights.scm
+++ b/runtime/queries/vue/highlights.scm
@@ -8,7 +8,7 @@
 [
   ":"
   "."
-] @punctuation.delimiter
+] @character.special
 
 [
   (interpolation)


### PR DESCRIPTION
cc @lucario387 