### PR TITLE
feat(parsers): add bpftrace support

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -28,6 +28,7 @@ Language | Tier | Queries | Maintainer
 [bitbake](https://github.com/tree-sitter-grammars/tree-sitter-bitbake) | unstable | `HFIJL` | @amaanq
 [blade](https://github.com/EmranMR/tree-sitter-blade) | unstable | `HFIJ ` | @calebdw
 [bp](https://github.com/ambroisie/tree-sitter-bp)[^bp] | unstable | `HFIJL` | @ambroisie
+[bpftrace](https://github.com/sgruszka/tree-sitter-bpftrace) | unstable | `H  J ` | @sgruszka
 [brightscript](https://github.com/ajdelcimmuto/tree-sitter-brightscript) | unstable | `HFIJ ` | @ajdelcimmuto
 [c](https://github.com/tree-sitter/tree-sitter-c) | unstable | `HFIJL` | @amaanq
 [c3](https://github.com/c3lang/tree-sitter-c3) | unstable | `HFIJ ` | @cbuttner

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -140,6 +140,14 @@ return {
     readme_note = 'Android Blueprint',
     tier = 2,
   },
+  bpftrace = {
+    install_info = {
+      revision = '9cdfa285bb4fd3abc74cce6e2fb46f381feca987',
+      url = 'https://github.com/sgruszka/tree-sitter-bpftrace',
+    },
+    maintainers = { '@sgruszka' },
+    tier = 2,
+  },
   brightscript = {
     install_info = {
       revision = '253fdfaa23814cb46c2d5fc19049fa0f2f62c6da',

--- a/runtime/queries/bpftrace/highlights.scm
+++ b/runtime/queries/bpftrace/highlights.scm
@@ -1,0 +1,228 @@
+; Comments
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell
+
+; String and numeric literals
+(string_literal) @string
+
+(escape_sequence) @string.escape
+
+(integer_literal) @number
+
+(boolean_literal) @boolean
+
+; Variables
+(identifier) @variable
+
+(args_keyword) @variable.builtin
+
+((identifier) @variable.builtin
+  (#lua-match? @variable.builtin "^arg[0-9]+$"))
+
+(scratch_variable) @variable
+
+(map_variable) @variable
+
+(script_parameter) @variable.parameter
+
+; Macro
+(macro_definition
+  (identifier) @function.macro)
+
+; Probes
+; fentry/fexit, kprobe/kretprobe, rawtracepoint
+(probe
+  provider: (_) @type.builtin
+  module: (wildcard_identifier) @module
+  function: (wildcard_identifier) @property)
+
+(probe
+  provider: (_) @type.builtin
+  function: (wildcard_identifier) @property)
+
+; uprobe/uretprobe
+(probe
+  provider: (uprobe_uretprobe_provider) @type.builtin
+  binary: (file_identifier) @string.special.path
+  function: (identifier) @property)
+
+; tracepoint
+(probe
+  provider: (_) @type.builtin
+  subsys: (wildcard_identifier) @module
+  event: (wildcard_identifier) @property)
+
+; software/hardware
+(probe
+  provider: (_) @type.builtin
+  event: (identifier_with_dash) @property
+  count: (integer_literal) @number)
+
+(probe
+  provider: (_) @type.builtin
+  event: (identifier_with_dash) @property)
+
+; bench/test
+(probe
+  provider: (bench_test_provider) @type.builtin
+  function: (identifier) @property)
+
+; profile/interval
+(probe
+  provider: (profile_interval_provider) @type.builtin
+  unit: (time_unit) @string.special
+  count: (integer_literal) @property)
+
+(probe
+  provider: (profile_interval_provider) @type.builtin
+  count: (integer_literal) @number)
+
+; iter
+(probe
+  provider: (iter_provider) @type.builtin
+  object: (identifier) @module
+  pin: (file_identifier) @property)
+
+(probe
+  provider: (iter_provider) @type.builtin
+  object: (identifier) @module)
+
+; ustd
+(probe
+  provider: (ustd_provider) @type.builtin
+  binary: (file_identifier) @string.special.path
+  namespace: (identifier) @variable
+  function: (identifier) @property)
+
+(probe
+  provider: (ustd_provider) @type.builtin
+  binary: (file_identifier) @string.special.path
+  function: (identifier) @property)
+
+; watchpoint/asyncwatchpoint
+(probe
+  provider: (watchpoint_provider) @type.builtin
+  address: (integer_literal) @number
+  length: (integer_literal) @number
+  mode: (watchpoint_mode) @property)
+
+; Types
+(type_specifier) @type
+
+(integer_type) @type.builtin
+
+[
+  "BEGIN"
+  "begin"
+  "END"
+  "end"
+] @type.builtin
+
+; Keywords
+(hashbang) @keyword.directive
+
+(return_statement) @keyword.return
+
+[
+  "config"
+  "let"
+  "macro"
+  "offsetof"
+  "sizeof"
+] @keyword
+
+[
+  "if"
+  "else"
+] @keyword.conditional
+
+[
+  "for"
+  "unroll"
+  "while"
+  (break_statement)
+  (continue_statement)
+] @keyword.repeat
+
+"import" @keyword.import
+
+(field_expression
+  field: (identifier) @property)
+
+(call_expression
+  function: (identifier) @function.call)
+
+; Punctuations
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ","
+  ";"
+  ":"
+  "."
+] @punctuation.delimiter
+
+; Operators
+[
+  ; Field access
+  "->"
+  ; Range
+  ".."
+  ; Assignment
+  "="
+  "<<="
+  ">>="
+  "+="
+  "-="
+  "*="
+  "/="
+  "%="
+  "&="
+  "|="
+  "^="
+  ; Update
+  "--"
+  "++"
+  ; Arithmetic
+  "%"
+  "+"
+  "-"
+  "*"
+  "/"
+  ; Relational
+  "<="
+  "<"
+  ">="
+  ">"
+  "=="
+  "!="
+  ; Bitwise
+  "&"
+  "^"
+  "|"
+  "~"
+  "<<"
+  ">>"
+  ; Logical
+  "&&"
+  "||"
+  "!"
+] @operator
+
+(conditional_expression
+  [
+    "?"
+    ":"
+  ] @keyword.conditional.ternary)
+
+(predicate
+  "/" @punctuation.delimiter)

--- a/runtime/queries/bpftrace/injections.scm
+++ b/runtime/queries/bpftrace/injections.scm
@@ -1,0 +1,12 @@
+([
+  (c_struct)
+  (c_preproc)
+  (c_preproc_block)
+] @injection.content
+  (#set! injection.language "c"))
+
+([
+  (line_comment)
+  (block_comment)
+] @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
# bpftrace

https://github.com/bpftrace/bpftrace

Language file extension: `.bt`

<details>
<summary>Representative code sample</summary>

```
#!/usr/bin/env bpftrace
// biolatency.bt	Block I/O latency as a histogram.
// 			For Linux, uses bpftrace, eBPF.
//
// This is a bpftrace version of the bcc tool of the same name.
//
// Copyright 2018 Netflix, Inc.
//
// 13-Sep-2018	Brendan Gregg	Created this.

BEGIN
{
  printf("Tracing block device I/O... Hit Ctrl-C to end.\n");
}

tracepoint:block:block_bio_queue
{
  @start[args.sector] = nsecs;
}

tracepoint:block:block_rq_complete,
tracepoint:block:block_bio_complete
/@start[args.sector]/
{
  @usecs = hist((nsecs - @start[args.sector]) / 1000);
  delete(@start, args.sector);
}

END
{
  clear(@start);
}
```
</details>

## Parser repo

https://github.com/sgruszka/tree-sitter-bpftrace

<details>
<summary>Parsed tree for code sample</summary>

```
(source_file [0, 0] - [32, 0]
  (hashbang [0, 0] - [0, 23])
  (line_comment [1, 0] - [1, 50])
  (line_comment [2, 0] - [2, 37])
  (line_comment [3, 0] - [3, 2])
  (line_comment [4, 0] - [4, 63])
  (line_comment [5, 0] - [5, 2])
  (line_comment [6, 0] - [6, 31])
  (line_comment [7, 0] - [7, 2])
  (line_comment [8, 0] - [8, 42])
  (action_block [10, 0] - [13, 1]
    (probes_list [10, 0] - [10, 5]
      (probe [10, 0] - [10, 5]
        provider: (begin_end_provider [10, 0] - [10, 5])))
    (action [11, 0] - [13, 1]
      (expression_statement [12, 2] - [12, 60]
        (call_expression [12, 2] - [12, 60]
          function: (identifier [12, 2] - [12, 8])
          arguments: (arguments [12, 8] - [12, 60]
            (string_literal [12, 9] - [12, 59]
              (string_content [12, 10] - [12, 56])
              (escape_sequence [12, 56] - [12, 58])))))))
  (action_block [15, 0] - [18, 1]
    (probes_list [15, 0] - [15, 32]
      (probe [15, 0] - [15, 32]
        provider: (tracepoint_provider [15, 0] - [15, 10])
        subsys: (wildcard_identifier [15, 11] - [15, 16])
        event: (wildcard_identifier [15, 17] - [15, 32])))
    (action [16, 0] - [18, 1]
      (assignment_statement [17, 2] - [17, 29]
        left: (map_subscript_expression [17, 2] - [17, 21]
          argument: (map_variable [17, 2] - [17, 8])
          indexes: (indexes_list [17, 8] - [17, 21]
            (field_expression [17, 9] - [17, 20]
              argument: (args_keyword [17, 9] - [17, 13])
              field: (identifier [17, 14] - [17, 20]))))
        right: (identifier [17, 24] - [17, 29]))))
  (action_block [20, 0] - [26, 1]
    (probes_list [20, 0] - [21, 35]
      (probe [20, 0] - [20, 34]
        provider: (tracepoint_provider [20, 0] - [20, 10])
        subsys: (wildcard_identifier [20, 11] - [20, 16])
        event: (wildcard_identifier [20, 17] - [20, 34]))
      (probe [21, 0] - [21, 35]
        provider: (tracepoint_provider [21, 0] - [21, 10])
        subsys: (wildcard_identifier [21, 11] - [21, 16])
        event: (wildcard_identifier [21, 17] - [21, 35])))
    (predicate [22, 0] - [22, 21]
      (map_subscript_expression [22, 1] - [22, 20]
        argument: (map_variable [22, 1] - [22, 7])
        indexes: (indexes_list [22, 7] - [22, 20]
          (field_expression [22, 8] - [22, 19]
            argument: (args_keyword [22, 8] - [22, 12])
            field: (identifier [22, 13] - [22, 19])))))
    (action [23, 0] - [26, 1]
      (assignment_statement [24, 2] - [24, 53]
        left: (map_variable [24, 2] - [24, 8])
        right: (call_expression [24, 11] - [24, 53]
          function: (identifier [24, 11] - [24, 15])
          arguments: (arguments [24, 15] - [24, 53]
            (binary_expression [24, 16] - [24, 52]
              left: (parenthesized_expression [24, 16] - [24, 45]
                (binary_expression [24, 17] - [24, 44]
                  left: (identifier [24, 17] - [24, 22])
                  right: (map_subscript_expression [24, 25] - [24, 44]
                    argument: (map_variable [24, 25] - [24, 31])
                    indexes: (indexes_list [24, 31] - [24, 44]
                      (field_expression [24, 32] - [24, 43]
                        argument: (args_keyword [24, 32] - [24, 36])
                        field: (identifier [24, 37] - [24, 43]))))))
              right: (integer_literal [24, 48] - [24, 52])))))
      (expression_statement [25, 2] - [25, 29]
        (call_expression [25, 2] - [25, 29]
          function: (identifier [25, 2] - [25, 8])
          arguments: (arguments [25, 8] - [25, 29]
            (map_variable [25, 9] - [25, 15])
            (field_expression [25, 17] - [25, 28]
              argument: (args_keyword [25, 17] - [25, 21])
              field: (identifier [25, 22] - [25, 28])))))))
  (action_block [28, 0] - [31, 1]
    (probes_list [28, 0] - [28, 3]
      (probe [28, 0] - [28, 3]
        provider: (begin_end_provider [28, 0] - [28, 3])))
    (action [29, 0] - [31, 1]
      (expression_statement [30, 2] - [30, 15]
        (call_expression [30, 2] - [30, 15]
          function: (identifier [30, 2] - [30, 7])
          arguments: (arguments [30, 7] - [30, 15]
            (map_variable [30, 8] - [30, 14]))))))
```

</details>

## Queries

Source of queries: https://github.com/sgruszka/tree-sitter-bpftrace/tree/main/queries

<details>
<summary>Screenshots of code sample</summary>

<img width="1003" height="970" alt="Screenshot From 2026-01-03 10-26-11" src="https://github.com/user-attachments/assets/e6ef56d2-30f9-4358-9109-994ffe99bec5" />


</details>

<!--
CHECKLIST: _Before_ submitting, make sure

* `./scripts/install-parsers.lua <language>` works without warnings
* `./scripts/install-parsers.lua --generate <language>` works without warnings
* `make query` works without warning
* `make docs` is run
-->