### PR TITLE
fix(health): healthcheck always fails runtimepath check

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -87,7 +87,7 @@ local function install_health()
     health.info(k .. ': ' .. v)
   end
 
-  local installdir = config.get_install_dir('')
+  local installdir = config.get_install_dir(''):gsub('/*$', '')
   health.start('Install directory for parsers and queries')
   health.info(installdir)
   if vim.uv.fs_access(installdir, 'w') then


### PR DESCRIPTION
Currently, running `:checkhealth` with the default configuration always says that the install dir is not in the runtimepath.

I've traced it back to `config.get_install_dir()` always returning a path with a trailing "/": i.e. `path/to/config/dir/`. 

Then, vim.api.nvim_list_runtime_paths always trims the trailing "/" when adding to the dir. 

The proposed solution is to strip the trailing / in the checkhealth call. 