### PR TITLE
Show errors on `vim.system` failure

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -98,11 +98,16 @@ local function system(cmd, opts)
   local cwd = opts and opts.cwd or uv.cwd()
   log.trace('running job: (cwd=%s) %s', cwd, table.concat(cmd, ' '))
 
+  ---vim.system throws an error when uv.spawn fails, in particular if cmd or cwd
+  ---does not exist. This kills the coroutine, so the async'ed call simply hangs.
+  ---Instead, we pass a wrapper that catches errors and propagates them as a proper
+  ---`SystemObj`.
+  ---TODO(clason): remove when https://github.com/neovim/neovim/issues/38257 is resolved.
   ---@param _cmd string[]
   ---@param _opts vim.SystemOpts
   ---@param on_exit fun(result: vim.SystemCompleted)
   ---@return vim.SystemObj?
-  local function safe_system(_cmd, _opts, on_exit)
+  local function system_wrap(_cmd, _opts, on_exit)
     local ok, ret = pcall(vim.system, _cmd, _opts, on_exit)
     if not ok then
       on_exit({
@@ -116,7 +121,7 @@ local function system(cmd, opts)
     return ret --[[@as vim.SystemObj]]
   end
 
-  local r = a.await(3, safe_system, cmd, opts) --[[@as vim.SystemCompleted]]
+  local r = a.await(3, system_wrap, cmd, opts) --[[@as vim.SystemCompleted]]
   a.schedule()
   if r.stdout and r.stdout ~= '' then
     log.trace('stdout -> %s', r.stdout)


### PR DESCRIPTION
This is a workaround for #8010.

Since `vim.system()` [throws an error](https://neovim.io/doc/user/lua/#vim.system()) in cases where a command cannot be run (e.g. when `tree-sitter` is not installed) it crashes the whole coroutine, so it never returns the error message.
To prevent this, I implemented a small helper function for `system()` that, in case of exception, returns a dummy `SystemCompleted` object containing the shell error in the `stderr` field.

I tested this change on the latest stable Neovim version (v0.11.6) with a clean configuration and this `init.lua`:

```lua
vim.opt.rtp:prepend(os.getenv('HOME') .. '/nvim-treesitter')

local ts = require('nvim-treesitter')
ts.setup()
``` 

This is what it looks like in action, after running `:TSInstall c` without having `tree-sitter-cli` installed:
<img width="1180" height="674" alt="image" src="https://github.com/user-attachments/assets/3f9f68d6-6ac4-4b3c-8849-7eade1df021d" />

This is the output of `:TSLog` afterwards:
```
info(install/c): Downloading tree-sitter-c...
trace: running job: (cwd=/home/luca/.config/nvim-debug) curl --silent --fail --show-error --retry 7 -L https://github.com/tree-sit
ter/tree-sitter-c/archive/ae19b676b13bdcc13b7665397e6d9b14975473dd.tar.gz --output /home/luca/.cache/nvim-debug/tree-sitter-c.tar.
gz
debug(install/c): Creating temporary directory: /home/luca/.cache/nvim-debug/tree-sitter-c-tmp
debug(install/c): Extracting /home/luca/.cache/nvim-debug/tree-sitter-c.tar.gz into tree-sitter-c...
trace: running job: (cwd=/home/luca/.cache/nvim-debug) tar -xzf tree-sitter-c.tar.gz -C tree-sitter-c-tmp
debug(install/c): Removing /home/luca/.cache/nvim-debug/tree-sitter-c.tar.gz...
debug(install/c): Moving /home/luca/.cache/nvim-debug/tree-sitter-c-tmp/tree-sitter-c-ae19b676b13bdcc13b7665397e6d9b14975473dd to
/home/luca/.cache/nvim-debug/tree-sitter-c/...
info(install/c): Compiling parser
trace: running job: (cwd=/home/luca/.cache/nvim-debug/tree-sitter-c) tree-sitter build -o parser.so
trace: stderr -> /usr/share/nvim/runtime/lua/vim/_system.lua:254: ENOENT: no such file or directory (cmd): 'tree-sitter'
error(install/c): Error during "tree-sitter build": /usr/share/nvim/runtime/lua/vim/_system.lua:254: ENOENT: no such file or direc
tory (cmd): 'tree-sitter'
```

---

I'm aware that the issue has been labeled as "upstream", but I thought this patch could still be useful in the meantime.