### PR TITLE
fix(kotlin): regex and printf injections not applying

### DIFF
--- a/runtime/queries/kotlin/injections.scm
+++ b/runtime/queries/kotlin/injections.scm
@@ -8,7 +8,8 @@
 ;    - "[abc]?".toRegex()
 (call_expression
   (navigation_expression
-    ((string_literal) @injection.content
+    ((string_literal
+      (string_content) @injection.content)
       (#set! injection.language "regex"))
     (navigation_suffix
       ((simple_identifier) @_function
@@ -21,7 +22,8 @@
   (call_suffix
     (value_arguments
       (value_argument
-        (string_literal) @injection.content
+        (string_literal
+          (string_content) @injection.content)
         (#set! injection.language "regex")))))
 
 ;    - Regex.fromLiteral("[abc]?")
@@ -35,13 +37,15 @@
   (call_suffix
     (value_arguments
       (value_argument
-        (string_literal) @injection.content
+        (string_literal
+          (string_content) @injection.content)
         (#set! injection.language "regex")))))
 
 ; "pi = %.2f".format(3.14159)
 ((call_expression
   (navigation_expression
-    (string_literal) @injection.content
+    (string_literal
+      (string_content) @injection.content)
     (navigation_suffix
       (simple_identifier) @_method)))
   (#eq? @_method "format")


### PR DESCRIPTION
<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
