### PR TITLE
Remove Node legend, it's not used anymore

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -5,7 +5,6 @@ The following is a list of languages for which a parser can be installed through
 Legend:
 - **Tier:** _stable_ (updates follow semver releases), _unstable_ (updates follow HEAD), _unmaintained_ (no automatic updates), or _unsupported_ (known to be broken, cannot be installed)
 - **Queries** available for **H**ighlights, **I**ndents, **F**olds, In**J**ections, **L**ocals
-- **Node:** Parser requires `node` for installation
 - **Maintainer** of queries in nvim-treesitter (may be different from parser maintainer!)
 
 <!--This section of the README is automatically updated by a CI job-->


### PR DESCRIPTION
It was removed in fd2880e8bc2c39eade94a4d329df3a14e603136d and then it was reintroduced in 69c76488f7c6929ce55222f6a887e497a24c74b8. This looks like a git issue.
