### PR TITLE
ci: migrate to emmyluals

### DIFF
--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -12,7 +12,14 @@
   },
   "diagnostics": {
     "disable": [
-      "unnecessary-if"
+      "unnecessary-if",
+      "incomplete-signature-doc"
+    ],
+    "enables": [
+      "iter-variable-reassign",
+      "non-literal-expressions-in-assert",
+      "incomplete-signature-doc",
+      "missing-global-doc"
     ]
   },
   "codeAction": {

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 NVIM_VERSION ?= nightly
-LUALS_VERSION := 3.17.1
 
 DEPDIR ?= .test-deps
 CURL ?= curl -sL --create-dirs
@@ -35,18 +34,18 @@ $(NVIM):
 	tar -xf $(NVIM_TARBALL) -C $@
 	rm -rf $(NVIM_TARBALL)
 
-LUALS := $(DEPDIR)/lua-language-server-$(LUALS_VERSION)-$(LUALS_ARCH)
-LUALS_TARBALL := $(LUALS).tar.gz
-LUALS_URL := https://github.com/LuaLS/lua-language-server/releases/download/$(LUALS_VERSION)/$(notdir $(LUALS_TARBALL))
+EMMYLUALS := $(DEPDIR)/emmylua_check-$(LUALS_ARCH)
+EMMYLUALS_TARBALL := $(EMMYLUALS).tar.gz
+EMMYLUALS_URL := https://github.com/emmyluals/emmylua-analyzer-rust/releases/latest/download/$(notdir $(EMMYLUALS_TARBALL))
 
-.PHONY: luals
-luals: $(LUALS)
+.PHONY: emmyluals
+emmyluals: $(EMMYLUALS)
 
-$(LUALS):
-	$(CURL) $(LUALS_URL) -o $(LUALS_TARBALL)
+$(EMMYLUALS):
+	$(CURL) $(EMMYLUALS_URL) -o $(EMMYLUALS_TARBALL)
 	mkdir $@
-	tar -xf $(LUALS_TARBALL) -C $@
-	rm -rf $(LUALS_TARBALL)
+	tar -xf $(EMMYLUALS_TARBALL) -C $@
+	rm -rf $(EMMYLUALS_TARBALL)
 
 STYLUA := $(DEPDIR)/stylua-$(STYLUA_ARCH)
 STYLUA_TARBALL := $(STYLUA).zip
@@ -104,10 +103,8 @@ formatlua: $(STYLUA)
 	$(STYLUA)/stylua .
 
 .PHONY: checklua
-checklua: $(LUALS) $(NVIM)
-	VIMRUNTIME=$(NVIM_RUNTIME) $(LUALS)/bin/lua-language-server \
-		--configpath=../.luarc.json \
-		--check=./
+checklua: $(EMMYLUALS) $(NVIM)
+	VIMRUNTIME=$(NVIM_RUNTIME) $(EMMYLUALS)/emmylua_check --warnings-as-errors .
 
 .PHONY: query
 query: formatquery lintquery checkquery

--- a/lua/nvim-treesitter/async.lua
+++ b/lua/nvim-treesitter/async.lua
@@ -1,3 +1,4 @@
+---@meta nvim-treesitter.async vendored file, don't diagnose
 local pcall = copcall or pcall
 
 --- @param ... any
@@ -345,8 +346,9 @@ end
 --- -- Since uv functions have sync versions. You can just do:
 --- local stat = vim.fs_stat('foo.txt')
 --- ```
---- @param func function
---- @param ... any
+--- @generic T, R
+--- @param func async fun(...: T...): R...
+--- @param ... T...
 --- @return async.Task
 function M.arun(func, ...)
   local task = Task._new(func)
@@ -354,19 +356,27 @@ function M.arun(func, ...)
   return task
 end
 
---- @class async.TaskFun
---- @field package _fun fun(...: any): any
---- @operator call(...): any
+--- @alias async.TaskFun<T, R> fun(...: T...): async.Task
+
+--- @generic T, R
+--- @class async._TaskFun<T, R>
+--- @field package _fun async fun(...: T...): R...
+--- @operator call(...: T...): async.Task
 local TaskFun = {}
 TaskFun.__index = TaskFun
 
+--- @generic T, R
+--- @param self async._TaskFun<T, R>
+--- @param ... T...
+--- @return async.Task
 function TaskFun:__call(...)
   return M.arun(self._fun, ...)
 end
 
 --- Create an async function
---- @param fun function
---- @return async.TaskFun
+--- @generic T, R
+--- @param fun async fun(...: T...): R...
+--- @return async.TaskFun<T, R>
 function M.async(fun)
   return setmetatable({ _fun = fun }, TaskFun)
 end
@@ -430,9 +440,10 @@ local function await_cbfun(argc, fun, ...)
   end)
 end
 
---- @param taskfun async.TaskFun
---- @param ... any
---- @return any ...
+--- @generic T, R
+--- @param taskfun async.TaskFun<T, R>
+--- @param ... T...
+--- @return R...
 local function await_taskfun(taskfun, ...)
   return taskfun._fun(...)
 end

--- a/lua/nvim-treesitter/indent.lua
+++ b/lua/nvim-treesitter/indent.lua
@@ -97,7 +97,7 @@ local get_indents = memoize(function(bufnr, root, lang)
     return map
   end
   for id, node, metadata in query:iter_captures(root, bufnr) do
-    if query.captures[id]:sub(1, 1) ~= '_' then
+    if assert(query.captures[id]):sub(1, 1) ~= '_' then
       map[query.captures[id]][node:id()] = metadata or {}
     end
   end

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -85,6 +85,7 @@ local function join(max_jobs, tasks)
     end
 
     for i = 1, max_jobs do
+      assert(tasks[i])
       tasks[i]():await(cb)
     end
   end)
@@ -155,7 +156,8 @@ end
 ---@param ... string
 ---@return string
 function M.get_package_path(...)
-  return fs.joinpath(fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h:h'), ...)
+  local info = assert(debug.getinfo(1, 'S'))
+  return fs.joinpath(fn.fnamemodify(info.source:sub(2), ':p:h:h:h'), ...)
 end
 
 ---@param lang string
@@ -487,8 +489,8 @@ end
 
 --- Reload the parser table and user modifications in case of update
 local function reload_parsers()
-  ---@diagnostic disable-next-line:no-unknown
   package.loaded['nvim-treesitter.parsers'] = nil
+  ---@diagnostic disable-next-line:duplicate-require
   parsers = require('nvim-treesitter.parsers')
   vim.api.nvim_exec_autocmds('User', { pattern = 'TSUpdate' })
 end


### PR DESCRIPTION
The remaining warnings are related to the `async` module. It's unclear to me whether these are emmyluals bugs, or whether the annotations are subtly wrong.

@lewis6991 