### PR TITLE
Add Roto to list of supported languages

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -249,6 +249,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` | @steelsojka
 [robots_txt](https://github.com/opa-oz/tree-sitter-robots-txt) | unstable | `H  J ` | @opa-oz
 [roc](https://github.com/faldor20/tree-sitter-roc) | unstable | `H IJL` | @nat-418
 [ron](https://github.com/tree-sitter-grammars/tree-sitter-ron) | unstable | `HFIJL` | @amaanq
+[roto](https://github.com/NLnetLabs/tree-sitter-roto) | unstable | `H   L` | @bsamseth
 [rst](https://github.com/stsewd/tree-sitter-rst) | unstable | `H  JL` | @stsewd
 [ruby](https://github.com/tree-sitter/tree-sitter-ruby) | unstable | `HFIJL` | @TravonteD
 [runescript](https://github.com/2004Scape/tree-sitter-runescript) | unstable | `H  J ` | @2004Scape

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1954,6 +1954,15 @@ return {
     maintainers = { '@amaanq' },
     tier = 2,
   },
+  roto = {
+    install_info = {
+      branch = 'main',
+      revision = '9ac03409ddee6ab8f3b74746756f12fc6adec740',
+      url = 'https://github.com/NLnetLabs/tree-sitter-roto',
+    },
+    maintainers = { '@bsamseth' },
+    tier = 2,
+  },
   rst = {
     install_info = {
       revision = '4e562e1598b95b93db4f3f64fe40ddefbc677a15',

--- a/runtime/queries/roto/highlights.scm
+++ b/runtime/queries/roto/highlights.scm
@@ -1,0 +1,111 @@
+; Identifiers
+(identifier) @variable
+
+; Assume that uppercase names in paths are types
+((identifier) @type
+  (#match? @type "^[A-Z]"))
+
+(optional_type) @type
+
+(type_name) @type
+
+(unit) @type.builtin
+
+(never) @type.builtin
+
+(record_type) @type
+
+(type_name
+  (path
+    (identifier) @type.builtin)
+  (#match? @type.builtin "^(u8|u16|u32|u64|i8|i16|i32|i64|f32|f64|String|bool|Asn|IpAddr|Prefix)$"))
+
+; Assume all-caps names are constants
+((identifier) @constant
+  (#match? @constant "^[A-Z][A-Z\\d_]+$'"))
+
+; Function calls
+; Unfortunately, we can't really distinguish them from methods if it's called
+; on a path
+(call_expression
+  function: (path
+    (identifier) @function .))
+
+(call_expression
+  function: (access_expression
+    (identifier) @function.method .))
+
+; Calling a function with an uppercase letter: it's an enum constructor
+(call_expression
+  function: (path
+    (identifier) @constructor .)
+  (#match? @constructor "^[A-Z]"))
+
+; Function definitions
+(function_item
+  (identifier) @function)
+
+(filtermap_item
+  (identifier) @function)
+
+(test_item
+  (identifier) @function)
+
+(line_comment) @comment
+
+(parameter
+  (identifier) @variable.parameter)
+
+[
+  "*"
+  "="
+  "=="
+  "!="
+  "&&"
+  "|"
+  "||"
+  "-"
+  "+"
+  "/"
+  ">"
+  "<"
+  ">="
+  "<="
+  "?"
+] @operator
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ":"
+  "."
+  ","
+  ";"
+  "->"
+] @punctuation.delimiter
+
+[
+  "filter"
+  "filtermap"
+  "fn"
+  "test"
+] @keyword.function
+
+"in" @keyword
+
+; "dep" @keyword
+; "std" @keyword
+; "super" @keyword
+; "pkg" @keyword
+"not" @keyword.operator
+
+(string_literal) @string
+
+(unit_literal) @constant.builtin

--- a/runtime/queries/roto/locals.scm
+++ b/runtime/queries/roto/locals.scm
@@ -1,0 +1,17 @@
+[
+  (function_item)
+  (filtermap_item)
+  (test_item)
+  (block)
+] @local.scope
+
+(let_statement
+  (identifier) @local.definition)
+
+(parameter
+  (identifier) @local.definition)
+
+(for_expression
+  (identifier) @local.definition)
+
+(identifier) @local.reference

--- a/runtime/queries/roto/outline.scm
+++ b/runtime/queries/roto/outline.scm
@@ -1,0 +1,23 @@
+(function_item
+  "fn" @context
+  name: (_) @name) @item
+
+(filtermap_item
+  "filtermap" @context
+  name: (_) @name) @item
+
+(filtermap_item
+  "filter" @context
+  name: (_) @name) @item
+
+(record_item
+  "record" @context
+  name: (_) @name) @item
+
+(variant_item
+  "variant" @context
+  name: (_) @name) @item
+
+(test_item
+  "test" @context
+  name: (_) @name) @item

--- a/runtime/queries/roto/tags.scm
+++ b/runtime/queries/roto/tags.scm
@@ -1,0 +1,14 @@
+(function_item
+  name: (identifier) @definition.function)
+
+(filtermap_item
+  name: (identifier) @definition.function)
+
+(test_item
+  name: (identifier) @definition.function)
+
+(record_item
+  name: (identifier) @definition.type)
+
+(variant_item
+  name: (identifier) @definition.type)

--- a/runtime/queries/roto/textobjects.scm
+++ b/runtime/queries/roto/textobjects.scm
@@ -1,0 +1,18 @@
+(function_item
+  body: (block) @function.inside) @function.around
+
+(filtermap_item
+  body: (block) @function.inside) @function.around
+
+(test_item
+  body: (block) @test.inside) @test.around
+
+(record_item
+  fields: (record_type) @class.inside) @class.around
+
+(variant_item
+  constructors: (variant_constructors) @class.inside) @class.around
+
+(line_comment) @comment.inside
+
+(line_comment)+ @comment.around


### PR DESCRIPTION

<!-- 
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  Make sure to fill out all fields and read the checklist at the end.
-->

# Roto

Roto is a strongly-typed, compiled embedded scripting language for Rust.
<!-- Link to an official description of the language -->
https://github.com/NLnetLabs/roto/tree/main/examples.

Language file extension: `.roto`

This only works if the filetype for Roto is added explicitly:

```lua
vim.filetype.add({ extension = { roto = "roto" } })
```

After that the queries seem to work well when testing it on all the example Roto scripts from https://github.com/NLnetLabs/roto/tree/main/examples.

I have a [PR to Vim](https://github.com/vim/vim/pull/19195) aiming to add `.roto` as a recognized extension for a `roto` filetype. Once there, NeoVim should eventually pull it in and users will not need to add the filetype themselves.

<details>
<summary>Representative code sample</summary>

```
fn main() { 
    print(123);
}

