### PR TITLE
ci(generate): increase max_jobs to 10

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -36,7 +36,7 @@ jobs:
 
       - if: inputs.type == 'generate'
         name: Generate and compile parsers
-        run: $NVIM -l ./scripts/install-parsers.lua --generate --max-jobs=2
+        run: $NVIM -l ./scripts/install-parsers.lua --generate --max-jobs=10
 
       - name: Check parsers
         run: $NVIM -l ./scripts/check-parsers.lua


### PR DESCRIPTION
In tree-sitter 0.27.0, the `tree-sitter generate` was reworked to
significantly reduce memory consumption, making higher parallelism
possible. The bottleneck is now network I/O in GHA, same as for the
basic build check.
