### PR TITLE
Remove erroneous priority for CData in xml highlights to permit user injections

### DIFF
--- a/queries/xml/highlights.scm
+++ b/queries/xml/highlights.scm
@@ -189,11 +189,10 @@
 ; Text
 (CharData) @none @spell
 
-((CDSect
+(CDSect
   (CDStart) @module
   (CData) @markup.raw
   "]]>" @module)
-  (#set! priority 105))
 
 ; Misc
 (Comment) @comment @spell


### PR DESCRIPTION
Fixes #8242 

Thought the issue this resolves was closed as "not planned", after further discussion, I was able to explain that the current priority breaks *some* template languages that rely on text existing inside of a `<[CDATA[` inside of a tag.

Additionally, this priority seems to be leftover from when this file was first committed, but there is no indication for why it is present, and it is possible it is a leftover from some debugging.

This change does not break existing injections that currently ship with `nvim-treesitter`, but instead allows additional injections to be defined by users, like those found in the Max/MSP Jitter XML Shader format.

This change also removes the now unnecessarily doubled up parentheses, so I apologize for my original assertion that this was a one line fix, when it is in fact a two line fix 🙂