### PR TITLE
Allow downloading with git instead of curl

### DIFF
--- a/lua/nvim-treesitter/config.lua
+++ b/lua/nvim-treesitter/config.lua
@@ -4,10 +4,12 @@ M.tiers = { 'stable', 'unstable', 'unmaintained', 'unsupported' }
 
 ---@class TSConfig
 ---@field install_dir string
+---@field prefer_git boolean
 
 ---@type TSConfig
 local config = {
   install_dir = vim.fs.joinpath(vim.fn.stdpath('data'), 'site'),
+  prefer_git = false,
 }
 
 ---Setup call for users to override configuration configurations.
@@ -18,8 +20,18 @@ function M.setup(user_data)
       user_data.install_dir = vim.fs.normalize(user_data.install_dir)
       vim.opt.runtimepath:prepend(user_data.install_dir)
     end
+    if user_data.prefer_git then
+      local log = require('nvim-treesitter.log')
+      log.warn('nvim-treesitter will use git to install parsers, which is slower and less stable.')
+    end
     config = vim.tbl_deep_extend('force', config, user_data)
   end
+end
+
+---Returns whether git should be used to obtain the parsers
+---@return boolean prefer_git
+function M.is_git_preferred()
+  return config.prefer_git
 end
 
 -- Returns the install path for parsers, parser info, and queries.

--- a/scripts/install-parsers.lua
+++ b/scripts/install-parsers.lua
@@ -17,10 +17,12 @@ for i = 1, #_G.arg do
 end
 
 vim.opt.runtimepath:append('.')
+local ts = require('nvim-treesitter')
+ts.setup({ prefer_git = true })
 
 ---@type async.Task
-local task = update and require('nvim-treesitter').update('all', { summary = true })
-  or require('nvim-treesitter').install(
+local task = update and ts.update('all', { summary = true })
+  or ts.install(
     #parsers > 0 and parsers or 'all',
     { force = true, summary = true, generate = generate, max_jobs = max_jobs }
   )


### PR DESCRIPTION
_(Yes, I know git uses curl under the hood, bear with me here)_

This is a bit of a weird one. I'm running this plugin in an environment which is heavily locked down. Only cloning from git works, downloading archives does not work. To use this plugin I forked and added a config option to use git to obtain the code, rather than using curl to download the archive.

I totally understand if this PR is rejected, arguably I'm adding code bloat with redundant functionality to side-step a limitation beyond the scope of this tool. But I felt like it might be worth trying to upstream this change, in case there is actually a good purpose for this.