### PR TITLE
feat(inko): update to 0.4.0

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -138,7 +138,7 @@ html_tags (queries only)[^html_tags] | unstable | `H IJ ` | @TravonteD
 [idl](https://github.com/cathaysia/tree-sitter-idl) | unstable | `H IJ ` | @cathaysia
 [idris](https://github.com/kayhide/tree-sitter-idris) | unstable | `HF JL` | 
 [ini](https://github.com/justinmk/tree-sitter-ini) | unstable | `HF J ` | @theHamsta
-[inko](https://github.com/inko-lang/tree-sitter-inko) | unmaintained | `HFIJL` | @yorickpeterse
+[inko](https://github.com/inko-lang/tree-sitter-inko) | stable | `HFIJL` | @yorickpeterse
 [ispc](https://github.com/tree-sitter-grammars/tree-sitter-ispc) | unstable | `HFIJL` | @fab4100
 [janet_simple](https://github.com/sogaiu/tree-sitter-janet-simple) | unstable | `HF JL` | @sogaiu
 [java](https://github.com/tree-sitter/tree-sitter-java) | unstable | `HFIJL` | @p00f

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1025,11 +1025,11 @@ return {
   },
   inko = {
     install_info = {
-      revision = '9d7ed4f6c0ea2a8f846f3bb00e33ab21ec9ca379',
+      revision = 'v0.4.0',
       url = 'https://github.com/inko-lang/tree-sitter-inko',
     },
     maintainers = { '@yorickpeterse' },
-    tier = 3,
+    tier = 1,
   },
   ispc = {
     install_info = {


### PR DESCRIPTION
This changes the structure of "if" expressions so the queries for nvim-treesitter-textobjects can be changed as to not cause any crashes.