### PR TITLE
feat: add token for match import special characters

### DIFF
--- a/.tsqueryrc.json
+++ b/.tsqueryrc.json
@@ -37,6 +37,7 @@
 
       "character": "character literals",
       "character.special": "special characters (e.g. wildcards)",
+      "character.import": "special characters in import statements",
 
       "boolean": "boolean literals",
       "number": "numeric literals",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,7 @@ The valid captures are listed below.
 
 @character              ; character literals
 @character.special      ; special characters (e.g. wildcards)
+@character.import       ; special characters in import statements
 
 @boolean                ; boolean literals
 @number                 ; numeric literals

--- a/runtime/queries/ecma/highlights.scm
+++ b/runtime/queries/ecma/highlights.scm
@@ -308,15 +308,15 @@
 ; Imports
 ;----------
 (namespace_import
-  "*" @character.special
+  "*" @character.import
   (identifier) @module)
 
 (namespace_export
-  "*" @character.special
+  "*" @character.import
   (identifier) @module)
 
 (export_statement
-  "*" @character.special)
+  "*" @character.import)
 
 ; Keywords
 ;----------

--- a/runtime/queries/groovy/highlights.scm
+++ b/runtime/queries/groovy/highlights.scm
@@ -145,7 +145,7 @@
   "!"
 ] @operator
 
-(wildcard_import) @character.special
+(wildcard_import) @character.import
 
 (string
   "/" @string)

--- a/runtime/queries/java/highlights.scm
+++ b/runtime/queries/java/highlights.scm
@@ -261,7 +261,7 @@
 
 (import_declaration
   (asterisk
-    "*" @character.special))
+    "*" @character.import))
 
 ; Punctuation
 [

--- a/runtime/queries/kotlin/highlights.scm
+++ b/runtime/queries/kotlin/highlights.scm
@@ -73,7 +73,7 @@
 (import_header
   "import" @keyword.import)
 
-(wildcard_import) @character.special
+(wildcard_import) @character.import
 
 ; The last `simple_identifier` in a `import_header` will always either be a function
 ; or a type. Classes can appear anywhere in the import path, unlike functions

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -184,7 +184,7 @@
   "as" @keyword.import)
 
 (wildcard_import
-  "*" @character.special)
+  "*" @character.import)
 
 (import_statement
   name: (dotted_name

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -209,13 +209,13 @@
 (null_literal) @constant.builtin
 
 (wildcard
-  "_") @character.special
+  "_") @character.import
 
 (namespace_wildcard
   [
     "*"
     "_"
-  ] @character.special)
+  ] @character.import)
 
 (annotation) @attribute
 


### PR DESCRIPTION
## Problem
In import statements, keywords like import are tokenized as `@keyword.import`. However, symbols such as * (e.g., in `import * as all from 'package'` in JavaScript) are not assigned a dedicated token. This makes it impossible to consistently distinguish these symbols from other characters like _, which are matched as `@character.special` and prevents proper highlighting in themes.

## Solution
Introduce a new token `@character.import` specifically for symbols used in import constructs.