### PR TITLE
fix(haskell): correct use of supertypes in `(decl)` patterns

### DIFF
--- a/runtime/queries/haskell/highlights.scm
+++ b/runtime/queries/haskell/highlights.scm
@@ -121,7 +121,21 @@
 
 ; ----------------------------------------------------------------------------
 ; Functions and variables
-(decl
+(decl/signature
+  [
+    name: (variable) @function
+    names: (binding_list
+      (variable) @function)
+  ])
+
+(decl/function
+  [
+    name: (variable) @function
+    names: (binding_list
+      (variable) @function)
+  ])
+
+(decl/bind
   [
     name: (variable) @function
     names: (binding_list
@@ -142,7 +156,14 @@
   type: (type))
   .
   (decl
-    name: (variable) @variable)
+    [
+      (signature
+        name: (variable) @variable)
+      (function
+        name: (variable) @variable)
+      (bind
+        name: (variable) @variable)
+    ])
   match: (_)
   (#eq? @_name @variable))
 
@@ -160,7 +181,14 @@
   (#eq? @_type "IO"))
   .
   (decl
-    name: (variable) @function)
+    [
+      (signature
+        name: (variable) @function)
+      (function
+        name: (variable) @function)
+      (bind
+        name: (variable) @function)
+    ])
   match: (_)
   (#eq? @_name @function))
 


### PR DESCRIPTION
Problem: These patterns were impossible, since children need to be children of
every subtype of a supertype to be captured in this way. As subtypes
could appear as children themselves, the query code silently "skipped
over" the supertype restriction in the pattern. This was fixed in
tree-sitter v0.26.0, which now (correctly) flags these patterns as
"impossible".

Solution: Add the appropriate child nodes explicitly.
