### PR TITLE
feat(vento)!: update parser and queries

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -316,7 +316,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` | @steelsojka
 [uxntal](https://github.com/tree-sitter-grammars/tree-sitter-uxntal) | unstable | `HFIJL` | @amaanq
 [v](https://github.com/vlang/v-analyzer) | unstable | `HFIJL` | @kkharji, @amaanq
 [vala](https://github.com/vala-lang/tree-sitter-vala) | unstable | `HF J ` | @Prince781
-[vento](https://github.com/ventojs/tree-sitter-vento) | unstable | `H  J ` | @wrapperup, @oscarotero
+[vento](https://github.com/ventojs/tree-sitter-vento) | unmaintained | `H  J ` | 
 [vhdl](https://github.com/jpt13653903/tree-sitter-vhdl) | unstable | `HF J ` | @jpt13653903
 [vhs](https://github.com/charmbracelet/tree-sitter-vhs) | unstable | `H  J ` | @caarlos0
 [vim](https://github.com/tree-sitter-grammars/tree-sitter-vim) | unstable | `HF JL` | @clason

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2510,11 +2510,10 @@ return {
   },
   vento = {
     install_info = {
-      revision = '3b32474bc29584ea214e4e84b47102408263fe0e',
+      revision = 'edd6596d4b0f392b87fc345dc26d84a6c32f7059',
       url = 'https://github.com/ventojs/tree-sitter-vento',
     },
-    maintainers = { '@wrapperup', '@oscarotero' },
-    tier = 2,
+    tier = 3,
   },
   vhdl = {
     install_info = {

--- a/runtime/queries/vento/highlights.scm
+++ b/runtime/queries/vento/highlights.scm
@@ -1,6 +1,26 @@
 (comment) @comment @spell
 
-(keyword) @keyword
+[
+  "if"
+  "/if"
+  "else"
+  "for"
+  "/for"
+  "layout"
+  "/layout"
+  "set"
+  "/set"
+  "import"
+  "export"
+  "/export"
+  "include"
+  "function"
+  "/function"
+  "fragment"
+  "/fragment"
+  "of"
+  "async"
+] @keyword
 
 (tag
   [


### PR DESCRIPTION
Breaking change: `(keyword)` node removed.

Also mark as unmaintained (Copilot-maintained) from now on.
