### PR TITLE
feat(protobuf): switch parser repo

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -219,7 +219,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` | @steelsojka
 [prolog](https://github.com/foxyseta/tree-sitter-prolog) | unstable | `HFIJ ` | @foxyseta
 [promql](https://github.com/MichaHoffmann/tree-sitter-promql) | unstable | `H  J ` | @MichaHoffmann
 [properties](https://github.com/tree-sitter-grammars/tree-sitter-properties)[^properties] | unstable | `H  JL` | @ObserverOfTime
-[proto](https://github.com/treywood/tree-sitter-proto) | unstable | `HFIJ ` | @treywood
+[proto](https://github.com/coder3101/tree-sitter-proto) | unstable | `HFIJ ` | @stefanvanburen
 [prql](https://github.com/PRQL/tree-sitter-prql) | unstable | `H  J ` | @matthias-Q
 [psv](https://github.com/tree-sitter-grammars/tree-sitter-csv) | unstable | `H    ` | @amaanq
 [pug](https://github.com/zealot128/tree-sitter-pug) | unstable | `H  J ` | @zealot128

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1710,10 +1710,10 @@ return {
   },
   proto = {
     install_info = {
-      revision = 'e9f6b43f6844bd2189b50a422d4e2094313f6aa3',
-      url = 'https://github.com/treywood/tree-sitter-proto',
+      revision = '0e122d8444fd67cd8fb72fc927323b36807e7ace',
+      url = 'https://github.com/coder3101/tree-sitter-proto',
     },
-    maintainers = { '@treywood' },
+    maintainers = { '@stefanvanburen' },
     tier = 2,
   },
   prql = {


### PR DESCRIPTION
This switches the protobuf parser to [coder3101/tree-sitter-proto][1], which is a maintained parser and used in [Zed][2].

The old https://github.com/treywood/tree-sitter-proto is effectively unmaintained AFAICT, so it would be nice to have a maintained repo here.

I'm not exactly sure how this works on this repo's end; let me know if there's anything else I need to do here. I've added @coder3101 as a maintainer here as it's their repository (I don't have contributing rights, currently), but also added myself in case issues come up that I can try to resolve. I've also [updated the repo recently][3] to try to follow the guidelines for new parsers in CONTRIBUTING.md, but let me know if there's anything I've missed.

[1]: https://github.com/coder3101/tree-sitter-proto
[2]: https://github.com/coder3101/tree-sitter-proto/issues/16#issuecomment-3851193773
[3]: https://github.com/coder3101/tree-sitter-proto/pull/17

<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
