### PR TITLE
queries(apex): Use Javadoc for comment injections

### DIFF
--- a/queries/apex/injections.scm
+++ b/queries/apex/injections.scm
@@ -2,4 +2,4 @@
   (line_comment)
   (block_comment)
 ] @injection.content
-  (#set! injection.language "comment"))
+  (#set! injection.language "javadoc"))


### PR DESCRIPTION
Apex codebases commonly use Javadoc-style comments, similar to Java (Apex is Salesforce's object-oriented language).

This updates the injection query to capture `javadoc` nodes instead of the generic `comment` for better highlighting and parsing accuracy.