### PR TITLE
ci(test): add parsers cache

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -31,7 +31,19 @@ jobs:
         run: |
           bash ./scripts/ci-install.sh
 
-      - if: inputs.type == 'build'
+      - name: Setup parsers cache
+        id: parsers-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/nvim/site/parser/
+          key: parsers-${{ join(matrix.*, '-') }}-${{ hashFiles(
+            './lua/nvim-treesitter/async.lua',
+            './lua/nvim-treesitter/config.lua',
+            './lua/nvim-treesitter/install.lua',
+            './lua/nvim-treesitter/parsers.lua'
+            ) }}
+
+      - if: ${{ inputs.type == 'build' && steps.parsers-cache.outputs.cache-hit != 'true' }}
         name: Compile parsers
         run: $NVIM -l ./scripts/install-parsers.lua --max-jobs=10
 


### PR DESCRIPTION
We originally said that the new async parser installation is fast enough not to _need_ a cache, but it's still good not to needlessly waste cycles. And as we move towards less frequent parser updates (e.g., by switching more and more parsers to version updates -- or no updates at all), the cache will pay off more and more.