### PR TITLE
fix(html): disable spell for tags

### DIFF
--- a/runtime/queries/html_tags/highlights.scm
+++ b/runtime/queries/html_tags/highlights.scm
@@ -1,9 +1,11 @@
-(tag_name) @tag
+(tag_name) @tag @nospell
 
 ; (erroneous_end_tag_name) @error ; we do not lint syntax errors
 (comment) @comment @spell
 
-(attribute_name) @tag.attribute
+(attribute_name) @tag.attribute @nospell
+
+(attribute_value) @nospell
 
 ((attribute
   (quoted_attribute_value) @string)


### PR DESCRIPTION
When tags are embedded into markdown, they'd get spell checked, in spite of that not really making sense. The real culprit of this issue is markdown's spell being too "loose".

Before

<img width="268" height="91" alt="image" src="https://github.com/user-attachments/assets/67744f42-7023-4366-9924-91c5f8215d39" />

After

<img width="284" height="82" alt="image" src="https://github.com/user-attachments/assets/55f6c2d9-dd68-4ecd-ac7a-ae0f7bf54210" />

