### PR TITLE
feat(perl): Add language injection based on heredoc delimiter

### DIFF
--- a/runtime/queries/perl/injections.scm
+++ b/runtime/queries/perl/injections.scm
@@ -16,4 +16,3 @@
 
 (heredoc_content
   (heredoc_end) @injection.language) @injection.content
-  (#set! injection.include-children)


### PR DESCRIPTION
Similar to other languages.

Before:
<img width="519" height="352" alt="Screenshot 2025-10-17 at 10 10 28" src="https://github.com/user-attachments/assets/08490c7e-84d8-4113-a080-fadb71b1cc7f" />

After:
<img width="499" height="324" alt="Screenshot 2025-10-17 at 10 10 53" src="https://github.com/user-attachments/assets/27f400ab-4470-4747-af90-576b90cebb6e" />
