### PR TITLE
fix(health): normalize both sides of runtimepath comparison

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -97,7 +97,7 @@ local function install_health()
   end
   if
     vim.iter(vim.api.nvim_list_runtime_paths()):any(function(p)
-      return installdir == vim.fs.normalize(p) .. '/'
+      return vim.fs.normalize(installdir) == vim.fs.normalize(p)
     end)
   then
     health.ok('is in runtimepath.')


### PR DESCRIPTION
**Summary**
Fixes a bug in the health check that incorrectly reports the install directory as not being in runtimepath, even when it is correctly configured.

**Problem**
The health check in lua/nvim-treesitter/health.lua compares the install directory path against runtimepath entries inconsistently: health.lua:98-106

Install directory: /home/user/.local/share/nvim/site (no trailing slash)
Runtimepath entries: /home/user/.local/share/nvim/site/ (with trailing slash added)
This mismatch causes the check to fail with "ERROR is not in runtimepath" even though the directory is properly configured.

**Solution**
Normalize both paths consistently before comparison:

**Impact**
Fixes false positive health check errors
No functional changes to nvim-treesitter operation
Users will no longer see confusing "not in runtimepath" errors when their configuration is correct

**Testing**
Verified that the health check now correctly reports "OK is in runtimepath" when the install directory is properly configured.

**Notes**
This is a straightforward bug fix that addresses an inconsistency in path comparison logic. The actual functionality of nvim-treesitter was never affected - only the health check reporting was incorrect. health.lua:99-101