### PR TITLE
fix(haskell): highlighting for operator and parameter handling

### DIFF
--- a/runtime/queries/haskell/highlights.scm
+++ b/runtime/queries/haskell/highlights.scm
@@ -226,7 +226,9 @@
     (qualified
       ((module) @module
         (variable) @function.call))
-  ])
+  ]
+  (operator) @_op
+  (#match? @_op "^[^:].*"))
 
 ; infix operators applied to variables
 ((expression/variable) @variable
@@ -245,7 +247,7 @@
 (function
   (infix
     left_operand: [
-      (variable) @variable
+      (variable) @variable.parameter
       (qualified
         ((module) @module
           (variable) @variable))


### PR DESCRIPTION
Fixes the highlighting of the left operand of operator declarations and the first argument for operator constructors (:, :%, :+).

<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
