### PR TITLE
fix(rust): highlight doc comment markers as @comment.documentation

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -476,9 +476,12 @@
 [
   (line_comment)
   (block_comment)
+] @comment @spell
+
+[
   (outer_doc_comment_marker)
   (inner_doc_comment_marker)
-] @comment @spell
+] @comment.documentation
 
 (line_comment
   (doc_comment)) @comment.documentation


### PR DESCRIPTION
Fixes #8275

Adds `@comment.documentation` capture for `outer_doc_comment_marker` and `inner_doc_comment_marker` nodes, ensuring the trailing `/` in `///` (and `!` in `//!`) receives consistent documentation comment highlighting.

Thanks to @LunarLambda for identifying the root cause and proposing this fix back in November. I ran into the same issue and figured I'd submit the PR since it's been a couple months.