### PR TITLE
fix(nix): match writers in nested attrpaths

### DIFF
--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -136,7 +136,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "bash")))
   ])
-  (#lua-match? @_func "^%a*%.*writeBash%a*$")
+  (#match? @_func "^([a-zA-Z]+.)*writeBash[a-zA-Z]*$")
   (#set! injection.combined))
 
 ((apply_expression
@@ -150,7 +150,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "bash")))
   ])
-  (#lua-match? @_func "^%a*%.*writeDash%a*$")
+  (#match? @_func "^([a-zA-Z]+.)*writeDash[a-zA-Z]*$")
   (#set! injection.combined))
 
 ((apply_expression
@@ -178,7 +178,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "fish")))
   ])
-  (#lua-match? @_func "^%a*%.*writeFish%a*$")
+  (#match? @_func "^([a-zA-Z]+.)*writeFish[a-zA-Z]*$")
   (#set! injection.combined))
 
 ((apply_expression
@@ -193,7 +193,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "haskell")))
   ])
-  (#lua-match? @_func "^%a*%.*writeHaskell%a*$")
+  (#match? @_func "^([a-zA-Z]+.)*writeHaskell[a-zA-Z]*$")
   (#set! injection.combined))
 
 ((apply_expression
@@ -207,7 +207,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "javascript")))
   ])
-  (#lua-match? @_func "^%a*%.*writeJS%a*$")
+  (#match? @_func "^([a-zA-Z]+.)*writeJS[a-zA-Z]*$")
   (#set! injection.combined))
 
 ((apply_expression
@@ -221,7 +221,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "perl")))
   ])
-  (#lua-match? @_func "^%a*%.*writePerl%a*$")
+  (#match? @_func "^([a-zA-Z]+.)*writePerl[a-zA-Z]*$")
   (#set! injection.combined))
 
 ((apply_expression
@@ -235,7 +235,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "python")))
   ])
-  (#lua-match? @_func "^%a*%.*writePy%a*%d*%a*$")
+  (#match? @_func "^([a-zA-Z]+.)*writePy[a-zA-Z]*[0-9]*[a-zA-Z]*$")
   (#set! injection.combined))
 
 ((apply_expression
@@ -248,7 +248,7 @@
       ((string_fragment) @injection.content
         (#set! injection.language "rust")))
   ])
-  (#lua-match? @_func "^%a*%.*writeRust%a*$")
+  (#match? @_func "^([a-zA-Z]+.)*writeRust[a-zA-Z]*$")
   (#set! injection.combined))
 
 ; (runTest) testScript


### PR DESCRIPTION
The current Nix injections don't mark this as bash:

```nix
pkgs.writers.writeBash "" ''
  echo Hello, world!
''
```

but do mark this as bash:

```nix
writers.............................writeBash "" ''
  echo hi
''
```

(and similar for other languages). Note that in order to solve this issue, I had to swap from Lua patterns to Vim regexps, which I know is less efficient. Unfortunately Lua patterns don't let you use modifiers on groups, so I swapped.

<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
