### PR TITLE
feat: add TOON parser support

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2434,6 +2434,15 @@ list.toml = {
   maintainers = { "@tk-shirasaka" },
 }
 
+list.toon = {
+  install_info = {
+    url = "https://github.com/DanEscher98/tree-sitter-toon",
+    files = { "src/parser.c", "src/scanner.c" },
+    branch = "main",
+  },
+  maintainers = { "@DanEscher98" },
+}
+
 list.tsv = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-csv",

--- a/queries/toon/folds.scm
+++ b/queries/toon/folds.scm
@@ -1,0 +1,17 @@
+; folds.scm - Folding queries for TOON
+; Allows collapsing nested structures in editors
+; Fold objects (nested key-value structures)
+(pair
+  value: (object)) @fold
+
+; Fold array declarations with content
+(array_declaration
+  content: (array_content)) @fold
+
+; Fold root arrays with content
+(root_array
+  content: (array_content)) @fold
+
+; Fold list items with nested objects
+(list_item
+  (object)) @fold

--- a/queries/toon/highlights.scm
+++ b/queries/toon/highlights.scm
@@ -1,0 +1,90 @@
+; highlights.scm - Syntax highlighting queries for TOON
+; Maps grammar nodes to standard Neovim highlight capture groups
+; Reference: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md
+; Literals
+; --------
+(null) @constant.builtin
+
+(true) @boolean
+
+(false) @boolean
+
+(number) @number
+
+(integer) @number
+
+; Strings
+(quoted_string) @string
+
+(unquoted_string) @string
+
+(escape_sequence) @string.escape
+
+; Properties/Keys
+; ---------------
+; Object keys
+(pair
+  key: (key
+    (identifier) @property))
+
+(pair
+  key: (key
+    (dotted_key
+      (identifier) @property)))
+
+(pair
+  key: (key
+    (quoted_string) @property))
+
+; Array declaration keys
+(array_declaration
+  key: (key
+    (identifier) @property))
+
+(array_declaration
+  key: (key
+    (dotted_key
+      (identifier) @property)))
+
+; Field names in tabular arrays
+(field_name
+  (identifier) @property)
+
+(field_name
+  (quoted_string) @property)
+
+; List item keys (objects as list items)
+(list_item
+  key: (key
+    (identifier) @property))
+
+; Punctuation
+; -----------
+; Delimiters
+":" @punctuation.delimiter
+
+"," @punctuation.delimiter
+
+"|" @punctuation.delimiter
+
+"." @punctuation.delimiter
+
+(delimiter) @punctuation.delimiter
+
+(field_delimiter) @punctuation.delimiter
+
+(delimiter_marker) @punctuation.delimiter
+
+; Brackets
+"[" @punctuation.bracket
+
+"]" @punctuation.bracket
+
+"{" @punctuation.bracket
+
+"}" @punctuation.bracket
+
+; Special
+"\"" @punctuation.special
+
+(list_marker) @punctuation.special

--- a/queries/toon/indents.scm
+++ b/queries/toon/indents.scm
@@ -1,0 +1,23 @@
+; indents.scm - Indentation queries for TOON
+; Guides automatic indentation in editors
+; Indent after opening a nested object
+(pair
+  value: (object) @indent.begin)
+
+; Indent after array declaration with content
+(array_declaration
+  content: (array_content) @indent.begin)
+
+; Indent after root array with content
+(root_array
+  content: (array_content) @indent.begin)
+
+; Indent inside list items with nested content
+(list_item
+  (object) @indent.begin)
+
+; Dedent at end of objects/arrays (handled by external scanner)
+; These markers indicate where indentation should decrease
+(object) @indent.end
+
+(array_content) @indent.end

--- a/queries/toon/locals.scm
+++ b/queries/toon/locals.scm
@@ -1,0 +1,15 @@
+; locals.scm - Local scope and reference queries for TOON
+; Used for features like go-to-definition, scope highlighting
+; Each object creates a new scope
+(object) @local.scope
+
+; Keys define local names within their scope
+(pair
+  key: (key) @local.definition)
+
+; Array declarations define names
+(array_declaration
+  key: (key) @local.definition)
+
+; Field names in tabular arrays are definitions
+(field_name) @local.definition


### PR DESCRIPTION
## Summary
- Add tree-sitter grammar for TOON (Token-Oriented Object Notation)
- TOON is a JSON-alternative data format featuring indentation-based structure, tabular arrays, and flexible delimiters

## Changes
- Add parser config in `lua/nvim-treesitter/parsers.lua`
- Add query files in `queries/toon/`:
  - `highlights.scm` - syntax highlighting
  - `folds.scm` - code folding
  - `indents.scm` - auto-indentation
  - `locals.scm` - scope/definition tracking

## Parser Repository
https://github.com/DanEscher98/tree-sitter-toon

## Language Specification
https://github.com/toon-format/spec

## Test Plan
- [x] Parser compiles successfully
- [x] All 32 test cases pass
- [x] Full TOON spec v3.0 compliance verified against official examples
- [x] Query files tested with nvim-treesitter

## Example TOON Syntax
```toon
# Simple object
name: Alice
age: 30

# Tabular array
users[3]{id,name,role}:
  1,Alice,admin
  2,Bob,user

# Nested object
config:
  database:
    host: localhost
    port: 5432
```