### PR TITLE
fix(nix): make all bash injections combined

### DIFF
--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -48,7 +48,8 @@
       ((string_fragment) @injection.content
         (#set! injection.language "bash")))
   ]
-  (#lua-match? @_path "^%a+Phase$"))
+  (#lua-match? @_path "^%a+Phase$")
+  (#set! injection.combined))
 
 (binding
   attrpath: (attrpath
@@ -61,7 +62,8 @@
       ((string_fragment) @injection.content
         (#set! injection.language "bash")))
   ]
-  (#lua-match? @_path "^pre%a+$"))
+  (#lua-match? @_path "^pre%a+$")
+  (#set! injection.combined))
 
 (binding
   attrpath: (attrpath
@@ -74,7 +76,8 @@
       ((string_fragment) @injection.content
         (#set! injection.language "bash")))
   ]
-  (#lua-match? @_path "^post%a+$"))
+  (#lua-match? @_path "^post%a+$")
+  (#set! injection.combined))
 
 (binding
   attrpath: (attrpath
@@ -87,7 +90,8 @@
       ((string_fragment) @injection.content
         (#set! injection.language "bash")))
   ]
-  (#lua-match? @_path "^script$"))
+  (#lua-match? @_path "^script$")
+  (#set! injection.combined))
 
 (apply_expression
   function: (_) @_func

--- a/tests/query/injections/nix/test-nix-injections.nix
+++ b/tests/query/injections/nix/test-nix-injections.nix
@@ -9,7 +9,8 @@ in {
   drv1 = stdenv.mkDerivation {
     buildPhase = "mkdir $out";
     installPhase = ''
-      echo "bar" > $out/foo.txt
+      echo "${bar}" > $out/foo.txt
+      echo "baz"" >> $out/foo.txt
     '';
   };
 


### PR DESCRIPTION
Some queries for bash injections weren't combined, which was causing issues with strings containing multiple fragments (i.e., interpolations).

Before:
<img width="805" height="382" alt="2026-01-28_15-55-35" src="https://github.com/user-attachments/assets/f8fe13e4-5e3a-45da-a076-49033e8bcf23" />
After:
<img width="805" height="382" alt="2026-01-28_15-55-25" src="https://github.com/user-attachments/assets/5a55eb02-a7cd-4971-bccf-f5c2066d2cc8" />

cc @leo60228 @mrcjkb @zimbatm