### PR TITLE
fix(health): normalize installdir to fix false runtimepath error

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -87,7 +87,7 @@ local function install_health()
     health.info(k .. ': ' .. v)
   end
 
-  local installdir = config.get_install_dir('')
+  local installdir = vim.fs.normalize(config.get_install_dir(''))
   health.start('Install directory for parsers and queries')
   health.info(installdir)
   if vim.uv.fs_access(installdir, 'w') then


### PR DESCRIPTION
Hello,

When I try to run `:checkhealth` 

`nvim-treesitter` reports:

`❌ ERROR is not in runtimepath`

even though the install directory is in runtimepath.

It looks like this was fixed previously by removing the trailing slash from `config.install_dir`, but it got reintroduced becuase `get_install_dir('')` calls `vim.fs.joinpath(install_dir, '')`, which adds the trailing slash back.

## Fix
The fix could be something like wrapping with `vim.fs.normalize()` to strip the trailing slash before comparison?

## Verification
Before:

- `❌ ERROR is not in runtimepath`

After:

- `✅ OK is in runtimepath`
