### PR TITLE
fix(config): normalize default `install_dir`

### DIFF
--- a/lua/nvim-treesitter/config.lua
+++ b/lua/nvim-treesitter/config.lua
@@ -7,7 +7,7 @@ M.tiers = { 'stable', 'unstable', 'unmaintained', 'unsupported' }
 
 ---@type TSConfig
 local config = {
-  install_dir = vim.fs.joinpath(vim.fn.stdpath('data') --[[@as string]], 'site'),
+  install_dir = vim.fs.joinpath(vim.fn.stdpath('data') --[[@as string]], 'site/'),
 }
 
 ---Setup call for users to override configuration configurations.


### PR DESCRIPTION
Problem: The default `install_dir` is not normalized, leading to a
false positive checkhealth failure when comparing against the normalized
`runtimepath` directories.

Solution: Use trailing slash in default `install_dir`.
