### PR TITLE
fix(gdshader): add missing keyword to group

### DIFF
--- a/runtime/queries/gdshader/highlights.scm
+++ b/runtime/queries/gdshader/highlights.scm
@@ -1,5 +1,6 @@
 [
   "global"
+  "instance"
   "group_uniforms"
   "uniform"
   "const"


### PR DESCRIPTION
Adds highlighting to the "instance" keyword which was forgotten in the original query.