### PR TITLE
fix(supercollider): mark as tier 3

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -277,7 +277,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` | @steelsojka
 [starlark](https://github.com/tree-sitter-grammars/tree-sitter-starlark) | unstable | `HFIJL` | @amaanq
 [strace](https://github.com/sigmaSd/tree-sitter-strace) | unstable | `H  J ` | @amaanq
 [styled](https://github.com/mskelton/tree-sitter-styled) | unstable | `HFIJ ` | @mskelton
-[supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) | unstable | `HFIJL` | @madskjeldgaard
+[supercollider](https://github.com/madskjeldgaard/tree-sitter-supercollider) | unmaintained | `HFIJL` | @madskjeldgaard
 [superhtml](https://github.com/kristoff-it/superhtml) | unstable | `H  J ` | @rockorager
 [surface](https://github.com/connorlay/tree-sitter-surface) | unstable | `HFIJ ` | @connorlay
 [svelte](https://github.com/tree-sitter-grammars/tree-sitter-svelte) | unstable | `HFIJL` | @amaanq

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -2188,7 +2188,7 @@ return {
       url = 'https://github.com/madskjeldgaard/tree-sitter-supercollider',
     },
     maintainers = { '@madskjeldgaard' },
-    tier = 2,
+    tier = 3,
   },
   superhtml = {
     install_info = {


### PR DESCRIPTION
This prevents the parser from being updated automatically and blocking other updates due to breaking changes.

@madskjeldgaard This is temporary until the breaking parser updates are done and you get around to updating the queries here (and in nvim-treesitter-textobjects and context).
