### PR TITLE
feat(rust): Add 'xml' to Rust lang injections

### DIFF
--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -5,7 +5,7 @@
     (identifier) @_macro_name
   ]
   (token_tree) @injection.content
-  (#not-any-of? @_macro_name "slint" "html" "json")
+  (#not-any-of? @_macro_name "slint" "html" "json" "xml")
   (#set! injection.language "rust")
   (#set! injection.include-children))
 
@@ -16,7 +16,7 @@
     (identifier) @injection.language
   ]
   (token_tree) @injection.content
-  (#any-of? @injection.language "slint" "html" "json")
+  (#any-of? @injection.language "slint" "html" "json" "xml")
   (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children))
 


### PR DESCRIPTION
Same as `html!` macro but for `xml!`