### PR TITLE
fix(fsharp): correct use of supertypes in `(_type)` patterns

### DIFF
--- a/runtime/queries/fsharp/highlights.scm
+++ b/runtime/queries/fsharp/highlights.scm
@@ -376,8 +376,9 @@
   (unit) @function.call)
 
 ((_type
-  (long_identifier
-    (identifier) @type.builtin))
+  (simple_type
+    (long_identifier
+      (identifier) @type.builtin)))
   (#any-of? @type.builtin
     "bool" "byte" "sbyte" "int16" "uint16" "int" "uint" "int64" "uint64" "nativeint" "unativeint"
     "decimal" "float" "double" "float32" "single" "char" "string" "unit"))
@@ -401,8 +402,9 @@
   (attributes
     (attribute
       (_type
-        (long_identifier
-          (identifier) @attribute))))
+        (simple_type
+          (long_identifier
+            (identifier) @attribute)))))
   (function_or_value_defn
     (value_declaration_left
       .


### PR DESCRIPTION
Problem: These patterns were impossible, since children need to be children of
every subtype of a supertype to be captured in this way. As subtypes
could appear as children themselves, the query code silently "skipped
over" the supertype restriction in the pattern. This was fixed in
tree-sitter v0.26.0, which now (correctly) flags these patterns as
"impossible".

Solution: Add the appropriate child nodes explicitly.

Thanks @willlillis for the fix and the explanation!