### PR TITLE
feat(scala)!: update parser and queries

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -250,7 +250,7 @@ jsx (queries only)[^jsx] | unstable | `HFIJ ` | @steelsojka
 [ruby](https://github.com/tree-sitter/tree-sitter-ruby) | unstable | `HFIJL` | @TravonteD
 [runescript](https://github.com/2004Scape/tree-sitter-runescript) | unstable | `H  J ` | @2004Scape
 [rust](https://github.com/tree-sitter/tree-sitter-rust) | unstable | `HFIJL` | @amaanq
-[scala](https://github.com/tree-sitter/tree-sitter-scala) | unstable | `HF JL` | @stevanmilic
+[scala](https://github.com/tree-sitter/tree-sitter-scala) | unstable | `HFIJL` | @stevanmilic
 [scfg](https://github.com/rockorager/tree-sitter-scfg) | unstable | `H  J ` | @WhyNotHugo
 [scheme](https://github.com/6cdh/tree-sitter-scheme) | unstable | `HF J ` | 
 [scss](https://github.com/serenadeai/tree-sitter-scss) | unstable | `HFIJ ` | @elianiva

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -1957,7 +1957,7 @@ return {
   },
   scala = {
     install_info = {
-      revision = '5877eb9f55dc396da0d9a3e890df01f5c4810233',
+      revision = 'bf9ac14f8b95c8ea341d830165de5a66e0f6664b',
       url = 'https://github.com/tree-sitter/tree-sitter-scala',
     },
     maintainers = { '@stevanmilic' },

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -183,10 +183,11 @@
   "with"
   "given"
   "using"
-  "end"
   "implicit"
   "extension"
 ] @keyword
+
+(end_marker) @keyword
 
 [
   "enum"

--- a/runtime/queries/scala/indents.scm
+++ b/runtime/queries/scala/indents.scm
@@ -1,0 +1,32 @@
+[
+  (template_body)
+  (block)
+  (parameters)
+  (arguments)
+  (match_expression)
+  (splice_expression)
+  (import_declaration)
+  (function_definition)
+  "match"
+  ":"
+  "="
+] @indent.begin
+
+(ERROR
+  ":") @indent.begin
+
+(ERROR
+  "=") @indent.begin
+
+(arguments
+  ")" @indent.end)
+
+"}" @indent.end
+
+(end_marker) @indent.end
+
+[
+  ")"
+  "]"
+  "}"
+] @indent.branch


### PR DESCRIPTION
Also add indents queries from upstream.

Breaking change: `(end)` node replaced by scanner-lexed `(end_marker)`
