### PR TITLE
fix(install): use rename-before-unlink on all platforms

### DIFF
--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -322,13 +322,9 @@ end
 local function do_install(logger, compile_location, target_location)
   logger:info(string.format('Installing parser'))
 
-  if uv.os_uname().sysname == 'Windows_NT' then -- why can't you just be normal?!
-    local tempfile = target_location .. tostring(uv.hrtime())
-    uv_rename(target_location, tempfile) -- parser may be in use: rename...
-    uv_unlink(tempfile) -- ...and mark for garbage collection
-  else
-    uv_unlink(target_location) -- don't disturb existing memory-mapped content
-  end
+  local tempfile = target_location .. tostring(uv.hrtime())
+  uv_rename(target_location, tempfile) -- parser may be in use: rename...
+  uv_unlink(tempfile) -- ...and mark for garbage collection
 
   local err = uv_copyfile(compile_location, target_location)
   a.schedule()


### PR DESCRIPTION
Apply the rename-then-unlink strategy unconditionally instead of only on Windows. On macOS Apple Silicon, a plain unlink can leave stale code signature metadata in the kernel cache, causing SIGKILL on next page fault after TSUpdate.

Fixes #8530
