### PR TITLE
DRAFT fix(dockerfile): correct highlighting of several RUN statements

### DIFF
--- a/runtime/queries/dockerfile/injections.scm
+++ b/runtime/queries/dockerfile/injections.scm
@@ -4,7 +4,6 @@
 ((shell_command
   (shell_fragment) @injection.content)
   (#set! injection.language "bash")
-  (#set! injection.combined))
 
 ((run_instruction
   (heredoc_block) @injection.content)


### PR DESCRIPTION
# DRAFT
## Description

Removes `(#set! injection.combined)` from the `shell_fragment` bash injection in `queries/dockerfile/injections.scm`.

Fixes #6530, #6975

## Root cause

`injection.combined` merges **all** `shell_fragment` captures across the entire file into a single bash parse tree. The bash parser receives the fragments at their original buffer byte offsets, with no bytes filling the gaps between them. This means the last fragment of one `RUN` block and the first fragment of the next `RUN` block appear **adjacent** to the bash parser with no whitespace between them.

For example, given:

```dockerfile
RUN cp -R build ./resources/spa/ \
    && echo done

RUN if [ -z "$CI" ]; then \
    apk add curl
```

The bash parser sees `./resources/spa/` immediately followed by `if`, and parses them as a single `command` node — `./resources/spa/` as the command name and everything that follows as its arguments. In bash's highlight query, `(command argument: (word) @variable.parameter)` captures all those arguments, which many colorschemes render as a distinct (often red/maroon) color, causing visible highlight bleed across `RUN` blocks.

## Fix

Remove `(#set! injection.combined)`. Each `shell_fragment` now gets its own independent bash parse tree, scoped to the bytes of that fragment only. Cross-block contamination is impossible.

**Tradeoff:** multi-line `RUN` commands with `\` continuations are split into one tree per continuation line. Lines ending with `&&` (e.g. `apt-get install -y curl && \`) are incomplete bash and produce `has_error: true` trees. In practice this is harmless — the bash parser still extracts valid nodes from each fragment and highlighting quality is unchanged.

## Before / after

**Before:** arguments in `RUN` blocks following a multi-line `RUN` are incorrectly highlighted as `@variable.parameter` (color bleed).

**After:** each `RUN` block is highlighted independently; no cross-block bleed.

The one-line diff:

```diff
 ((shell_command
   (shell_fragment) @injection.content)
   (#set! injection.language "bash")
-  (#set! injection.combined))
```
