### PR TITLE
fix(health): normalize installdir before runtimepath check

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -87,7 +87,7 @@ local function install_health()
     health.info(k .. ': ' .. v)
   end
 
-  local installdir = config.get_install_dir('')
+  local installdir = vim.fs.normalize(config.get_install_dir(''))
   health.start('Install directory for parsers and queries')
   health.info(installdir)
   if vim.uv.fs_access(installdir, 'w') then


### PR DESCRIPTION
`get_install_dir('')` calls `vim.fs.joinpath(install_dir, '')` which produces a trailing slash (e.g. `/path/to/site/`). This doesn't match the entry in `nvim_list_runtime_paths()` (`/path/to/site`), causing the health check to incorrectly report "is not in runtimepath."

