### PR TITLE
In sql/highlights.scm improve @type capture

### DIFF
--- a/runtime/queries/sql/highlights.scm
+++ b/runtime/queries/sql/highlights.scm
@@ -13,8 +13,12 @@
   (keyword_object_id)
 ] @function.call
 
-(object_reference
-  name: (identifier) @type)
+((object_reference
+  name: (identifier) @type) @_obj_ref
+  (#not-has-parent? @_obj_ref invocation))
+
+(cte
+  (identifier) @type)
 
 (relation
   alias: (identifier) @variable)


### PR DESCRIPTION
`@type` currently captures function calls, resulting in the wrong color assigned to them (the one of `@type` instead of `@function.call`).

Also `@type` doesn't capture CTE names. But to be consistent with the behavior that `@type` refers to tables it arguably should capture CTE names.

This PR is an improved version of #8313.

# Example

<img width="190" height="173" alt="image" src="https://github.com/user-attachments/assets/599d605e-9b3a-45ed-a871-2ec2a1269701" />


# Alternative

The alternative 
```
(relation
  (object_reference
    name: (identifier) @type))
```
was not chosen because it doesn't capture the table name if it is used to qualify a column name: `table.column`.

cc @DerekStride
