### PR TITLE
feat: add Dingo language parser

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -57,6 +57,7 @@ Language | Tier | Queries | Maintainer
 [devicetree](https://github.com/joelspadin/tree-sitter-devicetree) | unstable | `HFIJL` | @jedrzejboczar
 [dhall](https://github.com/jbellerb/tree-sitter-dhall) | unstable | `HF J ` | @amaanq
 [diff](https://github.com/tree-sitter-grammars/tree-sitter-diff) | unstable | `HF J ` | @gbprod
+[dingo](https://github.com/MadAppGang/dingo.nvim) | unmaintained | `HFI  ` | @erudenko
 [disassembly](https://github.com/ColinKennedy/tree-sitter-disassembly) | unstable | `H  J ` | @ColinKennedy
 [djot](https://github.com/treeman/tree-sitter-djot) | unstable | `HFIJL` | @NoahTheDuke
 [dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) | unstable | `H  J ` | @camdencheek

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -368,6 +368,15 @@ return {
     maintainers = { '@gbprod' },
     tier = 2,
   },
+  dingo = {
+    install_info = {
+      location = 'tree-sitter-dingo',
+      revision = '60f27ff6a102c3ba921a1939382064aec468e6ce',
+      url = 'https://github.com/MadAppGang/dingo.nvim',
+    },
+    maintainers = { '@erudenko' },
+    tier = 3,
+  },
   disassembly = {
     install_info = {
       revision = '0229c0211dba909c5d45129ac784a3f4d49c243a',

--- a/runtime/queries/dingo/folds.scm
+++ b/runtime/queries/dingo/folds.scm
@@ -1,0 +1,9 @@
+[
+  (block)
+  (function_declaration)
+  (enum_declaration)
+  (match_expression)
+  (struct_type)
+  (interface_type)
+  (import_declaration)
+] @fold

--- a/runtime/queries/dingo/highlights.scm
+++ b/runtime/queries/dingo/highlights.scm
@@ -1,0 +1,176 @@
+; Keywords
+[
+  "package"
+  "import"
+  "func"
+  "return"
+  "type"
+  "struct"
+  "interface"
+  "map"
+  "chan"
+  "for"
+  "if"
+  "else"
+  "var"
+  "const"
+  "range"
+] @keyword
+
+; Dingo-specific keywords
+[
+  "enum"
+  "match"
+] @keyword
+
+; Operators
+[
+  "="
+  ":="
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "&"
+  "|"
+  "^"
+  "!"
+  "<"
+  ">"
+  "=="
+  "!="
+  "<="
+  ">="
+  "&&"
+  "||"
+  "<<"
+  ">>"
+  "<-"
+  "+="
+  "-="
+  "*="
+  "/="
+] @operator
+
+; Dingo special operators
+"=>" @operator
+
+"?." @operator
+
+"??" @operator
+
+(error_propagation
+  "?" @operator)
+
+; Lambda pipes (special highlighting)
+(lambda_expression
+  "|" @punctuation.special)
+
+; Types
+(type_declaration
+  (identifier) @type.definition)
+
+(type_param
+  (identifier) @type)
+
+(generic_type
+  (identifier) @type)
+
+(qualified_type
+  (identifier) @type)
+
+; Dingo enum
+(enum_declaration
+  name: (identifier) @type.definition)
+
+(enum_variant
+  name: (identifier) @constructor)
+
+(variant_field
+  (identifier) @property)
+
+; Match patterns
+(match_expression
+  "match" @keyword.conditional)
+
+(variant_match
+  (identifier) @constructor)
+
+; Functions
+(function_declaration
+  name: (identifier) @function)
+
+(call_expr
+  (identifier) @function.call)
+
+(call_expr
+  (selector_expr
+    (identifier) @function.method.call))
+
+; Parameters
+(param_decl
+  (identifier) @variable.parameter)
+
+(lambda_param
+  (identifier) @variable.parameter)
+
+; Variables
+(var_spec
+  (identifier) @variable)
+
+(const_spec
+  (identifier) @constant)
+
+; Literals
+(int_literal) @number
+
+(float_literal) @number.float
+
+(string_literal) @string
+
+(rune_literal) @character
+
+; Booleans and nil
+"true" @boolean
+
+"false" @boolean
+
+"nil" @constant.builtin
+
+; Comments
+(comment) @comment
+
+; Punctuation
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ","
+  ";"
+  ":"
+  "."
+] @punctuation.delimiter
+
+; Import path
+(import_spec
+  (string_literal) @string.special)
+
+; Package name
+(package_clause
+  (identifier) @module)
+
+; Wildcard pattern
+"_" @variable.builtin
+
+; Error propagation expression (special styling)
+(error_propagation) @punctuation.special
+
+; Safe navigation (special styling)
+(safe_navigation) @punctuation.special

--- a/runtime/queries/dingo/indents.scm
+++ b/runtime/queries/dingo/indents.scm
@@ -1,0 +1,15 @@
+[
+  (block)
+  (parameter_list)
+  (import_declaration)
+  (enum_declaration)
+  (match_expression)
+  (struct_type)
+  (interface_type)
+] @indent.begin
+
+[
+  "}"
+  ")"
+  "]"
+] @indent.end @indent.branch


### PR DESCRIPTION
## Summary

Adds Tree-sitter parser support for **Dingo**, a meta-language for Go that transpiles to idiomatic Go code.

Dingo extends Go with:
- **Enums** with associated values (sum types)
- **Pattern matching** with exhaustiveness checking
- **Result/Option types** with error propagation (`?` operator)
- **Lambda expressions** (`|x| x + 1` or `x => x + 1`)
- **Safe navigation** (`x?.y`) and null coalescing (`a ?? b`)

## Parser Location

The parser is hosted in the [dingo.nvim](https://github.com/MadAppGang/dingo.nvim) repository under `tree-sitter-dingo/`.

## Checklist

- [x] Parser builds successfully with `tree-sitter generate`
- [x] Highlights queries included in the plugin repository
- [x] Tested with nvim-treesitter locally

## Links

- Main project: https://github.com/MadAppGang/dingo (1000+ stars)
- Neovim plugin: https://github.com/MadAppGang/dingo.nvim