### PR TITLE
feat: add backward compatibility for 'configs' module name

### DIFF
--- a/lua/nvim-treesitter/configs.lua
+++ b/lua/nvim-treesitter/configs.lua
@@ -1,0 +1,3 @@
+-- Backward compatibility module
+-- TODO: Remove this file in a future version when all users migrate to the new module name
+return require('nvim-treesitter.config')


### PR DESCRIPTION
## Problem

Users with existing configurations using `main = 'nvim-treesitter.configs'` receive a cryptic error:

```
module 'nvim-treesitter.configs' not found
```

This happens because the module was renamed from `configs` to `config` in a recent update, breaking backward compatibility.

## Solution

Add a backward compatibility shim at `lua/nvim-treesitter/configs.lua` that redirects to the new module name:

```lua
return require('nvim-treesitter.config')
```

This allows existing configurations to continue working while users migrate to the new module name.

## Alternative Considered

Simply updating documentation to tell users to change their config would require all users to update their configurations, which is a poor user experience for a breaking change.

## TODO

- Remove this backward compatibility module in a future major version (e.g., v2.0)