### PR TITLE
Add SASS block code highlighting for Svelte

### DIFF
--- a/runtime/queries/svelte/injections.scm
+++ b/runtime/queries/svelte/injections.scm
@@ -8,7 +8,7 @@
         (attribute_value) @_lang)))
   (raw_text) @injection.content)
   (#eq? @_attr "lang")
-  (#any-of? @_lang "scss" "postcss" "less")
+  (#any-of? @_lang "scss" "postcss" "less" "sass")
   (#set! injection.language "scss"))
 
 ((svelte_raw_text) @injection.content


### PR DESCRIPTION
When using SASS style block with Svelte the code is not injected into treesitter, so it is not highlighted.
Simply adding "sass" to the list fix it.

Before:
<img width="584" height="324" alt="before" src="https://github.com/user-attachments/assets/3302adf7-6868-4188-8447-9d419a47a899" />

After:
<img width="701" height="320" alt="after" src="https://github.com/user-attachments/assets/49bc123e-5a43-4b87-a38b-4b1f145892e3" />

