### PR TITLE
fix(haskell): syntax highlighting for Haskell

### DIFF
--- a/runtime/queries/haskell/highlights.scm
+++ b/runtime/queries/haskell/highlights.scm
@@ -227,7 +227,9 @@
     (qualified
       ((module) @module
         (variable) @function.call))
-  ])
+  ]
+  (operator) @_op
+  (#match? @_op "^[^:].*"))
 
 ; infix operators applied to variables
 ((expression/variable) @variable
@@ -246,7 +248,7 @@
 (function
   (infix
     left_operand: [
-      (variable) @variable
+      (variable) @variable.parameter
       (qualified
         ((module) @module
           (variable) @variable))


### PR DESCRIPTION
Fixes highlighting for lambdas with multiple parameters.
before:
<img width="528" height="85" alt="image" src="https://github.com/user-attachments/assets/563ff727-3f0b-4b0b-824f-834f4e338e46" />
after:
<img width="526" height="89" alt="image" src="https://github.com/user-attachments/assets/ea38861b-f3a0-47f2-b025-5ba3f29f9f93" />

Fixes the highlighting of the left operand of operator declarations. 
before:
<img width="638" height="86" alt="image" src="https://github.com/user-attachments/assets/af78e0e8-e235-41dc-9be2-36d5899ff088" />
after:
<img width="636" height="89" alt="image" src="https://github.com/user-attachments/assets/6c260451-4e00-41b8-80bd-bd78049e2239" />

Fixes the first argument for operator-like constructors (:, :%, :+).
before:
<img width="198" height="44" alt="image" src="https://github.com/user-attachments/assets/dfd2d69c-ed36-488c-ac1f-a3029eb02d7c" />
after:
<img width="194" height="45" alt="image" src="https://github.com/user-attachments/assets/ff5ca21a-97a6-48f1-8bb9-01f5e7926da8" />

<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
