### PR TITLE
feat(fstar): add parser and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ We are looking for maintainers to add more parsers and to write query files for 
 - [x] [fortran](https://github.com/stadelmanma/tree-sitter-fortran) (maintained by @amaanq)
 - [x] [fsh](https://github.com/mgramigna/tree-sitter-fsh) (maintained by @mgramigna)
 - [x] [fsharp](https://github.com/ionide/tree-sitter-fsharp) (maintained by @nsidorenco)
+- [x] [fstar](https://github.com/sei40kr/tree-sitter-fstar) (maintained by @sei40kr)
 - [x] [func](https://github.com/amaanq/tree-sitter-func) (maintained by @amaanq)
 - [x] [fusion](https://gitlab.com/jirgn/tree-sitter-fusion.git) (maintained by @jirgn)
 - [x] [GAP system](https://github.com/gap-system/tree-sitter-gap) (maintained by @reiniscirpons)

--- a/lockfile.json
+++ b/lockfile.json
@@ -221,6 +221,9 @@
   "fsharp": {
     "revision": "02929f084726db969e5b916d144436f248146824"
   },
+  "fstar": {
+    "revision": "cdb06d462e0ee727c313f3e07c71bc2d288e0f89"
+  },
   "func": {
     "revision": "f780ca55e65e7d7360d0229331763e16c452fc98"
   },

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -684,6 +684,14 @@ list.fsharp = {
   maintainers = { "@nsidorenco" },
 }
 
+list.fstar = {
+  install_info = {
+    url = "https://github.com/sei40kr/tree-sitter-fstar",
+    files = { "src/parser.c", "src/scanner.c" },
+  },
+  maintainers = { "@sei40kr" },
+}
+
 list.func = {
   install_info = {
     url = "https://github.com/amaanq/tree-sitter-func",

--- a/queries/fstar/highlights.scm
+++ b/queries/fstar/highlights.scm
@@ -1,0 +1,199 @@
+; Keywords
+[
+  "module"
+  "let"
+  "and"
+  "in"
+  "val"
+  "begin"
+  "end"
+  "forall"
+  "exists"
+  "assert"
+  "assert_norm"
+  "assume"
+  "calc"
+  "when"
+  "as"
+  "of"
+  "returns"
+  "with"
+  "match"
+] @keyword
+
+[
+  "if"
+  "then"
+  "else"
+] @keyword.conditional
+
+"fun" @keyword.function
+
+[
+  "open"
+  "include"
+  "friend"
+] @keyword.import
+
+[
+  "type"
+  "effect"
+  "new_effect"
+  "layered_effect"
+  "sub_effect"
+  "class"
+] @keyword.type
+
+[
+  "exception"
+  "try"
+] @keyword.exception
+
+[
+  "rec"
+  "mutable"
+] @keyword.modifier
+
+; Qualifiers
+(qualifier) @keyword.modifier
+
+; Operators
+[
+  "="
+  "<"
+  ">"
+  "<>"
+  "<="
+  ">="
+  "=="
+  "=!="
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "**"
+  "||"
+  "&&"
+  "!"
+  "~"
+  "->"
+  "|>"
+  "<|"
+  "::"
+  "@"
+  "^"
+  "$"
+  "<:"
+  ":="
+  "\\/"
+  "/\\"
+  "<==>"
+  "==>"
+  "|"
+  ":"
+  "."
+] @operator
+
+; Pragmas
+(pragma) @keyword.directive
+
+; Module names
+(module_declaration
+  (uid_path) @module)
+
+(open_declaration
+  (uid_path) @module)
+
+(include_declaration
+  (uid_path) @module)
+
+(friend_declaration
+  (uid_path) @module)
+
+(module_abbreviation
+  (uid) @module)
+
+(module_abbreviation
+  (uid_path) @module)
+
+; Type declarations
+(type_declaration
+  (lid) @type.definition)
+
+; Constructor definitions
+(constructor
+  (uid) @constructor)
+
+; Val declarations — function names
+(val_declaration
+  (lid) @function)
+
+(val_declaration
+  (uid_path_dot_lid
+    (lid) @function))
+
+; Let declarations — function names
+(let_binding
+  (lid) @function)
+
+(let_binding
+  (uid_path_dot_lid
+    (lid) @function))
+
+; Constructors (uppercase identifiers used in expressions/patterns)
+(uid) @constructor
+
+; Qualified paths
+(uid_path
+  (uid) @module)
+
+(uid_path_dot_lid
+  (uid) @module)
+
+(uid_path_dot_lid
+  (lid) @variable)
+
+; Variables
+(lid) @variable
+
+; Type variables
+(type_variable) @type
+
+; Literals
+(integer) @number
+
+(string) @string
+
+(char) @character
+
+(boolean) @boolean
+
+(unit) @constant.builtin
+
+; Wildcard
+(wildcard) @character.special
+
+; Operator identifiers
+(operator_id) @operator
+
+; Attributes
+(attribute) @attribute
+
+; Comments
+(line_comment) @comment @spell
+
+(block_comment) @comment @spell
+
+; Field access
+(field_access
+  (lid) @property)
+
+(field_assignment
+  (lid) @property)
+
+(field_declaration
+  (lid) @property)
+
+(field_pattern
+  (lid) @property)


### PR DESCRIPTION
## Summary
- Add [tree-sitter-fstar](https://github.com/sei40kr/tree-sitter-fstar) parser for the [F*](https://fstar-lang.org/) proof-oriented programming language
- Includes highlight queries

## Test plan
- [ ] `:TSInstall fstar`
- [ ] Open `.fst` / `.fsti` files and verify syntax highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)