### PR TITLE
feat(bpftrace)!: update parser and queries

### DIFF
--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -142,7 +142,7 @@ return {
   },
   bpftrace = {
     install_info = {
-      revision = '50b27d8b5cae89e77702ab249dcd743a41848e5b',
+      revision = '11453f5e4be5026b2b18d4b53f893ded972011ce',
       url = 'https://github.com/sgruszka/tree-sitter-bpftrace',
     },
     maintainers = { '@sgruszka' },

--- a/runtime/queries/bpftrace/highlights.scm
+++ b/runtime/queries/bpftrace/highlights.scm
@@ -47,7 +47,7 @@
 (probe
   provider: (uprobe_uretprobe_provider) @type.builtin
   binary: (file_identifier) @string.special.path
-  function: (identifier) @property)
+  function: (wildcard_identifier) @property)
 
 ; tracepoint
 (probe
@@ -94,13 +94,13 @@
 (probe
   provider: (ustd_provider) @type.builtin
   binary: (file_identifier) @string.special.path
-  namespace: (identifier) @variable
-  function: (identifier) @property)
+  namespace: (wildcard_identifier) @variable
+  function: (wildcard_identifier) @property)
 
 (probe
   provider: (ustd_provider) @type.builtin
   binary: (file_identifier) @string.special.path
-  function: (identifier) @property)
+  function: (wildcard_identifier) @property)
 
 ; watchpoint/asyncwatchpoint
 (probe


### PR DESCRIPTION
Breaking change: replace `(identifier)` by `(wildcard_identifier)` in
some patterns.
