### PR TITLE
fix(svelte): allow css language injection with pure <style> tags

### DIFF
--- a/queries/svelte/injections.scm
+++ b/queries/svelte/injections.scm
@@ -1,5 +1,9 @@
 ; inherits: html_tags
 
+(style_element
+  (raw_text) @injection.content
+  (#set! injection.language "css"))
+
 ((style_element
   (start_tag
     (attribute


### PR DESCRIPTION
Tested and works with multiple svelte files. Before it was all white, now it has correct CSS syntax highlighting.