### PR TITLE
fix: use proper `; inherits` syntax in queries

### DIFF
--- a/runtime/queries/html/injections.scm
+++ b/runtime/queries/html/injections.scm
@@ -1,4 +1,5 @@
-; inherits html_tags
+; inherits: html_tags
+
 (element
   (start_tag
     (tag_name) @_py_script)

--- a/runtime/queries/starlark/injections.scm
+++ b/runtime/queries/starlark/injections.scm
@@ -1,1 +1,1 @@
-; inherits python
+; inherits: python

--- a/runtime/queries/vue/injections.scm
+++ b/runtime/queries/vue/injections.scm
@@ -1,4 +1,5 @@
-; inherits html_tags
+; inherits: html_tags
+
 ; <script lang="css">
 ((style_element
   (start_tag

--- a/runtime/queries/wgsl_bevy/folds.scm
+++ b/runtime/queries/wgsl_bevy/folds.scm
@@ -1,2 +1,3 @@
-; inherits wgsl
+; inherits: wgsl
+
 (preproc_ifdef) @fold

--- a/runtime/queries/wgsl_bevy/highlights.scm
+++ b/runtime/queries/wgsl_bevy/highlights.scm
@@ -1,4 +1,5 @@
-; inherits wgsl
+; inherits: wgsl
+
 [
   "virtual"
   "override"

--- a/runtime/queries/wgsl_bevy/indents.scm
+++ b/runtime/queries/wgsl_bevy/indents.scm
@@ -1,4 +1,5 @@
-; inherits wgsl
+; inherits: wgsl
+
 [
   "#ifdef"
   "#ifndef"


### PR DESCRIPTION
Some queries don't add a colon after the `inherits` keyword, which nvim could handle but `ts_query_ls` could not, causing it to give incomplete diagnostics.