### PR TITLE
feat(ecma): variable definition from object destructure with alias

### DIFF
--- a/runtime/queries/ecma/locals.scm
+++ b/runtime/queries/ecma/locals.scm
@@ -25,6 +25,11 @@
   name: (object_pattern
     (shorthand_property_identifier_pattern) @local.definition.var))
 
+(variable_declarator
+  (object_pattern
+    (pair_pattern
+      (identifier) @local.definition.var)))
+
 (import_specifier
   (identifier) @local.definition.import)
 


### PR DESCRIPTION
Hello,

Basically, the same as https://github.com/nvim-treesitter/nvim-treesitter/pull/8233

**Before**:
<img width="524" height="223" alt="image" src="https://github.com/user-attachments/assets/bf91264f-1d4e-496b-bd6a-1359f468edf8" />

**After**:
<img width="537" height="216" alt="image" src="https://github.com/user-attachments/assets/64362f6f-8b3b-4da0-850d-bc5576570b8f" />
