### PR TITLE
fix: unlink files before copy to prevent crashes

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -302,6 +302,8 @@ local function do_install(logger, compile_location, target_location)
     local tempfile = target_location .. tostring(uv.hrtime())
     uv_rename(target_location, tempfile) -- parser may be in use: rename...
     uv_unlink(tempfile) -- ...and mark for garbage collection
+  else
+    uv_unlink(target_location) -- don't disturb existing memory-mapped content
   end
 
   local err = uv_copyfile(compile_location, target_location)


### PR DESCRIPTION
uv_fs_copyfile will truncate the file first, which can result in bad behavior if it is a shared object currently in use.

instead, unlink the target first, which doesn't modify any in-use files. the disk space won't be reclaimed until any processes relinquish their open file handles on the old parsers.
