### PR TITLE
feat(bash): update parser

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -77,7 +77,7 @@ return {
   },
   bash = {
     install_info = {
-      revision = '20f55fb9663568f16ebceaac7673d2aa530add46',
+      revision = 'a06c2e4415e9bc0346c6b86d401879ffb44058f7',
       url = 'https://github.com/tree-sitter/tree-sitter-bash',
     },
     maintainers = { '@TravonteD' },

--- a/tests/query/highlights/bash/double-parens.sh
+++ b/tests/query/highlights/bash/double-parens.sh
@@ -1,6 +1,6 @@
-if (( $(tree-sitter parse test/Petalisp/**/*.lisp -q | wc -l) > 2 )); then
-#  ^ @punctuation.special
-#                                                                  ^ @punctuation.special
-#                                                           ^ @punctuation.bracket
+if $(( $(tree-sitter parse test/Petalisp/**/*.lisp -q | wc -l) > 2 )); then
+#   ^ @punctuation.special
+#                                                                   ^ @punctuation.special
+#                                                            ^ @punctuation.bracket
    exit 1 
 fi


### PR DESCRIPTION
Breaking change: removed double parenthesis as valid opening to
arithmetic expansion. (Only `$((` is allowed according to the manual.)
