### PR TITLE
fix(haskell): use grammar for operator detection instead of match

### DIFF
--- a/runtime/queries/haskell/highlights.scm
+++ b/runtime/queries/haskell/highlights.scm
@@ -228,8 +228,7 @@
       ((module) @module
         (variable) @function.call))
   ]
-  (operator) @_op
-  (#match? @_op "^[^:].*"))
+  operator: (operator))
 
 ; infix operators applied to variables
 ((expression/variable) @variable


### PR DESCRIPTION
Improves performance. Last pull request somehow lost #lua-match. Anyways, grammar indeed differentiates operator from constructor_operator. 

<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
