### PR TITLE
fix(inko): downgrade parser

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -140,7 +140,7 @@ html_tags (queries only)[^html_tags] | unstable | `H IJ ` | @TravonteD
 [idl](https://github.com/cathaysia/tree-sitter-idl) | unstable | `H IJ ` | @cathaysia
 [idris](https://github.com/kayhide/tree-sitter-idris) | unstable | `HF JL` | 
 [ini](https://github.com/justinmk/tree-sitter-ini) | unstable | `HF J ` | @theHamsta
-[inko](https://github.com/inko-lang/tree-sitter-inko) | unstable | `HFIJL` | @yorickpeterse
+[inko](https://github.com/inko-lang/tree-sitter-inko) | unmaintained | `HFIJL` | @yorickpeterse
 [ispc](https://github.com/tree-sitter-grammars/tree-sitter-ispc) | unstable | `HFIJL` | @fab4100
 [janet_simple](https://github.com/sogaiu/tree-sitter-janet-simple) | unstable | `HF JL` | @sogaiu
 [java](https://github.com/tree-sitter/tree-sitter-java) | unstable | `HFIJL` | @p00f

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1041,11 +1041,11 @@ return {
   },
   inko = {
     install_info = {
-      revision = 'fc37d05c363ccf7f515354c5a47d72b2d3ff555e',
+      revision = '9d7ed4f6c0ea2a8f846f3bb00e33ab21ec9ca379',
       url = 'https://github.com/inko-lang/tree-sitter-inko',
     },
     maintainers = { '@yorickpeterse' },
-    tier = 2,
+    tier = 3,
   },
   ispc = {
     install_info = {


### PR DESCRIPTION
Problem: The commit https://github.com/inko-lang/tree-sitter-inko/commit/fc37d05c363ccf7f515354c5a47d72b2d3ff555e broke parsing a textobjects query.

Solution: Downgrade parser to previous commit and pin it (until we can move it to tier 1).
