### PR TITLE
fix(vim): remove invalid "tab" node type from highlights query

### DIFF
--- a/runtime/queries/vim/highlights.scm
+++ b/runtime/queries/vim/highlights.scm
@@ -110,7 +110,6 @@
   "cnext"
   "cprevious"
   "cNext"
-  "tab"
   "vertical"
   "leftabove"
   "aboveleft"


### PR DESCRIPTION
The "tab" node type was removed from the Vim treesitter parser. The tab command is now parsed as unknown_command_name, which is already captured in the same keyword list. The stale "tab" entry causes a query error (Invalid node type "tab") on every command mode entry in Neovim. Remove the invalid node type.

<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->
