### PR TITLE
feat(editorconfig)!: update parser and queries

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -66,7 +66,7 @@ Language | Tier | Queries | Maintainer
 [earthfile](https://github.com/glehmann/tree-sitter-earthfile) | unstable | `H  J ` | @glehmann
 [ebnf](https://github.com/RubixDev/ebnf) | unstable | `H  J ` | @RubixDev
 ecma (queries only)[^ecma] | unstable | `HFIJL` | @steelsojka
-[editorconfig](https://github.com/ValdezFOmar/tree-sitter-editorconfig) | unstable | `HF J ` | @ValdezFOmar
+[editorconfig](https://github.com/ValdezFOmar/tree-sitter-editorconfig) | stable | `HF J ` | @ValdezFOmar
 [eds](https://github.com/uyha/tree-sitter-eds) | unstable | `HF   ` | @uyha
 [eex](https://github.com/connorlay/tree-sitter-eex) | unstable | `H  J ` | @connorlay
 [elixir](https://github.com/elixir-lang/tree-sitter-elixir) | unstable | `HFIJL` | @connorlay

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -448,11 +448,11 @@ return {
   },
   editorconfig = {
     install_info = {
-      revision = '406ab80f7dc4f3aac252ad3d106737a621dde47d',
+      revision = 'v2.0.0',
       url = 'https://github.com/ValdezFOmar/tree-sitter-editorconfig',
     },
     maintainers = { '@ValdezFOmar' },
-    tier = 2,
+    tier = 1,
   },
   eds = {
     install_info = {

--- a/runtime/queries/editorconfig/highlights.scm
+++ b/runtime/queries/editorconfig/highlights.scm
@@ -1,14 +1,19 @@
 (comment) @comment @spell
 
-(section
-  (section_name) @string.special.path)
+(property) @property
 
-(character_choice
-  (character) @constant)
+(string) @string
 
-(character_range
-  start: (character) @constant
-  end: (character) @constant)
+(header
+  (glob) @string.special.path)
+
+(character) @character
+
+(character_escape) @string.escape
+
+(wildcard) @character.special
+
+(integer) @number
 
 [
   "["
@@ -20,36 +25,11 @@
 [
   ","
   ".."
-  (path_separator)
+  "/"
+  "-"
 ] @punctuation.delimiter
 
 [
-  "-"
   "="
-  (negation)
+  "!"
 ] @operator
-
-[
-  (wildcard_characters)
-  (wildcard_any_characters)
-  (wildcard_single_character)
-] @character.special
-
-(escaped_character) @string.escape
-
-(pair
-  key: (identifier) @property
-  value: (_) @string)
-
-(boolean) @boolean
-
-(integer) @number
-
-(unset) @constant.builtin
-
-[
-  (spelling_language)
-  (indent_style)
-  (end_of_line)
-  (charset)
-] @string.special


### PR DESCRIPTION
PR https://github.com/ValdezFOmar/tree-sitter-editorconfig/pull/56

Removed nodes:
section_name, expansion_string, wildcard_characters, wildcard_any_characters, wildcard_single_character, unset, boolean, spelling_language, indent_style, end_of_line, charset, unknown

Renamed nodes:
identifier -> property
negation -> "!"
path_separator -> "/"
escaped_character -> character_escape

I'm additionally marking the parser as tier 1 since I don't plan to make any more breaking changes.