### PR TITLE
docs(djot): mark as unmaintained

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -58,7 +58,7 @@ Language | Tier | Queries | Maintainer
 [dhall](https://github.com/jbellerb/tree-sitter-dhall) | unstable | `HF J ` | @amaanq
 [diff](https://github.com/tree-sitter-grammars/tree-sitter-diff) | unstable | `HF J ` | @gbprod
 [disassembly](https://github.com/ColinKennedy/tree-sitter-disassembly) | unstable | `H  J ` | @ColinKennedy
-[djot](https://github.com/treeman/tree-sitter-djot) | unstable | `HFIJL` | @NoahTheDuke
+[djot](https://github.com/treeman/tree-sitter-djot) | unmaintained | `HFIJL` | 
 [dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile) | unstable | `H  J ` | @camdencheek
 [dot](https://github.com/rydesun/tree-sitter-dot) | unstable | `HFIJ ` | @rydesun
 [doxygen](https://github.com/tree-sitter-grammars/tree-sitter-doxygen) | unstable | `H IJ ` | @amaanq

--- a/lua/nvim-treesitter/parsers.lua
+++ b/lua/nvim-treesitter/parsers.lua
@@ -388,8 +388,7 @@ return {
       revision = '759a61896ccb2200a4becec4443e768638a21d58',
       url = 'https://github.com/treeman/tree-sitter-djot',
     },
-    maintainers = { '@NoahTheDuke' },
-    tier = 2,
+    tier = 3,
   },
   dockerfile = {
     install_info = {


### PR DESCRIPTION
Project moved to codeberg with no Github mirror (repo was archived
instead), so document reality.

(The language may be dropped in the future.)
