### PR TITLE
fix(lua-ls): correct workspace.library format in .luarc.json

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -4,12 +4,12 @@
     "version": "LuaJIT"
   },
   "workspace": {
-    "library": [
-      "lua",
-      "$VIMRUNTIME",
-      "${3rd}/luv/library",
-      "${3rd}/busted/library"
-    ],
+    "library": {
+      "lua": true,
+      "$VIMRUNTIME": true,
+      "${3rd}/luv/library": true,
+      "${3rd}/busted/library": true
+    },
     "checkThirdParty": false
   },
   "diagnostics": {
@@ -21,6 +21,6 @@
       "strong": "Warning",
       "strict": "Warning"
     },
-    "unusedLocalExclude": [ "_*" ]
+    "unusedLocalExclude": ["_*"]
   }
 }


### PR DESCRIPTION
Updated .luarc.json to use the correct workspace.library object format required by LuaLS. Previously it was an array, which caused LuaLS to not recognize runtime libraries. No other settings were changed.