### PR TITLE
queries(apex): Use Javadoc for comment injections

### DIFF
--- a/runtime/queries/apex/injections.scm
+++ b/runtime/queries/apex/injections.scm
@@ -12,4 +12,3 @@
 ((line_comment) @injection.content
   (#lua-match? @injection.content "^///%s")
   (#set! injection.language "javadoc"))
-


### PR DESCRIPTION
Apex codebases commonly use Javadoc-style comments, similar to Java (Apex is Salesforce's object-oriented language).

This updates the injection query to capture javadoc nodes instead of the generic comment for better highlighting and parsing accuracy.

fixes; https://github.com/nvim-treesitter/nvim-treesitter/pull/8222