### PR TITLE
fix(lua): re-add missing assignment operator

### DIFF
--- a/runtime/queries/lua/highlights.scm
+++ b/runtime/queries/lua/highlights.scm
@@ -76,6 +76,8 @@
 (unary_expression
   operator: _ @operator)
 
+"=" @operator
+
 [
   "and"
   "not"


### PR DESCRIPTION
Fixup for #8386 (strange that this wasn't caught by tests...)