### PR TITLE
feat: add Concerto modelling language parser

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -42,6 +42,7 @@ Language | Tier | Queries | Maintainer
 [cmake](https://github.com/uyha/tree-sitter-cmake) | unstable | `HFIJ ` | @uyha
 [comment](https://github.com/stsewd/tree-sitter-comment) | unstable | `H    ` | @stsewd
 [commonlisp](https://github.com/tree-sitter-grammars/tree-sitter-commonlisp) | unstable | `HF JL` | @theHamsta
+[concerto](https://github.com/accordproject/concerto-tree-sitter) | unmaintained | `HFI L` | @jamieshorten
 [cooklang](https://github.com/addcninblue/tree-sitter-cooklang) | unstable | `H  J ` | @addcninblue
 [corn](https://github.com/jakestanger/tree-sitter-corn) | unstable | `HFIJL` | @jakestanger
 [cpon](https://github.com/tree-sitter-grammars/tree-sitter-cpon) | unstable | `HFIJL` | @amaanq

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -243,6 +243,14 @@ return {
     maintainers = { '@stsewd' },
     tier = 2,
   },
+  concerto = {
+    install_info = {
+      revision = '77ae6b9e09a58ac4c94fe36760df7e8d26ab5aca',
+      url = 'https://github.com/accordproject/concerto-tree-sitter',
+    },
+    maintainers = { '@jamieshorten' },
+    tier = 3,
+  },
   commonlisp = {
     install_info = {
       revision = '32323509b3d9fe96607d151c2da2c9009eb13a2f',

--- a/runtime/queries/concerto/folds.scm
+++ b/runtime/queries/concerto/folds.scm
@@ -1,0 +1,14 @@
+; Concerto Language - Fold Queries
+; =================================
+; Fold declaration bodies
+(class_body) @fold
+
+(enum_body) @fold
+
+(map_body) @fold
+
+; Fold block comments
+(block_comment) @fold
+
+; Fold decorator argument lists
+(decorator_arguments) @fold

--- a/runtime/queries/concerto/highlights.scm
+++ b/runtime/queries/concerto/highlights.scm
@@ -1,0 +1,231 @@
+; Concerto Language - Syntax Highlighting Queries
+; =================================================
+; Keywords
+; --------
+; Declaration keywords
+[
+  "concept"
+  "asset"
+  "participant"
+  "transaction"
+  "event"
+  "enum"
+  "scalar"
+  "map"
+] @keyword.type
+
+[
+  "namespace"
+  "import"
+  "from"
+] @keyword.import
+
+"extends" @keyword
+
+"abstract" @keyword.modifier
+
+[
+  "identified"
+  "by"
+] @keyword
+
+"optional" @keyword.modifier
+
+[
+  "concerto"
+  "version"
+] @keyword
+
+"default" @keyword
+
+[
+  "regex"
+  "range"
+  "length"
+] @keyword
+
+"as" @keyword
+
+; Primitive type keywords
+[
+  "String"
+  "Boolean"
+  "DateTime"
+  "Integer"
+  "Long"
+  "Double"
+] @type.builtin
+
+(primitive_type) @type.builtin
+
+; Boolean literals
+(boolean_literal) @boolean
+
+; Comments
+; --------
+(line_comment) @comment
+
+(block_comment) @comment
+
+; Strings
+; -------
+(string_literal) @string
+
+(escape_sequence) @string.escape
+
+; Numbers
+; -------
+(signed_integer) @number
+
+(signed_real) @number
+
+(signed_number) @number
+
+; Regex
+; -----
+(regex_literal) @string.regexp
+
+; Decorators
+; ----------
+(decorator
+  "@" @attribute
+  name: (identifier) @attribute)
+
+; Namespace and imports
+; --------------------
+(namespace_path) @module
+
+(import_path) @module
+
+(uri) @string.special
+
+; Version
+; -------
+(concerto_version
+  (string_literal) @string.special)
+
+; Type identifiers (in type position)
+; -----------------------------------
+(concept_declaration
+  name: (type_identifier) @type)
+
+(asset_declaration
+  name: (type_identifier) @type)
+
+(participant_declaration
+  name: (type_identifier) @type)
+
+(transaction_declaration
+  name: (type_identifier) @type)
+
+(event_declaration
+  name: (type_identifier) @type)
+
+(enum_declaration
+  name: (type_identifier) @type)
+
+(scalar_declaration
+  name: (type_identifier) @type)
+
+(map_declaration
+  name: (type_identifier) @type)
+
+(extends_clause
+  (type_identifier) @type)
+
+; Field type references
+(object_field
+  type: (type_identifier) @type)
+
+(relationship_field
+  type: (type_identifier) @type)
+
+; Map type references
+(map_key_type
+  type: (type_identifier) @type)
+
+(map_value_property
+  type: (type_identifier) @type)
+
+(map_value_relationship
+  type: (type_identifier) @type)
+
+; Decorator identifier references
+(decorator_identifier_ref
+  (type_identifier) @type)
+
+; Import type name
+(import_single
+  type: (identifier) @type)
+
+(type_list_item
+  (identifier) @type)
+
+(aliased_type
+  original: (identifier) @type
+  alias: (identifier) @type)
+
+; Field/property names
+; --------------------
+(string_field
+  name: (identifier) @property)
+
+(boolean_field
+  name: (identifier) @property)
+
+(datetime_field
+  name: (identifier) @property)
+
+(integer_field
+  name: (identifier) @property)
+
+(long_field
+  name: (identifier) @property)
+
+(double_field
+  name: (identifier) @property)
+
+(object_field
+  name: (identifier) @property)
+
+(relationship_field
+  name: (identifier) @property)
+
+(enum_property
+  name: (identifier) @property)
+
+; Identified by field name
+(identified_by
+  field: (identifier) @property)
+
+; Relationship arrow
+"-->" @operator
+
+; Property indicator
+"o" @punctuation.special
+
+; Array indicator
+(array_indicator) @punctuation.bracket
+
+; Wildcards in imports
+"*" @operator
+
+; Delimiters
+; ----------
+"{" @punctuation.bracket
+
+"}" @punctuation.bracket
+
+"(" @punctuation.bracket
+
+")" @punctuation.bracket
+
+"[" @punctuation.bracket
+
+"]" @punctuation.bracket
+
+"," @punctuation.delimiter
+
+"." @punctuation.delimiter
+
+"=" @operator

--- a/runtime/queries/concerto/indents.scm
+++ b/runtime/queries/concerto/indents.scm
@@ -1,0 +1,15 @@
+; Concerto Language - Indent Queries
+; ===================================
+; Indent inside declaration bodies
+[
+  (class_body)
+  (enum_body)
+  (map_body)
+  (decorator_arguments)
+] @indent.begin
+
+; Outdent at closing braces
+[
+  "}"
+  ")"
+] @indent.end

--- a/runtime/queries/concerto/locals.scm
+++ b/runtime/queries/concerto/locals.scm
@@ -1,0 +1,85 @@
+; Concerto Language - Locals Queries
+; ===================================
+; Scopes
+; ------
+; Each declaration body creates a new scope
+(concept_declaration) @local.scope
+
+(asset_declaration) @local.scope
+
+(participant_declaration) @local.scope
+
+(transaction_declaration) @local.scope
+
+(event_declaration) @local.scope
+
+(enum_declaration) @local.scope
+
+(map_declaration) @local.scope
+
+; Definitions
+; -----------
+; Type declarations define types
+(concept_declaration
+  name: (type_identifier) @local.definition)
+
+(asset_declaration
+  name: (type_identifier) @local.definition)
+
+(participant_declaration
+  name: (type_identifier) @local.definition)
+
+(transaction_declaration
+  name: (type_identifier) @local.definition)
+
+(event_declaration
+  name: (type_identifier) @local.definition)
+
+(enum_declaration
+  name: (type_identifier) @local.definition)
+
+(scalar_declaration
+  name: (type_identifier) @local.definition)
+
+(map_declaration
+  name: (type_identifier) @local.definition)
+
+; Property declarations define properties
+(string_field
+  name: (identifier) @local.definition)
+
+(boolean_field
+  name: (identifier) @local.definition)
+
+(datetime_field
+  name: (identifier) @local.definition)
+
+(integer_field
+  name: (identifier) @local.definition)
+
+(long_field
+  name: (identifier) @local.definition)
+
+(double_field
+  name: (identifier) @local.definition)
+
+(object_field
+  name: (identifier) @local.definition)
+
+(relationship_field
+  name: (identifier) @local.definition)
+
+(enum_property
+  name: (identifier) @local.definition)
+
+; References
+; ----------
+; Type references
+(extends_clause
+  (type_identifier) @local.reference)
+
+(object_field
+  type: (type_identifier) @local.reference)
+
+(relationship_field
+  type: (type_identifier) @local.reference)


### PR DESCRIPTION
## Description

Add tree-sitter parser and queries for the **Concerto Modelling Language** (`.cto` files) by the [Accord Project](https://accordproject.org).

Concerto is a schema/modelling language for defining data models used in smart legal contracts and business networks. It is the modelling language behind the Accord Project's open-source smart legal contract ecosystem.

## Language features

- 8 declaration types: `concept`, `asset`, `participant`, `transaction`, `event`, `enum`, `scalar`, `map`
- 6 primitive types: `String`, `Boolean`, `DateTime`, `Integer`, `Long`, `Double`
- Decorators with typed arguments (`@decorator("arg")`)
- Relationships (`-->`)
- Validators (regex, range, length)
- Imports with semantic versioning (`import org.example@1.0.0.Foo`)
- Namespace declarations with semver

## Example

```cto
namespace org.acme.hr@1.0.0

import org.acme.utils@2.0.0.{ Address, PhoneNumber as Phone }

@description("An employee in the HR system")
concept Employee identified by employeeId {
  o String employeeId
  o String firstName
  o String lastName
  o DateTime startDate
  o Address address optional
  --> Department department
}

enum Department {
  o ENGINEERING
  o MARKETING
  o SALES
}
```

## Parsed tree

```
(program
  (namespace_declaration
    (namespace_path))
  (import_declaration
    (import_multi
      (import_path)
      (type_list
        (type_list_item
          (identifier))
        (aliased_type
          original: (identifier)
          alias: (identifier)))))
  (concept_declaration
    (decorator
      (identifier)
      (decorator_arguments
        (string_literal)))
    name: (type_identifier)
    (identified_by
      field: (identifier))
    (class_body
      (string_field
        name: (identifier))
      (string_field
        name: (identifier))
      (string_field
        name: (identifier))
      (datetime_field
        name: (identifier))
      (object_field
        type: (type_identifier)
        name: (identifier)
        (optional_modifier))
      (relationship_field
        type: (type_identifier)
        name: (identifier))))
  (enum_declaration
    name: (type_identifier)
    (enum_body
      (enum_property
        name: (identifier))
      (enum_property
        name: (identifier))
      (enum_property
        name: (identifier)))))
```

## Queries included

| File | Purpose |
|---|---|
| `highlights.scm` | Full syntax highlighting |
| `folds.scm` | Code folding for declaration bodies and block comments |
| `locals.scm` | Scope, definition, and reference tracking |
| `indents.scm` | Auto-indentation for declaration bodies |

## Grammar source

- Repository: https://github.com/accordproject/concerto-tree-sitter
- Language spec: https://concerto.accordproject.org
- 120 corpus tests, 129 highlight assertions, 71 query validation tests — all passing
- `ts_query_ls check --format` passes on all query files
- Zero conflicts in grammar generation
- Language bindings: C, Node.js, Rust, Python, Go, Swift

## Filetype detection

Neovim does not yet natively detect `.cto` files. Users need to add:

```lua
vim.filetype.add({ extension = { cto = 'concerto' } })
```

This could also be submitted as a PR to Neovim core's `runtime/lua/vim/filetype.lua` if desired.

## Tier

Tier 3 — new parser, single maintainer.