### PR TITLE
fix(t32)!: update parser and queries

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2271,7 +2271,7 @@ return {
   },
   t32 = {
     install_info = {
-      revision = '2f604ad17a15c09d99648199da7f173eed8250dc',
+      revision = '056123923a10e3d537914885cfbacf79cd644e40',
       url = 'https://github.com/xasc/tree-sitter-t32',
     },
     maintainers = { '@xasc' },

--- a/runtime/queries/t32/highlights.scm
+++ b/runtime/queries/t32/highlights.scm
@@ -102,8 +102,6 @@
 
 (path) @string.special.path
 
-(symbol) @string.special.symbol
-
 [
   (character)
   (hll_char_literal)
@@ -159,7 +157,7 @@
 ; Variables, constants and labels
 (macro) @variable.builtin
 
-(trace32_hll_variable) @variable.builtin
+(symbol) @variable
 
 (argument_list
   (identifier) @constant.builtin)
@@ -167,6 +165,12 @@
 ((argument_list
   (identifier) @constant.builtin)
   (#lua-match? @constant.builtin "^[%%/][%l%u][%l%u%d.]*$"))
+
+((symbol) @constant
+  (#lua-match? @constant "^\\\\\\\\\\\\[^\\\\]*(\\\\\\\\[^\\\\]*)?(\\\\[^\\\\]*)?$"))
+
+((symbol) @constant
+  (#lua-match? @constant "^\\\\\\\\[^\\\\]*(\\\\[^\\\\]*)?$"))
 
 ((command_expression
   command: (identifier) @keyword

--- a/runtime/queries/t32/locals.scm
+++ b/runtime/queries/t32/locals.scm
@@ -13,7 +13,7 @@
 (command_expression
   command: (identifier)
   arguments: (argument_list
-    declarator: (trace32_hll_variable) @local.definition.var))
+    declarator: (symbol) @local.definition.var))
 
 ; Function definitions
 (subroutine_block
@@ -32,5 +32,5 @@
 
 [
   (macro)
-  (trace32_hll_variable)
+  (symbol)
 ] @local.reference

--- a/tests/query/highlights/t32/keywords.cmm
+++ b/tests/query/highlights/t32/keywords.cmm
@@ -109,7 +109,7 @@ SUBROUTINE start_debug
     COVerage.ListModule %MULTI.OBC \sieve
 ;    ^ @keyword
 ;                        ^ @constant.builtin
-;                                  ^ @string.special.symbol
+;                                  ^ @variable
 
     Var.DRAW flags[0..16] /Alternate 3
 ;    ^ @keyword

--- a/tests/query/highlights/t32/literals.cmm
+++ b/tests/query/highlights/t32/literals.cmm
@@ -20,7 +20,7 @@ DATA.SET P:&HEAD+0x4 %LONG DATA.LONG(EA:&HEAD+0x4)&0xFFFFFF
 ;                                    ^ @constant.builtin
 
 List `main`
-;    ^ @string.special.symbol
+;    ^ @variable
 
 &range = 'a'--'z'||'0'--'9'
 ;        ^ @character

--- a/tests/query/highlights/t32/var.cmm
+++ b/tests/query/highlights/t32/var.cmm
@@ -1,7 +1,7 @@
 Var.NEWGLOBAL char[4][32] \myarr
 ; <- @keyword
 ;             ^ @type.builtin
-;                          ^ @variable.builtin
+;                          ^ @variable
 LOCAL &i &data
 
 &data="zero|one|two|three"
@@ -12,20 +12,20 @@ WHILE &i<4
     PRIVATE &val
     &val=STRing.SPLIT("&data","|",&i)
     Var.Assign \myarr[&i]="&val"
-;              ^ @variable.builtin
+;              ^ @variable
 ;                        ^ @operator
     &i=&i+1.
 )
 
 Var.NEWLOCAL \x
 ; <- @keyword
-;             ^ @variable.builtin
+;             ^ @variable
 Var.set \x=func3(5,3)
-;       ^ @variable.builtin
+;       ^ @variable
 ;          ^ @function.call
 ;                ^ @number
 PRINT Var.VALUE(\x)
-;               ^ @variable.builtin
+;               ^ @variable
 PRINT Var.VALUE('a')
 ;               ^ @character
 Var.Assign (*ap)[2..4] = &a


### PR DESCRIPTION
`trace32_hll_variable` has been removed from the grammar. The queries are now capturing `symbol` instead. `symbol` is highlighted as variable or constant.