### PR TITLE
fix(install): explicitly set `gcc` as `CC` on Windows when `cl` is unavailable

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -281,6 +281,10 @@ end
 local function do_compile(logger, compile_location)
   logger:info(string.format('Compiling parser'))
 
+  if uv.os_uname().sysname == 'Windows_NT' and fn.executable('cl') == 0 then
+    vim.env.CC = 'gcc'
+  end
+
   local r = system({
     'tree-sitter',
     'build',


### PR DESCRIPTION
fix #8292