### PR TITLE
chore: update .github files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions:
+        patterns: ["*"]
+

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1372,7 +1372,7 @@ return {
   },
   meson = {
     install_info = {
-      revision = 'd4fa3c7260d1537ac5183740b9338373a673d5c0',
+      revision = '280b6e59186f18528bab1567f5cc43b78b9cd881',
       url = 'https://github.com/tree-sitter-grammars/tree-sitter-meson',
     },
     maintainers = { '@Decodetalkers' },


### PR DESCRIPTION
Now that `main` is the default branch, we can actually make these changes.

- **chore: remove FUNDING.yml**: current maintainers don't have access to the opencollective/github sponsor account
- **ci: add dependabot for GH actions**: what it says on the tin
