### PR TITLE
highlight(cuda): add Tile IR keywords

### DIFF
--- a/runtime/queries/cuda/highlights.scm
+++ b/runtime/queries/cuda/highlights.scm
@@ -8,7 +8,9 @@
 [
   "__host__"
   "__device__"
+  "__tile__"
   "__global__"
+  "__tile_global__"
   "__managed__"
   "__forceinline__"
   "__noinline__"


### PR DESCRIPTION
<!--
  Before proceeding, make sure you have read https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md!
  If you are adding a new parser, use this link instead:
  <https://github.com/nvim-treesitter/nvim-treesitter/compare/main...my-branch?quick_pull=1&template=new_language.md>
-->

This feature was added to the parser in https://github.com/tree-sitter-grammars/tree-sitter-cuda/pull/120