### PR TITLE
fix(c_sharp): missing highlight for lambda modifier

### DIFF
--- a/runtime/queries/c_sharp/highlights.scm
+++ b/runtime/queries/c_sharp/highlights.scm
@@ -327,6 +327,9 @@
 (lambda_expression
   type: (identifier) @type)
 
+(lambda_expression
+  (modifier) @keyword.modifier)
+
 (as_expression
   right: (identifier) @type)
 


### PR DESCRIPTION
Frequently used `static` keyword is currently not highlighted on lambdas as a modifier in C#:

# Before | After
<img width="307" height="91" alt="image" src="https://github.com/user-attachments/assets/67936bbb-f177-40fa-866c-16b8c0248010" />
<img width="296" height="86" alt="image" src="https://github.com/user-attachments/assets/8ee08992-1a4e-4ae1-8e1a-db9b4f318408" />

