### PR TITLE
tidy: standardise bracketing of the :che table column letter identifier

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -148,7 +148,7 @@ function M.check()
     end
     health.info(vim.fn.trim(out, ' ', 2))
   end
-  health.start('  Legend: H[ighlights], L[ocals], F[olds], I[ndents], In[J]ections')
+  health.start('  Legend: [H]ighlights, [L]ocals, [F]olds, [I]ndents, In[J]ections')
 
   if #error_collection > 0 then
     health.start('The following errors have been detected in query files:')


### PR DESCRIPTION
Use square brackets around only the letter used as a table column header.