### PR TITLE
[ruby] Fix highlighting for string-literal symbols.

### DIFF
--- a/runtime/queries/ruby/highlights.scm
+++ b/runtime/queries/ruby/highlights.scm
@@ -186,16 +186,13 @@
 [
   (bare_symbol)
   (simple_symbol)
-  (delimited_symbol)
   (hash_key_symbol)
 ] @string.special.symbol
 
 (delimited_symbol
-  (string_content) @string.special.symbol)
-
-; Ensure "symbol" highlight has priority over "string" highlight for closing quote character.
-((delimited_symbol) @string.special.symbol
-  (#set! priority 101))
+  ":\"" @string.special.symbol
+  (string_content) @string.special.symbol
+  "\"" @string.special.symbol)
 
 (regex
   (string_content) @string.regexp)


### PR DESCRIPTION
Before:
<img width="135" height="35" alt="Screenshot 2025-12-04 at 12 43 40" src="https://github.com/user-attachments/assets/333ddb0c-0620-405a-97dc-93778b364693" />

After:
<img width="132" height="27" alt="Screenshot 2025-12-04 at 12 43 11" src="https://github.com/user-attachments/assets/b6c84c0c-d19f-474d-bf72-78338c15c0eb" />

In ruby, a symbol literal can be defined with a leading colon, like this `:hello`. If you want the symbol to contain certain characters (numbers, spaces, dashes, etc), quotation marks can be used like a string, but with a leading colon. This is still a symbol literal, not a string.

The current highlight group applied to the "string" content is for strings, but it would be more accurate to apply the symbol highlight group.



Previous PR: https://github.com/nvim-treesitter/nvim-treesitter/pull/8314
