### PR TITLE
[ruby] Ensure string-symbols are highlighted properly

### DIFF
--- a/queries/ruby/highlights.scm
+++ b/queries/ruby/highlights.scm
@@ -193,11 +193,12 @@
   (hash_key_symbol)
 ] @string.special.symbol
 
-(delimited_symbol 
+(delimited_symbol
   (string_content) @string.special.symbol)
 
 ; Ensure "symbol" highlight has priority over "string" highlight for closing " char.
-((delimited_symbol) @string.special.symbol (#set! priority 101))
+((delimited_symbol) @string.special.symbol
+  (#set! priority 101))
 
 (regex
   (string_content) @string.regexp)


### PR DESCRIPTION
Ensure the entire symbol is highlighted properly, not just the leading `:"` characters.

set priority for closing `"` character so it has symbol highlight applied, instead of string highlight

Before:
<img width="135" height="35" alt="Screenshot 2025-12-04 at 12 43 40" src="https://github.com/user-attachments/assets/e4c3adac-d42f-4fb6-8b6a-0e0e18f3faee" />

After:
<img width="132" height="27" alt="Screenshot 2025-12-04 at 12 43 11" src="https://github.com/user-attachments/assets/f70ee8de-bc28-44a2-b23b-0cbda7bb9066" />
