### PR TITLE
feat(kitty): Update parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1206,7 +1206,7 @@ return {
   },
   kitty = {
     install_info = {
-      revision = '064d1b4d8ae1b93244de0ff6bc9f0ee0cffee3b5',
+      revision = '2e9b602ca676cac63887cca5a4535106f3475c82',
       url = 'https://github.com/OXY2DEV/tree-sitter-kitty',
     },
     maintainers = { '@OXY2DEV' },


### PR DESCRIPTION
Parser revision changed for the following bug fixes,

- Case-insensitive key names(e.g. `CTRL`, `Ctrl`, `ctrl`).
- Made `=` optional for `--type` flag in `launch` action.

Ref: OXY2DEV/tree-sitter-kitty#6