### PR TITLE
feat(kos): highlights improvements

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1189,7 +1189,7 @@ return {
   },
   kos = {
     install_info = {
-      revision = '5f11d41b3150b0837e8b3964151ebb7fc4f367e9',
+      revision = '03b261c1a78b71c38cf4616497f253c4a4ce118b',
       url = 'https://github.com/kos-lang/tree-sitter-kos',
     },
     maintainers = { '@cdragan' },

--- a/runtime/queries/kos/highlights.scm
+++ b/runtime/queries/kos/highlights.scm
@@ -4,7 +4,12 @@
 
 (number) @number
 
+(float_number) @number.float
+
 (identifier) @variable
+
+(parameter
+  parameter: (identifier) @variable.parameter)
 
 (property_identifier) @property
 
@@ -57,8 +62,9 @@
   "=>"
 ] @keyword.function
 
+"_" @character.special
+
 [
-  "_"
   (line)
   "assert"
   ;"async"
@@ -95,6 +101,15 @@
   "{"
   "}"
 ] @punctuation.bracket
+
+(string_literal_begin
+  "\\(" @punctuation.special)
+
+(string_literal_continuation
+  "\\(" @punctuation.special)
+
+(formatted_string
+  ")" @punctuation.special)
 
 [
   ";"

--- a/tests/query/highlights/kos/test.kos
+++ b/tests/query/highlights/kos/test.kos
@@ -21,15 +21,15 @@ fun name(arg1,
 # ^ keyword.function
 #   ^ function
 #       ^ punctuation.bracket
-#        ^ variable
+#        ^ variable.parameter
 #            ^ punctuation.delimiter
          arg2 = "default",
-#        ^ variable
+#        ^ variable.parameter
 #             ^ operator
 #               ^ string
 #                        ^ punctuation.delimiter
          arg3...)
-#        ^ variable
+#        ^ variable.parameter
 #            ^ operator
 #               ^ punctuation.bracket
 {
@@ -147,3 +147,37 @@ name.name()
 #    ^ function.method.call
 #        ^ punctuation.bracket
 #         ^ punctuation.bracket
+
+print("hello \(123 + var) world \(true)")
+# <- function.call
+#    ^ punctuation.bracket
+#     ^ string
+#            ^ punctuation.special
+#              ^ number
+#                  ^ operator
+#                    ^ variable
+#                       ^ punctuation.special
+#                        ^ string
+#                               ^ punctuation.special
+#                                 ^ boolean
+#                                     ^ punctuation.special
+#                                       ^ punctuation.bracket
+
+[] -> each((x,_,y) => x + y)
+# <- punctuation.bracket
+#^ punctuation.bracket
+#  ^ operator
+#     ^ function.call
+#         ^ punctuation.bracket
+#          ^ punctuation.bracket
+#           ^ variable.parameter
+#            ^ punctuation.delimiter
+#             ^ character.special
+#              ^ punctuation.delimiter
+#               ^ variable.parameter
+#                ^ punctuation.bracket
+#                  ^ keyword.function
+#                     ^ variable
+#                       ^ operator
+#                         ^ variable
+#                          ^ punctuation.bracket


### PR DESCRIPTION
Implement a few improvements based on suggestions from PR #8389

* Mark floats as number.float
* Mark function arguments as variable.parameter
* Mark _ placeholder as character.special
* Mark string interpolation delimiters as punctuation.special

## Checklist

<details>
```
$ ./scripts/install-parsers.lua kos
[nvim-treesitter/install/kos]: Downloading tree-sitter-kos...
[nvim-treesitter/install/kos]: Compiling parser
[nvim-treesitter/install/kos]: Installing parser
[nvim-treesitter/install/kos]: Language installed

$ ./scripts/install-parsers.lua --generate kos
[nvim-treesitter/install/kos]: Downloading tree-sitter-kos...
[nvim-treesitter/install/kos]: Generating parser.c from grammar.json...
[nvim-treesitter/install/kos]: Compiling parser
[nvim-treesitter/install/kos]: Installing parser
[nvim-treesitter/install/kos]: Language installed

$ make query
.test-deps/ts_query_ls-aarch64-apple-darwin/ts_query_ls format runtime/queries/kos
.test-deps/ts_query_ls-aarch64-apple-darwin/ts_query_ls lint runtime/queries/kos
.test-deps/ts_query_ls-aarch64-apple-darwin/ts_query_ls check runtime/queries/kos

$ make docs
.test-deps/nvim-macos-arm64/nvim-macos-arm64/bin/nvim -l scripts/update-readme.lua
SUPPORTED_LANGUAGES.md is up-to-date
```
</details>