### PR TITLE
fix(fennel): highlight `$[1-9]` in multi-symbol context properly

### DIFF
--- a/runtime/queries/fennel/highlights.scm
+++ b/runtime/queries/fennel/highlights.scm
@@ -102,13 +102,13 @@
   ])
 
 ((symbol) @variable.parameter
-  (#any-of? @variable.parameter "$" "$..."))
+  (#lua-match? @variable.parameter "^%$[1-9]?$"))
 
 ((symbol_fragment) @variable.parameter
-  (#eq? @variable.parameter "$"))
+  (#lua-match? @variable.parameter "^%$[1-9]?$"))
 
 ((symbol) @variable.parameter
-  (#lua-match? @variable.parameter "^%$[1-9]$"))
+  (#eq? @variable.parameter "$..."))
 
 ((symbol) @operator
   (#any-of? @operator


### PR DESCRIPTION
Highlights the dollar symbol properly in multi-symbol contexts, like `$3.some.properties`. There was already a fix for a similar issue on #8067, but it only addressed `$.some.properties`, but not the variant with the argument number in it.