### PR TITLE
Add inherits directive for typescript in indents.scm for glimmer_typescript

### DIFF
--- a/runtime/queries/glimmer_typescript/indents.scm
+++ b/runtime/queries/glimmer_typescript/indents.scm
@@ -1,4 +1,4 @@
-; inherits: ecma
+; inherits: typescript
 
 (glimmer_opening_tag) @indent.begin
 


### PR DESCRIPTION
<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