fn add_numbers(x : List [u64]) -> List[u64] {
    x + [1, 2, 3, 4, 5]
}

filtermap within_range(range : AddrRange, ip : IpAddr) {
    if range.contains(ip) && ip.is_ipv4() { 
        accept ip }
    else {
        reject
    }
}

filtermap rib_in_pre(output : Log, route : Route, ) {
    let my_prefix = 100.40.0.0/17;
    if route.prefix_matches(my_prefix) {
        output.log_custom(10, 100);
        reject
    }
    else {
        output.log_prefix(my_prefix);
        accept
    }
}
```
</details>

## Parser repo

https://github.com/NLnetLabs/tree-sitter-roto

<details>
<summary>Parsed tree for code sample</summary>

```
(source_file ; [0, 0] - [27, 0]
  (function_item ; [0, 0] - [2, 1]
    name: (identifier) ; [0, 3] - [0, 7]
    parameters: (parameter_list) ; [0, 7] - [0, 9]
    body: (block ; [0, 10] - [2, 1]
      (call_expression ; [1, 4] - [1, 14]
        function: (path ; [1, 4] - [1, 9]
          (identifier)) ; [1, 4] - [1, 9]
        (integer_literal)))) ; [1, 10] - [1, 13]
  (function_item ; [4, 0] - [6, 1]
    name: (identifier) ; [4, 3] - [4, 14]
    parameters: (parameter_list ; [4, 14] - [4, 30]
      (parameter ; [4, 15] - [4, 29]
        (identifier) ; [4, 15] - [4, 16]
        (type_name ; [4, 19] - [4, 29]
          (path ; [4, 19] - [4, 23]
            (identifier)) ; [4, 19] - [4, 23]
          (type_name ; [4, 25] - [4, 28]
            (path ; [4, 25] - [4, 28]
              (identifier)))))) ; [4, 25] - [4, 28]
    return_type: (type_name ; [4, 34] - [4, 43]
      (path ; [4, 34] - [4, 38]
        (identifier)) ; [4, 34] - [4, 38]
      (type_name ; [4, 39] - [4, 42]
        (path ; [4, 39] - [4, 42]
          (identifier)))) ; [4, 39] - [4, 42]
    body: (block ; [4, 44] - [6, 1]
      (binary_expression ; [5, 4] - [5, 23]
        left: (path ; [5, 4] - [5, 5]
          (identifier)) ; [5, 4] - [5, 5]
        right: (list_expression ; [5, 8] - [5, 23]
          (integer_literal) ; [5, 9] - [5, 10]
          (integer_literal) ; [5, 12] - [5, 13]
          (integer_literal) ; [5, 15] - [5, 16]
          (integer_literal) ; [5, 18] - [5, 19]
          (integer_literal))))) ; [5, 21] - [5, 22]
  (filtermap_item ; [8, 0] - [14, 1]
    name: (identifier) ; [8, 10] - [8, 22]
    parameters: (parameter_list ; [8, 22] - [8, 54]
      (parameter ; [8, 23] - [8, 40]
        (identifier) ; [8, 23] - [8, 28]
        (type_name ; [8, 31] - [8, 40]
          (path ; [8, 31] - [8, 40]
            (identifier)))) ; [8, 31] - [8, 40]
      (parameter ; [8, 42] - [8, 53]
        (identifier) ; [8, 42] - [8, 44]
        (type_name ; [8, 47] - [8, 53]
          (path ; [8, 47] - [8, 53]
            (identifier))))) ; [8, 47] - [8, 53]
    body: (block ; [8, 55] - [14, 1]
      (if_else_expression ; [9, 4] - [13, 5]
        condition: (binary_expression ; [9, 7] - [9, 41]
          left: (call_expression ; [9, 7] - [9, 25]
            function: (path ; [9, 7] - [9, 21]
              (path ; [9, 7] - [9, 12]
                (identifier)) ; [9, 7] - [9, 12]
              (identifier)) ; [9, 13] - [9, 21]
            (path ; [9, 22] - [9, 24]
              (identifier))) ; [9, 22] - [9, 24]
          right: (call_expression ; [9, 29] - [9, 41]
            function: (path ; [9, 29] - [9, 39]
              (path ; [9, 29] - [9, 31]
                (identifier)) ; [9, 29] - [9, 31]
              (identifier)))) ; [9, 32] - [9, 39]
        consequence: (block ; [9, 42] - [10, 19]
          (return_expression ; [10, 8] - [10, 17]
            (path ; [10, 15] - [10, 17]
              (identifier)))) ; [10, 15] - [10, 17]
        alternative: (block ; [11, 9] - [13, 5]
          (return_expression))))) ; [12, 8] - [12, 14]
  (filtermap_item ; [16, 0] - [26, 1]
    name: (identifier) ; [16, 10] - [16, 20]
    parameters: (parameter_list ; [16, 20] - [16, 51]
      (parameter ; [16, 21] - [16, 33]
        (identifier) ; [16, 21] - [16, 27]
        (type_name ; [16, 30] - [16, 33]
          (path ; [16, 30] - [16, 33]
            (identifier)))) ; [16, 30] - [16, 33]
      (parameter ; [16, 35] - [16, 48]
        (identifier) ; [16, 35] - [16, 40]
        (type_name ; [16, 43] - [16, 48]
          (path ; [16, 43] - [16, 48]
            (identifier))))) ; [16, 43] - [16, 48]
    body: (block ; [16, 52] - [26, 1]
      (let_statement ; [17, 4] - [17, 34]
        variable: (identifier) ; [17, 8] - [17, 17]
        value: (binary_expression ; [17, 20] - [17, 33]
          left: (ipv4_literal) ; [17, 20] - [17, 30]
          right: (integer_literal))) ; [17, 31] - [17, 33]
      (if_else_expression ; [18, 4] - [25, 5]
        condition: (call_expression ; [18, 7] - [18, 38]
          function: (path ; [18, 7] - [18, 27]
            (path ; [18, 7] - [18, 12]
              (identifier)) ; [18, 7] - [18, 12]
            (identifier)) ; [18, 13] - [18, 27]
          (path ; [18, 28] - [18, 37]
            (identifier))) ; [18, 28] - [18, 37]
        consequence: (block ; [18, 39] - [21, 5]
          (call_expression ; [19, 8] - [19, 34]
            function: (path ; [19, 8] - [19, 25]
              (path ; [19, 8] - [19, 14]
                (identifier)) ; [19, 8] - [19, 14]
              (identifier)) ; [19, 15] - [19, 25]
            (integer_literal) ; [19, 26] - [19, 28]
            (integer_literal)) ; [19, 30] - [19, 33]
          (return_expression)) ; [20, 8] - [20, 14]
        alternative: (block ; [22, 9] - [25, 5]
          (call_expression ; [23, 8] - [23, 36]
            function: (path ; [23, 8] - [23, 25]
              (path ; [23, 8] - [23, 14]
                (identifier)) ; [23, 8] - [23, 14]
              (identifier)) ; [23, 15] - [23, 25]
            (path ; [23, 26] - [23, 35]
              (identifier))) ; [23, 26] - [23, 35]
          (return_expression)))))) ; [24, 8] - [24, 14]
```

</details>

## Queries

Source of queries: https://github.com/NLnetLabs/tree-sitter-roto

<details>
<summary>Screenshots of code sample</summary>
<img width="646" height="642" alt="image" src="https://github.com/user-attachments/assets/cf72f3d9-2446-4ddd-bca5-dfbdd747140f" />
</details>

<!--
CHECKLIST: _Before_ submitting, make sure

* `./scripts/install-parsers.lua <language>` works without warnings
* `./scripts/install-parsers.lua --generate <language>` works without warnings
* `make query` works without warning
* `make docs` is run
-->
