### PR TITLE
fix(markdown): include trailing blank lines in section folds`

### DIFF
--- a/.github/workflows/rebase-patches.yml
+++ b/.github/workflows/rebase-patches.yml
@@ -1,0 +1,49 @@
+name: Rebase patches
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Sync upstream
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+concurrency:
+  group: rebase-patches
+  cancel-in-progress: false
+
+jobs:
+  rebase-patches:
+    name: Rebase my-patches onto main
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: my-patches
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch main and patch branches
+        run: |
+          git fetch origin \
+            +refs/heads/main:refs/remotes/origin/main \
+            +refs/heads/my-patches:refs/remotes/origin/my-patches
+
+          git show-ref --verify --quiet refs/remotes/origin/main
+          git show-ref --verify --quiet refs/remotes/origin/my-patches
+
+      - name: Rebase patch branch
+        run: |
+          git checkout my-patches
+          git rebase refs/remotes/origin/main
+
+      - name: Push my-patches
+        run: git push --force-with-lease origin my-patches

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,45 @@
+name: Sync upstream
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-upstream
+  cancel-in-progress: false
+
+jobs:
+  sync-main:
+    name: Sync main from upstream
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream main
+        run: |
+          if git remote get-url upstream >/dev/null 2>&1; then
+            git remote set-url upstream https://github.com/nvim-treesitter/nvim-treesitter.git
+          else
+            git remote add upstream https://github.com/nvim-treesitter/nvim-treesitter.git
+          fi
+          git fetch upstream +refs/heads/main:refs/remotes/upstream/main
+
+      - name: Rebase fork metadata onto upstream
+        run: |
+          git checkout main
+          git rebase refs/remotes/upstream/main
+
+      - name: Push main
+        run: git push --force-with-lease origin main

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ It is strongly recommended to automate this; e.g., using the following spec with
 >[!IMPORTANT]
 > This plugin does not support lazy-loading.
 
+## Using this fork
+
+If you are installing `mikeboiko/nvim-treesitter`, use `branch = 'my-patches'` in your plugin manager. The `main` branch is reserved for tracking upstream plus the small fork-maintenance commits that keep this repository in sync automatically.
+
+This fork uses two GitHub Actions workflows:
+
+- `Sync upstream` rebases the fork-maintenance commits on top of `nvim-treesitter/main` and force-pushes `main`.
+- `Rebase patches` rebases `my-patches` on top of `main` and force-pushes it when the rebase succeeds.
+
+If `Rebase patches` reports a conflict, resolve it locally with:
+
+```sh
+git checkout my-patches
+git fetch origin upstream
+git rebase origin/main
+git push --force-with-lease origin my-patches
+```
+
 ## Setup
 
 `nvim-treesitter` can be configured by calling `setup`. **You do not need to call `setup` for `nvim-treesitter` to work using default values.**


### PR DESCRIPTION
# Description

This PR updates the Markdown folding query to include trailing blank lines within `(section)` folds.

Currently, the `#trim!` directive is applied to all folds in Markdown. For sections, this results in blank lines between headers remaining visible when those sections are folded. By removing the `#trim!` directive specifically for `(section)` nodes, the trailing whitespace is included in the fold, leading to a much cleaner and more compact "headers-only" view.

This change follows a suggestion from the maintainer of `nvim-origami` regarding how fold providers (like Treesitter) should handle section boundaries.

# Motivation

As discussed in [chrisgrieser/nvim-origami#49](https://github.com/chrisgrieser/nvim-origami/issues/49), removing the trailing blank line in the fold region makes the folded state significantly easier to scan in large documents.

# Screenshots

## Before

<img width="433" height="183" alt="image" src="https://github.com/user-attachments/assets/63b7810c-b847-4077-beaf-8a7b12254a42" />

## After

<img width="424" height="111" alt="image" src="https://github.com/user-attachments/assets/9c23b4a4-48a5-4eb2-8ca8-0379a064276d" />