### PR TITLE
docs(supported_languages): fix order of available queries

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -4,7 +4,7 @@ The following is a list of languages for which a parser can be installed through
 
 Legend:
 - **Tier:** _stable_ (updates follow semver releases), _unstable_ (updates follow HEAD), _unmaintained_ (no automatic updates), or _unsupported_ (known to be broken, cannot be installed)
-- **Queries** available for **H**ighlights, **I**ndents, **F**olds, In**J**ections, **L**ocals
+- **Queries** available for **H**ighlights, **F**olds, **I**ndents, In**J**ections, **L**ocals
 - **Maintainer** of queries in nvim-treesitter (may be different from parser maintainer!)
 
 <!--This section of the README is automatically updated by a CI job-->


### PR DESCRIPTION
Reordered the list of available queries to match the table column order for better clarity.