### PR TITLE
feat(edf): add parser and queries

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -447,6 +447,14 @@ return {
     maintainers = { '@ValdezFOmar' },
     tier = 2,
   },
+  edf = {
+    install_info = {
+      revision = 'c983376fc85491d06b7c2b7fdd945bc157c414ed',
+      url = 'https://github.com/ph1losof/tree-sitter-edf',
+    },
+    maintainers = { '@ph1losof' },
+    tier = 2,
+  },
   eds = {
     install_info = {
       revision = '26d529e6cfecde391a03c21d1474eb51e0285805',

--- a/runtime/queries/edf/folds.scm
+++ b/runtime/queries/edf/folds.scm
@@ -1,0 +1,6 @@
+; Folds for EDF
+
+[
+  (double_quoted_string)
+  (single_quoted_string)
+] @fold

--- a/runtime/queries/edf/highlights.scm
+++ b/runtime/queries/edf/highlights.scm
@@ -1,0 +1,37 @@
+; Highlighting queries for EDF (Ecolog Dotenv File Format)
+
+; Comments
+(comment) @comment
+(comment_content) @comment
+(inline_comment) @comment
+
+; Export keyword
+(export_keyword) @keyword
+
+; Keys (variable names)
+(key) @property
+
+; String values
+(single_quoted_string) @string
+(single_quoted_content) @string
+(double_quoted_string) @string
+(double_quoted_content) @string
+(unquoted_content) @string
+
+; Escape sequences in double-quoted strings
+(escape_sequence) @string.escape
+
+; Variable expansion ${VAR} and ${VAR:-default}
+(variable_expansion) @variable
+
+; Simple variable $VAR
+(simple_variable) @variable
+
+; Command substitution $(command) and `command`
+(command_substitution) @function.macro
+(backtick_substitution) @function.macro
+
+; Operators and punctuation
+"=" @operator
+"'" @punctuation.delimiter
+"\"" @punctuation.delimiter


### PR DESCRIPTION
## Description

This PR adds support for the EDF (Ecolog Dotenv File Format) parser, a tree-sitter grammar for `.env` files following the [EDF specification](https://github.com/ph1losof/ecolog-spec).

## Parser Features

- Key-value pairs with optional `export` keyword
- Single-quoted strings (literal, no escaping)
- Double-quoted strings with escape sequences (`\n`, `\t`, `\\`, `\"`, `\$`)
- Unquoted values with backslash line continuation
- Shell-style variable interpolation (`$VAR`, `${VAR}`, `${VAR:-default}`)
- Command substitution (`$(command)` and backtick syntax)
- Comments (line and inline)

## Checklist

- [x] Parser listed in `lua/nvim-treesitter/parsers.lua`
- [x] Highlight queries added
- [x] Folds queries added
- [ ] Injections queries (not applicable for this language)
- [x] Parser repository includes `src/parser.c`
- [x] Parser repository includes `src/scanner.c` (external scanner)
- [x] Parser repository hosted on GitHub

## Testing

Install with `:TSInstall edf` and test with a `.env` file:

```env
# Database configuration
export DATABASE_URL="postgres://user:pass@localhost:5432/db"
API_KEY='secret-key-literal'
DEBUG=true
HOME_DIR=$HOME
COMPUTED=$(whoami)
FALLBACK=${UNDEFINED:-default_value}
```

## Filetype Configuration

Users can associate `.env` files with the `edf` filetype in their Neovim config:

```lua
vim.filetype.add({
  pattern = {
    ['%.env'] = 'edf',
    ['%.env%..*'] = 'edf',
  },
})
```

## Parser Repository

https://github.com/ph1losof/tree-sitter-edf