### PR TITLE
Ensure health check path matches configured path

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -87,7 +87,7 @@ local function install_health()
     health.info(k .. ': ' .. v)
   end
 
-  local installdir = config.get_install_dir('')
+  local installdir = config.get_install_dir('.')
   health.start('Install directory for parsers and queries')
   health.info(installdir)
   if vim.uv.fs_access(installdir, 'w') then


### PR DESCRIPTION
<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
Genuinely tiny fix - was just getting the scratch in my brain from the error in health check.

Was due to `vim.fs.joinpath` appending a `/` on a path if the string was empty resulting in a check against a path with a `/` and a check against a path without a `/`
```
Install directory for parsers and queries ~
- /home/path/.local/share/nvim/site/
- ✅ OK is writable.
- ❌ ERROR is not in runtimepath.

Actual runtimepath entry:
/home/path/.local/share/nvim/site
```

I can update the health check to normalise the path by stripping out trailing `/` if needed but figured the easiest (and least intrusive fix) was this bad boi.

Lemme know thoughts