### PR TITLE
fix(checkhealth): normalize paths when checking in runtime_paths

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -87,7 +87,7 @@ local function install_health()
     health.info(k .. ': ' .. v)
   end
 
-  local installdir = config.get_install_dir(''):gsub('/$', '')
+  local installdir = vim.fs.normalize(config.get_install_dir(''))
   health.start('Install directory for parsers and queries')
   health.info(installdir)
   if vim.uv.fs_access(installdir, 'w') then


### PR DESCRIPTION
<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->

On Windows, the paths returned by `vim.api.nvim_list_runtime_paths` contain escaped backslashes such as `C:\\Users\\user\\AppData\\Local\\nvim-data\\site` for the install site of nvim-treesitter.

In #8580, a loop where each path in the rtp was first called with `vim.fs.normalize` before comparing with `local installdir = config.get_install_dir('')` was removed, which meant the `install_dir` with forward slashes was compared against unnormalized paths in rtp. This raises an error in `:checkhealth nvim-treesitter`.

```
Install directory for parsers and queries ~
- C:/Users/<myusername>/AppData/Local/nvim-data/site/
- ✅ OK is writable.
- ❌ ERROR is not in runtimepath.
```

> [!NOTE]
> I see that in #8583 this is not a priority, but I would like to point out #8606 (and related issues) is not resolved yet.

This PR brings back the loop to normalize each runtime path before comparing to `installdir`, and calls `vim.fs.normalize()` on the `installdir` so both sides are equivalently UNIX-style paths without trailing slashes (caused by calling `config.get_install_dir` with an empty string). The changes are isolated to only `:checkhealth`.

With this change:
```
Install directory for parsers and queries ~
- C:/Users/<myusername>/AppData/Local/nvim-data/site
- ✅ OK is writable.
- ✅ OK is in runtimepath.
```

I have tested this on x86_64 Windows on:
- 0.11.6
- 0.12.0
- Nightly: 0.12.0-dev-2727+gad4bc2d90c

Thank you for all the hard work, let me know if changes are desired 😄 .