### PR TITLE
feat(typst): set url attribute for links

### DIFF
--- a/runtime/queries/typst/highlights.scm
+++ b/runtime/queries/typst/highlights.scm
@@ -106,7 +106,17 @@
 
 (emph) @markup.italic
 
-(url) @markup.link.url
+((url) @markup.link.url
+  (#set! @markup.link.url url @markup.link.url))
+
+(call
+  item: (ident) @_link
+  (#eq? @_link "link")
+  (group
+    .
+    (string) @markup.link.url
+    (#offset! @markup.link.url 0 1 0 -1)
+    (#set! @markup.link.url url @markup.link.url)))
 
 ; code blocks
 (raw_span) @markup.raw


### PR DESCRIPTION
In typst, there are [two ways to create a URL link](https://typst.app/docs/reference/model/link/): using the prefix `http://` or `https://`, or by calling the function `#link("https://example.com")`. This PR sets the `url` attribute for both.

before:
<img width="684" height="254" alt="before" src="https://github.com/user-attachments/assets/e0ef6604-3575-4c1d-88a7-130c5d7d440e" />

after:
<img width="684" height="254" alt="after" src="https://github.com/user-attachments/assets/02025474-5380-4f0a-b079-3510a9f4427f" />