### PR TITLE
feat(bash): add awk injection

### DIFF
--- a/runtime/queries/bash/injections.scm
+++ b/runtime/queries/bash/injections.scm
@@ -88,10 +88,10 @@
   (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children)
   (#set! injection.self))
- 
+
 (command
   name: (command_name
-    (word) @_command)
+    (word)) @_command
   .
   argument: (raw_string) @injection.content
   .
@@ -102,13 +102,14 @@
 
 (command
   name: (command_name
-    (word) @_command)
+    (word)) @_command
   argument: (_)? @_param
   .
   argument: (raw_string) @injection.content
   .
   (#eq? @_command "awk")
-  (#not-match? @_param "^(--file|--field-separator|-[^-]*[fF])")
+  (#not-any-of? @_param "--file" "--field-separator")
+  (#not-lua-match? @_param "^%-[^%-]*[fF]")
   (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children)
   (#set! injection.language "awk"))


### PR DESCRIPTION
This is a much improved attempt at awk injection than the closed #6407  
I've thoroughly analyzed that PR and fixed all discussed reasons it wasn't implemented, I'd be happy to fix any other edge cases reviewers may find.

# Before
<img width="575" height="133" alt="image" src="https://github.com/user-attachments/assets/74e72b82-7aaa-42c8-9cce-fde28f40771e" />


# Now
<img width="538" height="131" alt="image" src="https://github.com/user-attachments/assets/b0264b0b-3622-4dad-9d97-57a5ea81a07f" />


# Note
I've purposefully excluded the format: ```awk -F"" '...'``` due to gawk's manual discouraging such syntax, 

<img width="937" height="349" alt="image" src="https://github.com/user-attachments/assets/29f5d8b0-ed59-427b-8d57-2cfd87d3b337" />


<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
