### PR TITLE
CEL

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -36,6 +36,7 @@ Language | Tier | Queries | Maintainer
 [caddy](https://github.com/opa-oz/tree-sitter-caddy) | unmaintained | `HFIJ ` | 
 [cairo](https://github.com/tree-sitter-grammars/tree-sitter-cairo) | unstable | `HFIJL` | @amaanq
 [capnp](https://github.com/tree-sitter-grammars/tree-sitter-capnp) | unstable | `HFIJL` | @amaanq
+[cel](https://github.com/bufbuild/tree-sitter-cel) | unstable | `HFIJL` | @stefanvanburen
 [chatito](https://github.com/tree-sitter-grammars/tree-sitter-chatito) | unstable | `HFIJL` | @ObserverOfTime
 [circom](https://github.com/Decurity/tree-sitter-circom) | unstable | `HF JL` | @alexandr-martirosyan
 [clojure](https://github.com/sogaiu/tree-sitter-clojure) | unstable | `HF JL` | @NoahTheDuke

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -267,6 +267,14 @@ return {
     maintainers = { '@jakestanger' },
     tier = 2,
   },
+  cel = {
+    install_info = {
+      revision = 'e0b695e6c318babff09de7e66e0de0adaab7b8ad',
+      url = 'https://github.com/bufbuild/tree-sitter-cel',
+    },
+    maintainers = { '@stefanvanburen' },
+    tier = 2,
+  },
   cpon = {
     install_info = {
       revision = '594289eadfec719198e560f9d7fd243c4db678d5',

--- a/runtime/queries/cel/folds.scm
+++ b/runtime/queries/cel/folds.scm
@@ -1,0 +1,10 @@
+; Code folding queries for CEL (Common Expression Language).
+; Marks collection literals as foldable regions.
+; Fold map expressions
+(map_expression) @fold
+
+; Fold list expressions
+(list_expression) @fold
+
+; Fold struct expressions
+(struct_expression) @fold

--- a/runtime/queries/cel/highlights.scm
+++ b/runtime/queries/cel/highlights.scm
@@ -1,0 +1,95 @@
+; Syntax highlighting queries for CEL (Common Expression Language).
+; Maps CEL grammar nodes to standard tree-sitter highlight capture names.
+; Operators
+[
+  "-"
+  "!"
+  "*"
+  "/"
+  "&&"
+  "%"
+  "+"
+  "<"
+  "<="
+  "!="
+  "=="
+  ">"
+  ">="
+  "||"
+] @operator
+
+; Ternary operator
+"?" @operator
+
+(conditional_expression
+  ":" @operator)
+
+(map_entry
+  ":" @punctuation.delimiter)
+
+(field_initializer
+  ":" @punctuation.delimiter)
+
+; Punctuation
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+"," @punctuation.delimiter
+
+"." @punctuation.delimiter
+
+; Keywords
+"in" @keyword.operator
+
+(reserved_keyword) @keyword
+
+; Function calls
+(call_expression
+  function: (identifier) @function.call)
+
+(absolute_expression
+  name: (identifier) @function.call
+  arguments: (arguments))
+
+(member_call_expression
+  function: [
+    (identifier)
+    (reserved_keyword)
+  ] @function.method.call)
+
+; Member access
+(select_expression
+  member: [
+    (identifier)
+    (reserved_keyword)
+  ] @variable.member)
+
+; Variables
+(identifier) @variable
+
+; Literals
+[
+  (string_literal)
+  (bytes_literal)
+] @string
+
+[
+  (int_literal)
+  (uint_literal)
+] @number
+
+(float_literal) @number.float
+
+[
+  (true)
+  (false)
+  (null)
+] @constant.builtin
+
+(comment) @comment @spell

--- a/runtime/queries/cel/indents.scm
+++ b/runtime/queries/cel/indents.scm
@@ -1,0 +1,16 @@
+; Indentation queries for CEL (Common Expression Language).
+; Marks nodes that should increase or decrease indentation level.
+; Indent after opening delimiters of collection literals and function arguments
+[
+  (map_expression)
+  (list_expression)
+  (struct_expression)
+  (arguments)
+] @indent.begin
+
+; Dedent before closing delimiters
+[
+  "}"
+  "]"
+  ")"
+] @indent.dedent

--- a/runtime/queries/cel/injections.scm
+++ b/runtime/queries/cel/injections.scm
@@ -1,0 +1,4 @@
+; Inject the "comment" language into comments to enable highlighting of
+; TODO, FIXME, etc. markers within CEL comment text.
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/runtime/queries/cel/locals.scm
+++ b/runtime/queries/cel/locals.scm
@@ -1,0 +1,9 @@
+; CEL is a pure expression language — variables are provided by the evaluation
+; environment rather than declared in the expression itself. We mark the root
+; expression as a scope and all identifiers as references so that editors can
+; apply local-variable highlighting and scope-aware navigation.
+; Scopes
+(expr) @local.scope
+
+; References
+(identifier) @local.reference


### PR DESCRIPTION
https://cel.dev

`.cel` (supported on nvim nightly: https://github.com/neovim/neovim/pull/37834)

CEL is an expression-based language that's embeddable, so sorry for the short example. (Many more on https://celbyexample.com.)

(I don't think the details/summary work in the pull request template, because the markdown is within HTML, so I've just made it markdown below.)

## Representative code sample
```cel
// From cel.dev homepage
// Simple predicates
'tacocat'.startsWith('taco')
```

parser repo: https://github.com/bufbuild/tree-sitter-cel

## Parsed tree for code sample
```
(expr ; [0, 0] - [3, 0]
  (comment) ; [0, 0] - [0, 24]
  (comment) ; [1, 0] - [1, 20]
  (member_call_expression ; [2, 0] - [2, 28]
    operand: (string_literal ; [2, 0] - [2, 9]
      (single_quoted_string_literal)) ; [2, 0] - [2, 9]
    function: (identifier) ; [2, 10] - [2, 20]
    arguments: (arguments ; [2, 20] - [2, 28]
      (string_literal ; [2, 21] - [2, 27]
        (single_quoted_string_literal))))) ; [2, 21] - [2, 27]

```

Source of queries: written from scratch; cobbled together from other tree-sitter repositories.

<details>
<summary>Screenshots of code sample</summary>
<img width="206" height="51" alt="image" src="https://github.com/user-attachments/assets/7e5a7cb9-d56a-4551-8836-818db837abb4" />

</details>

<!--
CHECKLIST: _Before_ submitting, make sure

* `./scripts/install-parsers.lua <language>` works without warnings
* `./scripts/install-parsers.lua --generate <language>` works without warnings
* `make query` works without warning
* `make docs` is run -->

<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
