### PR TITLE
feat(install): support custom env in install_info for generating the parser

### DIFF
--- a/lua/nvim-treesitter/_meta/parsers.lua
+++ b/lua/nvim-treesitter/_meta/parsers.lua
@@ -28,7 +28,7 @@ error('Cannot require a meta file')
 ---@field queries? string
 ---
 ---Envrionment variables for generating the parser
----@field env table<string, string|number>
+---@field env? table<string, string|number>
 
 ---@class ParserInfo
 ---

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -167,7 +167,7 @@ end
 ---@param compile_location string
 ---@return string? err
 local function do_generate(logger, repo, compile_location)
-  local env = vim.tbl_extend('force', { TREE_SITTER_JS_RUNTIME = 'native' }, repo.env)
+  local env = vim.tbl_extend('force', { TREE_SITTER_JS_RUNTIME = 'native' }, repo.env or {})
   local from_json = true
   if repo.generate_from_json == false then
     from_json = false


### PR DESCRIPTION
Added a `env` field in parser `install_info`.
This allows passing custom environment variables when generating parser.

Use case:
1. [tree-sitter-markdown use environment variables when generating to control extensions to use](https://github.com/tree-sitter-grammars/tree-sitter-markdown?tab=readme-ov-file#extensions)
2. with #8243, it by default uses the native quickjs, but I am running nixos and the tree-sitter cli is not 0.26 yet, current implementation don't seem to auto fallback to node (and I think it should?). so this PR also allows overriding the native runtime and just use node.

To enable the extensions I want I ended up with this PR and the following snippet to compile a working parser that have the extensions enabled

```lua
vim.api.nvim_create_autocmd("User", {
   pattern = "TSUpdate",
   callback = function()
      local p = require("nvim-treesitter.parsers")
      p.markdown_inline.install_info.env = {
         EXTENSION_TAGS = 1,
         EXTENSION_WIKI_LINK = 1,
         TREE_SITTER_JS_RUNTIME = "node",
      }
      p.markdown_inline.install_info.generate = true
      p.markdown_inline.install_info.generate_from_json = false
   end,
})
```
