### PR TITLE
fix(ruby): fix highlights for pattern matching and for...in loops

### DIFF
--- a/runtime/queries/ruby/highlights.scm
+++ b/runtime/queries/ruby/highlights.scm
@@ -48,6 +48,9 @@
   "then"
 ] @keyword.conditional
 
+(in_clause
+  "in" @keyword.conditional)
+
 (if
   "end" @keyword.conditional)
 
@@ -60,6 +63,9 @@
   "retry"
   "next"
 ] @keyword.repeat
+
+(in
+  "in" @keyword.repeat)
 
 (constant) @constant
 
@@ -289,6 +295,9 @@
   "/" @punctuation.bracket)
 
 (pair
+  ":" @punctuation.delimiter)
+
+(keyword_pattern
   ":" @punctuation.delimiter)
 
 [


### PR DESCRIPTION
<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
1. Fix capture issues for `in` within `case_match` and `:` within `keyword_pattern`(#8384).
2. Add capture for `in` in `for...in` loops as `@keyword.repeat.ruby`.

Before:
<img width="511" height="363" alt="图片" src="https://github.com/user-attachments/assets/b9b1cc0c-fe57-4fcf-bdc6-4faa46f6e10f" />
After:
<img width="607" height="361" alt="图片" src="https://github.com/user-attachments/assets/2d39f135-cc1c-4170-8065-3eeb959ec347" />