### PR TITLE
fix(lua): injections in vim.{rpcrequest,rpcnotify}

### DIFF
--- a/runtime/queries/lua/injections.scm
+++ b/runtime/queries/lua/injections.scm
@@ -34,10 +34,10 @@
     (_)
     .
     (string
-      content: _ @_method)
+      content: (_) @_method)
     .
     (string
-      content: _ @injection.content)))
+      content: (_) @injection.content)))
   (#any-of? @_vimcmd_identifier "vim.rpcrequest" "vim.rpcnotify")
   (#eq? @_method "nvim_exec_lua")
   (#set! injection.language "lua"))


### PR DESCRIPTION
<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->

Injection hl don't seem work (I'm not sure if worked before)
e.g. `return 1 + 1` should be highlighted
```lua
print(vim.rpcrequest(chan, 'nvim_exec_lua', 'return 1 + 1', {}))
```
