### PR TITLE
fix(health): normalize rtp when checking install_dir

### DIFF
--- a/lua/nvim-treesitter/health.lua
+++ b/lua/nvim-treesitter/health.lua
@@ -95,7 +95,9 @@ local function install_health()
   else
     health.error('is not writable.')
   end
-  if vim.list_contains(vim.api.nvim_list_runtime_paths(), installdir) then
+  if
+    vim.list_contains(vim.tbl_map(vim.fs.normalize, vim.api.nvim_list_runtime_paths()), installdir)
+  then
     health.ok('is in runtimepath.')
   else
     health.error('is not in runtimepath.')


### PR DESCRIPTION
Problem: Windows.

Solution: vim.fs.normalize.

Closes #8606.