### PR TITLE
docs: add instructions for enabling highlighting for all filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ vim.api.nvim_create_autocmd('FileType', {
 })
 ```
 
+To enable highlighting for **all filetypes** that have a parser available, use `pcall` to safely start treesitter without specifying patterns:
+
+```lua
+vim.api.nvim_create_autocmd('FileType', {
+  callback = function()
+    pcall(vim.treesitter.start)
+  end,
+})
+```
+
+This will automatically enable highlighting for any filetype with an installed parser, while gracefully skipping filetypes without available parsers.
+
 ## Folds
 
 Treesitter-based folding is provided by Neovim. To enable it, put the following in your `ftplugin` or `FileType` autocommand:


### PR DESCRIPTION
This adds documentation on how to enable treesitter highlighting for all filetypes that have a parser available, using pcall to safely handle cases where no parser is installed.

This pattern is already used in the plugin's minimal_init.lua and is a common use case for users who want to enable highlighting globally rather than per-filetype.