### PR TITLE
feat(ecma): variable definition from object destructure

### DIFF
--- a/runtime/queries/ecma/locals.scm
+++ b/runtime/queries/ecma/locals.scm
@@ -21,6 +21,10 @@
 (variable_declarator
   name: (identifier) @local.definition.var)
 
+(variable_declarator
+  name: (object_pattern
+    (shorthand_property_identifier_pattern) @local.definition.var))
+
 (import_specifier
   (identifier) @local.definition.import)
 


### PR DESCRIPTION
Hello,

Motivation for this change comes from [nvim-dap-virtual-text](https://github.com/theHamsta/nvim-dap-virtual-text).

**Before**:

<img width="397" height="196" alt="image" src="https://github.com/user-attachments/assets/5fde5b29-0544-4662-826c-a420a86082b5" />

**After**:

<img width="441" height="190" alt="image" src="https://github.com/user-attachments/assets/edaed675-31e4-44b1-b4b2-6e11f0f58b9a" />
