### PR TITLE
fix(python): avoid duplicate regex injection matches

### DIFF
--- a/runtime/queries/python/injections.scm
+++ b/runtime/queries/python/injections.scm
@@ -3,7 +3,12 @@
     object: (identifier) @_re)
   arguments: (argument_list
     (string
-      (string_content) @injection.content))
+      (string_start)
+      [
+        (string_content) @injection.content
+        (interpolation)
+      ]+
+      (string_end)))
   (#eq? @_re "re")
   (#set! injection.language "regex"))
 
@@ -12,11 +17,14 @@
     object: (identifier) @_re)
   arguments: (argument_list
     (concatenated_string
-      [
-        (string
-          (string_content) @injection.content)
-        (comment)
-      ]+))
+      ((string
+         (string_start)
+         [
+           (string_content) @injection.content
+           (interpolation)
+         ]+
+         (string_end))
+       (comment)?)+))
   (#eq? @_re "re")
   (#set! injection.language "regex"))
 


### PR DESCRIPTION
The previous regex injection query repeated a captured `string_content` node inside `concatenated_string`. Interpolated Python strings can contain multiple
`string_content` nodes, so adjacent f-strings produced a combinatorial number of candidate matches.

Neovim used to hide this with the default treesitter `match_limit`, but recent core changes allow the query to enumerate all matches. That can hang redraw/search navigation while injections are computed.

Match complete string nodes instead and capture every literal part within each string. This keeps one injection for the regex call, preserves f-string literal fragments, and avoids duplicate candidate matches.
