### PR TITLE
From sql/highlights.scm, remove @type capture

### DIFF
--- a/queries/sql/highlights.scm
+++ b/queries/sql/highlights.scm
@@ -12,9 +12,6 @@
   (keyword_array)
 ] @function.call
 
-(object_reference
-  name: (identifier) @type)
-
 (relation
   alias: (identifier) @variable)
 


### PR DESCRIPTION
The capture `@type` is too generic and captures many different things, e.g. function calls and table references. It doesn't capture builtin types, which are captured by `@type.builtin`. See screenshots below for examples.

The outcome is that function calls are highlighted as types. Same for table names.

I guess one can make an argument that tables are composite types in SQL, but it doesn't feel right to highlight them in the same way as e.g. `DOUBLE`.

To fix this issue, just remove the `@type` capture rule.

# Examples

<img width="190" height="173" alt="Screenshot 2025-12-04 at 11 12 28" src="https://github.com/user-attachments/assets/8de81a13-c980-4974-ba47-205022c0876d" />
<img width="137" height="133" alt="Screenshot 2025-12-04 at 11 12 47" src="https://github.com/user-attachments/assets/a3f8363f-cd85-4358-9105-148e845f2fce" />
<img width="146" height="178" alt="Screenshot 2025-12-04 at 11 11 55" src="https://github.com/user-attachments/assets/057a797c-6f1a-45ad-b469-5eb3fb1a0d75" />
