### PR TITLE
README: note that GitLab is also supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ These queries can be used to look up definitions and references to identifiers i
 
 ## Adding custom languages
 
-If you have a parser that is not on the list of supported languages (either as a repository on Github or in a local directory), you can add it manually for use by `nvim-treesitter` as follows:
+If you have a parser that is not on the list of supported languages (either as a repository on GitHub or GitLab, or in a local directory), you can add it manually for use by `nvim-treesitter` as follows:
 
 1. Add the following snippet in a `User TSUpdate` autocommand:
 


### PR DESCRIPTION
https://github.com/nvim-treesitter/nvim-treesitter/blob/99dfc5acefd7728cec4ad0d0a6a9720f2c2896ff/lua/nvim-treesitter/install.lua#L200 shows that GitLab is checked/supported.

Additionally, fixed the incorrect casing of the fully-proprietary code forge.

…Tho I don’t think this is actually the correct abstraction to tie support to specific code forges. Supporting tarballs generally would open up Codeberg, SourceHut, self-hosted cgit & even _non-Git_ options.
