### PR TITLE
feat(bash): remove unnecessary captures

### DIFF
--- a/runtime/queries/bash/highlights.scm
+++ b/runtime/queries/bash/highlights.scm
@@ -117,9 +117,6 @@
     "SIGRTMAX-12" "SIGRTMAX-11" "SIGRTMAX-10" "SIGRTMAX-9" "SIGRTMAX-8" "SIGRTMAX-7" "SIGRTMAX-6"
     "SIGRTMAX-5" "SIGRTMAX-4" "SIGRTMAX-3" "SIGRTMAX-2" "SIGRTMAX-1" "SIGRTMAX"))
 
-((word) @boolean
-  (#any-of? @boolean "true" "false"))
-
 (comment) @comment @spell
 
 (test_operator) @operator
@@ -189,9 +186,6 @@
   (word) @variable.parameter)
 
 (number) @number
-
-((word) @number
-  (#lua-match? @number "^[0-9]+$"))
 
 (file_redirect
   (word) @string.special.path)


### PR DESCRIPTION
- Bash does not have boolean values and the builtin `true` and `false` commands are already covered by another capture.
- The grammar has a `number` node and it's already captured.