### PR TITLE
feat(fortran)!: update parser and queries

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -592,7 +592,7 @@ return {
   },
   fortran = {
     install_info = {
-      revision = '8334abca785db3a041292e3b3b818a82a55b238f',
+      revision = 'd0d1bc84c43870788c1b402f2e6b490b27257f9e',
       url = 'https://github.com/stadelmanma/tree-sitter-fortran',
     },
     maintainers = { '@amaanq' },

--- a/runtime/queries/fortran/folds.scm
+++ b/runtime/queries/fortran/folds.scm
@@ -3,7 +3,7 @@
   (if_statement)
   (where_statement)
   (enum_statement)
-  (do_loop_statement)
+  (do_loop)
   (derived_type_definition)
   (function)
   (subroutine)

--- a/runtime/queries/fortran/indents.scm
+++ b/runtime/queries/fortran/indents.scm
@@ -5,7 +5,7 @@
   (function)
   ; (interface)
   (if_statement)
-  (do_loop_statement)
+  (do_loop)
   (where_statement)
   (derived_type_definition)
   (enum)


### PR DESCRIPTION
Breaking change: `(do_loop_statement)` renamed to `(do_loop)`
