### PR TITLE
feat(ecmascript): add gql function highlighting for ecmascript injection

### DIFF
--- a/runtime/queries/ecma/injections.scm
+++ b/runtime/queries/ecma/injections.scm
@@ -59,10 +59,15 @@
   (#set! injection.include-children)
   (#set! injection.language "groq"))
 
+; gql`...` or gql(`...`)
 (call_expression
   function: (identifier) @_name
   (#eq? @_name "gql")
-  arguments: (template_string) @injection.content
+  arguments: [
+    (arguments
+      (template_string) @injection.content)
+    (template_string) @injection.content
+  ]
   (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children)
   (#set! injection.language "graphql"))


### PR DESCRIPTION
## What

Allow `gql` as a function to also have graphql treesitter highlighting in the template string

## Why

It is common to use something like [graphql-codegen](https://the-guild.dev/graphql/codegen) when writing graphql queries. We use it in our project as `import { graphql as gql } from "./gql/gql"` after setting up our codegen. However, we don't get syntax highlighting when using it this way. 

### Before

<img width="386" height="594" alt="before" src="https://github.com/user-attachments/assets/38d1e5cf-759a-4e9b-b499-f97825f3b2c4" />

We already have support for `graphql` function and template string in an earlier injection, and we already have support for `gql` as a template string, this PR just extends the `gql` injection to also support a `gql` function.

### After

<img width="438" height="610" alt="after" src="https://github.com/user-attachments/assets/24b07e1d-b7ce-4027-826d-f34354d97a9d" />

