### PR TITLE
improve highlights for wgsl (add operators and lower priority variable)

### DIFF
--- a/runtime/queries/wgsl/highlights.scm
+++ b/runtime/queries/wgsl/highlights.scm
@@ -1,4 +1,5 @@
-((identifier) @variable (#set! priority 99))
+((identifier) @variable
+  (#set! priority 99))
 
 (int_literal) @number
 


### PR DESCRIPTION
@variable at priority 100 was showing over function calls and types among other things. putting it at 99 is better behavior. also, added 8 compound assignment operators to highlight as operators. 

should note as well that the tree-sitter grammar being used is no longer maintained and is now quite behind the wgsl language spec. i am currently extending the query with stuff like `((identifier) @keyword (#eq? @keyword "const"))` to highlight keywords that are not included in this grammar. Since it does seem a bit hacky, I didn't include those changes in this PR, but let me know if that's something you want and I can add them. 