### PR TITLE
feat(nix): add `writeText`/`writeTextDir` injections

### DIFF
--- a/runtime/queries/nix/injections.scm
+++ b/runtime/queries/nix/injections.scm
@@ -255,6 +255,48 @@
   (#lua-match? @_func "^%a*%.*writeRust%a*$")
   (#set! injection.combined))
 
+((apply_expression
+  function: (apply_expression
+    function: (_) @_func
+    argument: [
+      (string_expression
+        .
+        (string_fragment) @injection.filename .)
+      (indented_string_expression
+        .
+        (string_fragment) @injection.filename .)
+    ])
+  . ; only match on adjacent text, so that we can use a comment to change the language
+  argument: [
+    (string_expression
+      (string_fragment) @injection.content)
+    (indented_string_expression
+      (string_fragment) @injection.content)
+  ])
+  (#lua-match? @_func "^%a*%.*writeText$")
+  (#set! injection.combined))
+
+((apply_expression
+  function: (apply_expression
+    function: (_) @_func
+    argument: [
+      (string_expression
+        .
+        (string_fragment) @injection.filename .)
+      (indented_string_expression
+        .
+        (string_fragment) @injection.filename .)
+    ])
+  . ; only match on adjacent text, so that we can use a comment to change the language
+  argument: [
+    (string_expression
+      (string_fragment) @injection.content)
+    (indented_string_expression
+      (string_fragment) @injection.content)
+  ])
+  (#lua-match? @_func "^%a*%.*writeTextDir$")
+  (#set! injection.combined))
+
 ; (runTest) testScript
 (apply_expression
   function: (_) @_func

--- a/tests/query/injections/nix/test-nix-injections.nix
+++ b/tests/query/injections/nix/test-nix-injections.nix
@@ -70,6 +70,19 @@ in {
     '';
   };
 
+  drv13 = pkgs.writeText "config.json" ''
+    {
+      "foo": 1,
+      "bar": 2
+    }
+  '';
+
+  drv14 = pkgs.writeTextDir "etc/ssh/ssh_config" ''
+    Host *
+    AddressFamily any
+    ForwardX11 no
+  '';
+
   mod1 = {
     type = "lua";
     config = ''


### PR DESCRIPTION
Right now I'm using the entire string content (interpolations and all) as the file name. Is there a better solution?

<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
