### PR TITLE
feat(nu): update highlights.scm to support new syntax

### DIFF
--- a/runtime/queries/nu/highlights.scm
+++ b/runtime/queries/nu/highlights.scm
@@ -219,6 +219,8 @@ file_path: (val_string) @variable.parameter
   "}"
   "["
   "]"
+  "<"
+  ">"
   "...["
   "...("
   "...{"
@@ -334,11 +336,7 @@ key: (identifier) @property
 (flat_type) @type
 
 (list_type
-  "list" @type.builtin
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
+  "list" @type.builtin)
 
 (collection_type
   [
@@ -350,20 +348,10 @@ key: (identifier) @property
   key: (_) @variable.parameter)
 
 (collection_type
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
-
-(collection_type
   ":" @punctuation.special)
 
 (composite_type
-  "oneof" @type.builtin
-  [
-    "<"
-    ">"
-  ] @punctuation.bracket)
+  "oneof" @type.builtin)
 
 (shebang) @keyword.directive
 


### PR DESCRIPTION
1. [sum-type](https://www.nushell.sh/blog/2025-06-10-nushell_0_105_0.html#oneof-the-things-toc)
2. [case-insensitive-cell-paths](https://www.nushell.sh/blog/2025-06-10-nushell_0_105_0.html#case-sensitive-cell-paths-or-not-toc)