### PR TITLE
fix(nu): inefficient and incorrect highlight query of `collection_type`

### DIFF
--- a/runtime/queries/nu/highlights.scm
+++ b/runtime/queries/nu/highlights.scm
@@ -344,7 +344,7 @@ key: (identifier) @property
   [
     "record"
     "table"
-  ] @type.enum)
+  ] @type.builtin)
 
 (collection_type
   key: (_) @variable.parameter)


### PR DESCRIPTION
Previously causing issues with verbose collection types.

https://github.com/nushell/tree-sitter-nu/pull/230